### PR TITLE
remove '==' bashism

### DIFF
--- a/packaging/irods
+++ b/packaging/irods
@@ -31,25 +31,25 @@ status)
     ;;
 start)
     su --shell=/bin/bash -c "$IRODS_CTL istart" irods
-    if [ "$DETECTEDOS" == "RedHatCompatible" -o "$DETECTEDOS" == "SuSE" ] ; then
+    if [ "$DETECTEDOS" = "RedHatCompatible" -o "$DETECTEDOS" = "SuSE" ] ; then
         touch /var/lock/subsys/irods
     fi
     ;;
 stop)
     su --shell=/bin/bash -c "$IRODS_CTL istop" irods
-    if [ "$DETECTEDOS" == "RedHatCompatible" -o "$DETECTEDOS" == "SuSE" ] ; then
+    if [ "$DETECTEDOS" = "RedHatCompatible" -o "$DETECTEDOS" = "SuSE" ] ; then
         rm /var/lock/subsys/irods
     fi
     ;;
 restart)
     su --shell=/bin/bash -c "$IRODS_CTL irestart" irods
-    if [ "$DETECTEDOS" == "RedHatCompatible" -o "$DETECTEDOS" == "SuSE" ] ; then
+    if [ "$DETECTEDOS" = "RedHatCompatible" -o "$DETECTEDOS" = "SuSE" ] ; then
         touch /var/lock/subsys/irods
     fi
     ;;
 force-reload)
     su --shell=/bin/bash -c "$IRODS_CTL irestart" irods
-    if [ "$DETECTEDOS" == "RedHatCompatible" -o "$DETECTEDOS" == "SuSE" ] ; then
+    if [ "$DETECTEDOS" = "RedHatCompatible" -o "$DETECTEDOS" = "SuSE" ] ; then
         touch /var/lock/subsys/irods
     fi
     ;;


### PR DESCRIPTION
'==' as an operator for [ is not defined by the posix standard, so it would create an error on systems where /bin/sh is dash instead of bash.
