### PR TITLE
Update irodsServerMonPerf

### DIFF
--- a/iRODS/server/bin/cmd/irodsServerMonPerf
+++ b/iRODS/server/bin/cmd/irodsServerMonPerf
@@ -117,7 +117,7 @@ $fsExists = 1;
 my @sysPathList = split(',', $sysFilePath);
 foreach my $pth(@sysPathList) {
 	if ($pth ne 'none') {
-		my $rc = system("LANG=C;export LANG;df -k $pth > /dev/null 2>&1"); # JMC - backport 4830
+		my $rc = system("LANG=C;export LANG;df -kP $pth > /dev/null 2>&1"); # JMC - backport 4830
 		if( $rc != 0 ) {
 			Log("The file $pth system doesn't exit. $!");
 			$fsExists = 0;
@@ -237,7 +237,7 @@ else
 	if ( $fsExists ) { 
 		foreach my $pth(@sysPathList) {
 			if ( $pth ne 'none' ) {
-				@result = `LANG=C;export LANG;df -k $pth`; # JMC - backport 4830
+				@result = `LANG=C;export LANG;df -kP $pth`; # JMC - backport 4830
 				chomp($result[0]);
 				foreach my $entry(@result) {
 					if ( $entry !~ /Filesystem/ && $entry =~ /%/) {
@@ -462,7 +462,7 @@ if ( $fsExists ) {
 			$diskAbsAvail .= -1;
 			next;
 		}
-		@result = `LANG=C;export LANG;df -k $pth`; # JMC - backport 4830
+		@result = `LANG=C;export LANG;df -kP $pth`; # JMC - backport 4830
 		while ( my $entry = shift(@result) ) {
 			if ( $entry !~ /Filesystem/ && $entry =~ /%/) {
 				chomp($entry);


### PR DESCRIPTION
solution for "top: failed tty get" on some linux (CentOS 6 in my case) 
On some systems top will not tolerate not being attached to a tty
-b invokes batch mode a non-interactive mode for sending output to other programs or a file
Untested on other platforms
