### PR TITLE
[#2420] Call readICatUserLogging after loading DVM

### DIFF
--- a/iRODS/server/re/src/nre.reLib1.cpp
+++ b/iRODS/server/re/src/nre.reLib1.cpp
@@ -332,10 +332,6 @@ initRuleStruct( int processType, rsComm_t *svrComm, char *irbSet, char *dvmSet, 
     if ( i < 0 ) {
         return i;
     }
-    /* read logging settings */
-    if ( svrComm != NULL ) { /* if this is not a process started by a client, then we used the default logging setting */
-        readICatUserLogging( svrComm->clientUser.userName, &ruleEngineConfig.logging, svrComm );
-    }
     /*strcpy(r2,r3);
     }*/
     snprintf( r2, sizeof( r2 ), "%s", dvmSet );
@@ -365,6 +361,11 @@ initRuleStruct( int processType, rsComm_t *svrComm, char *irbSet, char *dvmSet, 
             return i;
         }
         snprintf( r2, sizeof( r2 ), "%s", r3 );
+    }
+
+    /* read logging settings */
+    if ( svrComm != NULL ) { /* if this is not a process started by a client, then we used the default logging setting */
+        readICatUserLogging( svrComm->clientUser.userName, &ruleEngineConfig.logging, svrComm );
     }
 
     if ( getenv( RETESTFLAG ) != NULL ) {


### PR DESCRIPTION
Fixes #2420.

Delay the call to `readICatUserLogging` till after loading the DVM set.

Otherwise, use of `$userNameClient` breaks `acAclPolicy` rules break, as these are
loaded already from `rsGenQuery` invoked as part of `readICatUserLogging`.
