### PR TITLE
Regression in ability to compile C clients against 4.1.0

### DIFF
--- a/iRODS/lib/api/include/dataObjCreate.hpp
+++ b/iRODS/lib/api/include/dataObjCreate.hpp
@@ -15,20 +15,28 @@
 #include "initServer.hpp"
 #include "dataObjInpOut.hpp"
 #include "fileCreate.hpp"
+
+#ifdef __cplusplus
 #include <string>
+
+int
+_rsDataObjCreateWithResc( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
+                          const std::string& _resc_name );
+int
+getRescForCreate( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
+                  std::string& _resc_name );
+#endif
 
 #if defined(RODS_SERVER)
 #define RS_DATA_OBJ_CREATE rsDataObjCreate
 /* prototype for the server handler */
+
 int
 rsDataObjCreate( rsComm_t *rsComm, dataObjInp_t *dataObjInp );
 int
 _rsDataObjCreate( rsComm_t *rsComm, dataObjInp_t *dataObjInp );
 int
 specCollSubCreate( rsComm_t *rsComm, dataObjInp_t *dataObjInp );
-int
-_rsDataObjCreateWithResc( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
-                          const std::string& _resc_name );
 int
 dataObjCreateAndReg( rsComm_t *rsComm, int l1descInx );
 int
@@ -38,9 +46,7 @@ l3Create( rsComm_t *rsComm, int l1descInx );
 int
 l3CreateByObjInfo( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
                    dataObjInfo_t *dataObjInfo );
-int
-getRescForCreate( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
-                  std::string& _resc_name );
+
 #else
 #define RS_DATA_OBJ_CREATE NULL
 #endif

--- a/iRODS/lib/api/include/phyBundleColl.hpp
+++ b/iRODS/lib/api/include/phyBundleColl.hpp
@@ -11,7 +11,10 @@
 
 // =-=-=-=-=-=-=-
 // stl includes
+
+#ifdef __cplusplus
 #include <string>
+#endif
 
 #include "rods.hpp"
 #include "rcMisc.hpp"
@@ -66,9 +69,13 @@ remotePhyBundleColl( rsComm_t *rsComm,
 int
 _rsPhyBundleColl( rsComm_t *rsComm, structFileExtAndRegInp_t *phyBundleCollInp,
                   const char *_resc_name );
+
+#ifdef __cplusplus
 int
 createPhyBundleDataObj( rsComm_t *rsComm, char *collection, const std::string& _resc_name,
                         const char* rescHier, dataObjInp_t *dataObjInp, char *dataType ); // JMC - backport 4658
+#endif
+
 int
 createPhyBundleDir( rsComm_t *rsComm, char *bunFilePath,
                     char *outPhyBundleDir, char* hier );

--- a/iRODS/lib/core/include/getRodsEnv.hpp
+++ b/iRODS/lib/core/include/getRodsEnv.hpp
@@ -61,12 +61,14 @@ typedef struct {
 } rodsEnv;
 
 int getRodsEnv( rodsEnv *myRodsEnv );
-void _getRodsEnv( rodsEnv &myRodsEnv );
 
 char *getRodsEnvFileName();
 char *getRodsEnvAuthFileName();
 
 #ifdef __cplusplus
+
+void _getRodsEnv( rodsEnv &myRodsEnv );
+
 }
 #endif
 #endif	/* GET_RODS_ENV */

--- a/iRODS/server/core/include/initServer.hpp
+++ b/iRODS/server/core/include/initServer.hpp
@@ -169,9 +169,9 @@ int
 printServerHost( rodsServerHost_t *myServerHost );
 int
 printZoneInfo();
-int
-getAndConnRcatHost( rsComm_t *rsComm, int rcatType, char *rcatZoneHint,
-                    rodsServerHost_t **rodsServerHost );
+// int
+// getAndConnRcatHost( rsComm_t *rsComm, int rcatType, char *rcatZoneHint,
+//                     rodsServerHost_t **rodsServerHost );
 int
 getAndConnRcatHostNoLogin( rsComm_t *rsComm, int rcatType, char *rcatZoneHint,
                            rodsServerHost_t **rodsServerHost );


### PR DESCRIPTION
In running test builds of baton against master I came up against a regression that prevented
compilation. The minimal changes required to get something to compile are in this pull request.
They're not pretty, but they work around the problem.

Added ifdefs to avoid C++ code appearing in headers included by C clients.

Commented one of the two declarations of getAndConnRcatHost. This does
permit a C client to be compiled. However I don't know whether this is
correct.