### PR TITLE
Fix *_plugin_context::valid() pointer checks

### DIFF
--- a/iRODS/lib/core/include/irods_auth_plugin_context.hpp
+++ b/iRODS/lib/core/include/irods_auth_plugin_context.hpp
@@ -44,11 +44,9 @@ namespace irods {
 
                 // =-=-=-=-=-=-=
                 // trap case of incorrect type for first class object
-                try {
-                    boost::shared_ptr< OBJ_TYPE > ref = boost::dynamic_pointer_cast< OBJ_TYPE >( fco_ );
-                }
-                catch ( const std::bad_cast& ) {
-                    ret = PASSMSG( "invalid type for fco cast", ret );
+                boost::shared_ptr< OBJ_TYPE > ref = boost::dynamic_pointer_cast< OBJ_TYPE >( fco_ );
+                if ( ref == NULL ) {
+                    ret = ERROR( INVALID_DYNAMIC_CAST, "invalid type for fco cast" );
                 }
 
                 return ret;

--- a/iRODS/lib/core/include/irods_plugin_context.hpp
+++ b/iRODS/lib/core/include/irods_plugin_context.hpp
@@ -64,14 +64,9 @@ namespace irods {
 
                 // =-=-=-=-=-=-=
                 // trap case of incorrect type for first class object
-                try {
-                    OBJ_TYPE* ref = dynamic_cast< OBJ_TYPE* >( fco_.get() );
-                    if ( ref == NULL ) {
-                        ret = PASSMSG( "invalid type for fco cast", ret );
-                    }
-                }
-                catch ( const std::bad_cast& ) {
-                    ret = PASSMSG( "invalid type for fco cast", ret );
+                OBJ_TYPE* ref = dynamic_cast< OBJ_TYPE* >( fco_.get() );
+                if ( ref == NULL ) {
+                    ret = ERROR( INVALID_DYNAMIC_CAST, "invalid type for fco cast" );
                 }
 
                 return ret;

--- a/iRODS/lib/core/include/irods_resource_plugin_context.hpp
+++ b/iRODS/lib/core/include/irods_resource_plugin_context.hpp
@@ -57,11 +57,9 @@ namespace irods {
 
                 // =-=-=-=-=-=-=
                 // trap case of incorrect type for first class object
-                try {
-                    boost::shared_ptr< OBJ_TYPE > ref = boost::dynamic_pointer_cast< OBJ_TYPE >( fco_ );
-                }
-                catch ( const std::bad_cast& ) {
-                    ret = PASSMSG( "invalid type for fco cast", ret );
+                boost::shared_ptr< OBJ_TYPE > ref = boost::dynamic_pointer_cast< OBJ_TYPE >( fco_ );
+                if ( ref == NULL ) {
+                    ret = ERROR( INVALID_DYNAMIC_CAST, "invalid type for fco cast" );
                 }
 
                 return ret;


### PR DESCRIPTION
These `valid()` checks currently always succeed, because `boost::dynamic_pointer_cast<>` and `dynamic_cast<type*>` fail by returning a null pointer rather than by throwing std::bad_cast.

Once that is fixed, `valid().ok()` is still okay because PASSMSG just propagates the `SUCCESS` from the initialisation of `ret`.  This suggested patch uses ERROR instead with what seem like suitable arguments, but I don't know the code and perhaps there's a better approach here.