### PR TITLE
Actually use iFuseConn if opened

### DIFF
--- a/iRODS/clients/fuse/src/iFuseLib.Conn.cpp
+++ b/iRODS/clients/fuse/src/iFuseLib.Conn.cpp
@@ -127,8 +127,10 @@ int _getAndUseIFuseConn( iFuseConn_t **iFuseConn ) {
             addToConcurrentList( ConnectedConn, tmpIFuseConn );
             *iFuseConn = tmpIFuseConn;
         }
-        rodsLog( LOG_ERROR, "failure to acquire fuse connection; maximum fuse connections exceeded." );
-        return SYS_MAX_CONNECT_COUNT_EXCEEDED;
+        else {
+            rodsLog( LOG_ERROR, "failure to acquire fuse connection; maximum fuse connections exceeded." );
+            return SYS_MAX_CONNECT_COUNT_EXCEEDED;
+        }
     }
     else {
         useIFuseConn( tmpIFuseConn );


### PR DESCRIPTION
if an iFuseConn can be opened, there is no reason to fail with `SYS_MAX_CONNECT_COUNT_EXCEEDED`. I think the intent is to have this as the `else` for the `if ( listSize( ConnectedConn ) < MAX_NUM_CONN)`.

irodsFuse seems to be completely broken since e36c63ded853a36b0290756b6c0bcf48b741eea8 without this change, despite several subsequent commits. Do people test locally before committing to master?