### PR TITLE
OS X patch to use CommonCrypto MD5 instead of bundled MD5 implementation

### DIFF
--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -812,7 +812,7 @@ else
     echo "Detected unixODBC library [$UNIXODBC]"
 fi
 
-LIBFUSEDEV=`find /usr/include /usr/local/Cellar -name fuse.h 2> /dev/null | $GREPCMD -v linux`
+LIBFUSEDEV=`find /usr/include /usr/local /usr/local/fuse /usr/local/Cellar -name fuse.h 2> /dev/null | $GREPCMD -v linux`
 if [ "$LIBFUSEDEV" == "" ] ; then
     if [ "$DETECTEDOS" == "Ubuntu" -o "$DETECTEDOS" == "Debian" ] ; then
         PREFLIGHT="$PREFLIGHT libfuse-dev"

--- a/plugins/auth/native/libnative.cpp
+++ b/plugins/auth/native/libnative.cpp
@@ -1,8 +1,3 @@
-// Ilari Korhonen 26-11-2014 (on OS X builds use CC MD5!)
-#ifdef osx_platform
-#include <CommonCrypto/CommonDigest.h>
-#endif
-
 // =-=-=-=-=-=-=-
 // irods includes
 #include "rodsDef.hpp"
@@ -30,6 +25,12 @@
 #include <iostream>
 #include <termios.h>
 #include <unistd.h>
+
+// =-=-=-=-=-=-=-
+// osx commoncrypto
+#ifdef osx_platform
+#include <CommonCrypto/CommonDigest.h>
+#endif
 
 int get64RandomBytes( char *buf );
 void setSessionSignatureClientside( char* _sig );
@@ -196,18 +197,15 @@ extern "C" {
 
             // =-=-=-=-=-=-=-
             // create a md5 hash of the challenge
-
-
-#ifdef osx_platform
-	    // Ilari Korhonen 26-11-2014 (on OS X builds use CC MD5!)
 	    char digest[ RESPONSE_LEN + 2 ];
+
+	    // on OS X builds use CC MD5!
+#ifdef osx_platform
 	    CC_MD5(md5_buf, CHALLENGE_LEN + MAX_PASSWORD_LEN, (unsigned char*)digest);
 #else
             MD5_CTX context;
             MD5Init( &context );
             MD5Update( &context, ( unsigned char* )md5_buf, CHALLENGE_LEN + MAX_PASSWORD_LEN );
-
-            char digest[ RESPONSE_LEN + 2 ];
             MD5Final( ( unsigned char* )digest, &context );
 #endif
 

--- a/plugins/auth/native/libnative.cpp
+++ b/plugins/auth/native/libnative.cpp
@@ -1,3 +1,8 @@
+// Ilari Korhonen 26-11-2014 (on OS X builds use CC MD5!)
+#ifdef osx_platform
+#include <CommonCrypto/CommonDigest.h>
+#endif
+
 // =-=-=-=-=-=-=-
 // irods includes
 #include "rodsDef.hpp"
@@ -191,12 +196,20 @@ extern "C" {
 
             // =-=-=-=-=-=-=-
             // create a md5 hash of the challenge
+
+
+#ifdef osx_platform
+	    // Ilari Korhonen 26-11-2014 (on OS X builds use CC MD5!)
+	    char digest[ RESPONSE_LEN + 2 ];
+	    CC_MD5(md5_buf, CHALLENGE_LEN + MAX_PASSWORD_LEN, (unsigned char*)digest);
+#else
             MD5_CTX context;
             MD5Init( &context );
             MD5Update( &context, ( unsigned char* )md5_buf, CHALLENGE_LEN + MAX_PASSWORD_LEN );
 
             char digest[ RESPONSE_LEN + 2 ];
             MD5Final( ( unsigned char* )digest, &context );
+#endif
 
             // =-=-=-=-=-=-=-
             // make sure 'string' doesn't end early -


### PR DESCRIPTION
Change in the MD5 code in the native authentication module to solve the OS X dynamic linker runtime conflict of MD5 symbols.