### PR TITLE
Use printf("%lld") rather than the unusual "%Ld"

### DIFF
--- a/iRODS/clients/icommands/src/iinit.cpp
+++ b/iRODS/clients/icommands/src/iinit.cpp
@@ -400,7 +400,7 @@ main( int argc, char **argv ) {
         }
         else {
             printf(
-                "failed to get environment file - %Ld\n",
+                "failed to get environment file - %lld\n",
                 ret.code() );
 
         }

--- a/iRODS/lib/core/src/phybunUtil.cpp
+++ b/iRODS/lib/core/src/phybunUtil.cpp
@@ -127,7 +127,7 @@ initCondForPhybunOpr( rodsArguments_t *rodsArgs,
     }
 
     if ( rodsArgs->sizeFlag == True ) {
-        snprintf( tmpStr1, NAME_LEN, "%Ld", rodsArgs->size );
+        snprintf( tmpStr1, NAME_LEN, "%lld", (long long) rodsArgs->size );
         addKeyVal( &phyBundleCollInp->condInput, MAX_BUNDLE_SIZE_KW, tmpStr1 );
     }
 


### PR DESCRIPTION
The only warnings produced when compiling the icommands with Clang are

> iRODS/lib/core/src/phybunUtil.cpp:130:40: warning: length modifier 'L' results in undefined behavior or no effect with 'd' conversion specifier [-Wformat]
> `snprintf( tmpStr1, NAME_LEN, "%Ld", rodsArgs->size );`
>
> iRODS/clients/icommands/src/iinit.cpp:403:52: warning: length modifier 'L' results in undefined behavior or no effect with 'd' conversion specifier [-Wformat]
> `"failed to get environment file - %Ld\n",`

Fix these by using `%lld` as is used frequently elsewhere in the codebase.