### PR TITLE
Add --verbose option for less quiet builds

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -56,7 +56,7 @@ PGUNIXODBCARCHIVE=postgresql-$(PG_VERSION)_unixODBC-$(UNIXODBC_VERSION)-$(OSNAME
 
 default :
 	@echo "Getting $(IRODSEXTERNALARCHIVE) -> $(IRODSEXTERNALLOCAL)..."
-	@curl -o $(IRODSEXTERNALLOCAL) -z $(IRODSEXTERNALLOCAL) $(RENCI_FTP_BUILD)/$(IRODSEXTERNALARCHIVE) > /dev/null 2>&1
+	$(V_at)curl -o $(IRODSEXTERNALLOCAL) -z $(IRODSEXTERNALLOCAL) $(RENCI_FTP_BUILD)/$(IRODSEXTERNALARCHIVE) > /dev/null 2>&1
 	@$(MAKE) $(FAKETARGETFORMAKE)
 
 $(PGUNIXODBCARCHIVE) :
@@ -82,7 +82,7 @@ build_database_for_macosx : postgresql-$(PG_VERSION)/Makefile
 
 $(FAKETARGETFORMAKE) : $(IRODSEXTERNALLOCAL)
 	@echo "Unpacking $(IRODSEXTERNALLOCAL)..."
-	@tar zxf $(IRODSEXTERNALLOCAL)
+	$(V_at)tar zxf $(IRODSEXTERNALLOCAL)
 	@touch $(FAKETARGETFORMAKE)
 
 ifeq ($(OS_platform), osx_platform)
@@ -93,8 +93,8 @@ endif
 
 generate : build
 	@echo "Building $(IRODSEXTERNALARCHIVE)..."
-	@tar zfc $(IRODSEXTERNALARCHIVE) --exclude "*.tar.gz" --exclude "*.zip" --exclude "*cmake*" --exclude "Makefile" --exclude $(FAKETARGETFORMAKE) *
-	@cp $(IRODSEXTERNALARCHIVE) $(IRODSEXTERNALLOCAL)
+	$(V_at)tar zfc $(IRODSEXTERNALARCHIVE) --exclude "*.tar.gz" --exclude "*.zip" --exclude "*cmake*" --exclude "Makefile" --exclude $(FAKETARGETFORMAKE) *
+	$(V_at)cp $(IRODSEXTERNALARCHIVE) $(IRODSEXTERNALLOCAL)
 	@touch $(FAKETARGETFORMAKE)
 
 $(LIB_MYSQLUDF_PREG_ARCHIVE) :

--- a/iRODS/clients/c_api_test/Makefile
+++ b/iRODS/clients/c_api_test/Makefile
@@ -57,7 +57,7 @@ LDFLAGS += -lstdc++
 LDFLAGS += -rdynamic
 
 default:
-	@$(GCC) $(CFLAGS) -o mytest test.c $(LDFLAGS)
+	$(V_at)$(GCC) $(CFLAGS) -o mytest test.c $(LDFLAGS)
 
 clean:
 	@echo "Cleaning C API test..."

--- a/iRODS/clients/fuse/Makefile
+++ b/iRODS/clients/fuse/Makefile
@@ -136,15 +136,15 @@ fuse:	$(LIB_OBJS) $(OBJS) $(BINS)
 
 $(objDir)/%.o:	$(srcDir)/%.cpp $(LIBRARY)
 	@echo "Compile fuse `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 $(reObjDir)/%.o:	$(reSrcDir)/%.c $(LIBRARY)
 	@echo "Compile fuse `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 $(binDir)/%:	$(objDir)/%.o $(LIB_OBJS)
 	@echo "Link fuse `basename $@`..."
-	@$(LDR) -o $@ $< $(LIB_OBJS) $(SVR_OBJS) $(LDFLAGS) $(BOOST_LIBS) $(LDRTFLAGS) -lcrypto -lssl
+	$(V_at)$(LDR) -o $@ $< $(LIB_OBJS) $(SVR_OBJS) $(LDFLAGS) $(BOOST_LIBS) $(LDRTFLAGS) -lcrypto -lssl
 
 
 

--- a/iRODS/clients/icommands/Makefile
+++ b/iRODS/clients/icommands/Makefile
@@ -196,11 +196,11 @@ icommands:	$(OBJS) $(BINS) $(BOOST_LIBS)
 
 $(objDir)/%.o:	$(srcDir)/%.cpp $(LIBRARY) $(BOOST_LIBS)
 	@echo "Compile icommand `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 $(binDir)/%:	$(objDir)/%.o $(BOOST_LIBS)
 	@echo "Link icommand `basename $@`..."
-	@$(LDR) -o $@ $< $(LDFLAGS)
+	$(V_at)$(LDR) -o $@ $< $(LDFLAGS)
 
 # Show compile flags
 print_cflags:

--- a/iRODS/clients/icommands/rulegen/Makefile
+++ b/iRODS/clients/icommands/rulegen/Makefile
@@ -81,11 +81,11 @@ rulegen: $(OBJS) $(BINS)
 
 $(objDir)/%.o: $(srcDir)/%.c 
 	@echo "Compile rulegen `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 
 
 $(binDir)/%:    $(objDir)/%.o 
 	@echo "Link `basename $@`..."
-	@$(LDR) -g -o $@  $< $(LDFLAGS)
+	$(V_at)$(LDR) -g -o $@  $< $(LDFLAGS)
 

--- a/iRODS/config/config.mk.in
+++ b/iRODS/config/config.mk.in
@@ -215,6 +215,16 @@ CCMALLOC_DIR=/data/mwan/rods/ccmalloc/ccmalloc-0.4.0
 endif
 
 
+# VERBOSE - specify whether to show compilation commands
+ifndef VERBOSE
+V_at = @
+else ifeq ($(VERBOSE),0)
+V_at = @
+else
+V_at =
+endif
+
+
 # IRODS_FS - specify that irodsFuse should be built
 # The latest version is 26 for release 2.7. It default to 21 if not defined
 IRODS_FS = 1

--- a/iRODS/lib/Makefile
+++ b/iRODS/lib/Makefile
@@ -199,8 +199,8 @@ $(LIBRARY): $(OBJS) $(BOOST_LIBS)
 #	$(CC) -D${OS_platform} -fPIC "-Wl,-E" -shared -o $(LIBRARY) $(OBJS) 
 	@echo "Building lib$(LIBRARY_NAME).a"
 	@rm -f $(LIBRARY)
-	@$(AR) $(AROPT) $(LIBRARY) $^
-	@$(RANLIB) $(LIBRARY)
+	$(V_at)$(AR) $(AROPT) $(LIBRARY) $^
+	$(V_at)$(RANLIB) $(LIBRARY)
 
 # Server configuration
 $(svrConfigDir)/irodsHost:
@@ -224,21 +224,21 @@ clean:
 # Build core
 $(LIB_CORE_OBJS):  $(libCoreObjDir)/%.o: $(libCoreSrcDir)/%.cpp $(DEPEND) $(BOOST_LIBS)
 	@echo "Compile core `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 # Build API
 $(LIB_API_OBJS):  $(libApiObjDir)/%.o: $(libApiSrcDir)/%.cpp $(DEPEND) $(BOOST_LIBS)
 	@echo "Compile api `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 # Build Hasher
 $(LIB_HASHER_OBJS): $(libHasherObjDir)/%.o: $(libHasherSrcDir)/%.cpp $(configMk) $(platformMk)
 	@echo "Compile Hasher `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 $(LIB_RBUDP_OBJS):  $(libRbudpObjDir)/%.o: $(libRbudpSrcDir)/%.cpp $(configMk) $(platformMk)
 	@echo "Compile rbudp `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 # Build logging source
 rodslog:  $(LOG_SRC)

--- a/iRODS/server/Makefile
+++ b/iRODS/server/Makefile
@@ -10,7 +10,8 @@
 #	server		build the servers
 # 	clean		clean out all object files
 #
-# To see the gcc command lines as executed, change "@$(CC)" to "$(CC)".
+# To see the gcc command lines as executed, use "make VERBOSE=1" or run
+# build.sh with "--verbose".
 
 include ../config/external_versions.txt
 
@@ -349,81 +350,81 @@ BOOST_LIBS = $(BOOST_DIR)/stage/lib/libboost_system.a \
 
 db_plugin_with_re: $(DB_PLUGIN_SRC)
 	@echo "Compile With RE `basename $@`..."
-	@$(CC) -c $(CFLAGS) $(DB_PLUGIN_SRC) -o $(DB_PLUGIN_OBJ)
+	$(V_at)$(CC) -c $(CFLAGS) $(DB_PLUGIN_SRC) -o $(DB_PLUGIN_OBJ)
 
 db_plugin_with_no_re: $(DB_PLUGIN_SRC)
 	@echo "Compile Without RE `basename $@`..."
-	@$(CC) -DLINK_NO_OP_RE_MGR $(CFLAGS) -c $(DB_PLUGIN_SRC) -o $(DB_PLUGIN_OBJ_WITH_NO_RE)
+	$(V_at)$(CC) -DLINK_NO_OP_RE_MGR $(CFLAGS) -c $(DB_PLUGIN_SRC) -o $(DB_PLUGIN_OBJ_WITH_NO_RE)
 
 # Compilation Targets
 #
 # Build server API
 $(SVR_API_OBJS):	$(svrApiObjDir)/%.o: $(svrApiSrcDir)/%.cpp $(DEPEND) $(BOOST_LIBS)
 	@echo "Compile api `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 # Build server core
 $(SVR_CORE_OBJS):	$(svrCoreObjDir)/%.o: $(svrCoreSrcDir)/%.cpp $(DEPEND) $(BOOST_LIBS)
 	@echo "Compile core `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 # Build server drivers
 $(SVR_DRIVERS_OBJS):	$(svrDriversObjDir)/%.o: $(svrDriversSrcDir)/%.cpp $(DEPEND) $(BOOST_LIBS)
 	@echo "Compile drivers `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 # Build server ICAT
 $(SVR_ICAT_OBJS):	$(svrIcatObjDir)/%.o: $(svrIcatSrcDir)/%.cpp $(DEPEND) $(BOOST_LIBS)
 	@echo "Compile icat `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 # Build server DBR
 $(SVR_DBR_OBJS):	$(svrIcatObjDir)/%.o: $(svrIcatSrcDir)/%.cpp $(BOOST_LIBS)
 	@echo "Compile dbr `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 # Builder server rule engine
 $(SVR_RE_OBJS):		$(svrReObjDir)/%.o: $(svrReSrcDir)/%.cpp $(DEPEND) $(BOOST_LIBS)
 	@echo "Compile re `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 # Servers
 #
 # Agent
 $(svrCoreObjDir)/rodsAgent.o: $(svrCoreObjDir)/%.o: $(svrCoreSrcDir)/%.cpp $(LIBRARY) $(OBJS) $(BOOST_LIBS)
 	@echo "Compile agent server `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 $(serverBinDir)/irodsAgent: db_plugin_with_re $(svrCoreObjDir)/rodsAgent.o $(LIBRARY) $(OBJS) $(BOOST_LIBS)
 	@echo "Link agent server `basename $@`..."
-	@$(LDR) -o $@ $(svrCoreObjDir)/rodsAgent.o $(LIBRARY) $(OBJS)  $(DB_PLUGIN_OBJ) $(BOOST_LIBS) $(LDFLAGS) $(AG_LDADD)
+	$(V_at)$(LDR) -o $@ $(svrCoreObjDir)/rodsAgent.o $(LIBRARY) $(OBJS)  $(DB_PLUGIN_OBJ) $(BOOST_LIBS) $(LDFLAGS) $(AG_LDADD)
 
 # Rule engine
 $(svrCoreObjDir)/irodsReServer.o: $(svrCoreObjDir)/%.o: $(svrCoreSrcDir)/%.cpp $(LIBRARY) $(OBJS)
 	@echo "Compile rule engine server `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 $(serverBinDir)/irodsReServer: db_plugin_with_re $(svrCoreObjDir)/irodsReServer.o $(LIBRARY) $(OBJS) $(BOOST_LIBS)
 	@echo "Link rule engine server `basename $@`..."
-	@$(LDR) -o $@ $(svrCoreObjDir)/irodsReServer.o $(LIBRARY) $(OBJS) $(DB_PLUGIN_OBJ) $(BOOST_LIBS) $(LDFLAGS)
+	$(V_at)$(LDR) -o $@ $(svrCoreObjDir)/irodsReServer.o $(LIBRARY) $(OBJS) $(DB_PLUGIN_OBJ) $(BOOST_LIBS) $(LDFLAGS)
 
 # RODS
 $(svrCoreObjDir)/rodsServer.o: $(svrCoreObjDir)/%.o: $(svrCoreSrcDir)/%.cpp $(LIBRARY) $(OBJS) $(BOOST_LIBS)
 	@echo "Compile rods server `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 $(serverBinDir)/irodsServer: db_plugin_with_re $(svrCoreObjDir)/rodsServer.o $(LIBRARY) $(OBJS) $(BOOST_LIBS)
 	@echo "Link rods server `basename $@`..."
-	@$(LDR) -o $@ $(svrCoreObjDir)/rodsServer.o $(LIBRARY) $(OBJS) $(DB_PLUGIN_OBJ) $(BOOST_LIBS) $(LDFLAGS)
+	$(V_at)$(LDR) -o $@ $(svrCoreObjDir)/rodsServer.o $(LIBRARY) $(OBJS) $(DB_PLUGIN_OBJ) $(BOOST_LIBS) $(LDFLAGS)
 
 # xmsg server
 $(svrCoreObjDir)/irodsXmsgServer.o: $(svrCoreObjDir)/%.o: $(svrCoreSrcDir)/%.cpp $(LIBRARY) $(OBJS)
 	@echo "Compile xmsg server `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 $(serverBinDir)/irodsXmsgServer: db_plugin_with_re $(svrCoreObjDir)/irodsXmsgServer.o $(LIBRARY) $(OBJS) $(BOOST_LIBS)
 	@echo "Link xmsg server `basename $@`..."
-	@$(LDR) -o $@ $(svrCoreObjDir)/irodsXmsgServer.o $(LIBRARY) $(OBJS) $(DB_PLUGIN_OBJ) $(BOOST_LIBS) $(LDFLAGS)
+	$(V_at)$(LDR) -o $@ $(svrCoreObjDir)/irodsXmsgServer.o $(LIBRARY) $(OBJS) $(DB_PLUGIN_OBJ) $(BOOST_LIBS) $(LDFLAGS)
 
 
 #
@@ -431,28 +432,28 @@ $(serverBinDir)/irodsXmsgServer: db_plugin_with_re $(svrCoreObjDir)/irodsXmsgSer
 #
 $(svrAuthObjDir)/PamAuthCheck.o: $(svrAuthSrcDir)/PamAuthCheck.cpp
 	@echo "Compile PamAuthCheck utility `basename $@`..."
-	@$(CC) -c $(AUTH_CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(AUTH_CFLAGS) -o $@ $<
 
 $(serverBinDir)/PamAuthCheck: $(svrAuthObjDir)/PamAuthCheck.o
 	@echo "Link PamAuthCheck utility `basename $@`..."
-	@$(CC) -o $@ $(svrAuthObjDir)/PamAuthCheck.o $(AUTH_LDFLAGS)
+	$(V_at)$(CC) -o $@ $(svrAuthObjDir)/PamAuthCheck.o $(AUTH_LDFLAGS)
 
 #
 # Tests
 #
 $(TEST_OBJS):	$(svrTestObjDir)/%.o: $(svrTestSrcDir)/%.cpp $(DEPEND) $(BOOST_LIBS)
 	@echo "Compile server test `basename $@`..."
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 # reTest
 $(svrTestBinDir)/reTest: $(svrTestObjDir)/reTest.o $(OBJS) $(BOOST_LIBS) $(BOOST_LIBS)
 	@echo "Link server test `basename $@`..."
-	@$(LDR) -o $@ $^ $(LDFLAGS) $(BOOST_LIBS)
+	$(V_at)$(LDR) -o $@ $^ $(LDFLAGS) $(BOOST_LIBS)
 
 # chl
 $(svrTestBinDir)/test_chl: db_plugin_with_no_re $(svrTestObjDir)/test_chl.o $(SVR_ICAT_OBJS) $(LIBRARY) $(BOOST_LIBS) $(DB_IFACE_OBJS)
 	@echo "Link server test `basename $@`..."
-	@$(LDR) -o $@ $(svrTestObjDir)/test_chl.o $(LIBRARY) $(SVR_ICAT_OBJS) $(DB_PLUGIN_OBJ_WITH_NO_RE) $(DB_IFACE_OBJS) $(BOOST_LIBS) $(LDFLAGS)
+	$(V_at)$(LDR) -o $@ $(svrTestObjDir)/test_chl.o $(LIBRARY) $(SVR_ICAT_OBJS) $(DB_PLUGIN_OBJ_WITH_NO_RE) $(DB_IFACE_OBJS) $(BOOST_LIBS) $(LDFLAGS)
 
 #
 # Rule Admin Targets
@@ -461,7 +462,7 @@ ruleadmin:: $(serverBinDir)/ruleAdmin
 	@cp $(serverBinDir)/ruleAdmin /misc/www/projects/srb-secure/cgi-bin/ruleAdminRaja.cgi
 
 $(svrCoreObjDir)/ruleAdmin.o: $(svrCoreObjDir)/%.o: %.cpp $(LIBRARY) $(OBJS)
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V_at)$(CC) -c $(CFLAGS) -o $@ $<
 
 $(serverBinDir)/ruleAdmin: $(svrCoreObjDir)/ruleAdmin.o $(LIBRARY) $(OBJS)
-	@$(LDR) -o $@ $^ $(LDFLAGS)
+	$(V_at)$(LDR) -o $@ $^ $(LDFLAGS)

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -27,13 +27,21 @@ Options:
 -c      Build with coverage support (gcov)
 -f      Fast build, skip dev, runtime, and icommands packages
 -h      Show this help
+-j NUM  Run NUM make jobs simultaneously (instead of using all cores)
 -r      Build a release package (no debugging information, optimized)
 -s      Skip compilation of iRODS source
 -p      Portable option, ignores OS and builds a tar.gz
 -v      Show the actual compilation commands executed
 
 Long Options:
+--coverage        Build with coverage support (gcov)
+--fast            Fast build, skip dev, runtime, and icommands packages
+--help            Show this help
+--jobs NUM        Run NUM make jobs simultaneously (instead of using all cores)
+--portable        Portable option, ignores OS and builds a tar.gz
+--release         Build a release package (no debugging information, optimized)
 --run-in-place    Build server for in-place execution (not recommended)
+--skip            Skip compilation of iRODS source
 --verbose         Show the actual compilation commands executed
 
 Examples:

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -10,6 +10,7 @@ CPUJOBS=""
 RELEASE="0"
 BUILDIRODS="1"
 PORTABLE="0"
+VERBOSE="0"
 COVERAGEBUILDDIR="/var/lib/irods"
 PREFLIGHT=""
 PREFLIGHTDOWNLOAD=""
@@ -29,9 +30,11 @@ Options:
 -r      Build a release package (no debugging information, optimized)
 -s      Skip compilation of iRODS source
 -p      Portable option, ignores OS and builds a tar.gz
+-v      Show the actual compilation commands executed
 
 Long Options:
 --run-in-place    Build server for in-place execution (not recommended)
+--verbose         Show the actual compilation commands executed
 
 Examples:
 $SCRIPTNAME icat postgres
@@ -89,6 +92,7 @@ do
         --release) args="${args}-r ";;
         --skip) args="${args}-s ";;
         --portable) args="${args}-p ";;
+        --verbose) args="${args}-v ";;
         --run-in-place) args="${args}-z ";;
         # pass through anything else
         *) [[ "${arg:0:1}" == "-" ]] || delim="\""
@@ -98,7 +102,7 @@ done
 # reset the translated args
 eval set -- $args
 # now we can process with getopts
-while getopts ":chfj:rspz" opt; do
+while getopts ":chfj:rspvz" opt; do
     case $opt in
         c)
         COVERAGE="1"
@@ -131,6 +135,10 @@ while getopts ":chfj:rspz" opt; do
         p)
         PORTABLE="1"
         echo "-p detected -- Building portable package"
+        ;;
+        v)
+        VERBOSE="1"
+        echo "-v/--verbose detected -- Showing compilation commands"
         ;;
         z)
         RUNINPLACE="1"
@@ -276,7 +284,12 @@ detect_number_of_cpus_and_set_makejcmd() {
     else
         CPUCOUNT=$(( $DETECTEDCPUCOUNT + 3 ))
     fi
-    MAKEJCMD="make --no-print-directory -j $CPUCOUNT"
+    if [ "$VERBOSE" == "1" ] ; then
+        VERBOSITYOPTION="VERBOSE=1"
+    else
+        VERBOSITYOPTION="--no-print-directory"
+    fi
+    MAKEJCMD="make $VERBOSITYOPTION -j $CPUCOUNT"
 
     # print out CPU information
     echo "${text_cyan}${text_bold}-------------------------------------"

--- a/plugins/Makefile.base
+++ b/plugins/Makefile.base
@@ -70,15 +70,15 @@ clean-base:
 
 $(AGNOSTIC_OBJS) : $(SODIR)/lib%.so : $(SRCDIR)/%.cpp $(DEPDIR)/%.d $(DEPFILE) $(AGNOSTIC_DEPS)
 	@echo "Compile plugin `basename $@`..."
-	@$(GCC) $(CFLAGS) $(AGNOSTIC_CFLAGS) $(INC) -fPIC -shared -o $@ $< $(LDADD) $(EXTRALIBS) $(AGNOSTIC_LIBS)
+	$(V_at)$(GCC) $(CFLAGS) $(AGNOSTIC_CFLAGS) $(INC) -fPIC -shared -o $@ $< $(LDADD) $(EXTRALIBS) $(AGNOSTIC_LIBS)
 
 $(SERVER_OBJS) : $(SODIR)/lib%_server.so : $(SRCDIR)/%.cpp $(DEPDIR)/%.d $(DEPFILE) $(SERVER_DEPS)
 	@echo "Compile plugin `basename $@`..."
-	@$(GCC) $(CFLAGS) $(SERVER_CFLAGS) $(INC) -fPIC -shared -o $@ $< $(LDADD) $(EXTRALIBS) $(SERVER_LIBS)
+	$(V_at)$(GCC) $(CFLAGS) $(SERVER_CFLAGS) $(INC) -fPIC -shared -o $@ $< $(LDADD) $(EXTRALIBS) $(SERVER_LIBS)
 
 $(CLIENT_OBJS) : $(SODIR)/lib%_client.so : $(SRCDIR)/%.cpp $(DEPDIR)/%.d $(DEPFILE) $(CLIENT_DEPS)
 	@echo "Compile plugin `basename $@`..."
-	@$(GCC) $(CFLAGS) $(CLIENT_CFLAGS) $(INC) -fPIC -shared -o $@ $< $(LDADD) $(EXTRALIBS) $(CLIENT_LIBS)
+	$(V_at)$(GCC) $(CFLAGS) $(CLIENT_CFLAGS) $(INC) -fPIC -shared -o $@ $< $(LDADD) $(EXTRALIBS) $(CLIENT_LIBS)
 
 $(DEPFILE): $(DEPS)
 	@-rm -f $(DEPFILE) > /dev/null 2>&1
@@ -88,7 +88,7 @@ $(DEPFILE): $(DEPS)
 
 $(DEPS): $(DEPDIR)/%.d : $(SRCDIR)/%.cpp $(HEADERS)
 	@-mkdir -p $(DEPDIR) > /dev/null 2>&1
-	@$(GCC) $(CFLAGS) $(INC) -MM $< -MT $(patsubst $(DEPDIR)/%.d, $(SODIR)/lib%.so, $@) -MF $@
+	$(V_at)$(GCC) $(CFLAGS) $(INC) -MM $< -MT $(patsubst $(DEPDIR)/%.d, $(SODIR)/lib%.so, $@) -MF $@
 
 -include $(DEPFILE)
 

--- a/plugins/auth/Makefile.base
+++ b/plugins/auth/Makefile.base
@@ -46,7 +46,7 @@ clean:
 $(FULLTARGET): $(OBJS)
 	@echo "Building Auth Plugins"
 	@-mkdir -p $(SODIR) > /dev/null 2>&1
-	@$(GCC) $(MY_CFLAG) $(LDRFLAGS) -D$(OS_platform) -fPIC $(LDADD) -shared -o $(FULLTARGET) $(OBJS) $(EXTRALIBS) ../../../iRODS/lib/api/obj/rcAuthCheck.o
+	$(V_at)$(GCC) $(MY_CFLAG) $(LDRFLAGS) -D$(OS_platform) -fPIC $(LDADD) -shared -o $(FULLTARGET) $(OBJS) $(EXTRALIBS) ../../../iRODS/lib/api/obj/rcAuthCheck.o
 
 $(OBJDIR)/%.o: %.cpp
-	@$(GCC) $(MY_CFLAG) -D$(OS_platform) -fPIC -c -g -o $@ $<
+	$(V_at)$(GCC) $(MY_CFLAG) -D$(OS_platform) -fPIC -c -g -o $@ $<

--- a/plugins/database/Makefile.base
+++ b/plugins/database/Makefile.base
@@ -69,23 +69,23 @@ clean:
 $(FULLTARGET): $(OBJS)
 	@echo "Building Database Plugins"
 	@-mkdir -p $(SODIR) > /dev/null 2>&1
-	@$(GCC) $(INC) -D$(OS_platform) $(CFLAGS) $(LDRFLAGS) -fPIC $(LDADD)  -shared -o $(FULLTARGET) $(OBJS) $(EXTRALIBS) $(EXTRA_LDRFLAGS) $(DBMS_LIB)
+	$(V_at)$(GCC) $(INC) -D$(OS_platform) $(CFLAGS) $(LDRFLAGS) -fPIC $(LDADD)  -shared -o $(FULLTARGET) $(OBJS) $(EXTRALIBS) $(EXTRA_LDRFLAGS) $(DBMS_LIB)
 
 $(OBJDIR)/%.o: ../src/%.cpp
-	@$(GCC) $(INC) $(EXTRA_CFLAGS) -D$(OS_platform) -fPIC -c -g -o $@ $<
+	$(V_at)$(GCC) $(INC) $(EXTRA_CFLAGS) -D$(OS_platform) -fPIC -c -g -o $@ $<
 
 $(DB_PLUGIN_OBJ_WITH_NO_RE): $(DB_PLUGIN_SRC)
 	@echo "Compile Without RE `basename $@`..."
-	@$(CC) -DLINK_NO_OP_RE_MGR $(EXTRA_CFLAGS) $(INC) -c $(DB_PLUGIN_SRC) -o $(DB_PLUGIN_OBJ_WITH_NO_RE)
+	$(V_at)$(CC) -DLINK_NO_OP_RE_MGR $(EXTRA_CFLAGS) $(INC) -c $(DB_PLUGIN_SRC) -o $(DB_PLUGIN_OBJ_WITH_NO_RE)
 
 $(SODIR)/test_cll: $(OBJDIR)/test_cll.o $(CLL_OBJS) $(LIBRARY) $(BOOST_LIBS)
 	@echo "Link server test `basename $@`..."
-	@$(LDR) -o $@ $^ $(LIBRARY) $(LDFLAGS) $(BOOST_LIBS) $(DBMS_LIB) $(LDRFLAGS) $(EXTRA_LDRFLAGS) -fPIC -rdynamic -ldl -lpthread -lssl -lcrypto
+	$(V_at)$(LDR) -o $@ $^ $(LIBRARY) $(LDFLAGS) $(BOOST_LIBS) $(DBMS_LIB) $(LDRFLAGS) $(EXTRA_LDRFLAGS) -fPIC -rdynamic -ldl -lpthread -lssl -lcrypto
 
 $(SODIR)/test_genq: $(OBJDIR)/test_genq.o  $(DB_PLUGIN_OBJ_WITH_NO_RE) $(CLL_OBJS) $(GENQ_OBJS) $(CHL_OBJS) $(LIBRARY) $(BOOST_LIBS)
 	@echo "Link server test `basename $@`..."
-	@$(LDR) -o $@ $^ $(LIBRARY) $(LDFLAGS) $(DBMS_LIB) $(LDRFLAGS) $(EXTRA_LDRFLAGS) -fPIC -rdynamic -ldl -lpthread -lssl -lcrypto
+	$(V_at)$(LDR) -o $@ $^ $(LIBRARY) $(LDFLAGS) $(DBMS_LIB) $(LDRFLAGS) $(EXTRA_LDRFLAGS) -fPIC -rdynamic -ldl -lpthread -lssl -lcrypto
 
 $(SODIR)/test_genu: $(OBJDIR)/test_genu.o $(GENU_OBJS) $(CHL_OBJS) $(CLL_OBJS) $(DB_PLUGIN_OBJ_WITH_NO_RE) $(LIBRARY) $(BOOST_LIBS)
 	@echo "Link server test `basename $@`..."
-	@$(LDR) -o $@ $^ $(LIBRARY) $(LDFLAGS) $(DBMS_LIB) $(LDRFLAGS) $(EXTRA_LDRFLAGS) -fPIC -rdynamic -ldl -lpthread -lssl -lcrypto
+	$(V_at)$(LDR) -o $@ $^ $(LIBRARY) $(LDFLAGS) $(DBMS_LIB) $(LDRFLAGS) $(EXTRA_LDRFLAGS) -fPIC -rdynamic -ldl -lpthread -lssl -lcrypto

--- a/plugins/microservices/mso_drivers/Makefile.base
+++ b/plugins/microservices/mso_drivers/Makefile.base
@@ -30,7 +30,7 @@ ifeq ($(IRODS_BUILD_COVERAGE), 1)
 GCC += -fprofile-arcs -ftest-coverage -lgcov
 OBJS = $(patsubst %.cpp, %.o, $(SRCS))
 %.o: %.cpp
-	@$(GCC) $(CFLAGS) $(INC) -D$(OS_platform) -fPIC -c -g -o $@ $<
+	$(V_at)$(GCC) $(CFLAGS) $(INC) -D$(OS_platform) -fPIC -c -g -o $@ $<
 endif
 
 .PHONY: clean
@@ -44,7 +44,7 @@ clean:
 
 $(FULLTARGET): $(OBJS)
 	@-mkdir -p $(SODIR) > /dev/null 2>&1
-	@$(GCC) $(LDRFLAGS) -D$(OS_platform) -fPIC $(LDADD) -shared -o $(FULLTARGET) $(OBJS) ../../../../iRODS/lib/core/obj/irods_plugin_base.o $(EXTRALIBS)
+	$(V_at)$(GCC) $(LDRFLAGS) -D$(OS_platform) -fPIC $(LDADD) -shared -o $(FULLTARGET) $(OBJS) ../../../../iRODS/lib/core/obj/irods_plugin_base.o $(EXTRALIBS)
 
 $(OBJDIR)/%.o: %.cpp
-	@$(GCC) $(MY_CFLAG) -D$(OS_platform) -fPIC -c -g -o $@ $<
+	$(V_at)$(GCC) $(MY_CFLAG) -D$(OS_platform) -fPIC -c -g -o $@ $<

--- a/plugins/network/Makefile.base
+++ b/plugins/network/Makefile.base
@@ -45,7 +45,7 @@ clean:
 $(FULLTARGET): $(OBJS)
 	@echo "Building Network Plugins"
 	@-mkdir -p $(SODIR) > /dev/null 2>&1
-	@$(GCC) $(LDRFLAGS) -D$(OS_platform) -fPIC $(LDADD) -shared -o $(FULLTARGET) $(OBJS) $(EXTRALIBS)
+	$(V_at)$(GCC) $(LDRFLAGS) -D$(OS_platform) -fPIC $(LDADD) -shared -o $(FULLTARGET) $(OBJS) $(EXTRALIBS)
 
 $(OBJDIR)/%.o: %.cpp
-	@$(GCC) $(MY_CFLAG) -D$(OS_platform) -fPIC -c -g -o $@ $<
+	$(V_at)$(GCC) $(MY_CFLAG) -D$(OS_platform) -fPIC -c -g -o $@ $<

--- a/plugins/resources/Makefile.base
+++ b/plugins/resources/Makefile.base
@@ -52,7 +52,7 @@ clean:
 
 $(FULLTARGET): $(OBJS)
 	@-mkdir -p $(SODIR) > /dev/null 2>&1
-	@$(GCC) $(LDRFLAGS) -D$(OS_platform) -fPIC $(LDADD) -shared -o $(FULLTARGET) $(OBJS) ../../../iRODS/lib/core/obj/irods_plugin_base.o $(EXTRALIBS)
+	$(V_at)$(GCC) $(LDRFLAGS) -D$(OS_platform) -fPIC $(LDADD) -shared -o $(FULLTARGET) $(OBJS) ../../../iRODS/lib/core/obj/irods_plugin_base.o $(EXTRALIBS)
 
 $(OBJDIR)/%.o: %.cpp
-	@$(GCC) $(MY_CFLAG) -D$(OS_platform) -fPIC -c -g -o $@ $<
+	$(V_at)$(GCC) $(MY_CFLAG) -D$(OS_platform) -fPIC -c -g -o $@ $<


### PR DESCRIPTION
Especially for those not intimately familiar with iRODS source, seeing the actual compilation commands used is important in various debugging scenarios.

Also update the `packaging/build.sh` usage display.  I had been hacking the code that sets `$MAKEJCMD` for ages and was unaware a `--jobs` option had been added.