### PR TITLE
Performance Improvement on iRods Fuse

### DIFF
--- a/iRODS/clients/fuse/Makefile
+++ b/iRODS/clients/fuse/Makefile
@@ -52,6 +52,7 @@ BINS =		\
 LIB_OBJS =	\
 		$(objDir)/iFuseCmdLineOpt.o \
 		$(objDir)/iFuseOper.o \
+		$(objDir)/iFuse.Preload.o \
 		$(objDir)/iFuse.BufferedFS.o \
 		$(objDir)/iFuse.Lib.o \
 		$(objDir)/iFuse.Lib.Conn.o \

--- a/iRODS/clients/fuse/Makefile
+++ b/iRODS/clients/fuse/Makefile
@@ -73,6 +73,7 @@ INCLUDES +=	-I$(incDir) -I$(reIncDir)
 CFLAGS_OPTIONS := -g $(CFLAGS) $(MY_CFLAG)
 ifdef IRODS_FS
 CFLAGS_OPTIONS += -D_REENTRANT
+CFLAGS_OPTIONS += -D_MYSQL_ICAT_DRIVER_PATCH_
     ifeq (${OS_platform}, osx_platform)
     INCLUDES +=    -I$(fuseHomeDir)/include/osxfuse
     else

--- a/iRODS/clients/fuse/README.txt
+++ b/iRODS/clients/fuse/README.txt
@@ -60,11 +60,15 @@ work. Type in:
 
 and do the normal login.
 
-4) The 2.0 irodsFs caches small files in the local disk to improve 
-performance. By default, the cached files are put in the /tmp/fuseCache
-directory. The env variable "FuseCacheDir" can be used to change the
-default cache directory. This env varible much be set before starting
-irodsFs (step 5).
+4) The irodsFs uses block-based file content transfer. Regardless of physical file 
+blocks of iRODS, the irodsFs divides the file content into fixed sized blocks 
+logically and requests content reads or writes to iRODS in the block level. 
+Hence, small reads or writes will be buffered and cached in memory temporarily. 
+Block size is set to 1MB by default. To change block size, you will need to 
+change the value of a definition of "IFUSE_BUFFER_CACHE_BLOCK_SIZE" 
+in iFuse.BufferedFS.hpp file. 
+To turn off this memory cache and buffered I/O, pass "-onocache" to command line 
+argument.
 
 5) Mount the home collection to the local directory by typing in:
 ./irodsFs /usr/tmp/fmount

--- a/iRODS/clients/fuse/include/iFuse.BufferedFS.hpp
+++ b/iRODS/clients/fuse/include/iFuse.BufferedFS.hpp
@@ -2,8 +2,8 @@
  *** For more information please refer to files in the COPYRIGHT directory ***/
 /*** This code is written by Illyoung Choi (iychoi@email.arizona.edu)      ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
-#ifndef IFUSE_LIB_BUFFERED_FS_HPP
-#define	IFUSE_LIB_BUFFERED_FS_HPP
+#ifndef IFUSE_BUFFEREDFS_HPP
+#define	IFUSE_BUFFEREDFS_HPP
 
 #include <pthread.h>
 #include "iFuse.Lib.Fd.hpp"
@@ -28,5 +28,5 @@ int iFuseBufferedFsFlush(iFuseFd_t *iFuseFd);
 int iFuseBufferedFsRead(iFuseFd_t *iFuseFd, char *buf, off_t off, size_t size);
 int iFuseBufferedFsWrite(iFuseFd_t *iFuseFd, const char *buf, off_t off, size_t size);
 
-#endif	/* IFUSE_LIB_BUFFERED_FS_HPP */
+#endif	/* IFUSE_BUFFEREDFS_HPP */
 

--- a/iRODS/clients/fuse/include/iFuse.BufferedFS.hpp
+++ b/iRODS/clients/fuse/include/iFuse.BufferedFS.hpp
@@ -21,10 +21,16 @@ typedef struct IFuseBufferCache {
 void iFuseBufferedFSInit();
 void iFuseBufferedFSDestroy();
 
+size_t getBufferCacheBlockSize();
+unsigned int getBlockID(off_t off);
+off_t getBlockStartOffset(unsigned int blockID);
+off_t getInBlockOffset(off_t off);
+
 int iFuseBufferedFsGetAttr(const char *iRodsPath, struct stat *stbuf);
 int iFuseBufferedFsOpen(const char *iRodsPath, iFuseFd_t **iFuseFd, int openFlag);
 int iFuseBufferedFsClose(iFuseFd_t *iFuseFd);
 int iFuseBufferedFsFlush(iFuseFd_t *iFuseFd);
+int iFuseBufferedFsReadBlock(iFuseFd_t *iFuseFd, char *buf, unsigned int blockID);
 int iFuseBufferedFsRead(iFuseFd_t *iFuseFd, char *buf, off_t off, size_t size);
 int iFuseBufferedFsWrite(iFuseFd_t *iFuseFd, const char *buf, off_t off, size_t size);
 

--- a/iRODS/clients/fuse/include/iFuse.FS.hpp
+++ b/iRODS/clients/fuse/include/iFuse.FS.hpp
@@ -22,6 +22,7 @@ int iFuseFsOpen(const char *iRodsPath, iFuseFd_t **iFuseFd, int openFlag);
 int iFuseFsClose(iFuseFd_t *iFuseFd);
 int iFuseFsRead(iFuseFd_t *iFuseFd, char *buf, off_t off, size_t size);
 int iFuseFsWrite(iFuseFd_t *iFuseFd, const char *buf, off_t off, size_t size);
+int iFuseFsFlush(iFuseFd_t *iFuseFd);
 int iFuseFsCreate(const char *iRodsPath, mode_t mode);
 int iFuseFsUnlink(const char *iRodsPath);
 int iFuseFsOpenDir(const char *iRodsPath, iFuseDir_t **iFuseDir);

--- a/iRODS/clients/fuse/include/iFuse.FS.hpp
+++ b/iRODS/clients/fuse/include/iFuse.FS.hpp
@@ -2,8 +2,8 @@
  *** For more information please refer to files in the COPYRIGHT directory ***/
 /*** This code is rewritten by Illyoung Choi (iychoi@email.arizona.edu)    ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
-#ifndef IFUSE_BASEOPS_HPP
-#define	IFUSE_BASEOPS_HPP
+#ifndef IFUSE_FS_HPP
+#define	IFUSE_FS_HPP
 
 #include "iFuse.Lib.hpp"
 #include "iFuse.Lib.Fd.hpp"

--- a/iRODS/clients/fuse/include/iFuse.Lib.Conn.hpp
+++ b/iRODS/clients/fuse/include/iFuse.Lib.Conn.hpp
@@ -8,17 +8,19 @@
 #include <pthread.h>
 #include "rodsClient.h"
 
-#define IFUSE_MAX_NUM_CONN	5
+#define IFUSE_MAX_NUM_CONN	10
 
-#define IFUSE_CONN_TYPE_FOR_STATUS   1
-#define IFUSE_CONN_TYPE_FOR_FILE_IO   0
+#define IFUSE_CONN_TYPE_FOR_FILE_IO      0
+#define IFUSE_CONN_TYPE_FOR_SHORTOP      1
+#define IFUSE_CONN_TYPE_FOR_ONETIMEUSE   2
 
 #define IFUSE_FREE_CONN_CHECK_PERIOD    10
 #define IFUSE_FREE_CONN_TIMEOUT_SEC     (60*5)
-#define IFUSE_FREE_CONN_KEEPALIVE_SEC     (60*3)
+#define IFUSE_FREE_CONN_KEEPALIVE_SEC   (60*3)
 
 typedef struct IFuseConn {
     unsigned long connId;
+    int type;
     rcComm_t *conn;
     time_t actTime;
     time_t lastKeepAliveTime;
@@ -45,7 +47,5 @@ int iFuseConnUnuse(iFuseConn_t *iFuseConn);
 int iFuseConnReconnect(iFuseConn_t *iFuseConn);
 void iFuseConnLock(iFuseConn_t *iFuseConn);
 void iFuseConnUnlock(iFuseConn_t *iFuseConn);
-int _freeConn(iFuseConn_t *iFuseConn);
-int _newConn(iFuseConn_t **iFuseConn);
 
 #endif	/* IFUSE_LIB_CONN_HPP */

--- a/iRODS/clients/fuse/include/iFuse.Lib.Fd.hpp
+++ b/iRODS/clients/fuse/include/iFuse.Lib.Fd.hpp
@@ -34,6 +34,7 @@ void iFuseDirInit();
 void iFuseFdDestroy();
 void iFuseDirDestroy();
 int iFuseFdOpen(iFuseFd_t **iFuseFd, iFuseConn_t *iFuseConn, const char* iRodsPath, int openFlag);
+int iFuseFdReopen(iFuseFd_t *iFuseFd);
 int iFuseDirOpen(iFuseDir_t **iFuseDir, iFuseConn_t *iFuseConn, const char* iRodsPath);
 int iFuseFdClose(iFuseFd_t *iFuseFd);
 int iFuseDirClose(iFuseDir_t *iFuseDir);

--- a/iRODS/clients/fuse/include/iFuse.Lib.Fd.hpp
+++ b/iRODS/clients/fuse/include/iFuse.Lib.Fd.hpp
@@ -15,6 +15,7 @@ typedef struct IFuseFd {
     iFuseConn_t *conn;
     char *iRodsPath;
     int openFlag;
+    off_t lastFilePointer;
     pthread_mutexattr_t lockAttr;
     pthread_mutex_t lock;
 } iFuseFd_t;

--- a/iRODS/clients/fuse/include/iFuse.Lib.RodsClientAPI.hpp
+++ b/iRODS/clients/fuse/include/iFuse.Lib.RodsClientAPI.hpp
@@ -11,26 +11,47 @@
 
 #define IFUSE_RODSCLIENTAPI_TIMEOUT_SEC     (30)
 
+//#define IFUSE_RODSCLIENTAPI_LOG_PRINT_TIME
+//#define IFUSE_RODSCLIENTAPI_LOG_OUT_TO_FILE
+#define IFUSE_RODSCLIENTAPI_LOG_OUT_FILE_PATH   "/tmp/irods_debug.out"
+
 void iFuseRodsClientInit();
 void iFuseRodsClientDestroy();
 
 int iFuseRodsClientReadMsgError(int status);
 
-#define iFuseRodsClientLog \
+#ifdef IFUSE_RODSCLIENTAPI_LOG_OUT_TO_FILE
+#   define iFuseRodsClientLogBase       iFuseRodsClientLogToFile
+#   define iFuseRodsClientLogErrorBase  iFuseRodsClientLogErrorToFile 
+#else
+#   define iFuseRodsClientLogBase       rodsLog
+#   define iFuseRodsClientLogErrorBase  rodsLogError
+#endif // IFUSE_RODSCLIENTAPI_LOG_OUT_TO_FILE
+
+
+#ifdef IFUSE_RODSCLIENTAPI_LOG_PRINT_TIME
+#   define iFuseRodsClientLog \
     { \
     char logtimes[100]; \
     iFuseLibGetStrCurrentTime(logtimes); \
-    rodsLog(LOG_DEBUG, "%s", logtimes); \
+    iFuseRodsClientLogBase(LOG_DEBUG, "%s", logtimes); \
     } \
-    rodsLog
-            
-#define iFuseRodsClientLogError \
+    iFuseRodsClientLogBase
+#else
+#   define iFuseRodsClientLog   iFuseRodsClientLogBase
+#endif // IFUSE_RODSCLIENTAPI_LOG_PRINT_TIME
+
+#ifdef IFUSE_RODSCLIENTAPI_LOG_PRINT_TIME
+#   define iFuseRodsClientLogError \
     { \
     char logtimes[100]; \
     iFuseLibGetStrCurrentTime(logtimes); \
-    rodsLog(LOG_DEBUG, "%s", logtimes); \
+    iFuseRodsClientLogBase(LOG_DEBUG, "%s", logtimes); \
     } \
-    rodsLogError
+    iFuseRodsClientLogErrorBase
+#else
+#   define iFuseRodsClientLogError  iFuseRodsClientLogErrorBase
+#endif // IFUSE_RODSCLIENTAPI_LOG_PRINT_TIME
 
 rcComm_t *iFuseRodsClientConnect(const char *rodsHost, int rodsPort, const char *userName, const char *rodsZone, int reconnFlag, rErrMsg_t *errMsg);
 int iFuseRodsClientLogin(rcComm_t *conn);
@@ -54,6 +75,9 @@ int iFuseRodsClientRmColl(rcComm_t *conn, collInp_t *rmCollInp, int vFlag);
 int iFuseRodsClientDataObjRename(rcComm_t *conn, dataObjCopyInp_t *dataObjRenameInp);
 int iFuseRodsClientDataObjTruncate(rcComm_t *conn, dataObjInp_t *dataObjInp);
 int iFuseRodsClientModDataObjMeta(rcComm_t *conn, modDataObjMeta_t *modDataObjMetaInp);
+
+void iFuseRodsClientLogToFile(int level, const char *formatStr, ...);
+void iFuseRodsClientLogErrorToFile(int level, int errCode, char *formatStr, ...);
 
 #endif	/* IFUSE_LIB_RODSCLIENTAPI_HPP */
 

--- a/iRODS/clients/fuse/include/iFuse.Lib.hpp
+++ b/iRODS/clients/fuse/include/iFuse.Lib.hpp
@@ -18,6 +18,7 @@ typedef struct IFuseOpt {
     bool debug;
     bool foreground;
     bool bufferedFS;
+    bool preload;
     int maxConn;
     int connTimeoutSec;
     int connKeepAliveSec;

--- a/iRODS/clients/fuse/include/iFuse.Preload.hpp
+++ b/iRODS/clients/fuse/include/iFuse.Preload.hpp
@@ -1,0 +1,52 @@
+/*** Copyright (c), The Regents of the University of California            ***
+ *** For more information please refer to files in the COPYRIGHT directory ***/
+/*** This code is written by Illyoung Choi (iychoi@email.arizona.edu)      ***
+ *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
+#ifndef IFUSE_PRELOAD_HPP
+#define	IFUSE_PRELOAD_HPP
+
+#include <list>
+#include <pthread.h>
+#include "iFuse.BufferedFS.hpp"
+#include "iFuse.Lib.Fd.hpp"
+
+#define IFUSE_PRELOAD_PBLOCK_NUM         3
+
+#define IFUSE_PRELOAD_PBLOCK_STATUS_INIT                 0
+#define IFUSE_PRELOAD_PBLOCK_STATUS_RUNNING              1
+#define IFUSE_PRELOAD_PBLOCK_STATUS_COMPLETED            2
+#define IFUSE_PRELOAD_PBLOCK_STATUS_TASK_FAILED          3
+#define IFUSE_PRELOAD_PBLOCK_STATUS_CREATION_FAILED      4
+
+typedef struct IFusePreloadPBlock {
+    iFuseFd_t *fd;
+    unsigned int blockID;
+    int status;
+    bool threadJoined;
+    pthread_t thread;
+    pthread_mutexattr_t lockAttr;
+    pthread_mutex_t lock;
+} iFusePreloadPBlock_t;
+
+typedef struct IFusePreload {
+    unsigned long fdId;
+    char *iRodsPath;
+    std::list<iFusePreloadPBlock_t*> *pblocks;
+    pthread_mutexattr_t lockAttr;
+    pthread_mutex_t lock;
+} iFusePreload_t;
+
+typedef struct IFusePreloadThreadParam {
+    iFusePreload_t *preload;
+    iFusePreloadPBlock_t *pblock;
+} iFusePreloadThreadParam_t;
+
+void iFusePreloadInit();
+void iFusePreloadDestroy();
+
+int iFusePreloadOpen(const char *iRodsPath, iFuseFd_t **iFuseFd, int openFlag);
+int iFusePreloadClose(iFuseFd_t *iFuseFd);
+int iFusePreloadRead(iFuseFd_t *iFuseFd, char *buf, off_t off, size_t size);
+
+#endif	/* IFUSE_PRELOAD_HPP */
+

--- a/iRODS/clients/fuse/include/iFuseOper.hpp
+++ b/iRODS/clients/fuse/include/iFuseOper.hpp
@@ -2,8 +2,8 @@
  *** For more information please refer to files in the COPYRIGHT directory ***/
 /*** This code is rewritten by Illyoung Choi (iychoi@email.arizona.edu)    ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
-#ifndef I_FUSE_OPER_HPP_
-#define I_FUSE_OPER_HPP_
+#ifndef IFUSE_OPER_HPP
+#define IFUSE_OPER_HPP
 
 #include <sys/statvfs.h>
 
@@ -43,4 +43,4 @@ extern "C" {
 }
 #endif
 
-#endif	/* I_FUSE_OPER_HPP_ */
+#endif	/* IFUSE_OPER_HPP */

--- a/iRODS/clients/fuse/src/iFuse.BufferedFS.cpp
+++ b/iRODS/clients/fuse/src/iFuse.BufferedFS.cpp
@@ -465,7 +465,8 @@ int iFuseBufferedFsClose(iFuseFd_t *iFuseFd) {
     int status = 0;
     std::map<unsigned long, iFuseBufferCache_t*>::iterator it_cachemap;
     iFuseBufferCache_t *iFuseBufferCache = NULL;
-
+    char *iRodsPath;
+    
     assert(iFuseFd != NULL);
 
     iFuseRodsClientLog(LOG_DEBUG, "iFuseBufferedFsClose: %s", iFuseFd->iRodsPath);
@@ -493,14 +494,18 @@ int iFuseBufferedFsClose(iFuseFd_t *iFuseFd) {
     }
 
     pthread_mutex_unlock(&g_BufferCacheLock);
-
+    
+    iRodsPath = strdup(iFuseFd->iRodsPath);
+    
     status = iFuseFsClose(iFuseFd);
     if (status < 0) {
         iFuseRodsClientLogError(LOG_ERROR, status, "iFuseBufferedFsClose: iFuseFsClose of %s error, status = %d",
-                iFuseFd->iRodsPath, status);
+                iRodsPath, status);
+        free(iRodsPath);
         return -ENOENT;
     }
-
+    
+    free(iRodsPath);
     return status;
 }
 

--- a/iRODS/clients/fuse/src/iFuse.BufferedFS.cpp
+++ b/iRODS/clients/fuse/src/iFuse.BufferedFS.cpp
@@ -572,6 +572,13 @@ int iFuseBufferedFsFlush(iFuseFd_t *iFuseFd) {
         }
     }
     
+    status = iFuseFsFlush(iFuseFd);
+    if (status < 0) {
+        iFuseRodsClientLogError(LOG_ERROR, status, "iFuseBufferedFsFlush: iFuseFsFlush of %s error, status = %d",
+                iFuseFd->iRodsPath, status);
+        return -ENOENT;
+    }
+    
     return status;
 }
 

--- a/iRODS/clients/fuse/src/iFuse.FS.cpp
+++ b/iRODS/clients/fuse/src/iFuse.FS.cpp
@@ -539,6 +539,25 @@ int iFuseFsWrite(iFuseFd_t *iFuseFd, const char *buf, off_t off, size_t size) {
     return status;
 }
 
+int iFuseFsFlush(iFuseFd_t *iFuseFd) {
+    int status = 0;
+    
+    assert(iFuseFd != NULL);
+    assert(iFuseFd->iRodsPath != NULL);
+    assert(iFuseFd->fd > 0);
+
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseFsFlush: %s", iFuseFd->iRodsPath);
+
+    status = iFuseFdReopen(iFuseFd);
+    if (status < 0) {
+        iFuseRodsClientLogError(LOG_ERROR, status, "iFuseFsClose: iFuseFdReopen of %s error, status = %d",
+                iFuseFd->iRodsPath, status);
+        return -ENOENT;
+    }
+
+    return 0;
+}
+
 int iFuseFsCreate(const char *iRodsPath, mode_t mode) {
     int status = 0;
     dataObjInp_t dataObjInp;

--- a/iRODS/clients/fuse/src/iFuse.FS.cpp
+++ b/iRODS/clients/fuse/src/iFuse.FS.cpp
@@ -203,7 +203,8 @@ int iFuseFsOpen(const char *iRodsPath, iFuseFd_t **iFuseFd, int openFlag) {
 int iFuseFsClose(iFuseFd_t *iFuseFd) {
     int status = 0;
     iFuseConn_t *iFuseConn = NULL;
-
+    char *iRodsPath;
+    
     assert(iFuseFd != NULL);
     assert(iFuseFd->iRodsPath != NULL);
     assert(iFuseFd->fd > 0);
@@ -211,14 +212,18 @@ int iFuseFsClose(iFuseFd_t *iFuseFd) {
     iFuseRodsClientLog(LOG_DEBUG, "iFuseFsClose: %s", iFuseFd->iRodsPath);
 
     iFuseConn = iFuseFd->conn;
-
+    
+    iRodsPath = strdup(iFuseFd->iRodsPath);
+    
     status = iFuseFdClose(iFuseFd);
     if (status < 0) {
         iFuseRodsClientLogError(LOG_ERROR, status, "iFuseFsClose: iFuseFdClose of %s error, status = %d",
-                iFuseFd->iRodsPath, status);
+                iRodsPath, status);
+        free(iRodsPath);
         return -ENOENT;
     }
 
+    free(iRodsPath);
     _freeConn(iFuseConn);
     return 0;
 }
@@ -713,7 +718,8 @@ int iFuseFsOpenDir(const char *iRodsPath, iFuseDir_t **iFuseDir) {
 int iFuseFsCloseDir(iFuseDir_t *iFuseDir) {
     int status = 0;
     iFuseConn_t *iFuseConn = NULL;
-
+    char *iRodsPath;
+    
     assert(iFuseDir != NULL);
     assert(iFuseDir->iRodsPath != NULL);
     assert(iFuseDir->handle != NULL);
@@ -721,15 +727,18 @@ int iFuseFsCloseDir(iFuseDir_t *iFuseDir) {
     iFuseRodsClientLog(LOG_DEBUG, "iFuseFsCloseDir: %s", iFuseDir->iRodsPath);
 
     iFuseConn = iFuseDir->conn;
-
+    
+    iRodsPath = strdup(iFuseDir->iRodsPath);
+    
     status = iFuseDirClose(iFuseDir);
     if (status < 0) {
         iFuseRodsClientLogError(LOG_ERROR, status, "iFuseFsCloseDir: iFuseDirClose of %s error, status = %d",
-                iFuseDir->iRodsPath, status);
-        iFuseConnUnlock(iFuseConn);
+                iRodsPath, status);
+        free(iRodsPath);
         return -ENOENT;
     }
 
+    free(iRodsPath);
     _freeConn(iFuseConn);
     return 0;
 }

--- a/iRODS/clients/fuse/src/iFuse.Lib.Conn.cpp
+++ b/iRODS/clients/fuse/src/iFuse.Lib.Conn.cpp
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <pthread.h>
 #include <list>
+#include <map>
 #include "iFuse.Lib.hpp"
 #include "iFuse.Lib.RodsClientAPI.hpp"
 #include "iFuse.Lib.Conn.hpp"
@@ -16,9 +17,10 @@
 
 static pthread_mutex_t g_ConnectedConnLock;
 static pthread_mutexattr_t g_ConnectedConnLockAttr;
-static iFuseConn_t* g_InUseStatConn;
+static iFuseConn_t* g_InUseShortopConn;
 static iFuseConn_t** g_InUseConn;
-static iFuseConn_t* g_FreeStatConn;
+static std::map<unsigned long, iFuseConn_t*> g_InUseOnetimeuseConn;
+static iFuseConn_t* g_FreeShortopConn;
 static std::list<iFuseConn_t*> g_FreeConn;
 
 static pthread_t g_FreeConnCollector;
@@ -100,7 +102,7 @@ static void _disconnect(iFuseConn_t *iFuseConn) {
     pthread_mutex_unlock(&iFuseConn->lock);
 }
 
-int _newConn(iFuseConn_t **iFuseConn) {
+static int _newConn(iFuseConn_t **iFuseConn) {
     int status = 0;
     iFuseConn_t *tmpIFuseConn = NULL;
 
@@ -126,7 +128,7 @@ int _newConn(iFuseConn_t **iFuseConn) {
     return status;
 }
 
-int _freeConn(iFuseConn_t *iFuseConn) {
+static int _freeConn(iFuseConn_t *iFuseConn) {
     assert(iFuseConn != NULL);
 
     iFuseRodsClientLog(LOG_DEBUG, "_freeConn: disconnecting - %lu", iFuseConn->connId);
@@ -143,6 +145,7 @@ int _freeConn(iFuseConn_t *iFuseConn) {
 
 static int _freeAllConn() {
     iFuseConn_t *tmpIFuseConn;
+    std::map<unsigned long, iFuseConn_t*>::iterator it_connmap;
     int i;
 
     pthread_mutex_lock(&g_ConnectedConnLock);
@@ -155,9 +158,9 @@ static int _freeAllConn() {
         _freeConn(tmpIFuseConn);
     }
 
-    if(g_FreeStatConn != NULL) {
-        _freeConn(g_FreeStatConn);
-        g_FreeStatConn = NULL;
+    if(g_FreeShortopConn != NULL) {
+        _freeConn(g_FreeShortopConn);
+        g_FreeShortopConn = NULL;
     }
 
     // disconnect all inuse connections
@@ -169,11 +172,21 @@ static int _freeAllConn() {
         }
     }
 
-    if(g_InUseStatConn != NULL) {
-        _freeConn(g_InUseStatConn);
-        g_InUseStatConn = NULL;
+    if(g_InUseShortopConn != NULL) {
+        _freeConn(g_InUseShortopConn);
+        g_InUseShortopConn = NULL;
     }
+    
+    while(!g_InUseOnetimeuseConn.empty()) {
+        it_connmap = g_InUseOnetimeuseConn.begin();
+        if(it_connmap != g_InUseOnetimeuseConn.end()) {
+            tmpIFuseConn = it_connmap->second;
+            g_InUseOnetimeuseConn.erase(it_connmap);
 
+            _freeConn(tmpIFuseConn);
+        }
+    }
+    
     pthread_mutex_unlock(&g_ConnectedConnLock);
 
     return 0;
@@ -218,8 +231,8 @@ static void _keepAlive(iFuseConn_t *iFuseConn) {
 static void* _connChecker(void* param) {
     std::list<iFuseConn_t*> removeList;
     std::list<iFuseConn_t*>::iterator it_conn;
+    std::map<unsigned long, iFuseConn_t*>::iterator it_connmap;
     iFuseConn_t *iFuseConn;
-    time_t currentTime;
     int i;
 
     UNUSED(param);
@@ -229,31 +242,38 @@ static void* _connChecker(void* param) {
     while(g_FreeConnCollectorRunning) {
         pthread_mutex_lock(&g_ConnectedConnLock);
 
-        currentTime = iFuseLibGetCurrentTime();
-
         for(i=0;i<g_maxConnNum;i++) {
             if(g_InUseConn[i] != NULL) {
-                if(IFuseLibDiffTimeSec(currentTime, g_InUseConn[i]->lastKeepAliveTime) >= g_connKeepAliveSec) {
+                if(IFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_InUseConn[i]->lastKeepAliveTime) >= g_connKeepAliveSec) {
                     _keepAlive(g_InUseConn[i]);
-                    g_InUseConn[i]->lastKeepAliveTime = currentTime;
+                    g_InUseConn[i]->lastKeepAliveTime = iFuseLibGetCurrentTime();
                 }
             }
         }
 
-        if(g_InUseStatConn != NULL) {
-            if(IFuseLibDiffTimeSec(currentTime, g_InUseStatConn->lastKeepAliveTime) >= g_connKeepAliveSec) {
-                _keepAlive(g_InUseStatConn);
-                g_InUseStatConn->lastKeepAliveTime = currentTime;
+        if(g_InUseShortopConn != NULL) {
+            if(IFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_InUseShortopConn->lastKeepAliveTime) >= g_connKeepAliveSec) {
+                _keepAlive(g_InUseShortopConn);
+                g_InUseShortopConn->lastKeepAliveTime = iFuseLibGetCurrentTime();
             }
         }
+        
+        for(it_connmap=g_InUseOnetimeuseConn.begin();it_connmap!=g_InUseOnetimeuseConn.end();it_connmap++) {
+            iFuseConn = it_connmap->second;
 
+            if(IFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), iFuseConn->lastKeepAliveTime) >= g_connKeepAliveSec) {
+                _keepAlive(iFuseConn);
+                iFuseConn->lastKeepAliveTime = iFuseLibGetCurrentTime();
+            }
+        }
+        
         //iFuseRodsClientLog(LOG_DEBUG, "_freeConnCollector: checking idle connections");
 
         // iterate free conn list to check timedout connections
         for(it_conn=g_FreeConn.begin();it_conn!=g_FreeConn.end();it_conn++) {
             iFuseConn = *it_conn;
 
-            if(IFuseLibDiffTimeSec(currentTime, iFuseConn->actTime) >= g_connTimeoutSec) {
+            if(IFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), iFuseConn->actTime) >= g_connTimeoutSec) {
                 removeList.push_back(iFuseConn);
             }
         }
@@ -266,10 +286,10 @@ static void* _connChecker(void* param) {
             _freeConn(iFuseConn);
         }
 
-        if(g_FreeStatConn != NULL) {
-            if(IFuseLibDiffTimeSec(currentTime, g_FreeStatConn->actTime) >= g_connTimeoutSec) {
-                _freeConn(g_FreeStatConn);
-                g_FreeStatConn = NULL;
+        if(g_FreeShortopConn != NULL) {
+            if(IFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_FreeShortopConn->actTime) >= g_connTimeoutSec) {
+                _freeConn(g_FreeShortopConn);
+                g_FreeShortopConn = NULL;
             }
         }
 
@@ -350,24 +370,24 @@ int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType) {
 
     pthread_mutex_lock(&g_ConnectedConnLock);
 
-    if(connType == IFUSE_CONN_TYPE_FOR_STATUS) {
-        if(g_InUseStatConn != NULL) {
-            pthread_mutex_lock(&g_InUseStatConn->lock);
-            g_InUseStatConn->actTime = iFuseLibGetCurrentTime();
-            g_InUseStatConn->inuseCnt++;
-            pthread_mutex_unlock(&g_InUseStatConn->lock);
+    if(connType == IFUSE_CONN_TYPE_FOR_SHORTOP) {
+        if(g_InUseShortopConn != NULL) {
+            pthread_mutex_lock(&g_InUseShortopConn->lock);
+            g_InUseShortopConn->actTime = iFuseLibGetCurrentTime();
+            g_InUseShortopConn->inuseCnt++;
+            pthread_mutex_unlock(&g_InUseShortopConn->lock);
 
-            *iFuseConn = g_InUseStatConn;
+            *iFuseConn = g_InUseShortopConn;
             pthread_mutex_unlock(&g_ConnectedConnLock);
             return 0;
         }
 
-        // not in inusestatconn
+        // not in inuseshortopconn
         // check free conn
-        if (g_FreeStatConn != NULL) {
+        if (g_FreeShortopConn != NULL) {
             // reuse existing connection
-            tmpIFuseConn = g_FreeStatConn;
-            g_FreeStatConn = NULL;
+            tmpIFuseConn = g_FreeShortopConn;
+            g_FreeShortopConn = NULL;
 
             pthread_mutex_lock(&tmpIFuseConn->lock);
             tmpIFuseConn->actTime = iFuseLibGetCurrentTime();
@@ -376,7 +396,7 @@ int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType) {
 
             *iFuseConn = tmpIFuseConn;
 
-            g_InUseStatConn = tmpIFuseConn;
+            g_InUseShortopConn = tmpIFuseConn;
 
             pthread_mutex_unlock(&g_ConnectedConnLock);
             return 0;
@@ -390,15 +410,16 @@ int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType) {
             return status;
         }
 
+        tmpIFuseConn->type = IFUSE_CONN_TYPE_FOR_SHORTOP;
         tmpIFuseConn->actTime = iFuseLibGetCurrentTime();
         tmpIFuseConn->inuseCnt++;
 
-        g_InUseStatConn = tmpIFuseConn;
+        g_InUseShortopConn = tmpIFuseConn;
         *iFuseConn = tmpIFuseConn;
 
         pthread_mutex_unlock(&g_ConnectedConnLock);
         return 0;
-    } else {
+    } else if(connType == IFUSE_CONN_TYPE_FOR_FILE_IO) {
         // Decide whether creating a new connection or reuse one of existing connections
         targetIndex = -1;
         for(i=0;i<g_maxConnNum;i++) {
@@ -433,6 +454,7 @@ int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType) {
                     return status;
                 }
 
+                tmpIFuseConn->type = IFUSE_CONN_TYPE_FOR_FILE_IO;
                 tmpIFuseConn->actTime = iFuseLibGetCurrentTime();
                 tmpIFuseConn->inuseCnt++;
 
@@ -472,6 +494,26 @@ int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType) {
             pthread_mutex_unlock(&g_ConnectedConnLock);
             return 0;
         }
+    } else if(connType == IFUSE_CONN_TYPE_FOR_ONETIMEUSE) {
+        // create new
+        status = _newConn(&tmpIFuseConn);
+        if (status < 0) {
+            _freeConn(tmpIFuseConn);
+            pthread_mutex_unlock(&g_ConnectedConnLock);
+            return status;
+        }
+
+        tmpIFuseConn->type = IFUSE_CONN_TYPE_FOR_ONETIMEUSE;
+        tmpIFuseConn->actTime = iFuseLibGetCurrentTime();
+        tmpIFuseConn->inuseCnt++;
+
+        g_InUseOnetimeuseConn[tmpIFuseConn->connId] = tmpIFuseConn;
+        *iFuseConn = tmpIFuseConn;
+
+        pthread_mutex_unlock(&g_ConnectedConnLock);
+        return 0;
+    } else {
+        assert(0);
     }
 }
 
@@ -480,6 +522,7 @@ int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType) {
  */
 int iFuseConnUnuse(iFuseConn_t *iFuseConn) {
     int i;
+    std::map<unsigned long, iFuseConn_t*>::iterator it_connmap;
 
     assert(iFuseConn != NULL);
 
@@ -493,12 +536,17 @@ int iFuseConnUnuse(iFuseConn_t *iFuseConn) {
 
     if(iFuseConn->inuseCnt == 0) {
         // move to free list
-        if(g_InUseStatConn == iFuseConn) {
-            g_InUseStatConn = NULL;
-
-            assert(g_FreeStatConn == NULL);
-            g_FreeStatConn = iFuseConn;
-        } else {
+        if(iFuseConn->type == IFUSE_CONN_TYPE_FOR_SHORTOP) {
+            assert(g_InUseShortopConn == iFuseConn);
+            assert(g_FreeShortopConn == NULL);
+            
+            g_InUseShortopConn = NULL;
+            g_FreeShortopConn = iFuseConn;
+            
+            pthread_mutex_unlock(&iFuseConn->lock);
+            pthread_mutex_unlock(&g_ConnectedConnLock);
+            return 0;
+        } else if(iFuseConn->type == IFUSE_CONN_TYPE_FOR_FILE_IO) {
             for(i=0;i<g_maxConnNum;i++) {
                 if(g_InUseConn[i] == iFuseConn) {
                     g_InUseConn[i] = NULL;
@@ -507,9 +555,27 @@ int iFuseConnUnuse(iFuseConn_t *iFuseConn) {
             }
 
             g_FreeConn.push_back(iFuseConn);
+            
+            pthread_mutex_unlock(&iFuseConn->lock);
+            pthread_mutex_unlock(&g_ConnectedConnLock);
+            return 0;
+        } else if(iFuseConn->type == IFUSE_CONN_TYPE_FOR_ONETIMEUSE) {
+            it_connmap = g_InUseOnetimeuseConn.find(iFuseConn->connId);
+            if(it_connmap != g_InUseOnetimeuseConn.end()) {
+                // has it - remove
+                g_InUseOnetimeuseConn.erase(it_connmap);
+            }
+            
+            pthread_mutex_unlock(&iFuseConn->lock);
+            pthread_mutex_unlock(&g_ConnectedConnLock);
+            
+            _freeConn(iFuseConn);
+            return 0;
+        } else {
+            assert(0);
         }
     }
-
+    
     pthread_mutex_unlock(&iFuseConn->lock);
     pthread_mutex_unlock(&g_ConnectedConnLock);
     return 0;

--- a/iRODS/clients/fuse/src/iFuse.Lib.Fd.cpp
+++ b/iRODS/clients/fuse/src/iFuse.Lib.Fd.cpp
@@ -332,6 +332,97 @@ int iFuseFdOpen(iFuseFd_t **iFuseFd, iFuseConn_t *iFuseConn, const char* iRodsPa
 }
 
 /*
+ * Close and Reopen a file descriptor
+ */
+int iFuseFdReopen(iFuseFd_t *iFuseFd) {
+    int status = 0;
+    openedDataObjInp_t dataObjCloseInp;
+    dataObjInp_t dataObjOpenInp;
+    int fd;
+    
+    assert(iFuseFd != NULL);
+    assert(iFuseFd->conn != NULL);
+    assert(iFuseFd->fd > 0);
+
+    pthread_mutex_lock(&iFuseFd->lock);
+    
+    iFuseConnLock(iFuseFd->conn);
+
+    bzero(&dataObjCloseInp, sizeof (openedDataObjInp_t));
+    dataObjCloseInp.l1descInx = iFuseFd->fd;
+
+    status = iFuseRodsClientDataObjClose(iFuseFd->conn->conn, &dataObjCloseInp);
+    if (status < 0) {
+        if (iFuseRodsClientReadMsgError(status)) {
+            // reconnect and retry 
+            if(iFuseConnReconnect(iFuseFd->conn) < 0) {
+                iFuseRodsClientLogError(LOG_ERROR, status, "iFuseFdReopen: iFuseConnReconnect of %s (%d) error",
+                    iFuseFd->iRodsPath, iFuseFd->fd);
+            } else {
+                status = iFuseRodsClientDataObjClose(iFuseFd->conn->conn, &dataObjCloseInp);
+                if (status < 0) {
+                    iFuseRodsClientLogError(LOG_ERROR, status, "iFuseFdReopen: close of %s (%d) error",
+                        iFuseFd->iRodsPath, iFuseFd->fd);
+                }
+            }
+        } else {
+            iFuseRodsClientLogError(LOG_ERROR, status, "iFuseFdReopen: close of %s (%d) error",
+                iFuseFd->iRodsPath, iFuseFd->fd);
+        }
+    }
+    
+    if(status < 0) {
+        iFuseConnUnlock(iFuseFd->conn);
+        pthread_mutex_unlock(&iFuseFd->lock);
+        return status;
+    }
+    
+    iFuseFd->lastFilePointer = -1;
+
+    bzero(&dataObjOpenInp, sizeof ( dataObjInp_t));
+    dataObjOpenInp.openFlags = iFuseFd->openFlag;
+    rstrcpy(dataObjOpenInp.objPath, iFuseFd->iRodsPath, MAX_NAME_LEN);
+
+    assert(iFuseFd->conn->conn != NULL);
+    
+    fd = iFuseRodsClientDataObjOpen(iFuseFd->conn->conn, &dataObjOpenInp);
+    if (fd <= 0) {
+        if (iFuseRodsClientReadMsgError(fd)) {
+            // reconnect and retry 
+            if(iFuseConnReconnect(iFuseFd->conn) < 0) {
+                iFuseRodsClientLogError(LOG_ERROR, fd, "iFuseFdReopen: iFuseConnReconnect of %s error, status = %d",
+                    iFuseFd->iRodsPath, fd);
+                iFuseConnUnlock(iFuseFd->conn);
+                pthread_mutex_unlock(&iFuseFd->lock);
+                return -ENOENT;
+            } else {
+                fd = iFuseRodsClientDataObjOpen(iFuseFd->conn->conn, &dataObjOpenInp);
+                if (fd <= 0) {
+                    iFuseRodsClientLogError(LOG_ERROR, fd, "iFuseFdReopen: iFuseRodsClientDataObjOpen of %s error, status = %d",
+                        iFuseFd->iRodsPath, fd);
+                    iFuseConnUnlock(iFuseFd->conn);
+                    pthread_mutex_unlock(&iFuseFd->lock);
+                    return -ENOENT;
+                }
+            }
+        } else {
+            iFuseRodsClientLogError(LOG_ERROR, fd, "iFuseFdReopen: iFuseRodsClientDataObjOpen of %s error, status = %d",
+                iFuseFd->iRodsPath, fd);
+            iFuseConnUnlock(iFuseFd->conn);
+            pthread_mutex_unlock(&iFuseFd->lock);
+            return -ENOENT;
+        }
+    }
+    
+    iFuseFd->fd = fd;
+    
+    iFuseConnUnlock(iFuseFd->conn);
+    
+    pthread_mutex_unlock(&iFuseFd->lock);
+    return status;
+}
+
+/*
  * Open a new directory descriptor
  */
 int iFuseDirOpen(iFuseDir_t **iFuseDir, iFuseConn_t *iFuseConn, const char* iRodsPath) {

--- a/iRODS/clients/fuse/src/iFuse.Lib.RodsClientAPI.cpp
+++ b/iRODS/clients/fuse/src/iFuse.Lib.RodsClientAPI.cpp
@@ -353,3 +353,49 @@ int iFuseRodsClientModDataObjMeta(rcComm_t *conn, modDataObjMeta_t *modDataObjMe
     _endOperationTimeout(oper);
     return status;
 }
+
+void iFuseRodsClientLogToFile(int level, const char *formatStr, ...) {
+    va_list args;
+    va_start(args, formatStr);
+    
+    FILE *logFile;
+    
+    logFile = fopen(IFUSE_RODSCLIENTAPI_LOG_OUT_FILE_PATH, "a");
+    if(logFile != NULL) {
+        if(level == 7) {
+            // debug
+            fprintf(logFile, "DEBUG: ");
+        } else {
+            fprintf(logFile, "errorLevel : %d\n", level);
+        }
+        vfprintf(logFile, formatStr, args);
+        fprintf(logFile, "\n");
+        
+        fclose(logFile);
+    }
+    
+    va_end(args);
+}
+
+void iFuseRodsClientLogErrorToFile(int level, int errCode, char *formatStr, ...) {
+    va_list args;
+    va_start(args, formatStr);
+    
+    FILE *logFile;
+    
+    logFile = fopen(IFUSE_RODSCLIENTAPI_LOG_OUT_FILE_PATH, "a");
+    if(logFile != NULL) {
+        if(level == 7) {
+            // debug
+            fprintf(logFile, "DEBUG - ERROR_CODE(%d): ", errCode);
+        } else {
+            fprintf(logFile, "errorLevel : %d, errorCode : %d\n", level, errCode);
+        }
+        vfprintf(logFile, formatStr, args);
+        fprintf(logFile, "\n");
+        
+        fclose(logFile);
+    }
+    
+    va_end(args);
+}

--- a/iRODS/clients/fuse/src/iFuse.Lib.RodsClientAPI.cpp
+++ b/iRODS/clients/fuse/src/iFuse.Lib.RodsClientAPI.cpp
@@ -69,6 +69,10 @@ static void* _timeoutChecker(void* param) {
 
 static iFuseRodsClientOperation_t *_startOperationTimeout(rcComm_t *conn) {
     iFuseRodsClientOperation_t *oper = (iFuseRodsClientOperation_t *)calloc(1, sizeof(iFuseRodsClientOperation_t));
+    if(oper == NULL) {
+        return NULL;
+    }
+    
     oper->start = iFuseLibGetCurrentTime();
     oper->conn = conn;
     
@@ -134,6 +138,10 @@ int iFuseRodsClientLogin(rcComm_t *conn) {
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
     
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
+    
     status = clientLogin(conn);
     _endOperationTimeout(oper);
     return status;
@@ -151,6 +159,10 @@ int iFuseRodsClientDataObjOpen(rcComm_t *conn, dataObjInp_t *dataObjInp) {
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
     
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
+    
     status = rcDataObjOpen(conn, dataObjInp);
     _endOperationTimeout(oper);
     return status;
@@ -160,6 +172,10 @@ int iFuseRodsClientDataObjClose(rcComm_t *conn, openedDataObjInp_t *dataObjClose
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
     
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
+    
     status = rcDataObjClose(conn, dataObjCloseInp);
     _endOperationTimeout(oper);
     return status;
@@ -168,6 +184,10 @@ int iFuseRodsClientDataObjClose(rcComm_t *conn, openedDataObjInp_t *dataObjClose
 int iFuseRodsClientOpenCollection(rcComm_t *conn, char *collection, int flag, collHandle_t *collHandle) {
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
+    
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
     
     status = rclOpenCollection(conn, collection, flag, collHandle);
     _endOperationTimeout(oper);
@@ -182,6 +202,10 @@ int iFuseRodsClientObjStat(rcComm_t *conn, dataObjInp_t *dataObjInp, rodsObjStat
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
     
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
+    
     status = rcObjStat(conn, dataObjInp, rodsObjStatOut);
     _endOperationTimeout(oper);
     return status;
@@ -190,6 +214,10 @@ int iFuseRodsClientObjStat(rcComm_t *conn, dataObjInp_t *dataObjInp, rodsObjStat
 int iFuseRodsClientDataObjLseek(rcComm_t *conn, openedDataObjInp_t *dataObjLseekInp, fileLseekOut_t **dataObjLseekOut) {
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
+    
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
     
     status = rcDataObjLseek(conn, dataObjLseekInp, dataObjLseekOut);
     _endOperationTimeout(oper);
@@ -200,6 +228,10 @@ int iFuseRodsClientDataObjRead(rcComm_t *conn, openedDataObjInp_t *dataObjReadIn
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
     
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
+    
     status = rcDataObjRead(conn, dataObjReadInp, dataObjReadOutBBuf);
     _endOperationTimeout(oper);
     return status;
@@ -208,6 +240,10 @@ int iFuseRodsClientDataObjRead(rcComm_t *conn, openedDataObjInp_t *dataObjReadIn
 int iFuseRodsClientDataObjWrite(rcComm_t *conn, openedDataObjInp_t *dataObjWriteInp, bytesBuf_t *dataObjWriteInpBBuf) {
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
+    
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
     
     status = rcDataObjWrite(conn, dataObjWriteInp, dataObjWriteInpBBuf);
     _endOperationTimeout(oper);
@@ -218,6 +254,10 @@ int iFuseRodsClientDataObjCreate(rcComm_t *conn, dataObjInp_t *dataObjInp) {
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
     
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
+    
     status = rcDataObjCreate(conn, dataObjInp);
     _endOperationTimeout(oper);
     return status;
@@ -226,6 +266,10 @@ int iFuseRodsClientDataObjCreate(rcComm_t *conn, dataObjInp_t *dataObjInp) {
 int iFuseRodsClientDataObjUnlink(rcComm_t *conn, dataObjInp_t *dataObjUnlinkInp) {
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
+    
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
     
     status = rcDataObjUnlink(conn, dataObjUnlinkInp);
     _endOperationTimeout(oper);
@@ -236,6 +280,10 @@ int iFuseRodsClientReadCollection(rcComm_t *conn, collHandle_t *collHandle, coll
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
     
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
+    
     status = rclReadCollection(conn, collHandle, collEnt);
     _endOperationTimeout(oper);
     return status;
@@ -244,6 +292,10 @@ int iFuseRodsClientReadCollection(rcComm_t *conn, collHandle_t *collHandle, coll
 int iFuseRodsClientCollCreate(rcComm_t *conn, collInp_t *collCreateInp) {
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
+    
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
     
     status = rcCollCreate(conn, collCreateInp);
     _endOperationTimeout(oper);
@@ -254,6 +306,10 @@ int iFuseRodsClientRmColl(rcComm_t *conn, collInp_t *rmCollInp, int vFlag) {
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
     
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
+    
     status = rcRmColl(conn, rmCollInp, vFlag);
     _endOperationTimeout(oper);
     return status;
@@ -262,6 +318,10 @@ int iFuseRodsClientRmColl(rcComm_t *conn, collInp_t *rmCollInp, int vFlag) {
 int iFuseRodsClientDataObjRename(rcComm_t *conn, dataObjCopyInp_t *dataObjRenameInp) {
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
+    
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
     
     status = rcDataObjRename(conn, dataObjRenameInp);
     _endOperationTimeout(oper);
@@ -272,6 +332,10 @@ int iFuseRodsClientDataObjTruncate(rcComm_t *conn, dataObjInp_t *dataObjInp) {
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
     
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
+    
     status = rcDataObjTruncate(conn, dataObjInp);
     _endOperationTimeout(oper);
     return status;
@@ -280,6 +344,10 @@ int iFuseRodsClientDataObjTruncate(rcComm_t *conn, dataObjInp_t *dataObjInp) {
 int iFuseRodsClientModDataObjMeta(rcComm_t *conn, modDataObjMeta_t *modDataObjMetaInp) {
     iFuseRodsClientOperation_t *oper = _startOperationTimeout(conn);
     int status;
+    
+    if(oper == NULL) {
+        return SYS_MALLOC_ERR;
+    }
     
     status = rcModDataObjMeta(conn, modDataObjMetaInp);
     _endOperationTimeout(oper);

--- a/iRODS/clients/fuse/src/iFuse.Preload.cpp
+++ b/iRODS/clients/fuse/src/iFuse.Preload.cpp
@@ -1,0 +1,648 @@
+/*** Copyright (c), The Regents of the University of California            ***
+ *** For more information please refer to files in the COPYRIGHT directory ***/
+/*** This code is written by Illyoung Choi (iychoi@email.arizona.edu)      ***
+ *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <time.h>
+#include <assert.h>
+#include <pthread.h>
+#include <map>
+#include <cstring>
+#include "iFuse.FS.hpp"
+#include "iFuse.Lib.hpp"
+#include "iFuse.Lib.Fd.hpp"
+#include "iFuse.Preload.hpp"
+#include "iFuse.BufferedFS.hpp"
+#include "iFuse.Lib.Util.hpp"
+#include "iFuse.Lib.RodsClientAPI.hpp"
+#include "miscUtil.h"
+
+static pthread_mutexattr_t g_PreloadLockAttr;
+static pthread_mutex_t g_PreloadLock;
+
+static std::map<unsigned long, iFusePreload_t*> g_PreloadMap;
+
+static int _newPreloadPBlock(const char *iRodsPath, iFusePreloadPBlock_t **iFusePreloadPBlock) {
+    int status = 0;
+    iFusePreloadPBlock_t *tmpIFusePreloadPBlock = NULL;
+    
+    assert(iRodsPath != NULL);
+    assert(iFusePreloadPBlock != NULL);
+    
+    tmpIFusePreloadPBlock = (iFusePreloadPBlock_t *) calloc(1, sizeof ( iFusePreloadPBlock_t));
+    if (tmpIFusePreloadPBlock == NULL) {
+        *iFusePreloadPBlock = NULL;
+        return SYS_MALLOC_ERR;
+    }
+    
+    tmpIFusePreloadPBlock->fd = NULL;
+    tmpIFusePreloadPBlock->status = IFUSE_PRELOAD_PBLOCK_STATUS_INIT;
+    
+    pthread_mutexattr_init(&tmpIFusePreloadPBlock->lockAttr);
+    pthread_mutexattr_settype(&tmpIFusePreloadPBlock->lockAttr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&tmpIFusePreloadPBlock->lock, &tmpIFusePreloadPBlock->lockAttr);
+    
+    *iFusePreloadPBlock = tmpIFusePreloadPBlock;
+    return 0;
+}
+
+static int _newPreload(iFusePreload_t **iFusePreload) {
+    iFusePreload_t *tmpIFusePreload = NULL;
+    
+    assert(iFusePreload != NULL);
+    
+    tmpIFusePreload = (iFusePreload_t *) calloc(1, sizeof ( iFusePreload_t));
+    if (tmpIFusePreload == NULL) {
+        *iFusePreload = NULL;
+        return SYS_MALLOC_ERR;
+    }
+    
+    // we must use new keyword instead of calloc since it contains c++ stl list object
+    tmpIFusePreload->pblocks = new std::list<iFusePreloadPBlock_t*>();
+    if(tmpIFusePreload->pblocks == NULL) {
+        *iFusePreload = NULL;
+        return SYS_MALLOC_ERR;
+    }
+    
+    pthread_mutexattr_init(&tmpIFusePreload->lockAttr);
+    pthread_mutexattr_settype(&tmpIFusePreload->lockAttr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&tmpIFusePreload->lock, &tmpIFusePreload->lockAttr);
+    
+    *iFusePreload = tmpIFusePreload;
+    return 0;
+}
+
+static int _freePreloadPBlock(iFusePreloadPBlock_t *iFusePreloadPBlock) {
+    assert(iFusePreloadPBlock != NULL);
+    
+    if(iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_RUNNING || 
+            iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_INIT ||
+            iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_COMPLETED ||
+            iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_TASK_FAILED) {
+        if(!iFusePreloadPBlock->threadJoined) {
+            pthread_join(iFusePreloadPBlock->thread, NULL);
+            
+            pthread_mutex_lock(&iFusePreloadPBlock->lock);
+
+            // set to joined
+            iFusePreloadPBlock->threadJoined = true;
+
+            pthread_mutex_unlock(&iFusePreloadPBlock->lock);
+        }
+    }
+    
+    pthread_mutex_lock(&iFusePreloadPBlock->lock);
+    
+    if(iFusePreloadPBlock->fd != NULL) {
+        iFuseBufferedFsClose(iFusePreloadPBlock->fd);
+        iFusePreloadPBlock->fd = NULL;
+    }
+    
+    iFusePreloadPBlock->blockID = 0;
+    
+    pthread_mutex_unlock(&iFusePreloadPBlock->lock);
+    
+    pthread_mutex_destroy(&iFusePreloadPBlock->lock);
+    pthread_mutexattr_destroy(&iFusePreloadPBlock->lockAttr);
+    
+    free(iFusePreloadPBlock);
+    return 0;
+}
+
+static int _freePreload(iFusePreload_t *iFusePreload) {
+    iFusePreloadPBlock_t *iFusePreloadPBlock = NULL;
+    
+    assert(iFusePreload != NULL);
+    
+    if(iFusePreload->pblocks != NULL) {
+        while(!iFusePreload->pblocks->empty()) {
+            iFusePreloadPBlock = iFusePreload->pblocks->front();
+            iFusePreload->pblocks->pop_front();
+
+            _freePreloadPBlock(iFusePreloadPBlock);
+        }
+        
+        delete iFusePreload->pblocks;
+    }
+    
+    if(iFusePreload->iRodsPath != NULL) {
+        free(iFusePreload->iRodsPath);
+        iFusePreload->iRodsPath = NULL;
+    }
+    
+    pthread_mutex_destroy(&iFusePreload->lock);
+    pthread_mutexattr_destroy(&iFusePreload->lockAttr);
+    
+    free(iFusePreload);
+    return 0;
+}
+
+static int _releaseAllPreload() {
+    std::map<unsigned long, iFusePreload_t*>::iterator it_preloadmap;
+    iFusePreload_t *iFusePreload = NULL;
+
+    pthread_mutex_lock(&g_PreloadLock);
+    
+    // release all get
+    while(!g_PreloadMap.empty()) {
+        it_preloadmap = g_PreloadMap.begin();
+        if(it_preloadmap != g_PreloadMap.end()) {
+            iFusePreload = it_preloadmap->second;
+            g_PreloadMap.erase(it_preloadmap);
+            
+            _freePreload(iFusePreload);
+        }
+    }
+    
+    pthread_mutex_unlock(&g_PreloadLock);
+    return 0;
+}
+
+static void* _preloadTask(void* param) {
+    int status = 0;
+    iFusePreloadThreadParam_t *iFusePreloadThreadParam;
+    iFusePreload_t *iFusePreload;
+    iFusePreloadPBlock_t *iFusePreloadPBlock;
+    iFuseFd_t *iFuseFd;
+    char *blockBuffer = (char*)calloc(1, getBufferCacheBlockSize());
+    
+    assert(param != NULL);
+    
+    iFusePreloadThreadParam = (iFusePreloadThreadParam_t*)param;
+    iFusePreload = iFusePreloadThreadParam->preload;
+    iFusePreloadPBlock = iFusePreloadThreadParam->pblock;
+    
+    if(blockBuffer == NULL) {
+        free(iFusePreloadThreadParam);
+        
+        pthread_mutex_lock(&iFusePreloadPBlock->lock);
+        iFusePreloadPBlock->status = IFUSE_PRELOAD_PBLOCK_STATUS_TASK_FAILED;
+        pthread_mutex_unlock(&iFusePreloadPBlock->lock);
+        return NULL;
+    }
+    
+    iFuseRodsClientLog(LOG_DEBUG, "_preloadTask: preloading %s, blockID: %u", iFusePreload->iRodsPath, iFusePreloadPBlock->blockID);
+    
+    if(iFusePreloadPBlock->fd == NULL) {
+        status = iFuseBufferedFsOpen(iFusePreload->iRodsPath, &iFuseFd, O_RDONLY);
+        if (status < 0) {
+            iFuseRodsClientLogError(LOG_ERROR, status, "_preloadTask: iFuseBufferedFsOpen of %s error, status = %d",
+                    iFusePreload->iRodsPath, status);
+            free(blockBuffer);
+            free(iFusePreloadThreadParam);
+            
+            pthread_mutex_lock(&iFusePreloadPBlock->lock);
+            iFusePreloadPBlock->status = IFUSE_PRELOAD_PBLOCK_STATUS_TASK_FAILED;
+            pthread_mutex_unlock(&iFusePreloadPBlock->lock);
+            return NULL;
+        }
+        
+        pthread_mutex_lock(&iFusePreloadPBlock->lock);
+        iFusePreloadPBlock->fd = iFuseFd;
+        pthread_mutex_unlock(&iFusePreloadPBlock->lock);
+    }
+    
+    status = iFuseBufferedFsReadBlock(iFusePreloadPBlock->fd, blockBuffer, iFusePreloadPBlock->blockID);
+    if (status < 0) {
+        iFuseRodsClientLogError(LOG_ERROR, status, "_preloadTask: iFuseBufferedFsReadBlock of %s error, status = %d",
+                iFusePreloadPBlock->fd->iRodsPath, status);
+        free(blockBuffer);
+        free(iFusePreloadThreadParam);
+            
+        pthread_mutex_lock(&iFusePreloadPBlock->lock);
+        iFusePreloadPBlock->status = IFUSE_PRELOAD_PBLOCK_STATUS_TASK_FAILED;
+        pthread_mutex_unlock(&iFusePreloadPBlock->lock);
+        return NULL;
+    }
+    
+    free(blockBuffer);
+
+    pthread_mutex_lock(&iFusePreloadPBlock->lock);
+    iFusePreloadPBlock->status = IFUSE_PRELOAD_PBLOCK_STATUS_COMPLETED;
+    pthread_mutex_unlock(&iFusePreloadPBlock->lock);
+    
+    free(iFusePreloadThreadParam);
+    
+    return NULL;
+}
+
+int _startPreload(iFusePreload_t *iFusePreload, unsigned int blockID, iFuseFd_t *iFuseFd) {
+    int status = 0;
+    iFusePreloadThreadParam_t *iFusePreloadThreadParam;
+    iFusePreloadPBlock_t *iFusePreloadPBlock;
+    
+    assert(iFusePreload != NULL);
+    
+    iFuseRodsClientLog(LOG_DEBUG, "_startPreload: preloading %s, blockID: %u", iFusePreload->iRodsPath, blockID);
+    
+    status = _newPreloadPBlock(iFusePreload->iRodsPath, &iFusePreloadPBlock);
+    if(status < 0) {
+        return status;
+    }
+    
+    iFusePreloadPBlock->fd = iFuseFd;
+    iFusePreloadPBlock->blockID = blockID;
+    iFusePreloadPBlock->status = IFUSE_PRELOAD_PBLOCK_STATUS_RUNNING;
+    
+    iFusePreloadThreadParam = (iFusePreloadThreadParam_t*) calloc(1, sizeof(iFusePreloadThreadParam_t));
+    if(iFusePreloadThreadParam == NULL) {
+        return SYS_MALLOC_ERR;
+    }
+    
+    iFusePreloadThreadParam->preload = iFusePreload;
+    iFusePreloadThreadParam->pblock = iFusePreloadPBlock;
+    
+    status = pthread_create(&iFusePreloadPBlock->thread, NULL, _preloadTask, (void*)iFusePreloadThreadParam);
+    if(status != 0) {
+        iFuseRodsClientLogError(LOG_ERROR, status, "_startPreload: failed to create a thread for %s of block id %u, status = %d",
+                iFusePreload->iRodsPath, blockID, status);
+        iFusePreloadPBlock->status = IFUSE_PRELOAD_PBLOCK_STATUS_CREATION_FAILED;
+        _freePreloadPBlock(iFusePreloadPBlock);
+        free(iFusePreloadThreadParam);
+        return -1;
+    }
+
+    pthread_mutex_lock(&iFusePreload->lock);
+    
+    iFusePreload->pblocks->push_back(iFusePreloadPBlock);
+    
+    pthread_mutex_unlock(&iFusePreload->lock);
+    return status;
+}
+
+int _readPreload(iFusePreload_t *iFusePreload, char *buf, unsigned int blockID) {
+    int status = 0;
+    size_t readSize = 0;
+    std::list<iFusePreloadPBlock_t*> removeList;
+    std::list<iFusePreloadPBlock_t*> recycleList;
+    std::list<iFusePreloadPBlock_t*>::iterator it_preloadpblock;
+    iFusePreloadPBlock_t *iFusePreloadPBlock = NULL;
+    iFuseFd_t *iFuseFd = NULL;
+    bool hasBlock = false;
+    bool *pblockExistance = (bool*)calloc(IFUSE_PRELOAD_PBLOCK_NUM, sizeof(bool));
+    int i;
+    
+    assert(iFusePreload != NULL);
+    assert(buf != NULL);
+
+    if(pblockExistance == NULL) {
+        return SYS_MALLOC_ERR;
+    }
+    
+    bzero(pblockExistance, IFUSE_PRELOAD_PBLOCK_NUM * sizeof(bool));
+    
+    pthread_mutex_lock(&iFusePreload->lock);
+    
+    // check loaded
+    for(it_preloadpblock=iFusePreload->pblocks->begin();it_preloadpblock!=iFusePreload->pblocks->end();it_preloadpblock++) {
+        iFusePreloadPBlock = *it_preloadpblock;
+
+        if(blockID == iFusePreloadPBlock->blockID) {
+            // has block
+            hasBlock = true;
+        } else if(blockID > iFusePreloadPBlock->blockID ||
+                blockID + IFUSE_PRELOAD_PBLOCK_NUM < iFusePreloadPBlock->blockID) {
+            // remove old blocks
+            // if block id is less than current block id
+            // or block id is far larger than current block id (for backward read)
+            
+            iFuseRodsClientLog(LOG_DEBUG, "_readPreload: found old preloaded data of %s, blockID: %u, cur blockID: %u", iFusePreload->iRodsPath, iFusePreloadPBlock->blockID, blockID);
+            removeList.push_back(iFusePreloadPBlock);
+        } else {
+            // preloaded blocks
+            if(iFusePreloadPBlock->blockID - blockID - 1 < IFUSE_PRELOAD_PBLOCK_NUM) {
+                pblockExistance[iFusePreloadPBlock->blockID - blockID - 1] = true;
+            }
+        }
+    }
+    
+    // wait old blocks to be joined
+    for(it_preloadpblock=removeList.begin();it_preloadpblock!=removeList.end();it_preloadpblock++) {
+        iFusePreloadPBlock = *it_preloadpblock;
+        
+        if(iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_RUNNING || 
+                iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_INIT ||
+                iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_COMPLETED ||
+                iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_TASK_FAILED) {
+            if(!iFusePreloadPBlock->threadJoined) {
+                iFuseRodsClientLog(LOG_DEBUG, "_readPreload: waiting for a preload thread of %s, blockID: %u", iFusePreload->iRodsPath, iFusePreloadPBlock->blockID);
+
+                pthread_join(iFusePreloadPBlock->thread, NULL);
+
+                pthread_mutex_lock(&iFusePreloadPBlock->lock);
+
+                // set to joined
+                iFusePreloadPBlock->threadJoined = true;
+
+                pthread_mutex_unlock(&iFusePreloadPBlock->lock);
+            }
+        }
+    }
+    
+    // find reusable pblocks -> moves to recycleList
+    // release old pblocks
+    while(!removeList.empty()) {
+        iFusePreloadPBlock = removeList.front();
+        
+        iFuseRodsClientLog(LOG_DEBUG, "_readPreload: removing preloaded data of %s, blockID: %u", iFusePreload->iRodsPath, iFusePreloadPBlock->blockID);
+        
+        removeList.pop_front();
+        iFusePreload->pblocks->remove(iFusePreloadPBlock);
+        if(iFusePreloadPBlock->fd != NULL &&
+                iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_COMPLETED &&
+                iFusePreloadPBlock->threadJoined) {
+            // reusable
+            recycleList.push_back(iFusePreloadPBlock);
+        } else {
+            _freePreloadPBlock(iFusePreloadPBlock);
+        }
+    }
+    
+    if(!hasBlock) {
+        iFuseFd = NULL;
+        if(!recycleList.empty()) {
+            iFusePreloadPBlock = recycleList.front();
+            recycleList.pop_front();
+            
+            iFuseFd = iFusePreloadPBlock->fd;
+            iFusePreloadPBlock->fd = NULL;
+
+            _freePreloadPBlock(iFusePreloadPBlock);
+        }
+
+        // param iFuseFd can be null
+        _startPreload(iFusePreload, blockID, iFuseFd);
+    }
+    
+    for(it_preloadpblock=iFusePreload->pblocks->begin();it_preloadpblock!=iFusePreload->pblocks->end();it_preloadpblock++) {
+        iFusePreloadPBlock = *it_preloadpblock;
+
+        if(blockID == iFusePreloadPBlock->blockID) {
+            
+            if(iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_INIT ||
+                    iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_RUNNING || 
+                    iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_COMPLETED ||
+                    iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_TASK_FAILED) {
+                if(!iFusePreloadPBlock->threadJoined) {
+                    iFuseRodsClientLog(LOG_DEBUG, "_readPreload: waiting for a preload thread of %s, blockID: %u", iFusePreload->iRodsPath, blockID);
+
+                    pthread_join(iFusePreloadPBlock->thread, NULL);
+
+                    pthread_mutex_lock(&iFusePreloadPBlock->lock);
+
+                    // set to joined
+                    iFusePreloadPBlock->threadJoined = true;
+
+                    pthread_mutex_unlock(&iFusePreloadPBlock->lock);
+                }
+            }
+            
+            if(iFusePreloadPBlock->status == IFUSE_PRELOAD_PBLOCK_STATUS_COMPLETED &&
+                    iFusePreloadPBlock->threadJoined) {
+                pthread_mutex_lock(&iFusePreloadPBlock->lock);
+
+                if(iFusePreloadPBlock->fd != NULL) {
+                    iFuseRodsClientLog(LOG_DEBUG, "_readPreload: reading a block from preloaded data of %s, blockID: %u", iFusePreload->iRodsPath, blockID);
+                    readSize = iFuseBufferedFsReadBlock(iFusePreloadPBlock->fd, buf, blockID);
+                } else {
+                    readSize = -1;
+                }
+
+                pthread_mutex_unlock(&iFusePreloadPBlock->lock);
+            } else {
+                readSize = -1;
+            }
+        }
+    }
+    
+    for(i=0;i<IFUSE_PRELOAD_PBLOCK_NUM;i++) {
+        if(!pblockExistance[i]) {
+            // start preload
+            iFuseFd = NULL;
+            if(!recycleList.empty()) {
+                iFusePreloadPBlock = recycleList.front();
+                recycleList.pop_front();
+                
+                iFuseFd = iFusePreloadPBlock->fd;
+                iFusePreloadPBlock->fd = NULL;
+                
+                _freePreloadPBlock(iFusePreloadPBlock);
+            }
+            
+            // param iFuseFd can be null
+            _startPreload(iFusePreload, i + blockID + 1, iFuseFd);
+        }
+    }
+    
+    // release entries in recycleList that will not be used
+    while(!recycleList.empty()) {
+        iFusePreloadPBlock = recycleList.front();
+        removeList.pop_front();
+        _freePreloadPBlock(iFusePreloadPBlock);
+    }
+    
+    free(pblockExistance);
+    pthread_mutex_unlock(&iFusePreload->lock);
+    return readSize;
+}
+
+/*
+ * Initialize preload manager
+ */
+void iFusePreloadInit() {
+    pthread_mutexattr_init(&g_PreloadLockAttr);
+    pthread_mutexattr_settype(&g_PreloadLockAttr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&g_PreloadLock, &g_PreloadLockAttr);
+}
+
+/*
+ * Destroy preload manager
+ */
+void iFusePreloadDestroy() {
+    _releaseAllPreload();
+    
+    pthread_mutex_destroy(&g_PreloadLock);
+    pthread_mutexattr_destroy(&g_PreloadLockAttr);
+}
+
+/*
+ * Create a new preload
+ */
+int iFusePreloadOpen(const char *iRodsPath, iFuseFd_t **iFuseFd, int openFlag) {
+    int status = 0;
+    std::map<unsigned long, iFusePreload_t*>::iterator it_preloadmap;
+    iFusePreload_t *iFusePreload = NULL;
+    int i;
+    
+    assert(iRodsPath != NULL);
+    assert(iFuseFd != NULL);
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFusePreloadOpen: %s, openFlag: 0x%08x", iRodsPath, openFlag);
+    
+    status = iFuseBufferedFsOpen(iRodsPath, iFuseFd, openFlag);
+    if (status < 0) {
+        iFuseRodsClientLogError(LOG_ERROR, status, "iFusePreloadOpen: iFuseBufferedFsOpen of %s error, status = %d",
+                iRodsPath, status);
+        return status;
+    }
+    
+    status = _newPreload(&iFusePreload);
+    if (status == 0) {
+        iFusePreload->fdId = (*iFuseFd)->fdId;
+        iFusePreload->iRodsPath = strdup(iRodsPath);
+
+        // start preload thread
+        for(i=0;i<IFUSE_PRELOAD_PBLOCK_NUM;i++) {
+            _startPreload(iFusePreload, i, NULL);
+        }
+        
+        pthread_mutex_lock(&g_PreloadLock);
+
+        g_PreloadMap[(*iFuseFd)->fdId] = iFusePreload;
+
+        pthread_mutex_unlock(&g_PreloadLock);
+    }
+    
+    return 0;
+}
+
+/*
+ * Release a new preload
+ */
+int iFusePreloadClose(iFuseFd_t *iFuseFd) {
+    int status = 0;
+    std::map<unsigned long, iFusePreload_t*>::iterator it_preloadmap;
+    iFusePreload_t *iFusePreload = NULL;
+    char *iRodsPath;
+    
+    assert(iFuseFd != NULL);
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFusePreloadClose: %s", iFuseFd->iRodsPath);
+    
+    pthread_mutex_lock(&g_PreloadLock);
+    
+    it_preloadmap = g_PreloadMap.find(iFuseFd->fdId);
+    if(it_preloadmap != g_PreloadMap.end()) {
+        // has it
+        iFusePreload = it_preloadmap->second;
+        g_PreloadMap.erase(it_preloadmap);
+
+        _freePreload(iFusePreload);
+    }
+    
+    pthread_mutex_unlock(&g_PreloadLock);
+    
+    iRodsPath = strdup(iFuseFd->iRodsPath);
+    
+    status = iFuseBufferedFsClose(iFuseFd);
+    if (status < 0) {
+        iFuseRodsClientLogError(LOG_ERROR, status, "iFusePreloadClose: iFuseBufferedFsClose of %s error, status = %d",
+                iRodsPath, status);
+        free(iRodsPath);
+        return -ENOENT;
+    }
+    
+    free(iRodsPath);
+    return status;
+}
+
+/*
+ * Read preloaded data
+ */
+int iFusePreloadRead(iFuseFd_t *iFuseFd, char *buf, off_t off, size_t size) {
+    int status = 0;
+    size_t readSize = 0;
+    size_t remain = 0;
+    off_t curOffset = 0;
+    char *blockBuffer = (char*)calloc(1, getBufferCacheBlockSize());
+    std::map<unsigned long, iFusePreload_t*>::iterator it_preloadmap;
+    iFusePreload_t *iFusePreload = NULL;
+    
+    assert(iFuseFd != NULL);
+    assert(buf != NULL);
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFusePreloadRead: %s, offset: %lld, size: %lld", iFuseFd->iRodsPath, (long long)off, (long long)size);
+    
+    pthread_mutex_lock(&g_PreloadLock);
+    
+    it_preloadmap = g_PreloadMap.find(iFuseFd->fdId);
+    if(it_preloadmap != g_PreloadMap.end()) {
+        // has it
+        iFusePreload = it_preloadmap->second;
+        
+        // read in block level
+        remain = size;
+        curOffset = off;
+        while(remain > 0) {
+            off_t inBlockOffset = getInBlockOffset(curOffset);
+            size_t inBlockAvail = getBufferCacheBlockSize() - inBlockOffset;
+            size_t curSize = inBlockAvail > remain ? remain : inBlockAvail;
+            size_t blockSize = 0;
+
+            status = _readPreload(iFusePreload, blockBuffer, getBlockID(curOffset));
+            if(status < 0) {
+                iFuseRodsClientLogError(LOG_ERROR, status, "iFusePreloadRead: _readPreload of %s error, status = %d",
+                        iFuseFd->iRodsPath, status);
+                
+                status = iFuseBufferedFsRead(iFuseFd, buf, off, size);
+                if (status < 0) {
+                    iFuseRodsClientLogError(LOG_ERROR, status, "iFusePreloadRead: iFuseBufferedFsRead of %s error, status = %d",
+                            iFuseFd->iRodsPath, status);
+                    pthread_mutex_unlock(&g_PreloadLock);
+                    free(blockBuffer);
+                    return -ENOENT;
+                }
+                
+                pthread_mutex_unlock(&g_PreloadLock);
+                free(blockBuffer);
+                return status;
+            } else if(status == 0) {
+                // eof
+                break;
+            }
+
+            blockSize = (size_t)status;
+
+            if(inBlockOffset + curSize > blockSize) {
+                curSize = blockSize - inBlockOffset;
+            }
+
+            if(curSize == 0) {
+                // eof
+                break;
+            }
+
+            // copy
+            memcpy(buf + readSize, blockBuffer + inBlockOffset, curSize);
+
+            readSize += curSize;
+            remain -= curSize;
+            curOffset += curSize;
+
+            if(blockSize < getBufferCacheBlockSize()) {
+                // eof
+                break;
+            }
+        }
+        
+        pthread_mutex_unlock(&g_PreloadLock);
+        free(blockBuffer);
+        return readSize;
+    }
+    
+    // no preloaded data
+    pthread_mutex_unlock(&g_PreloadLock);
+    
+    free(blockBuffer);
+    
+    status = iFuseBufferedFsRead(iFuseFd, buf, off, size);
+    if (status < 0) {
+        iFuseRodsClientLogError(LOG_ERROR, status, "iFusePreloadRead: iFuseBufferedFsRead of %s error, status = %d",
+                iFuseFd->iRodsPath, status);
+        return -ENOENT;
+    }
+    
+    return status;
+}

--- a/iRODS/clients/fuse/src/iFuse.Preload.cpp
+++ b/iRODS/clients/fuse/src/iFuse.Preload.cpp
@@ -493,9 +493,11 @@ int iFusePreloadOpen(const char *iRodsPath, iFuseFd_t **iFuseFd, int openFlag) {
         iFusePreload->fdId = (*iFuseFd)->fdId;
         iFusePreload->iRodsPath = strdup(iRodsPath);
 
-        // start preload thread
-        for(i=0;i<IFUSE_PRELOAD_PBLOCK_NUM;i++) {
-            _startPreload(iFusePreload, i, NULL);
+        // start preload thread - only when the file is opened for read
+        if((openFlag & O_ACCMODE) == O_RDONLY || (openFlag & O_ACCMODE) == O_RDWR) {
+            for(i=0;i<IFUSE_PRELOAD_PBLOCK_NUM;i++) {
+                _startPreload(iFusePreload, i, NULL);
+            }
         }
         
         pthread_mutex_lock(&g_PreloadLock);

--- a/iRODS/clients/fuse/src/iFuseCmdLineOpt.cpp
+++ b/iRODS/clients/fuse/src/iFuseCmdLineOpt.cpp
@@ -20,6 +20,7 @@ void iFuseCmdOptsInit() {
     bzero(&g_Opt, sizeof(iFuseOpt_t));
 
     g_Opt.bufferedFS = true;
+    g_Opt.preload = true;
     g_Opt.maxConn = IFUSE_MAX_NUM_CONN;
     g_Opt.connTimeoutSec = IFUSE_FREE_CONN_TIMEOUT_SEC;
     g_Opt.connKeepAliveSec = IFUSE_FREE_CONN_KEEPALIVE_SEC;
@@ -73,6 +74,10 @@ void iFuseCmdOptsParse(int argc, char **argv) {
     for(i=0;i<argc;i++) {
         if(strcmp("-onocache", argv[i]) == 0) {
             g_Opt.bufferedFS = false;
+            g_Opt.preload = false;
+            argv[i] = "-Z";
+        } else if(strcmp("-onopreload", argv[i]) == 0) {
+            g_Opt.preload = false;
             argv[i] = "-Z";
         } else if(strcmp("-omaxconn", argv[i]) == 0) {
             if(argc > i+1) {

--- a/iRODS/clients/fuse/src/iFuseOper.cpp
+++ b/iRODS/clients/fuse/src/iFuseOper.cpp
@@ -185,6 +185,13 @@ int iFuseFlush(const char *path, struct fuse_file_info *fi) {
                     "iFuseFlush: cannot flush file content for %s error", iRodsPath);
             return -ENOENT;
         }
+    } else {
+        status = iFuseFsFlush(iFuseFd);
+        if (status < 0) {
+            iFuseRodsClientLogError(LOG_ERROR, status, 
+                    "iFuseFlush: cannot flush file content for %s error", iRodsPath);
+            return -ENOENT;
+        }
     }
     
     return status;
@@ -213,6 +220,13 @@ int iFuseFsync(const char *path, int isdatasync, struct fuse_file_info *fi) {
     
     if(iFuseLibGetOption()->bufferedFS) {
         status = iFuseBufferedFsFlush(iFuseFd);
+        if (status < 0) {
+            iFuseRodsClientLogError(LOG_ERROR, status, 
+                    "iFuseFsync: cannot flush file content for %s error", iRodsPath);
+            return -ENOENT;
+        }
+    } else {
+        status = iFuseFsFlush(iFuseFd);
         if (status < 0) {
             iFuseRodsClientLogError(LOG_ERROR, status, 
                     "iFuseFsync: cannot flush file content for %s error", iRodsPath);

--- a/iRODS/clients/fuse/src/irodsFs.cpp
+++ b/iRODS/clients/fuse/src/irodsFs.cpp
@@ -89,6 +89,7 @@ int main(int argc, char **argv) {
     iFuseLibSetOption(&myiFuseOpt);
 
     iFuseGenCmdLineForFuse(&fuse_argc, &fuse_argv);
+    iFuseRodsClientLog(LOG_DEBUG, "main: iRods Fuse gets started.");
     status = fuse_main(fuse_argc, fuse_argv, &irodsOper, NULL);
     iFuseReleaseCmdLineForFuse(fuse_argc, fuse_argv);
 


### PR DESCRIPTION
Introduce "preload" which reads ahead for better file read performance.
Remove unnecessary seek operations at file read and write.
Reorganize locks to allow concurrent file accesses.
Fix potential memory access to a freed memory.