### PR TITLE
Handle unreachable iCAT or invalid irods environment configuration

### DIFF
--- a/iRODS/clients/fuse/include/iFuse.Lib.Conn.hpp
+++ b/iRODS/clients/fuse/include/iFuse.Lib.Conn.hpp
@@ -40,6 +40,7 @@ typedef struct IFuseConn {
  * - iFuseConnDestroy
  */
 
+int iFuseConnTest();
 void iFuseConnInit();
 void iFuseConnDestroy();
 int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType);

--- a/iRODS/clients/fuse/include/iFuse.Lib.hpp
+++ b/iRODS/clients/fuse/include/iFuse.Lib.hpp
@@ -16,6 +16,7 @@ typedef struct IFuseExtendedOpt {
 typedef struct IFuseOpt {
     char *program;
     bool debug;
+    bool nonempty;
     bool foreground;
     bool bufferedFS;
     bool preload;

--- a/iRODS/clients/fuse/src/iFuseCmdLineOpt.cpp
+++ b/iRODS/clients/fuse/src/iFuseCmdLineOpt.cpp
@@ -122,6 +122,11 @@ void iFuseCmdOptsParse(int argc, char **argv) {
                         fprintf(stderr, "use_ino fuse option not supported, ignoring\n");
                         break;
                     }
+                    if (!strcmp("nonempty", optarg)) {
+                        // fuse nonempty option
+                        g_Opt.nonempty = true;
+                        break;
+                    }
                     bzero(buff, MAX_NAME_LEN);
                     sprintf(buff, "-o%s", optarg);
                     iFuseCmdOptsAdd(buff);
@@ -230,6 +235,15 @@ void iFuseGenCmdLineForFuse(int *fuse_argc, char ***fuse_argv) {
 
         if(g_Opt.debug) {
             fprintf(stdout, "foreground : %d\n", g_Opt.foreground);
+        }
+    }
+    
+    if(g_Opt.nonempty) {
+        argv[i] = strdup("-nonempty");
+        i++;
+
+        if(g_Opt.debug) {
+            fprintf(stdout, "nonempty : %d\n", g_Opt.nonempty);
         }
     }
 

--- a/iRODS/clients/fuse/src/irodsFs.cpp
+++ b/iRODS/clients/fuse/src/irodsFs.cpp
@@ -147,6 +147,11 @@ static int checkMountPoint(char *mountPoint, bool nonempty) {
     char cwd[MAX_NAME_LEN];
     char mpath[MAX_NAME_LEN];
     char mpathabs[MAX_NAME_LEN];
+
+    if(mountPoint == NULL || strlen(mountPoint) == 0) {
+        fprintf(stderr, "Mount point is not given\n");
+        return -1;
+    }
     
     if(getcwd(cwd, sizeof(cwd)) != NULL) {
         if(mountPoint[0] == '/') {


### PR DESCRIPTION
This handles unreachable iCAT or invalid irods environment configuration by making a test connection before iRODS FUSE starts FUSE client routine.

Incorrect configuration or unreachable iCAT host will cause iRODS FUSE to terminate immediately with error messages.
