### PR TITLE
Add "unmount" option to documentation of msiPhyPathReg

### DIFF
--- a/iRODS/server/re/src/reDataObjOpr.cpp
+++ b/iRODS/server/re/src/reDataObjOpr.cpp
@@ -2066,7 +2066,8 @@ msiRmColl( msParam_t *inpParam1, msParam_t *msKeyValStr, msParam_t *outParam, ru
  *    indicates the path is a directory. A "null" string indicates the path
  *    is a file.  A "mountPoint" (MOUNT_POINT_STR) means mounting the file
  *      directory given in inpParam3. A "linkPoint" (LINK_POINT_STR)
- *      means soft link the collection given in inpParam3.
+ *      means soft link the collection given in inpParam3. A "unmount" (UNMOUNT_STR)
+ *      means unmount the collection.
  * \param[out] outParam - a INT_MS_T containing the status.
  * \param[in,out] rei - The RuleExecInfo structure that is automatically
  *    handled by the rule engine. The user does not include rei as a


### PR DESCRIPTION
[This line of documentation](https://wiki.irods.org/doxygen/re_data_obj_opr_8c_a237b48cd51c8b8feb50b47e9549e9dd3.html#a237b48cd51c8b8feb50b47e9549e9dd3) was present in 3.3.1 but probably fell off somewhere.

The functionality is still there. This just re adds the documentation.


