### PR TITLE
Oracle home fixes

### DIFF
--- a/iRODS/config/config.mk.in
+++ b/iRODS/config/config.mk.in
@@ -29,7 +29,6 @@
 #
 #	MYSQL_HOME	The home directory of MySQL
 #
-#	ORACLE_HOME	The home directory of Oracle
 #
 
 #RELEASE_FLAG=1
@@ -38,7 +37,6 @@ FILE_64BITS=1
 #RODS_CAT=1
 POSTGRES_HOME=
 MYSQL_HOME=
-ORACLE_HOME=
 
 IRODS_BUILD_DIR=
 CPU_COUNT=

--- a/plugins/database/packaging/find_oracle_include.sh
+++ b/plugins/database/packaging/find_oracle_include.sh
@@ -4,7 +4,7 @@ if [ ${ORACLE_HOME} ] ; then
     oci=`find $ORACLE_HOME -name "oci.h"`
     if [ ! -z ${oci} ] ; then
         if [ -e ${oci} ] ; then
-            echo ${ORACLE_HOME}
+            dirname $oci
 	    else
 		echo "/usr/include/oracle/11.2/client64"
 	    fi


### PR DESCRIPTION
Using the Oracle Instant Client, we encountered two issues, which this pull request addresses.

`iRODS/config/config.mk.in` has a default empty value for ORACLE_HOME:

```
ORACLE_HOME=
```

and `packaging/build.sh` copies this to config.mk, but does not set the ORACLE_HOME from the environment variable. This means that anything that sources `config.mk`, like `plugins/database/Makefile` has its ORACLE_HOME erased before calling `plugins/database/oracle/Makefile` and the scripts in `plugins/database/packaging/find_oracle*`, so the value can never be used. This means Oracle plugin builds fail unless your client libraries and includes are in the default locations of `/usr/lib/oracle/11.2/client64` and `/usr/include/oracle/11.2/client64`

While it should be possible to add to `packaging/build.sh` to copy the ORACLE_HOME value in, it seems cleaner to just remove the null value from the template, so that's what's done here. 

The second issue was that the instant client provides the header files in `sdk/include`, and so returning a valid ORACLE_HOME is not helpful. Thankfully `find_oracle_include.sh` already does a `find` to locate `oci.h` inside ORACLE_HOME, so we can return `dirname $oci` which will always point to the right directory.
