### PR TITLE
Fixed libodbc detection on Solaris for build

### DIFF
--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -855,7 +855,7 @@ else
 fi
 
 if [ "$DETECTEDOS" == "Solaris" ] ; then
-    UNIXODBC=`ld --verbose --library odbc 2> /dev/null | sed --quiet 's/^attempt to open \(.*\) succeeded$/\1/p'`
+    UNIXODBC=`ld --verbose --library odbc -o/dev/null 2> /dev/null | sed --quiet 's/^attempt to open \(.*\) succeeded$/\1/p'`
 else
     UNIXODBC=`/sbin/ldconfig -p 2> /dev/null | grep libodbc\.so`
 fi

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -854,7 +854,12 @@ else
     GREPCMD="grep"
 fi
 
-UNIXODBC=`/sbin/ldconfig -p 2> /dev/null | grep libodbc\.so`
+if [ "$DETECTEDOS" == "Solaris" ] ; then
+    UNIXODBC=`ld --verbose --library odbc 2> /dev/null | sed --quiet 's/^attempt to open \(.*\) succeeded$/\1/p'`
+else
+    UNIXODBC=`/sbin/ldconfig -p 2> /dev/null | grep libodbc\.so`
+fi
+
 if [ "$?" != "0" ] ; then
     if [ "$DETECTEDOS" == "Ubuntu" -o "$DETECTEDOS" == "Debian" ] ; then
         PREFLIGHT="$PREFLIGHT unixodbc"


### PR DESCRIPTION
Solaris doesn't use `ldconfig`, so `ld` needs to be used directly.
