### PR TITLE
Ensure that oracle include directory can be found

### DIFF
--- a/plugins/database/packaging/find_oracle_include.sh
+++ b/plugins/database/packaging/find_oracle_include.sh
@@ -4,7 +4,7 @@ if [ ${ORACLE_HOME} ] ; then
     oci=`find $ORACLE_HOME -name "oci.h"`
     if [ ! -z ${oci} ] ; then
         if [ -e ${oci} ] ; then
-            echo ${ORACLE_HOME}
+            dirname $oci
 	    else
 		echo "/usr/include/oracle/11.2/client64"
 	    fi

--- a/plugins/database/packaging/irods_database_plugin_mysql.list.template
+++ b/plugins/database/packaging/irods_database_plugin_mysql.list.template
@@ -69,14 +69,6 @@ $IRODS_HOME=$IRODS_HOME_DIR/iRODS
 # preinstall
 # =-=-=-=-=-=-=-
 %preinstall << END_PREINSTALL
-REQUIRED_VERSION="4.1.8"
-DETECTED_VERSION=`python -c 'import json; print json.loads(open("/var/lib/irods/VERSION.json").read())["irods_version"]'`
-if [ "$$DETECTED_VERSION" != "$$REQUIRED_VERSION" ] ; then
-    echo "Local iRODS is $$DETECTED_VERSION"
-    echo "This plugin requires iRODS $$REQUIRED_VERSION"
-    exit 1
-fi
-
 # determine whether this is an upgrade
 if [ "$$1" -eq "$$1" ] 2>/dev/null ; then
   # integer, therefore rpm

--- a/plugins/database/packaging/irods_database_plugin_oracle.list.template
+++ b/plugins/database/packaging/irods_database_plugin_oracle.list.template
@@ -61,14 +61,6 @@ $IRODS_HOME=$IRODS_HOME_DIR/iRODS
 # preinstall
 # =-=-=-=-=-=-=-
 %preinstall << END_PREINSTALL
-REQUIRED_VERSION="4.1.8"
-DETECTED_VERSION=`python -c 'import json; print json.loads(open("/var/lib/irods/VERSION.json").read())["irods_version"]'`
-if [ "$$DETECTED_VERSION" != "$$REQUIRED_VERSION" ] ; then
-    echo "Local iRODS is $$DETECTED_VERSION"
-    echo "This plugin requires iRODS $$REQUIRED_VERSION"
-    exit 1
-fi
-
 # determine whether this is an upgrade
 if [ "$$1" -eq "$$1" ] 2>/dev/null ; then
   # integer, therefore rpm

--- a/plugins/database/packaging/irods_database_plugin_postgres.list.template
+++ b/plugins/database/packaging/irods_database_plugin_postgres.list.template
@@ -74,14 +74,6 @@ $IRODS_HOME=$IRODS_HOME_DIR/iRODS
 # preinstall
 # =-=-=-=-=-=-=-
 %preinstall << END_PREINSTALL
-REQUIRED_VERSION="4.1.8"
-DETECTED_VERSION=`python -c 'import json; print json.loads(open("/var/lib/irods/VERSION.json").read())["irods_version"]'`
-if [ "$$DETECTED_VERSION" != "$$REQUIRED_VERSION" ] ; then
-    echo "Local iRODS is $$DETECTED_VERSION"
-    echo "This plugin requires iRODS $$REQUIRED_VERSION"
-    exit 1
-fi
-
 # determine whether this is an upgrade
 if [ "$$1" -eq "$$1" ] 2>/dev/null ; then
   # integer, therefore rpm


### PR DESCRIPTION
This is a version of https://github.com/irods/irods/pull/3037 for 4-1-stable instead of master. 

In this branch, ORACLE_HOME is not set to an empty value unless there is no environment variable, so that modification isn't needed. Instead, have just included the chance to `find_oracle_include.sh`

For the Oracle instant client, the library changes mentioned in https://github.com/irods/irods/issues/3038 still need to happen before the build succeeds