### PR TITLE
Remove unnecessary linker prerequisites

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,7 +405,6 @@ target_link_libraries(
   ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
   ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_thread.so
   ${IRODS_EXTERNALS_FULLPATH_JANSSON}/lib/libjansson.so
-  ${IRODS_EXTERNALS_FULLPATH_ZMQ}/lib/libzmq.so
   ${OPENSSL_SSL_LIBRARY}
   ${OPENSSL_CRYPTO_LIBRARY}
   )

--- a/plugins/network/CMakeLists.txt
+++ b/plugins/network/CMakeLists.txt
@@ -75,7 +75,6 @@ foreach(PLUGIN ${IRODS_NETWORK_PLUGINS})
       irods_common
       ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so
       ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
-      ${IRODS_EXTERNALS_FULLPATH_ARCHIVE}/lib/libarchive.so
       ${OPENSSL_CRYPTO_LIBRARY}
       ${OPENSSL_SSL_LIBRARY}
       )


### PR DESCRIPTION
Building only client-side code currently requires _libzmq_ and _libarchive_ to be installed, which is unnecessary as the code does not use these libraries' facilities at all.  This PR removes these unnecessary libraries.

There are probably others, but this suffices to build the iRODS CMake targets needed for my third-party client development without requiring excess system libraries to be installed.  It remains undocumented what CMake targets are actually needed for various purposes (cf #3228), but for now I have been building with `make irods_client irods_plugin_dependencies irods_common tcp_client native_client`.

In general many of the CMakeLists have overly-conservative `target_link_libraries` that list lots of link libraries that are unused by the particular targets.  Part of the problem is the use of loops over the targets — for example, in _plugins/network/CMakeLists.txt_ presumably the `tcp` transports do not use _crypto_ or _ssl_ libraries at all, but because they are in a loop that defines the `ssl` transport's requirements, they get them too.

These things should really be written out with individual targets' actual individual requirements rather than using loops and getting supersets of the real requirements.