### PR TITLE
Fixed issue in irods::configuration_parser::convert_json

### DIFF
--- a/lib/core/src/irods_configuration_parser.cpp
+++ b/lib/core/src/irods_configuration_parser.cpp
@@ -127,8 +127,10 @@ namespace irods {
             return boost::any(json_real_value(_val));
 
             case JSON_TRUE:
+            return boost::any(json_true());
+            
             case JSON_FALSE:
-            return boost::any(json_boolean( _val ));
+            return boost::any(json_false());
 
             case JSON_NULL:
             return boost::any(std::string("NULL"));


### PR DESCRIPTION
Booleans in JSON config were always returning true.

http://jansson.readthedocs.io/en/2.7/apiref.html#c.json_boolean

JSON_TRUE and JSON_FALSE will both evaluate to `json_t*` with JSON_TRUE type if passed directly to `json_boolean()` macro.