### PR TITLE
[#3575] type ascription

### DIFF
--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/functions.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/functions.cpp
@@ -1163,13 +1163,13 @@ Res *smsi_tuple( Node** params, int n, Node*, ruleExecInfo_t*, int, Env*, rError
     }
     return res;
 }
-Res *smsi_elem( Node** params, int, Node*, ruleExecInfo_t*, int, Env*, rError_t* errmsg, Region* r ) {
+Res *smsi_elem( Node** params, int, Node* node, ruleExecInfo_t*, int, Env*, rError_t* errmsg, Region* r ) {
     char errbuf[ERR_MSG_LEN];
     int index = RES_INT_VAL( params[1] );
     if ( TYPE( params[0] ) == T_CONS ) {
         if ( index < 0 || index >= params[0]->degree ) {
             snprintf( errbuf, ERR_MSG_LEN, "error: index out of range %d.", index );
-            addRErrorMsg( errmsg, RE_RUNTIME_ERROR, errbuf );
+            generateAndAddErrMsg( errbuf, node, RE_RUNTIME_ERROR, errmsg );
             return newErrorRes( r, RE_RUNTIME_ERROR );
         }
         Res *res = params[0]->subtrees[index];
@@ -1179,7 +1179,7 @@ Res *smsi_elem( Node** params, int, Node*, ruleExecInfo_t*, int, Env*, rError_t*
         if ( index < 0 || index >= getCollectionSize( params[0]->exprType->text,
                 RES_UNINTER_STRUCT( params[0] ) ) ) {
             snprintf( errbuf, ERR_MSG_LEN, "error: index out of range %d. %s", index, ( ( Res * )params[0] )->exprType->text );
-            addRErrorMsg( errmsg, RE_RUNTIME_ERROR, errbuf );
+            generateAndAddErrMsg( errbuf, node, RE_RUNTIME_ERROR, errmsg );
             return newErrorRes( r, RE_RUNTIME_ERROR );
         }
         Res *res2 = getValueFromCollection( params[0]->exprType->text,

--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/functions.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/functions.cpp
@@ -147,7 +147,7 @@ Node *wrapToActions( Node* node, Region* r ) {
     return node;
 }
 Res *smsi_ifExec( Node** params, int, Node*, ruleExecInfo_t* rei, int reiSaveFlag, Env* env, rError_t* errmsg, Region* r ) {
-    Res *res = evaluateExpression3( ( Node * )params[0], 0, 1, rei, reiSaveFlag, env, errmsg, r );
+    Res *res = evaluateExpression3( ( Node * )params[0], 0, 1, rei, reiSaveFlag & ~DISCARD_EXPRESSION_RESULT, env, errmsg, r );
     if ( getNodeType( res ) == N_ERROR ) {
         return res;
     }
@@ -160,7 +160,7 @@ Res *smsi_ifExec( Node** params, int, Node*, ruleExecInfo_t* rei, int reiSaveFla
 }
 
 Res *smsi_if2Exec( Node** params, int, Node*, ruleExecInfo_t* rei, int reiSaveFlag, Env* env, rError_t* errmsg, Region* r ) {
-    Res *res = evaluateExpression3( ( Node * )params[0], 0, 1, rei, reiSaveFlag, env, errmsg, r );
+    Res *res = evaluateExpression3( ( Node * )params[0], 0, 1, rei, reiSaveFlag & ~DISCARD_EXPRESSION_RESULT, env, errmsg, r );
     if ( getNodeType( res ) == N_ERROR ) {
         return res;
     }
@@ -182,7 +182,7 @@ Res *smsi_do( Node** params, int, Node*, ruleExecInfo_t* rei, int reiSaveFlag, E
 
 }
 Res *smsi_letExec( Node** params, int, Node*, ruleExecInfo_t* rei, int reiSaveFlag, Env* env, rError_t* errmsg, Region* r ) {
-    Res *res = evaluateExpression3( params[1], 0, 1, rei, reiSaveFlag, env, errmsg, r );
+    Res *res = evaluateExpression3( params[1], 0, 1, rei, reiSaveFlag & ~DISCARD_EXPRESSION_RESULT, env, errmsg, r );
     if ( getNodeType( res ) == N_ERROR ) {
         return res;
     }
@@ -198,7 +198,7 @@ Res *smsi_letExec( Node** params, int, Node*, ruleExecInfo_t* rei, int reiSaveFl
     return res;
 }
 Res *smsi_matchExec( Node** params, int n, Node* node, ruleExecInfo_t* rei, int reiSaveFlag, Env* env, rError_t* errmsg, Region* r ) {
-    Res *res = evaluateExpression3( params[0], 0, 1, rei, reiSaveFlag, env, errmsg, r );
+    Res *res = evaluateExpression3( params[0], 0, 1, rei, reiSaveFlag & ~DISCARD_EXPRESSION_RESULT, env, errmsg, r );
     if ( getNodeType( res ) == N_ERROR ) {
         return res;
     }
@@ -226,7 +226,7 @@ Res *smsi_whileExec( Node** params, int, Node*, ruleExecInfo_t* rei, int reiSave
     GC_BEGIN
     while ( 1 ) {
 
-        cond = evaluateExpression3( ( Node * )params[0], 0, 1, rei, reiSaveFlag, env, errmsg, GC_REGION );
+        cond = evaluateExpression3( ( Node * )params[0], 0, 1, rei, reiSaveFlag & ~DISCARD_EXPRESSION_RESULT, env, errmsg, GC_REGION );
         if ( getNodeType( cond ) == N_ERROR ) {
             res = cond;
             break;
@@ -260,7 +260,7 @@ Res *smsi_forExec( Node** params, int, Node*, ruleExecInfo_t* rei, int reiSaveFl
 
     Res *init, *cond, *res = NULL, *step;
     Region* rnew = make_region( 0, NULL );
-    init = evaluateExpression3( ( Node * )params[0], 0, 1, rei, reiSaveFlag, env, errmsg, rnew );
+    init = evaluateExpression3( ( Node * )params[0], 0, 1, rei, reiSaveFlag | DISCARD_EXPRESSION_RESULT, env, errmsg, rnew );
     if ( getNodeType( init ) == N_ERROR ) {
         res = init;
         cpEnv( env, r );
@@ -271,7 +271,7 @@ Res *smsi_forExec( Node** params, int, Node*, ruleExecInfo_t* rei, int reiSaveFl
     GC_BEGIN
     while ( 1 ) {
 
-        cond = evaluateExpression3( ( Node * )params[1], 0, 1, rei, reiSaveFlag, env, errmsg, GC_REGION );
+        cond = evaluateExpression3( ( Node * )params[1], 0, 1, rei, reiSaveFlag & ~DISCARD_EXPRESSION_RESULT, env, errmsg, GC_REGION );
         if ( getNodeType( cond ) == N_ERROR ) {
             res = cond;
             break;
@@ -292,7 +292,7 @@ Res *smsi_forExec( Node** params, int, Node*, ruleExecInfo_t* rei, int reiSaveFl
         else if ( TYPE( res ) == T_SUCCESS ) {
             break;
         }
-        step = evaluateExpression3( ( Node * )params[2], 0, 1, rei, reiSaveFlag, env, errmsg, GC_REGION );
+        step = evaluateExpression3( ( Node * )params[2], 0, 1, rei, reiSaveFlag & DISCARD_EXPRESSION_RESULT, env, errmsg, GC_REGION );
         if ( getNodeType( step ) == N_ERROR ) {
             res = step;
             break;
@@ -826,7 +826,7 @@ Res *smsi_query( Node** subtrees, int, Node* node, ruleExecInfo_t* rei, int reiS
                 Node* node = subQueNode->subtrees[k];
 
                 /* Make the condition */
-                res0 = evaluateExpression3( node->subtrees[0], 0, 0, rei, reiSaveFlag, env, errmsg, r );
+                res0 = evaluateExpression3( node->subtrees[0], 0, 0, rei, reiSaveFlag & ~DISCARD_EXPRESSION_RESULT, env, errmsg, r );
                 if ( getNodeType( res0 ) == N_ERROR ) {
                     deleteHashTable( queCondHashTable, nop );
                     return res0;
@@ -848,7 +848,7 @@ Res *smsi_query( Node** subtrees, int, Node* node, ruleExecInfo_t* rei, int reiS
                 free( value0 );
 
                 if ( strcmp( node->text, "between" ) == 0 ) {
-                    res1 = evaluateExpression3( node->subtrees[1], 0, 0, rei, reiSaveFlag, env, errmsg, r );
+                    res1 = evaluateExpression3( node->subtrees[1], 0, 0, rei, reiSaveFlag & ~DISCARD_EXPRESSION_RESULT, env, errmsg, r );
                     if ( getNodeType( res1 ) == N_ERROR ) {
                         deleteHashTable( queCondHashTable, nop );
                         return res1;
@@ -932,7 +932,7 @@ Res *smsi_assign( Node** subtrees, int, Node*, ruleExecInfo_t* rei, int reiSaveF
 
     /* An smsi shares the same env as the enclosing rule. */
     /* Therefore, our modification to the env is reflected to the enclosing rule automatically. */
-    Res *val = evaluateExpression3( ( Node * )subtrees[1], 0, 1, rei, reiSaveFlag,  env, errmsg, r );
+    Res *val = evaluateExpression3( ( Node * )subtrees[1], 0, 1, rei, reiSaveFlag & ~DISCARD_EXPRESSION_RESULT,  env, errmsg, r );
     if ( getNodeType( val ) == N_ERROR ) {
         return val;
     }
@@ -965,7 +965,7 @@ Res *smsi_getValByKey( Node** params, int, Node* node, ruleExecInfo_t* rei, int 
         key = N_APP_FUNC( params[1] )->text;
     }
     else {
-        res = evaluateExpression3( params[1], 0, 1, rei, reiSaveFlag, env, errmsg, r );
+        res = evaluateExpression3( params[1], 0, 1, rei, reiSaveFlag & ~DISCARD_EXPRESSION_RESULT, env, errmsg, r );
         if ( TYPE( res ) != T_STRING ) {
             snprintf( errbuf, ERR_MSG_LEN, "malformatted key" );
             generateAndAddErrMsg( errbuf, params[1], UNMATCHED_KEY_OR_INDEX, errmsg );
@@ -2242,7 +2242,7 @@ Res *smsi_getstderr( Node** paramsr, int, Node* node, ruleExecInfo_t* rei, int r
 }
 
 Res *smsi_assignStr( Node** subtrees, int, Node* node, ruleExecInfo_t* rei, int reiSaveFlag, Env* env, rError_t* errmsg, Region* r ) {
-    Res *val = evaluateExpression3( ( Node * )subtrees[1], 0, 1, rei, reiSaveFlag,  env, errmsg, r );
+    Res *val = evaluateExpression3( ( Node * )subtrees[1], 0, 1, rei, reiSaveFlag & ~DISCARD_EXPRESSION_RESULT,  env, errmsg, r );
     if ( getNodeType( val ) == N_ERROR ) {
         return val;
     }

--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/include/restructs.hpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/include/restructs.hpp
@@ -89,6 +89,9 @@
 #define getIOType(n) ((n)->option & OPTION_IO_TYPE_MASK)
 #define setIOType(n, v) (n)->option ^= ((n)->option & OPTION_IO_TYPE_MASK) ^ (v);
 
+#define SYSTEM_SPACE_RULE 0x100
+#define DISCARD_EXPRESSION_RESULT 0x200
+
 typedef struct node Node;
 typedef struct node ExprType;
 typedef struct node Res;

--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/parser.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/parser.cpp
@@ -1263,6 +1263,11 @@ if ( !done ) {
     break;
 }
 END_TRY(term0)
+OPTIONAL_BEGIN(typeascription)
+    TTEXT(":");
+    NT2(_Type, 0, 0);
+    BUILD_NODE( N_EXTERN_DEF, "EXTERN", &start, 2, 2 );
+OPTIONAL_END(typeascription)
 PARSER_FUNC_END( Term )
 
 PARSER_FUNC_BEGIN1( StringExpression, Token *tk )

--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/typing.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/typing.cpp
@@ -241,6 +241,7 @@ Satisfiability simplifyR( ExprType *a, ExprType *b, int flex, Node *node, Hashta
         if ( bn == b ) {
             return TAUTOLOGY;
         }
+//        insertIntoHashTable( typingEnv, b->text, bn );
         return createSimpleConstraint( a, bn, flex, node, typingEnv, equivalence, simpleTypingConstraints, r );
     }
 }
@@ -275,6 +276,7 @@ Satisfiability simplifyL( ExprType *a, ExprType *b, int flex, Node *node, Hashta
         if ( an == a ) {
             return TAUTOLOGY;
         }
+//        insertIntoHashTable( typingEnv, a->text, an );
         return createSimpleConstraint( an, b, flex, node, typingEnv, equivalence, simpleTypingConstraints, r );
     }
 

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -460,6 +460,44 @@ class Test_AllRules(resource_suite.ResourceBase, unittest.TestCase):
     def test_str_2528(self):
         self.rods_session.assert_icommand('''irule "*a.a = 'A'; *a.b = 'B'; writeLine('stdout', str(*a))" null ruleExecOut''', 'STDOUT_SINGLELINE', "a=A++++b=B")
 
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for irods_rule_language REP')
+    def test_type_3575(self):
+        rule_file = "test_rule_file.r"
+        rule_string = '''
+main{
+  *a:string;
+  *a="0";
+  func1(*a);
+  *a == "-1";
+  int(*a);
+}
+func1(*i) {
+}
+input null
+output ruleExecOut
+'''
+        with open(rule_file, 'wt') as f:
+            print(rule_string, file=f, end='')
+
+        self.admin.assert_icommand('irule -F ' + rule_file)
+
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for irods_rule_language REP')
+    def test_pattern_3575(self):
+        rule_file = "test_rule_file.r"
+        rule_string = '''
+main {
+  *a."a" = "a";
+  asdf("a");
+}
+asdf(*a) {}
+input null
+output ruleExecOut
+'''
+        with open(rule_file, 'wt') as f:
+            print(rule_string, file=f, end='')
+
+        self.admin.assert_icommand('irule -F ' + rule_file)
+
     @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'msiGetStderrInExecCmdOut not available in Python yet - RTS')
     def test_return_data_structure_non_null_2604(self):
         self.rods_session.assert_icommand(


### PR DESCRIPTION
This add a feature to the rule language that allows specifying the type of an expression to avoid the type checker from using the default type that may cause type errors.