### PR TITLE
[#3679] Fix dereference of null pointer in packStruct

### DIFF
--- a/lib/core/src/packStruct.cpp
+++ b/lib/core/src/packStruct.cpp
@@ -42,12 +42,13 @@ packStruct( const void *inStruct, bytesBuf_t **packedResult, const char *packIns
 
     if ( irodsProt == XML_PROT ) {
         void *outPtr;
-        /* add a NULL termination */
-        extendPackedOutput( packedOutput, 1, outPtr );
-        *static_cast<char*>(outPtr) = '\0';
-        if ( getRodsLogLevel() >= LOG_DEBUG9 ) {
-            printf( "packed XML: \n%s\n", ( char * ) packedOutput.bBuf.buf );
-        }
+        if ( SYS_MALLOC_ERR != extendPackedOutput( packedOutput, 1, outPtr ) ) {
+            /* add a NULL termination */
+            *static_cast<char*>(outPtr) = '\0';
+            if ( getRodsLogLevel() >= LOG_DEBUG9 ) {
+                printf( "packed XML: \n%s\n", ( char * ) packedOutput.bBuf.buf );
+                }
+            }
     }
 
     *packedResult = (bytesBuf_t*)malloc(sizeof(**packedResult));

--- a/lib/core/src/packStruct.cpp
+++ b/lib/core/src/packStruct.cpp
@@ -1910,6 +1910,7 @@ unpackXmlString( const void *&inPtr, packedOutput_t &unpackedOutput, int maxStrL
         return origStrLen;
     }
 
+    int extLen = maxStrLen;
     char* strBuf;
     myStrlen = xmlStrToStr( ( const char * )inPtr, origStrLen, strBuf );
 
@@ -1918,19 +1919,18 @@ unpackXmlString( const void *&inPtr, packedOutput_t &unpackedOutput, int maxStrL
             return USER_PACKSTRUCT_INPUT_ERR;
         }
         else {
-            extendPackedOutput( unpackedOutput, myStrlen, outPtr );
+            extLen = myStrlen;
         }
     }
-    else {
-        extendPackedOutput( unpackedOutput, maxStrLen, outPtr );
-    }
 
-    if ( myStrlen > 0 ) {
-        strncpy( static_cast<char*>(outPtr), strBuf, myStrlen );
-        outStr = static_cast<char*>(outPtr);
-        outPtr = static_cast<char*>(outPtr) + myStrlen;
+    if ( SYS_MALLOC_ERR != extendPackedOutput( unpackedOutput, extLen, outPtr ) ) {
+        if ( myStrlen > 0 ) {
+            strncpy( static_cast<char*>(outPtr), strBuf, myStrlen );
+            outStr = static_cast<char*>(outPtr);
+            outPtr = static_cast<char*>(outPtr) + myStrlen;
+        }
+        *static_cast<char*>(outPtr) = '\0';
     }
-    *static_cast<char*>(outPtr) = '\0';
     free(strBuf);
 
     inPtr = static_cast<const char*>(inPtr) + ( origStrLen + 1 );


### PR DESCRIPTION
When null-terminating the outPtr of extendPackedOutput, outPtr is
dereferenced in a static cast to a char pointer. It is possible for
extendPackedOutput to fail when allocating space for the packedOutput
buffer, and outPtr will be explicitly set to NULL.

This change adds a check for the error code indicating the failure
of extendPackedOutput before null-terminating outPtr. Failure now
prevents the "packed XML" log message because the packedOutput
buffer will be NULL in the event of failure as well.