### PR TITLE
[#3679] Add null pointer checks in a few files

### DIFF
--- a/plugins/network/ssl/libssl.cpp
+++ b/plugins/network/ssl/libssl.cpp
@@ -1056,7 +1056,7 @@ irods::error ssl_send_rods_msg(
                 // =-=-=-=-=-=-=-
                 // send the message buffer
                 int bytes_written = 0;
-                if ( _msg_buf != NULL &&
+                if ( NULL != _msg_buf &&
                         msg_header.msgLen > 0 ) {
                     if ( XML_PROT == _protocol &&
                             getRodsLogLevel() >= LOG_DEBUG8 ) {
@@ -1070,7 +1070,7 @@ irods::error ssl_send_rods_msg(
 
                     // =-=-=-=-=-=-=-
                     // send the error buffer
-                    if ( _error_buf != NULL &&
+                    if ( NULL != _error_buf &&
                             msg_header.errorLen > 0 ) {
                         if ( XML_PROT == _protocol &&
                                 getRodsLogLevel() >= LOG_DEBUG8 ) {
@@ -1086,7 +1086,7 @@ irods::error ssl_send_rods_msg(
 
                         // =-=-=-=-=-=-=-
                         // send the stream buffer
-                        if ( _stream_bbuf != NULL &&
+                        if ( NULL != _stream_bbuf &&
                                 msg_header.bsLen > 0 ) {
                             if ( XML_PROT == _protocol &&
                                     getRodsLogLevel() >= LOG_DEBUG8 ) {

--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/utils.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/utils.cpp
@@ -819,16 +819,18 @@ const void *lookupFromEnv( Env *env, const char *key ) {
 }
 
 void updateInEnv( Env *env, char *varName, Res *res ) {
-    Env *defined = env;
+    if ( NULL != env ) {
+        Env *defined = env;
 
-    while ( defined  != NULL && lookupFromHashTable( defined->current, varName ) == NULL ) {
-        defined  = defined ->previous;
-    }
-    if ( defined != NULL ) {
-        updateInHashTable( defined->current, varName, res );
-    }
-    else {
-        insertIntoHashTable( env->current, varName, res );
+        while ( NULL != defined && NULL == lookupFromHashTable( defined->current, varName ) ) {
+            defined = defined->previous;
+        }
+        if ( NULL != defined ) {
+            updateInHashTable( defined->current, varName, res );
+        }
+        else {
+            insertIntoHashTable( env->current, varName, res );
+        }
     }
 }
 

--- a/server/api/src/rsCollCreate.cpp
+++ b/server/api/src/rsCollCreate.cpp
@@ -100,13 +100,15 @@ rsCollCreate( rsComm_t *rsComm, collInp_t *collCreateInp ) {
             else if ( status == SYS_SPEC_COLL_OBJ_NOT_EXIST ) {
                 /* for STRUCT_FILE_COLL to make a directory in the structFile, the
                  * COLLECTION_TYPE_KW must be set */
-                if ( dataObjInfo != NULL && dataObjInfo->specColl != NULL &&
-                        dataObjInfo->specColl->collClass == LINKED_COLL ) {
-                    /*  should not be here because if has been translated */
-                    return SYS_COLL_LINK_PATH_ERR;
-                }
-                else {
-                    status = l3Mkdir( rsComm, dataObjInfo );
+                if ( NULL != dataObjInfo ) {
+                    if ( NULL != dataObjInfo->specColl &&
+                         LINKED_COLL == dataObjInfo->specColl->collClass ) {
+                        /*  should not be here because if has been translated */
+                        return SYS_COLL_LINK_PATH_ERR;
+                    }
+                    else {
+                        status = l3Mkdir( rsComm, dataObjInfo );
+                    }
                 }
                 freeDataObjInfo( dataObjInfo );
                 return status;

--- a/server/core/src/dataObjOpr.cpp
+++ b/server/core/src/dataObjOpr.cpp
@@ -1776,22 +1776,21 @@ getDataObjInfoIncSpecColl( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
                 *dataObjInfo = NULL;
             }
         }
-        if ( status2 >= 0 ) {
+        else {
             status = 0;
         }
     }
-    if ( status >= 0 ) {
-        if ( ( *dataObjInfo )->specColl != NULL ) {
-            if ( ( *dataObjInfo )->specColl->collClass == LINKED_COLL ) {
-                /* already been translated */
-                rstrcpy( dataObjInp->objPath, ( *dataObjInfo )->objPath,
-                         MAX_NAME_LEN );
-                free( ( *dataObjInfo )->specColl );
-                ( *dataObjInfo )->specColl = NULL;
-            }
-            else if ( getStructFileType( ( *dataObjInfo )->specColl ) >= 0 ) {
-                dataObjInp->numThreads = NO_THREADING;
-            }
+    if ( status >= 0 &&
+         NULL != dataObjInfo && NULL != ( *dataObjInfo )->specColl ) {
+        if ( LINKED_COLL == ( *dataObjInfo )->specColl->collClass ) {
+            /* already been translated */
+            rstrcpy( dataObjInp->objPath, ( *dataObjInfo )->objPath,
+                     MAX_NAME_LEN );
+            free( ( *dataObjInfo )->specColl );
+            ( *dataObjInfo )->specColl = NULL;
+        }
+        else if ( getStructFileType( ( *dataObjInfo )->specColl ) >= 0 ) {
+            dataObjInp->numThreads = NO_THREADING;
         }
     }
     return status;


### PR DESCRIPTION
All null pointer checks are roughly the same. Grouped together since there were no real logic path changes and so review is a little easier to do.

**In l3Mkdir**:
Fixed situation where dataObjInfo could be null when passed into l3Mkdir. The intention was likely to only call l3Mkdir if specColl was null or colClass == LINKED_COLL, not when dataObjInfo itself is null.

**In updateInEnv:**
updateInEnv takes an Env pointer as argument, and the pointer can be null. Since the entire function depends on env, ensure that it is not null before proceeding with any operations.

**In getDataObjInfoIncSpecColl:**
This change adds a null check before dereferencing dataObjInfo or checking specColl.

Also fixed constants going on the left in change with SHA: eaab3c4549b954d2df701117d8a7b631449998fb