### PR TITLE
[#3679] Fix dereference of null pointer in ssl_send_rods_msg (#1)

### DIFF
--- a/plugins/network/ssl/libssl.cpp
+++ b/plugins/network/ssl/libssl.cpp
@@ -1056,7 +1056,8 @@ irods::error ssl_send_rods_msg(
                 // =-=-=-=-=-=-=-
                 // send the message buffer
                 int bytes_written = 0;
-                if ( msg_header.msgLen > 0 ) {
+                if ( _msg_buf != NULL &&
+                        msg_header.msgLen > 0 ) {
                     if ( XML_PROT == _protocol &&
                             getRodsLogLevel() >= LOG_DEBUG8 ) {
                         printf( "sending msg: \n%s\n", ( char* ) _msg_buf->buf );
@@ -1069,7 +1070,8 @@ irods::error ssl_send_rods_msg(
 
                     // =-=-=-=-=-=-=-
                     // send the error buffer
-                    if ( msg_header.errorLen > 0 ) {
+                    if ( _error_buf != NULL &&
+                            msg_header.errorLen > 0 ) {
                         if ( XML_PROT == _protocol &&
                                 getRodsLogLevel() >= LOG_DEBUG8 ) {
                             printf( "sending msg: \n%s\n", ( char* ) _error_buf->buf );
@@ -1084,7 +1086,8 @@ irods::error ssl_send_rods_msg(
 
                         // =-=-=-=-=-=-=-
                         // send the stream buffer
-                        if ( msg_header.bsLen > 0 ) {
+                        if ( _stream_bbuf != NULL &&
+                                msg_header.bsLen > 0 ) {
                             if ( XML_PROT == _protocol &&
                                     getRodsLogLevel() >= LOG_DEBUG8 ) {
                                 printf( "sending msg: \n%s\n", ( char* ) _stream_bbuf->buf );


### PR DESCRIPTION
_msg_buf, _error_buf, and _stream_bbuf are parameters of the function and are not null-checked before dereferencing when printing to log or when attempting to write to socket.

This change adds the needed null checks to accompany the zero-length buffer checks such that the result returned by the function is the same for either case.

The buffer lengths "should" never be non-zero when _msg_buf, _error_buf, and _stream_bbuf are null, so the null pointer dereferences "should" never happen. This adds an extra layer of protection.

(cherry-picked from SHA: eaab3c4549b954d2df701117d8a7b631449998fb)