### PR TITLE
[#3701] Fix missing frees on early returns

### DIFF
--- a/lib/core/src/packStruct.cpp
+++ b/lib/core/src/packStruct.cpp
@@ -1914,6 +1914,7 @@ unpackXmlString( const void *&inPtr, packedOutput_t &unpackedOutput, int maxStrL
 
     if ( myStrlen >= maxStrLen ) {
         if ( maxStrLen >= 0 ) {
+            free(strBuf);
             return USER_PACKSTRUCT_INPUT_ERR;
         }
         else {

--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/functions.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/functions.cpp
@@ -791,6 +791,8 @@ Res *smsi_query( Node** subtrees, int, Node* node, ruleExecInfo_t* rei, int reiS
                 snprintf( errmsgBuf, ERR_MSG_LEN, "Unable to get valid ICAT column index for %s.", subQueNode->subtrees[0]->text );
                 generateAndAddErrMsg( errmsgBuf, subQueNode->subtrees[0], RE_DYNAMIC_TYPE_ERROR, errmsg );
                 deleteHashTable( queCondHashTable, nop );
+                freeGenQueryInp( &genQueryInp );
+                clearMsParam( &genQInpParam, 0 );
                 return newErrorRes( r, RE_DYNAMIC_TYPE_ERROR );
             }
 
@@ -805,6 +807,8 @@ Res *smsi_query( Node** subtrees, int, Node* node, ruleExecInfo_t* rei, int reiS
                 deleteHashTable( queCondHashTable, nop );
                 snprintf( errmsgBuf, ERR_MSG_LEN, "Unsupported gen query format: multiple query conditions on one attribute %s.", attr );
                 generateAndAddErrMsg( errmsgBuf, subQueNode, RE_DYNAMIC_TYPE_ERROR, errmsg );
+                freeGenQueryInp( &genQueryInp );
+                clearMsParam( &genQInpParam, 0 );
                 return newErrorRes( r, RE_DYNAMIC_TYPE_ERROR );
             }
             insertIntoHashTable( queCondHashTable, attr, attr );
@@ -817,6 +821,8 @@ Res *smsi_query( Node** subtrees, int, Node* node, ruleExecInfo_t* rei, int reiS
                 snprintf( errmsgBuf, ERR_MSG_LEN, "Unable to get valid ICAT column index for %s.", subQueNode->subtrees[0]->text );
                 generateAndAddErrMsg( errmsgBuf, subQueNode->subtrees[0], RE_DYNAMIC_TYPE_ERROR, errmsg );
                 deleteHashTable( queCondHashTable, nop );
+                freeGenQueryInp( &genQueryInp );
+                clearMsParam( &genQInpParam, 0 );
                 return newErrorRes( r, RE_DYNAMIC_TYPE_ERROR );
             }
 
@@ -831,12 +837,16 @@ Res *smsi_query( Node** subtrees, int, Node* node, ruleExecInfo_t* rei, int reiS
                 res0 = evaluateExpression3( node->subtrees[0], 0, 0, rei, reiSaveFlag & ~DISCARD_EXPRESSION_RESULT, env, errmsg, r );
                 if ( getNodeType( res0 ) == N_ERROR ) {
                     deleteHashTable( queCondHashTable, nop );
+                    freeGenQueryInp( &genQueryInp );
+                    clearMsParam( &genQInpParam, 0 );
                     return res0;
                 }
                 nodeType0 = ( NodeType ) TYPE( res0 );
                 if ( nodeType0 != T_DOUBLE && nodeType0 != T_INT && nodeType0 != T_STRING ) {
                     generateAndAddErrMsg( "dynamic type error", node->subtrees[0], RE_DYNAMIC_TYPE_ERROR, errmsg );
                     deleteHashTable( queCondHashTable, nop );
+                    freeGenQueryInp( &genQueryInp );
+                    clearMsParam( &genQInpParam, 0 );
                     return newErrorRes( r, RE_DYNAMIC_TYPE_ERROR );
                 }
                 value0 = convertResToString( res0 );
@@ -853,12 +863,16 @@ Res *smsi_query( Node** subtrees, int, Node* node, ruleExecInfo_t* rei, int reiS
                     res1 = evaluateExpression3( node->subtrees[1], 0, 0, rei, reiSaveFlag & ~DISCARD_EXPRESSION_RESULT, env, errmsg, r );
                     if ( getNodeType( res1 ) == N_ERROR ) {
                         deleteHashTable( queCondHashTable, nop );
+                        freeGenQueryInp( &genQueryInp );
+                        clearMsParam( &genQInpParam, 0 );
                         return res1;
                     }
                     nodeType1 = ( NodeType ) TYPE( res1 );
                     if ( ( ( nodeType0 == T_DOUBLE || nodeType0 == T_INT ) && nodeType1 != T_DOUBLE && nodeType1 != T_INT ) || ( nodeType0 == T_STRING && nodeType1 != T_STRING ) ) {
                         generateAndAddErrMsg( "dynamic type error", node->subtrees[1], RE_DYNAMIC_TYPE_ERROR, errmsg );
                         deleteHashTable( queCondHashTable, nop );
+                        freeGenQueryInp( &genQueryInp );
+                        clearMsParam( &genQInpParam, 0 );
                         return newErrorRes( r, RE_DYNAMIC_TYPE_ERROR );
                     }
                     value1 = convertResToString( res1 );
@@ -881,6 +895,8 @@ Res *smsi_query( Node** subtrees, int, Node* node, ruleExecInfo_t* rei, int reiS
         default:
             generateAndAddErrMsg( "unsupported node type", subQueNode, RE_DYNAMIC_TYPE_ERROR, errmsg );
             deleteHashTable( queCondHashTable, nop );
+            freeGenQueryInp( &genQueryInp );
+            clearMsParam( &genQInpParam, 0 );
             return newErrorRes( r, RE_DYNAMIC_TYPE_ERROR );
         }
     }

--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/index.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/index.cpp
@@ -25,15 +25,16 @@ int createRuleStructIndex( ruleStruct_t *inRuleStrct, Hashtable *ruleIndex ) {
     if ( ruleIndex == NULL ) {
         return 0;
     }
-    int i;
-    for ( i = 0; i < inRuleStrct->MaxNumOfRules; i++ ) {
+    for ( int i = 0; i < inRuleStrct->MaxNumOfRules; i++ ) {
         char *key = inRuleStrct->action[i];
         int *value = ( int * )malloc( sizeof( int ) );
         *value = i;
 
-        if ( insertIntoHashTable( ruleIndex, key, value ) == 0 ) {
+        if ( 0 == insertIntoHashTable( ruleIndex, key, value ) ) {
+            free( value );
             return 0;
         }
+        free( value );
     }
     return 1;
 }
@@ -269,17 +270,18 @@ int createFuncMapDefIndex( rulefmapdef_t *inFuncStrct, Hashtable **ruleIndex ) {
     if ( *ruleIndex == NULL ) {
         return 0;
     }
-    int i;
-    for ( i = 0; i < inFuncStrct->MaxNumOfFMaps; i++ ) {
+    for ( int i = 0; i < inFuncStrct->MaxNumOfFMaps; i++ ) {
         char *key = inFuncStrct->funcName[i];
         int *value = ( int * )malloc( sizeof( int ) );
         *value = i;
 
-        if ( insertIntoHashTable( *ruleIndex, key, value ) == 0 ) {
+        if ( 0 == insertIntoHashTable( *ruleIndex, key, value ) ) {
             deleteHashTable( *ruleIndex, free_const );
             *ruleIndex = NULL;
+            free( value );
             return 0;
         }
+        free( value );
     }
     return 1;
 }

--- a/server/core/src/rodsServer.cpp
+++ b/server/core/src/rodsServer.cpp
@@ -241,6 +241,7 @@ main( int argc, char **argv )
     char* mkdtemp_result = mkdtemp(mkdtemp_template); 
     if ( mkdtemp_result == NULL ) {
         rodsLog( LOG_ERROR, "Error creating tmp directory for iRODS sockets, mkdtemp errno [%d]: [%s]", errno, strerror(errno) );
+        free( logDir );
         return SYS_INTERNAL_ERR;
     }
     strcpy( agent_factory_socket_dir, mkdtemp_result );
@@ -255,6 +256,7 @@ main( int argc, char **argv )
     if ( agent_spawning_pid == 0 ) {
         // Child process
         ProcessType = AGENT_PT;
+        free( logDir );
         return runIrodsAgent( local_addr );
     } else if ( agent_spawning_pid > 0 ) {
         // Parent process
@@ -272,12 +274,14 @@ main( int argc, char **argv )
             int saved_errno = errno;
             if ( ( time( 0 ) - sock_connect_start_time ) > 5 ) {
                 rodsLog(LOG_ERROR, "Error connecting to agent factory socket, errno = [%d]: %s", saved_errno, strerror( saved_errno ) );
+                free( logDir );
                 return SYS_SOCK_CONNECT_ERR;
             }
         }
     } else {
         // Error, fork failed
         rodsLog( LOG_ERROR, "fork() failed when attempting to create agent factory process" );
+        free( logDir );
         return SYS_FORK_ERROR;
     }
 

--- a/server/re/src/extractAvuMS.cpp
+++ b/server/re/src/extractAvuMS.cpp
@@ -216,19 +216,25 @@ int msiGetTaggedValueFromString( msParam_t *inTagParam, msParam_t *inStrParam,
 
     t1 = ( char * ) inStrParam->inOutStruct;
     pstr[0] = ( char * ) malloc( strlen( ( char* )inTagParam->inOutStruct ) + 6 );
-    pstr[1] = ( char * ) malloc( strlen( ( char* )inTagParam->inOutStruct ) + 6 );
     sprintf( pstr[0], "<%s>", ( char * ) inTagParam->inOutStruct );
     j = regcomp( &preg[0], pstr[0], REG_EXTENDED );
     if ( j != 0 ) {
         regerror( j, &preg[0], errbuff, sizeof( errbuff ) );
         rodsLog( LOG_NOTICE, "msiGetTaggedValueFromString: Error in regcomp: %s\n", errbuff );
+        regfree( &preg[0] );
+        free( pstr[0] );
         return INVALID_REGEXP;
     }
+    pstr[1] = ( char * ) malloc( strlen( ( char* )inTagParam->inOutStruct ) + 6 );
     sprintf( pstr[1], "</%s>", ( char * ) inTagParam->inOutStruct );
     j = regcomp( &preg[1], pstr[1], REG_EXTENDED );
     if ( j != 0 ) {
         regerror( j, &preg[1], errbuff, sizeof( errbuff ) );
         rodsLog( LOG_NOTICE, "msiGetTaggedValueFromString: Error in regcomp: %s\n", errbuff );
+        regfree( &preg[0] );
+        regfree( &preg[1] );
+        free( pstr[0] );
+        free( pstr[1] );
         return INVALID_REGEXP;
     }
     /*    rodsLog (LOG_NOTICE,"TTTTT:%s",t1);*/


### PR DESCRIPTION
There are several places where the program can return early due to some kind of error. Make sure any allocated memory is freed up before returning.