### PR TITLE
[#3705] Fix iquest not returning DATA_RESC_HIER

### DIFF
--- a/scripts/irods/test/test_iquest.py
+++ b/scripts/irods/test/test_iquest.py
@@ -27,3 +27,21 @@ class Test_Iquest(ResourceBase, unittest.TestCase):
 
         self.admin.assert_icommand(['iquest', "select count(DATA_ID) where DATA_NAME like '{0}%'".format(data_object_prefix)], 'STDOUT_SINGLELINE', 'DATA_ID = {0}'.format(MAX_SQL_ROWS))
         self.admin.assert_icommand_fail(['iquest', '--no-page', "select DATA_ID where DATA_NAME like '{0}%'".format(data_object_prefix)], 'STDOUT_SINGLELINE', 'CAT_NO_ROWS_FOUND')
+
+    def test_iquest_with_data_resc_hier__3705(self):
+        filename = 'test_iquest_data_name_with_data_resc_hier__3705'
+        lib.make_file(filename, 1)
+        self.admin.assert_icommand(['iput', filename])
+
+        # Make sure DATA_RESC_HIER appears
+        self.admin.assert_icommand(['iquest', "select DATA_NAME, DATA_RESC_HIER where DATA_RESC_HIER = '{0}'".format(self.admin.default_resource)], 'STDOUT_SINGLELINE', 'DATA_RESC_HIER')
+
+        # Make sure DATA_RESC_ID appears
+        self.admin.assert_icommand(['iquest', "select DATA_RESC_ID where DATA_RESC_HIER = '{0}'".format(self.admin.default_resource)], 'STDOUT_SINGLELINE', 'DATA_RESC_ID')
+
+        # Make sure HIER and ID appear in the correct order
+        _,out,_ = self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER, DATA_RESC_ID where DATA_NAME = '{0}' and DATA_RESC_HIER = '{1}'".format(filename, self.admin.default_resource)], 'STDOUT_SINGLELINE')
+        assert "DATA_RESC_HIER" in out.split('\n')[0]
+        assert "DATA_RESC_ID" in out.split('\n')[1]
+
+        os.remove(filename)

--- a/server/api/src/rsGenQuery.cpp
+++ b/server/api/src/rsGenQuery.cpp
@@ -384,7 +384,6 @@ irods::error strip_resc_hier_name_from_query_inp( genQueryInp_t* _inp, int& _pos
             }
 
             addInxVal( &_inp->sqlCondInp, COL_D_RESC_ID, new_cond.c_str() );
-            _pos = i;
         }
         else {
             addInxVal( &_inp->sqlCondInp, tmpV.inx[i], tmpV.value[i] );


### PR DESCRIPTION
Adds some tests for iquest in DATA_RESC_HIER which expose an issue
where the hier name is not being substituted correctly in the output.

If DATA_RESC_HIER is used in a GenQuery, the DATA_RESC_ID for the
hierarchy is used instead in the actual query and then replaced at the end
with DATA_RESC_HIER again. There is a bug where selecting DATA_RESC_HIER
as a column and using the DATA_RESC_HIER as a filter causes the replacement
of the ID at the end to fail. This change fixes this issue by not
allowing the inputs for the filter to override the saved position of
the column in the output.