### PR TITLE
[#3679] Fix null pointer dereferences in libnative.cpp

### DIFF
--- a/plugins/auth/native/libnative.cpp
+++ b/plugins/auth/native/libnative.cpp
@@ -405,11 +405,7 @@ irods::error native_auth_agent_response(
         rodsServerHost->conn = NULL;
     }
 
-    if ( status < 0 || NULL == authCheckOut ) {
-        ret = ERROR( status, "rcAuthCheck failed." );
-    }
-
-    if ( ret.ok() ) {
+    if ( status >= 0 && NULL != authCheckOut ) {
         if ( rodsServerHost->localFlag != LOCAL_HOST ) {
             if ( authCheckOut->serverResponse == NULL ) {
                 rodsLog( LOG_NOTICE, "Warning, cannot authenticate remote server, no serverResponse field" );
@@ -557,6 +553,9 @@ irods::error native_auth_agent_response(
                 }
             }
         }
+    }
+    else {
+        ret = ERROR( status, "rcAuthCheck failed." );
     }
 
     if ( authCheckOut != NULL ) {


### PR DESCRIPTION
Even though it is not a valid code path, the static analyzer has detected some potential null pointer dereferences.

Passed Jenkins tests.

Note: This should be the last of the null pointer dereferences from scanbuild. Must have missed these in the last round.