### PR TITLE
[#3714] Fix GenQuery for resource hierarchies

### DIFF
--- a/scripts/irods/test/test_iquest.py
+++ b/scripts/irods/test/test_iquest.py
@@ -1,14 +1,37 @@
 import os
 import sys
+import shutil
+import socket
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
 
+from ..configuration import IrodsConfig
 from .resource_suite import ResourceBase
 from .. import lib
 
+def create_large_hierarchy(self, count, hostname, directory):
+    self.admin.assert_icommand("iadmin mkresc repRescPrime replication", 'STDOUT_SINGLELINE', 'replication')
+    for i in range(count):
+        self.admin.assert_icommand("iadmin mkresc repResc{0} replication".format(i), 'STDOUT_SINGLELINE', 'replication')
+        self.admin.assert_icommand("iadmin mkresc ptResc{0} passthru".format(i), 'STDOUT_SINGLELINE', 'passthru')
+        self.admin.assert_icommand("iadmin mkresc ufs{0} unixfilesystem ".format(i) + hostname + ":" + directory + "/ufs{0}Vault".format(i), 'STDOUT_SINGLELINE', 'unixfilesystem')
+        self.admin.assert_icommand("iadmin addchildtoresc repResc{0} ptResc{0}".format(i))
+        self.admin.assert_icommand("iadmin addchildtoresc ptResc{0} ufs{0}".format(i))
+        self.admin.assert_icommand("iadmin addchildtoresc repRescPrime repResc{0}".format(i))
+
+def remove_large_hierarchy(self, count, directory):
+    for i in range(count):
+        self.admin.assert_icommand("iadmin rmchildfromresc repRescPrime repResc{0}".format(i))
+        self.admin.assert_icommand("iadmin rmchildfromresc ptResc{0} ufs{0}".format(i))
+        self.admin.assert_icommand("iadmin rmchildfromresc repResc{0} ptResc{0}".format(i))
+        self.admin.assert_icommand("iadmin rmresc repResc{0}".format(i))
+        self.admin.assert_icommand("iadmin rmresc ptResc{0}".format(i))
+        self.admin.assert_icommand("iadmin rmresc ufs{0}".format(i))
+        shutil.rmtree(directory + "/ufs{0}Vault".format(i), ignore_errors=True)
+    self.admin.assert_icommand("iadmin rmresc repRescPrime")
 
 class Test_Iquest(ResourceBase, unittest.TestCase):
     def setUp(self):
@@ -41,7 +64,44 @@ class Test_Iquest(ResourceBase, unittest.TestCase):
 
         # Make sure HIER and ID appear in the correct order
         _,out,_ = self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER, DATA_RESC_ID where DATA_NAME = '{0}' and DATA_RESC_HIER = '{1}'".format(filename, self.admin.default_resource)], 'STDOUT_SINGLELINE')
-        assert "DATA_RESC_HIER" in out.split('\n')[0]
-        assert "DATA_RESC_ID" in out.split('\n')[1]
+        self.assertTrue("DATA_RESC_HIER" in out.split('\n')[0])
+        self.assertTrue("DATA_RESC_ID" in out.split('\n')[1])
 
         os.remove(filename)
+
+    def test_iquest_resc_hier_with_like__3714(self):
+        # Create a hierarchy to test
+        LEAF_COUNT = 10
+        directory = IrodsConfig().irods_directory
+        create_large_hierarchy(self, LEAF_COUNT, socket.gethostname(), directory)
+        filename = 'test_iquest_resc_hier_with_like__3714'
+        lib.make_file(filename, 1)
+        self.admin.assert_icommand("iput -R repRescPrime " + filename)
+        expected_hier = 'repRescPrime;repResc3;ptResc3;ufs3'
+
+        # SUCCESS
+        # Matches ufs3's hierarchy
+        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER like '%ufs3'"], 'STDOUT_SINGLELINE', expected_hier)
+        # Matches all hierarchies starting with repRescPrime
+        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER like 'repRescPrime;%'"], 'STDOUT_SINGLELINE', expected_hier)
+        # Matches all hierarchies containing resource ptResc3
+        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER like '%;ptResc3;%'"], 'STDOUT_SINGLELINE', expected_hier)
+        # Matches leaf resource from full hierarchy
+        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER = '{0}'".format(expected_hier)], 'STDOUT_SINGLELINE', expected_hier)
+        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER like '{0}'".format(expected_hier)], 'STDOUT_SINGLELINE', expected_hier)
+        # Matches leaf resource
+        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER = 'ufs3'"], 'STDOUT_SINGLELINE', expected_hier)
+        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER like 'ufs3'"], 'STDOUT_SINGLELINE', expected_hier)
+
+        # FAILURE
+        # % needed at front - ufs is not a root
+        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER like 'ufs%'"], 'STDOUT_SINGLELINE', 'CAT_NO_ROWS_FOUND')
+        # % needed at end - repRescPrime has children
+        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER like 'repRescPrime'"], 'STDOUT_SINGLELINE', 'CAT_NO_ROWS_FOUND')
+        # = with % results in error
+        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER = '%ufs3'"], 'STDOUT_SINGLELINE', 'CAT_NO_ROWS_FOUND')
+
+        # Clean up
+        os.remove(filename)
+        self.admin.assert_icommand("irm -f " + filename)
+        remove_large_hierarchy(self, LEAF_COUNT, directory)

--- a/server/core/include/irods_resource_manager.hpp
+++ b/server/core/include/irods_resource_manager.hpp
@@ -97,6 +97,10 @@ namespace irods {
             int call_maintenance_operations( rcComm_t* );
 
             // =-=-=-=-=-=-=-
+            /// @brief construct a vector of all resource hierarchies in the system
+            std::vector<std::string> get_all_resc_hierarchies( void );
+
+            // =-=-=-=-=-=-=-
             /// @brief get the resc id of the leaf resource in the hierarchy
             error hier_to_leaf_id( const std::string&, rodsLong_t& );
 

--- a/server/core/src/irods_resource_manager.cpp
+++ b/server/core/src/irods_resource_manager.cpp
@@ -1049,6 +1049,40 @@ namespace irods {
         return result;
     } // call_maintenance_operations
 
+    /*
+     * construct a vector of all resource hierarchies in the system
+     * throws irods::exception
+     */
+    std::vector<std::string> resource_manager::get_all_resc_hierarchies( void ) {
+        /*
+         * Iterate through all the resources in the map and
+         * construct a hierarchy vector for leaf resources.
+         */
+        std::vector<std::string> hier_list;
+        for ( auto itr : resource_name_map_ ) {
+            resource_ptr resc = itr.second;
+            if ( resc->num_children() > 0 ) {
+                continue;
+            }  
+
+            rodsLong_t leaf_id = 0;
+            error err = resc->get_property<rodsLong_t>(
+                            RESOURCE_ID,
+                            leaf_id );
+            if ( !err.ok() ) {
+                THROW( err.code(), err.result() );
+            }
+
+            std::string curr_hier;
+            err = leaf_id_to_hier( leaf_id, curr_hier );
+            if ( !err.ok() ) {
+                THROW( err.code(), err.result() );
+            }
+            hier_list.push_back( curr_hier );
+        }
+        return hier_list;
+    } // get_all_resc_hierarchies
+
     error resource_manager::hier_to_leaf_id(
         const std::string& _hier,
         rodsLong_t&        _id ) {


### PR DESCRIPTION
DATA_RESC_HIER is no longer stored in the metadata table, so SQL cannot be used to query resource hierarchies directly. As a result, using DATA_RESC_HIER in the WHERE clause of a GenQuery can cause strange returns. Using DATA_RESC_HIER in the WHERE clause of a GenQuery will now return a
result consistent with the rules below:

 - '=' with %: error
 - '=' without %: direct match for leaf
 - 'like' without %: direct match for leaf
 - 'like' with %: consistent with 'like' for other columns

Add tests for expected behavior when using GenQuery with DATA_RESC_HIER. This includes adding a number of resources in a hierarchy to demonstrate results from the various queries.

Also replaced some raw asserts in the 3705 test with self.assertTrue.

---
Jenkins tests passed.