### PR TITLE
[#3711] Remove remaining dead stores

### DIFF
--- a/plugins/resources/replication/librepl.cpp
+++ b/plugins/resources/replication/librepl.cpp
@@ -1468,18 +1468,17 @@ irods::error replValidOperation(
     try {
         irods::file_object_ptr file_obj = boost::dynamic_pointer_cast<irods::file_object >( _ctx.fco() );
         // if the file object has a requested replica then fail since that circumvents the coordinating nodes management.
-        if ( false && file_obj->repl_requested() >= 0 ) { // For migration we no longer have this restriction but will be added back later - harry
+        if ( file_obj->repl_requested() >= 0 && false ) { // For migration we no longer have this restriction but will be added back later - harry
             std::stringstream msg;
             msg << __FUNCTION__;
             msg << " - Requesting replica: " << file_obj->repl_requested();
             msg << "\tCannot request specific replicas from replicating resource.";
             result = ERROR( INVALID_OPERATION, msg.str() );
         }
-
         else {
             // if the api commands involve replication we have to error out since managing replicas is our job
             char* in_repl = getValByKey( &file_obj->cond_input(), IN_REPL_KW );
-            if ( false && in_repl != NULL ) { // For migration we no longer have this restriction but might be added later. - harry
+            if ( in_repl != NULL && false ) { // For migration we no longer have this restriction but might be added later. - harry
                 std::stringstream msg;
                 msg << __FUNCTION__;
                 msg << " - Using repl or trim commands on a replication resource is not allowed. ";

--- a/server/api/src/rsRmColl.cpp
+++ b/server/api/src/rsRmColl.cpp
@@ -391,11 +391,13 @@ _rsPhyRmColl( rsComm_t *rsComm, collInp_t *rmCollInp,
         }
         else {
             status = svrUnregColl( rsComm, rmCollInp );
-            if ( status < 0 ) {
-                savedStatus = status;
-            }
         }
     }
+
+    if ( status < 0 ) {
+        savedStatus = status;
+    }
+
     clearKeyVal( &tmpCollInp.condInput );
     clearKeyVal( &dataObjInp.condInput );
 


### PR DESCRIPTION
Fix the remaining dead stores reported by scanbuild.

---
Passed Jenkins tests.

For this change, I took the short path to quiet scanbuild. However, there is great potential for improvement in the code surrounding these changes, so I am open to doing some refactoring, if desired. In particular, the massive conditional in rsRmColl.cpp could be inverted so that the status = 0 could be removed, but I found it even harder to understand than in its original form.