### PR TITLE
[#3714] Tweak behavior of LIKE for DATA_RESC_HIER

### DIFF
--- a/scripts/irods/test/test_iquest.py
+++ b/scripts/irods/test/test_iquest.py
@@ -89,9 +89,6 @@ class Test_Iquest(ResourceBase, unittest.TestCase):
         # Matches leaf resource from full hierarchy
         self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER = '{0}'".format(expected_hier)], 'STDOUT_SINGLELINE', expected_hier)
         self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER like '{0}'".format(expected_hier)], 'STDOUT_SINGLELINE', expected_hier)
-        # Matches leaf resource
-        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER = 'ufs3'"], 'STDOUT_SINGLELINE', expected_hier)
-        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER like 'ufs3'"], 'STDOUT_SINGLELINE', expected_hier)
 
         # FAILURE
         # % needed at front - ufs is not a root
@@ -100,6 +97,9 @@ class Test_Iquest(ResourceBase, unittest.TestCase):
         self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER like 'repRescPrime'"], 'STDOUT_SINGLELINE', 'CAT_NO_ROWS_FOUND')
         # = with % results in error
         self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER = '%ufs3'"], 'STDOUT_SINGLELINE', 'CAT_NO_ROWS_FOUND')
+        # Results in direct match - must match full hier
+        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER = 'ufs3'"], 'STDOUT_SINGLELINE', 'CAT_NO_ROWS_FOUND')
+        self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_RESC_HIER like 'ufs3'"], 'STDOUT_SINGLELINE', 'CAT_NO_ROWS_FOUND')
 
         # Clean up
         os.remove(filename)

--- a/server/api/src/rsGenQuery.cpp
+++ b/server/api/src/rsGenQuery.cpp
@@ -319,30 +319,13 @@ irods::error get_resc_id_cond_for_hier_cond(
         return ERROR( SYS_RESC_DOES_NOT_EXIST, hier );
     }
 
-    std::string::size_type pos = hier.find_first_of( "%" );
-
-    /*
-     * Attempt direct match to leaf node since no wildcards given.
-     * All leaves are unique, so there should be at most one result.
-     */
-    if ( std::string::npos == pos ) {
-        rodsLong_t leaf_id{};
-        irods::error ret = resc_mgr.hier_to_leaf_id( hier, leaf_id );
-        if ( !ret.ok() ) {
-            return PASS( ret );
-        }
-        std::stringstream leaf_id_str;
-        leaf_id_str << leaf_id;
-        _new_cond = "='" + leaf_id_str.str() + "'";
-        return SUCCESS();
-    }
-
     /* 
      * Convert input condition to regex syntax and filter list of
      * hierarchies. For each matching result, get the leaf ID and
      * add it to the list of results. Generate 'IN' condition with
      * the resulting leaf IDs. Return early if none found.
      */
+    std::string::size_type pos( hier.find_first_of( "%" ) );
     std::string hierRegex( hier );
     while ( std::string::npos != pos ) {
         hierRegex.replace( pos, 1, "(.*)" );


### PR DESCRIPTION
Wildcard-less likes (that is, direct matches) should be interpreted as direct matches for hierarchies instead of for leaves. This modifies the rules to be consistent with the following:

 - '=' with %: error
 - '=' without %: direct match
 - 'like' without %: direct match (like '=')
 - 'like' with %: consistent with 'like' for other columns

---
Passed Jenkins tests