### PR TITLE
[#3736] Fix msiServerMonPerf wrong dir reference

### DIFF
--- a/msiExecCmd_bin/irodsServerMonPerf
+++ b/msiExecCmd_bin/irodsServerMonPerf
@@ -131,7 +131,7 @@ foreach my $pth(@sysPathList) {
 ###############################################
 $systype = `/bin/uname`; chomp($systype);
 $rhost = `/bin/uname -n`; chomp($rhost);
-$path = dirname($0)."/../../config/scriptMonPerf.config";
+$path = dirname($0)."/../config/scriptMonPerf.config";
 
 ##################################################
 # Test the existence of the configuration file   #

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -590,3 +590,18 @@ output ruleExecOut
         irods_config.commit(irods_config.server_config, irods_config.server_config_path, make_backup=True)
 
 
+    def test_msiServerMonPerf_default_3736(self):
+        rule_file="test_msiServerMonPerf.r"
+        rule_string= '''
+msiTestServerMonPerf {{
+    msiServerMonPerf("default", "default");
+}}
+
+INPUT null
+OUTPUT ruleExecOut
+'''
+
+        with open(rule_file, 'w') as f:
+            f.write(rule_string)
+
+        self.rods_session.assert_icommand("irule -F " + rule_file);


### PR DESCRIPTION
Due to restructuring in 4.2, msiServerMonPerf refers to a dependency in a location where it does not reside.

---
Jenkins tests passed except for occasional failure described in #3706 (cen6-psql-resc-ssl)

I can move the test to a different file if desired. Current location seemed the most appropriate from what I was able to find.