### PR TITLE
[#3736] Fix msiServerMonPerf wrong dir reference

### DIFF
--- a/msiExecCmd_bin/irodsServerMonPerf
+++ b/msiExecCmd_bin/irodsServerMonPerf
@@ -131,7 +131,7 @@ foreach my $pth(@sysPathList) {
 ###############################################
 $systype = `/bin/uname`; chomp($systype);
 $rhost = `/bin/uname -n`; chomp($rhost);
-$path = dirname($0)."/../../config/scriptMonPerf.config";
+$path = dirname($0)."/../config/scriptMonPerf.config";
 
 ##################################################
 # Test the existence of the configuration file   #

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -590,3 +590,18 @@ output ruleExecOut
         irods_config.commit(irods_config.server_config, irods_config.server_config_path, make_backup=True)
 
 
+    def test_msiServerMonPerf_default_3736(self):
+        rule_file="test_msiServerMonPerf.r"
+        rule_string= '''
+msiTestServerMonPerf {{
+    msiServerMonPerf("default", "default");
+}}
+
+INPUT null
+OUTPUT ruleExecOut
+'''
+
+        with open(rule_file, 'w') as f:
+            f.write(rule_string)
+
+        self.rods_session.assert_icommand("irule -F " + rule_file);


### PR DESCRIPTION
Adds a test to make sure msiServerMonPerf is referring to the correct directory when looking for resources.

(cherry-picked from SHA: 13abb694667cc9dfce59de0bb1cc11e94c1abf5d)

Due to restructuring in 4.2, msiServerMonPerf refers to a dependency in a location where it does not reside.

(cherry-picked from SHA: 575ec5449c245ad05c9067979ce8fd4f2cc0d888)

---
Jenkins tests passed.