### PR TITLE
[#3769] Fix remaining scanbuild issues

### DIFF
--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/rules.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/rules.cpp
@@ -50,10 +50,12 @@ int readRuleSetFromLocalFile( const char *ruleBaseName, const char *rulesFileNam
         return ret;
     }
 
-    Node *errnode;
+    Node *errnode{};
     ExprType *restype = typeRuleSet( ruleSet, errmsg, &errnode, r );
     if ( getNodeType( restype ) == T_ERROR ) {
-        *errloc = NODE_EXPR_POS( errnode );
+        if ( NULL != errnode ) {
+            *errloc = NODE_EXPR_POS( errnode );
+        }
         return RE_TYPE_ERROR;
     }
 

--- a/server/re/src/reIn2p3SysRule.cpp
+++ b/server/re/src/reIn2p3SysRule.cpp
@@ -629,6 +629,13 @@ int msiServerMonPerf( msParam_t *verb, msParam_t *ptime, ruleExecInfo_t *rei ) {
     }
     getListOfResc( rsComm, serverList, nservers, rescList, &nresc );
 
+    /* If the list of resources is empty, just return early because
+     * there is no work to be done below. */
+    if ( 0 == nresc ) {
+        rodsLog( LOG_NOTICE, "msiServerMonPerf: no resources found\n" );
+        return rei->status;
+    }
+
     strcpy( cmd, MON_PERF_SCRIPT );
 #ifndef windows_platform
     pthread_t *threads = ( pthread_t* )malloc( sizeof( pthread_t ) * nresc );


### PR DESCRIPTION
Fixed a malloc of 0 bytes (undefined behavior) and dereference of an uninitialized pointer.

---
Jenkins tests passed except for occasional failure noted in #3689 (ub16-oracle)