### PR TITLE
[#3265] Add admin flag to ichksum

### DIFF
--- a/iRODS/clients/icommands/src/ichksum.cpp
+++ b/iRODS/clients/icommands/src/ichksum.cpp
@@ -27,7 +27,7 @@ main( int argc, char **argv ) {
     rodsPathInp_t rodsPathInp;
 
 
-    optStr = "hKfarR:vVn:Z";
+    optStr = "hKfarMR:vVn:Z";
 
     status = parseCmdLineOpt( argc, argv, optStr, 1, &myRodsArgs );
     if ( status < 0 ) {
@@ -97,7 +97,7 @@ main( int argc, char **argv ) {
 void
 usage() {
     char *msgs[] = {
-        "Usage: ichksum [-harvV] [-K|f] [-n replNum] [-R resource] [--silent]",
+        "Usage: ichksum [-haMrvV] [-K|f] [-n replNum] [-R resource] [--silent]",
         "           dataObj|collection ... ",
         "Checksum one or more data-object or collection from iRODS space.",
         "Options are:",
@@ -105,6 +105,7 @@ usage() {
         " -a  checksum all replicas. ils -L should be used to list the values of all replicas",
         " -K  verify the checksum value in iCAT. If the checksum value does not exist,",
         "     compute and register one.",
+        " -M  admin - admin user uses this option to checksum other users' files.",
         " -n  replNum  - the replica to checksum; use -a to checksum all replicas.",
         " -R  resource  - the resource of the replica to checksum,",
         " -r  recursive - checksum the whole subtree; the collection, all data-objects",

--- a/iRODS/lib/core/src/chksumUtil.cpp
+++ b/iRODS/lib/core/src/chksumUtil.cpp
@@ -148,6 +148,10 @@ initCondForChksum( rodsArguments_t *rodsArgs,
         return USER_OPTION_INPUT_ERR;
     }
 
+    if ( rodsArgs->admin == True ) {
+        addKeyVal( &dataObjInp->condInput, ADMIN_KW, "" );
+    }
+
     if ( rodsArgs->force == True ) {
         addKeyVal( &dataObjInp->condInput, FORCE_CHKSUM_KW, "" );
         addKeyVal( &collInp->condInput, FORCE_CHKSUM_KW, "" );

--- a/tests/pydevtest/test_icommands_file_operations.py
+++ b/tests/pydevtest/test_icommands_file_operations.py
@@ -805,3 +805,22 @@ acSetRescSchemeForCreate { msiSetDefaultResc("demoResc","null"); }
             os.unlink(filename)
         else:
             print('skipping test_ichksum_file_size_verification__3537 due to unsupported database for this test.')
+
+    def test_ichksum_admin_flag__3265(self):
+        filename = 'test_ichksum_admin_flag__3265'
+        file_size = 50
+        lib.make_file(filename, file_size)
+        self.user0.assert_icommand(['iput', filename])
+
+        # Get the current directory
+        rc, data_path, err = self.user0.run_icommand("ipwd")
+        data_path = data_path.rstrip() + '/' + filename
+
+        # Perform checksum as the owner
+        self.user0.assert_icommand(['ichksum', '-K', data_path], 'STDOUT_SINGLELINE', 'Total checksum performed = 1, Failed checksum = 0')
+        # Perform checksum as admin user (should fail)
+        self.admin.assert_icommand(['ichksum', '-K', data_path], 'STDERR_SINGLELINE', 'CAT_NO_ACCESS_PERMISSION')
+        # Add admin flag
+        self.admin.assert_icommand(['ichksum', '-K', '-M', data_path], 'STDOUT_SINGLELINE', 'Total checksum performed = 1, Failed checksum = 0')
+
+        os.unlink(filename)


### PR DESCRIPTION
ichksum can now be run with the '-M' option to run the command in admin mode. This allows admin users to ichksum files that they do not have permissions for.

---
All Jenkins tests passed except for ub16 (which was not part of the test suite for 4-1-stable up to this point).