### PR TITLE
[#3722] Fix segfault in remote rule execution

### DIFF
--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/rules.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/rules.cpp
@@ -131,10 +131,14 @@ int parseAndComputeRuleAdapter( char *rule, msParamArray_t *msParamArray, ruleEx
     rei->msParamArray = msParamArray;
 
     rescode = parseAndComputeRule( rule, env, rei, reiSaveFlag, &errmsgBuf, r );
-
-    convertEnvToMsParamArray( rei->msParamArray, env, &errmsgBuf, r );
-
     RE_ERROR( rescode < 0 );
+
+    if ( NULL == rei->msParamArray ) {
+        rei->msParamArray = newMsParamArray();
+    }
+    rescode = convertEnvToMsParamArray( rei->msParamArray, env, &errmsgBuf, r );
+    RE_ERROR( rescode < 0 );
+
     freeRErrorContent( &errmsgBuf );
     /* deleteEnv(env, 3); */
 


### PR DESCRIPTION
Remote rule execution will fail in versions >4.2.1 due to a segmentation fault in convertHashtableToMsParamArray. To prevent this, msParamArray is being generated for rei before calling the offending function in the event that it is made null.

Tests write to the server log using the remote execution microservice. First test writes to the local zone's log. Second test writes to the remote zone's log (configured in test_federation).

Passed Jenkins tests except for occasional failure described in #3689 (ub16-oracle).