### PR TITLE
[#3787] added imeta mod functionality for moving to/from blank units

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -9828,17 +9828,22 @@ irods::error db_mod_avu_metadata_op(
 //        icatSessionStruct icss;
 //        _ctx.prop_map().get< icatSessionStruct >( ICSS_PROP, icss );
     int status, atype;
-    char myUnits[MAX_NAME_LEN] = "";
+    const char *dummy = NULL;
+    const char *myUnits = "";
     const char *addAttr = "";
     const char *addValue = "";
-    const char  *addUnits = "";
-    int newUnits = 0;
-    //if ( _unitsOrArg0 == NULL || *_unitsOrArg0 == '\0' ) {
-    //    return ERROR( CAT_INVALID_ARGUMENT, "unitsOrArg0 empty or null" );
-    //}
+    const char  *addUnits = NULL;
+    // int newUnits = 0;
+    if ( _unitsOrArg0 == NULL ) {
+        return ERROR( CAT_INVALID_ARGUMENT, "unitsOrArg0 empty or null" );
+    }
+
     atype = checkModArgType( _unitsOrArg0 );
     if ( atype == 0 ) {
-        snprintf( myUnits, sizeof( myUnits ), "%s", _unitsOrArg0 );
+        myUnits = _unitsOrArg0;
+    }
+    else {
+        dummy = _unitsOrArg0;
     }
 
     status = chlDeleteAVUMetadata( _ctx.comm(), 0, _type, _name, _attribute, _value,
@@ -9852,6 +9857,7 @@ irods::error db_mod_avu_metadata_op(
     bool new_val_set = false;
     bool new_unit_set = false;
 
+	/**
     if ( atype == 1 ) {
         new_attr_set = true;
         addAttr = _unitsOrArg0 + 2;
@@ -9864,97 +9870,44 @@ irods::error db_mod_avu_metadata_op(
         new_unit_set = true;
         addUnits = _unitsOrArg0 + 2;
     }
+	**/
 
-    atype = checkModArgType( _arg1 );
-    if ( atype == 1 ) {
+    for (auto arg : { dummy , _arg1, _arg2, _arg3 } )
+    {
+      if (arg == NULL) continue;
+      atype = checkModArgType( arg );
+      if ( atype == 1 ) {
         if (new_attr_set) {
             _rollback( "chlModAVUMetadata" );
             return ERROR( CAT_INVALID_ARGUMENT, "new attribute specified more than once" );
         } else {
             new_attr_set = true;
         }
-        addAttr = _arg1 + 2;
-    }
-    if ( atype == 2 ) {
+        addAttr = arg + 2;
+      }
+      if ( atype == 2 ) {
         if (new_val_set) {
             _rollback( "chlModAVUMetadata" );
             return ERROR( CAT_INVALID_ARGUMENT, "new value specified more than once" );
         } else {
             new_val_set = true;
         }
-        addValue = _arg1 + 2;
-    }
-    if ( atype == 3 ) {
+        addValue = arg + 2;
+      }
+      if ( atype == 3 ) {
         if (new_unit_set) {
             _rollback( "chlModAVUMetadata" );
             return ERROR( CAT_INVALID_ARGUMENT, "new unit specified more than once" );
         } else {
             new_unit_set = true;
         }
-        addUnits = _arg1 + 2;
-    }
-
-    atype = checkModArgType( _arg2 );
-    if ( atype == 1 ) {
-        if (new_attr_set) {
-            _rollback( "chlModAVUMetadata" );
-            return ERROR( CAT_INVALID_ARGUMENT, "new attribute specified more than once" );
-        } else {
-            new_attr_set = true;
-        }
-        addAttr = _arg2 + 2;
-    }
-    if ( atype == 2 ) {
-        if (new_val_set) {
-            _rollback( "chlModAVUMetadata" );
-            return ERROR( CAT_INVALID_ARGUMENT, "new value specified more than once" );
-        } else {
-            new_val_set = true;
-        }
-        addValue = _arg2 + 2;
-    }
-    if ( atype == 3 ) {
-        if (new_unit_set) {
-            _rollback( "chlModAVUMetadata" );
-            return ERROR( CAT_INVALID_ARGUMENT, "new unit specified more than once" );
-        } else {
-            new_unit_set = true;
-        }
-        addUnits = _arg2 + 2;
-    }
-
-    atype = checkModArgType( _arg3 );
-    if ( atype == 1 ) {
-        if (new_attr_set) {
-            _rollback( "chlModAVUMetadata" );
-            return ERROR( CAT_INVALID_ARGUMENT, "new attribute specified more than once" );
-        } else {
-            new_attr_set = true;
-        }
-        addAttr = _arg3 + 2;
-    }
-    if ( atype == 2 ) {
-        if (new_val_set) {
-            _rollback( "chlModAVUMetadata" );
-            return ERROR( CAT_INVALID_ARGUMENT, "new value specified more than once" );
-        } else {
-            new_val_set = true;
-        }
-        addValue = _arg3 + 2;
-    }
-    if ( atype == 3 ) {
-        if (new_unit_set) {
-            _rollback( "chlModAVUMetadata" );
-            return ERROR( CAT_INVALID_ARGUMENT, "new unit specified more than once" );
-        } else {
-            new_unit_set = true;
-        }
-        addUnits = _arg3 + 2;
+        addUnits = arg + 2;
+      }
     }
 
     if ( *addAttr  == '\0' &&
             *addValue == '\0' &&
-            *addUnits == '\0' ) {
+            addUnits == NULL ) {
         _rollback( "chlModAVUMetadata" );
         return ERROR( CAT_INVALID_ARGUMENT, "arg check failed" );
     }
@@ -9965,7 +9918,7 @@ irods::error db_mod_avu_metadata_op(
     if ( *addValue == '\0' ) {
         addValue = _value;
     }
-    if ( *addUnits == '\0' && newUnits == 0 ) {
+    if ( addUnits == NULL ) {
         addUnits = myUnits;
     }
 

--- a/scripts/irods/test/test_imeta_set.py
+++ b/scripts/irods/test/test_imeta_set.py
@@ -245,6 +245,12 @@ class Test_ImetaSet(ResourceBase, unittest.TestCase):
         wild = self.user0.session_collection+'/'+base_name+"%"
         self.admin.assert_icommand(['imeta', 'addw', '-d', wild, attribute, value], 'STDERR_SINGLELINE', 'CAT_NO_ACCESS_PERMISSION')
 
+    def test_imeta_duplicate_attr_3787(self):
+        self.admin.assert_icommand(['imeta', 'add', '-d', self.testfile, 'a1', 'v1', 'u1'])
+        self.admin.assert_icommand(['imeta', 'mod', '-d', self.testfile, 'a1', 'v1', 'u1', 'n:a2', 'v:v2', 'u:'])
+        self.admin.assert_icommand(['imeta', 'mod', '-d', self.testfile, 'a2', 'v2',       'n:a3', 'v:v3', 'u:u3'])
+        self.check_avu_data_obj(self.testfile, 'a3', 'v3', 'u3')
+
     def test_imeta_duplicate_attr_3788(self):
         self.admin.assert_icommand(['imeta', 'add', '-d', self.testfile, 'a', 'v', 'u'])
         self.admin.assert_icommand('imeta mod -d ' + self.testfile + 'a v u n:newa1 n:newa2', 'STDOUT_SINGLELINE', 'Error: New attribute specified more than once')


### PR DESCRIPTION
For 'imeta' with mod sub-command, this change to the DB plugin enables:
 (1) matching on metadata records with zero-length unit fields and 
 (2) erasing (i.e. rendering  zero-length) previously non-zero-length unit fields

Also, a test was added to verify this function.