### PR TITLE
database_interface.py: don't modify dict while iterating through it

### DIFF
--- a/scripts/irods/database_interface.py
+++ b/scripts/irods/database_interface.py
@@ -92,7 +92,7 @@ def setup_database_config(irods_config):
         'has been properly configured.\n'
         )
 
-    for k in irods_config.server_config.setdefault('plugin_configuration', {}).setdefault('database', {}):
+    for k in list(irods_config.server_config.setdefault('plugin_configuration', {}).setdefault('database', {})):
         if k != db_type:
             del irods_config.server_config['plugin_configuration']['database'][k]
     irods_config.server_config['plugin_configuration']['database'].setdefault(db_type, {})


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/var/lib/irods/scripts/setup_irods.py", line 448, in <module>
    sys.exit(main())
  File "/var/lib/irods/scripts/setup_irods.py", line 436, in main
    setup_server(irods_config, json_configuration_file=options.json_configuration_file)
  File "/var/lib/irods/scripts/setup_irods.py", line 115, in setup_server
    database_interface.setup_database_config(irods_config)
  File "/var/lib/irods/scripts/irods/database_interface.py", line 95, in setup_database_config
    for k in irods_config.server_config.setdefault('plugin_configuration', {}).setdefault('database', {}):
RuntimeError: dictionary changed size during iteration
```