### PR TITLE
Add functionality for generic auth object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,6 +790,7 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_auth_factory.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_auth_manager.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_auth_object.cpp
+  ${CMAKE_SOURCE_DIR}/lib/core/src/irods_generic_auth_object.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_gsi_object.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_krb_object.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_native_auth_object.cpp
@@ -992,6 +993,7 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_auth_factory.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_auth_manager.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_auth_object.cpp
+  ${CMAKE_SOURCE_DIR}/lib/core/src/irods_generic_auth_object.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_buffer_encryption.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_children_parser.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_c_api.cpp

--- a/cmake/development_library.cmake
+++ b/cmake/development_library.cmake
@@ -32,6 +32,7 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/core/include/irods_auth_factory.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/irods_auth_manager.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/irods_auth_object.hpp
+  ${CMAKE_SOURCE_DIR}/lib/core/include/irods_generic_auth_object.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/irods_auth_plugin.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/irods_auth_types.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/irods_buffer_encryption.hpp

--- a/lib/core/include/irods_generic_auth_object.hpp
+++ b/lib/core/include/irods_generic_auth_object.hpp
@@ -1,0 +1,54 @@
+#ifndef _GENERIC_AUTH_OBJECT_HPP_
+#define _GENERIC_AUTH_OBJECT_HPP_
+
+#include "irods_error.hpp"
+#include "irods_auth_object.hpp"
+#include "irods_stacktrace.hpp"
+
+#include "rcMisc.h"
+
+namespace irods {
+
+    /**
+     * @brief Auth object for generic authentication
+     */
+    class generic_auth_object : public auth_object {
+        public:
+            /// @brief Constructor
+            generic_auth_object( const std::string& _type, rError_t* _r_error );
+            generic_auth_object( const generic_auth_object& _rhs ); virtual ~generic_auth_object();
+
+            /// @brief Plugin resolution operator
+            virtual error resolve( const std::string& _name, plugin_ptr& _plugin ); // resolve plugin
+
+            /// @brief Comparison operator
+            virtual bool operator==( const generic_auth_object& _rhs ) const;
+            
+            /// @brief Assignment operator
+            virtual generic_auth_object& operator=( const generic_auth_object& _rhs ); 
+            
+            /// @brief serialize to key-value pairs
+            virtual error get_re_vars( rule_engine_vars_t& );
+            
+            /// @brief get the socket number
+            virtual int sock( void ) const {
+                return sock_;
+            }
+
+            /// @brief set the socket number
+            virtual void sock( int s ) {
+                sock_ = s;
+            }
+
+            
+        private:
+            std::string type_;
+            int sock_;
+
+    };
+
+    typedef boost::shared_ptr<generic_auth_object> generic_auth_object_ptr;
+
+}; // namespace irods
+
+#endif // _GENERIC_AUTH_OBJECT_HPP_

--- a/lib/core/src/irods_auth_factory.cpp
+++ b/lib/core/src/irods_auth_factory.cpp
@@ -5,6 +5,7 @@
 #include "irods_osauth_auth_object.hpp"
 #include "irods_gsi_object.hpp"
 #include "irods_krb_object.hpp"
+#include "irods_generic_auth_object.hpp"
 #include "rodsErrorTable.h"
 #include <boost/algorithm/string.hpp>
 
@@ -35,9 +36,7 @@ namespace irods {
             _ptr.reset( new krb_auth_object( _r_error ) );
         }
         else {
-            std::string msg( "auth scheme not supported [" );
-            msg += scheme + "]";
-            return ERROR( SYS_INVALID_INPUT_PARAM, msg );
+            _ptr.reset( new irods::generic_auth_object( scheme, _r_error ) );
         }
 
         return SUCCESS();

--- a/lib/core/src/irods_generic_auth_object.cpp
+++ b/lib/core/src/irods_generic_auth_object.cpp
@@ -1,0 +1,81 @@
+#include "irods_auth_manager.hpp"
+#include "irods_auth_plugin.hpp"
+#include "irods_generic_auth_object.hpp"
+
+extern int ProcessType;
+
+namespace irods {
+
+    generic_auth_object::generic_auth_object(
+        const std::string& _type,
+        rError_t* _r_error ) :
+        auth_object( _r_error ),
+        type_( _type ),
+        sock_( 0 ) {
+
+    } // constructor
+
+    generic_auth_object::generic_auth_object(
+        const generic_auth_object& _rhs ) :
+        auth_object( _rhs ), type_( _rhs.type_ ) {
+
+    } // constructor
+
+    generic_auth_object::~generic_auth_object() {
+
+    } // destructor
+
+
+    error generic_auth_object::resolve(
+        const std::string& _interface,
+        plugin_ptr& _plugin ) {
+        
+        if ( AUTH_INTERFACE != _interface ) {
+            std::stringstream msg;
+            msg << "generic_auth_object does not support a [";
+            msg << _interface;
+            msg << "] plugin interface";
+            return ERROR( SYS_INVALID_INPUT_PARAM, msg.str() );
+        }
+
+        auth_ptr auth_p;
+        error ret = auth_mgr.resolve( type_, auth_p );
+        if ( !ret.ok() ) {
+            std::string empty_context("");
+            ret = auth_mgr.init_from_type(
+                    ProcessType,
+                    type_,
+                    type_,
+                    type_,
+                    empty_context,
+                    auth_p );
+
+            if ( !ret.ok() ) {
+                return PASS( ret );
+            }
+            else {
+                _plugin = boost::dynamic_pointer_cast<plugin_base>( auth_p );
+                return SUCCESS();
+            }
+        }
+
+        _plugin = boost::dynamic_pointer_cast<plugin_base>( auth_p );
+        return SUCCESS();
+    }
+
+    bool generic_auth_object::operator==(
+        const generic_auth_object& _rhs ) const {
+        return false;
+    }
+
+    generic_auth_object& generic_auth_object::operator=(
+        const generic_auth_object& _rhs ) {
+        return *this;
+    }
+
+    error generic_auth_object::get_re_vars(
+        rule_engine_vars_t& _kvp ) {
+        
+        return SUCCESS(); 
+    }
+}


### PR DESCRIPTION
Fall through in auth factory to resolve a string value to a library containing an arbitrary subclass of generic_auth_object. 

Utilized by an openid auth plugin here: https://github.com/irods-contrib/irods_auth_plugin_openid
