### PR TITLE
Collection of bug fixes: [#3658] [#858] [#3865]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 tags
 .dir-locals.el
+.project
+.cproject
+*.swp
 *.pyc

--- a/lib/core/src/rodsPath.cpp
+++ b/lib/core/src/rodsPath.cpp
@@ -265,6 +265,23 @@ addSrcInPath( rodsPathInp_t *rodsPathInp, const char *inPath ) {
         return USER__NULL_INPUT_ERR;
     }
 
+    // Issue #3658 - This section removes trailing slashes from the 
+    // incoming directory path in an invoking icommand (e.g. ireg).
+    //
+    // TODO:  This is a localized fix that addresses any trailing slashes
+    // in inPath. Any future refactoring of the code that deals with paths
+    // would most probably take care of this issue, and the code segment
+    // below would/should then be removed.
+
+    char tmpStr[MAX_NAME_LEN];
+
+    rstrcpy( tmpStr, inPath, MAX_NAME_LEN );
+    size_t len = strlen(tmpStr);
+    for (size_t i = len-1; i > 0 && tmpStr[i] == '/'; i--) {
+        tmpStr[i] = '\0';
+    }
+    const char *modInPath = const_cast<const char *>(tmpStr);   // end of 3658 fix
+
     if ( ( rodsPathInp->numSrc % PTR_ARRAY_MALLOC_LEN ) == 0 ) {
         newNumSrc = rodsPathInp->numSrc + PTR_ARRAY_MALLOC_LEN;
         newSrcPath = ( rodsPath_t * ) malloc( newNumSrc * sizeof( rodsPath_t ) );
@@ -285,7 +302,7 @@ addSrcInPath( rodsPathInp_t *rodsPathInp, const char *inPath ) {
     else {
         newSrcPath = rodsPathInp->srcPath;
     }
-    rstrcpy( newSrcPath[rodsPathInp->numSrc].inPath, inPath, MAX_NAME_LEN );
+    rstrcpy( newSrcPath[rodsPathInp->numSrc].inPath, modInPath, MAX_NAME_LEN );
     rodsPathInp->numSrc++;
 
     return 0;
@@ -478,3 +495,4 @@ clearRodsPath( rodsPath_t *rodsPath ) {
 
     return;
 }
+

--- a/scripts/irods/test/test_ireg.py
+++ b/scripts/irods/test/test_ireg.py
@@ -142,7 +142,7 @@ class Test_Ireg(resource_suite.ResourceBase, unittest.TestCase):
         filename_2 = filename + '_2'
         lib.make_file(filename, 1024, 'arbitrary')
         lib.make_file(filename_2, 1024, 'arbitrary')
-        self.admin.assert_icommand(['ireg', '-Kk', '-R', 'demoResc', os.path.abspath(filename), self.admin.session_collection + '/' + filename]) 
+        self.admin.assert_icommand(['ireg', '-Kk', '-R', 'demoResc', os.path.abspath(filename), self.admin.session_collection + '/' + filename])
         # ireg --repl should fail if it targets a coordinating (i.e. non-leaf) resource
         self.admin.assert_icommand_fail(['ireg', '-Kk', '--repl', '-R', 'r_resc', os.path.abspath(filename_2), self.admin.session_collection + '/' + filename], 'STDOUT_SINGLELINE', 'coordinating resource')
         # ireg --repl should fail if it targets a coordinating (i.e. non-leaf) resource
@@ -216,3 +216,13 @@ class Test_Ireg(resource_suite.ResourceBase, unittest.TestCase):
 
         # Remove the files from iRODS.
         self.admin.assert_icommand('irm -rf {0}'.format(dst_dir))
+
+    def test_ireg_double_slashes__issue_3658(self):
+        dirname = 'dir_3658'
+        lib.create_directory_of_small_files(dirname,2)
+        # This introduces the trailing slash to the end of the physical directory path name
+        self.admin.assert_icommand('ireg -R {0} -C {1} {2}'.format(self.testresc, os.path.abspath(dirname)+"/", self.admin.session_collection+"/"+dirname))
+        # And this shows the problem (or not, if the bug is fixed)
+        self.admin.assert_icommand('iscan {0}'.format(os.path.abspath(dirname)))
+        shutil.rmtree(os.path.abspath(dirname), ignore_errors=True)
+

--- a/scripts/irods/test/test_log_levels.py
+++ b/scripts/irods/test/test_log_levels.py
@@ -1,0 +1,51 @@
+from __future__ import print_function
+import sys
+import os
+
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    import unittest2 as unittest
+
+from .. import lib
+from ..configuration import IrodsConfig
+from ..controller import IrodsController
+
+class Test_LogLevels(unittest.TestCase):
+
+    def setUp(self):
+        super(Test_LogLevels, self).setUp()
+
+    def tearDown(self):
+        super(Test_LogLevels, self).tearDown()
+
+    def test_log_sql__issue_3865(self):
+
+        # PART 1:
+        # We take two measurements/counts.  The first for when no
+        # LOG_SQL lines should be showing up in the server log:
+        initial_log_size = lib.get_file_size_by_path(IrodsConfig().server_log_path)
+
+        # Restart with spLogSql not set in the environment
+        IrodsController().restart()
+
+        # There should be no LOG_SQL lines in the log at this point.  None.
+        self.assertEqual( lib.count_occurrences_of_string_in_log(IrodsConfig().server_log_path, ' LOG_SQL: ', initial_log_size), 0 )
+
+        # PART 2:
+        # The second measurement is for when more than 20 lines with
+        # LOG_SQL should be in the logfile.
+        initial_log_size = lib.get_file_size_by_path(IrodsConfig().server_log_path)
+
+        env = os.environ.copy()
+        env['spLogSql'] = '1'
+
+        # Restart with spLogSql set in the environment
+        IrodsController(IrodsConfig(injected_environment=env)).restart()
+
+        # Restart with spLogSql not set in the environment
+        IrodsController().restart()
+
+        # There should be more than 20 LOG_SQL lines in the log at this point.
+        self.assertGreater( lib.count_occurrences_of_string_in_log(IrodsConfig().server_log_path, ' LOG_SQL: ', initial_log_size), 20 )
+

--- a/server/api/src/rsPhyPathReg.cpp
+++ b/server/api/src/rsPhyPathReg.cpp
@@ -727,7 +727,24 @@ dirPathReg( rsComm_t *rsComm, dataObjInp_t *phyPathRegInp, char *filePath,
         fileStatInp_t fileStatInp;
         memset( &fileStatInp, 0, sizeof( fileStatInp ) );
 
-        snprintf( fileStatInp.fileName, MAX_NAME_LEN, "%s/%s", filePath, rodsDirent->d_name );
+        // Issue #3658 - This section removes trailing slashes from the 
+        // directory path in the server when the path is already in the catalog.
+        //
+        // TODO:  This is a localized fix that addresses any trailing slashes
+        // in inPath. Any future refactoring of the code that deals with paths
+        // would most probably take care of this issue, and the code segment
+        // below would/should then be removed.
+
+        char tmpStr[MAX_NAME_LEN];
+        rstrcpy( tmpStr, filePath, MAX_NAME_LEN );
+        size_t len = strlen(tmpStr);
+
+        for (size_t i = len-1; i > 0 && tmpStr[i] == '/'; i--) {
+            tmpStr[i] = '\0';
+        }
+
+        snprintf( fileStatInp.fileName, MAX_NAME_LEN, "%s/%s", tmpStr, rodsDirent->d_name );
+
         rstrcpy( fileStatInp.objPath, subPhyPathRegInp.objPath, MAX_NAME_LEN );
         fileStatInp.addr = fileOpendirInp.addr;
         rstrcpy( fileStatInp.rescHier, resc_hier, MAX_NAME_LEN );

--- a/server/core/src/rodsServer.cpp
+++ b/server/core/src/rodsServer.cpp
@@ -161,11 +161,22 @@ main( int argc, char **argv )
 
     ProcessType = SERVER_PT;    /* I am a server */
 
-    if ( const char* log_level = getenv( SP_LOG_LEVEL ) ) {
+    const char* log_level = getenv(SP_LOG_LEVEL);
+    if (log_level)
+    {
         rodsLogLevel( atoi( log_level ) );
     }
-    else {
+    else
+    {
         rodsLogLevel( LOG_NOTICE );
+    }
+
+    // Issue #3865 - The mere existence of the environment variable sets 
+    // the value to 1.  Otherwise it stays at the default level (currently 0).
+    const char* sql_log_level = getenv(SP_LOG_SQL);
+    if (sql_log_level)
+    {
+    	rodsLogSqlReq(1);
     }
 
 #ifdef SYSLOG


### PR DESCRIPTION
Resolves:

#3658 irods/irods ireg should trim trailing slash

In lib/core/src/rodsPath.cpp (around line# 268), a check is made for trailing slashes in the physical directory path, and they are removed if they're there. (This is the code path for dealing with "ireg -C ......").

In server/api/src/rsPhyPathReg.cpp (line# around 730), a check is made by the server for trailing slashes in the physical directory path, and they are removed if they're there before a /filename is appended to that string. This takes care of physical directory paths associated with resources in the catalog pre-dating this fix.

Test case:  test_ireg_double_slashes__issue_3658() in scripts/irods/test/test_ireg.py

Continuous Integration:  Build 713 - http://172.25.14.125:8080/view/2.%20Personal/job/irods-build-and-test-workflow/713/
