### PR TITLE
[#3436] Add retry capability to replication resource

### DIFF
--- a/lib/core/src/sockComm.cpp
+++ b/lib/core/src/sockComm.cpp
@@ -303,7 +303,7 @@ sockOpenForInConn( rsComm_t *rsComm, int *portNum, char **addr, int proto ) {
     if ( sock < 0 ) {
         status = SYS_SOCK_OPEN_ERR - errno;
         rodsLogError( LOG_NOTICE, status,
-                      "sockOpenForInConn: open socket error. status = %d", status );
+                      "sockOpenForInConn: open socket error." );
         return status;
     }
 
@@ -410,19 +410,19 @@ rsAcceptConn( rsComm_t *svrComm ) {
     const int saved_socket_flags = fcntl( svrComm->sock, F_GETFL );
     int status = fcntl( svrComm->sock, F_SETFL, saved_socket_flags | O_NONBLOCK );
     if ( status < 0 ) {
-        rodsLogError( LOG_NOTICE, status, "failed to set flags with nonblock on fnctl with status %d", status );
+        rodsLogError( LOG_NOTICE, status, "failed to set flags with nonblock on fnctl" );
     }
     const int newSock = accept( svrComm->sock, ( struct sockaddr * ) &svrComm->remoteAddr, &len );
     status = fcntl( svrComm->sock, F_SETFL, saved_socket_flags );
     if ( status < 0 ) {
-        rodsLogError( LOG_NOTICE, status, "failed to revert flags on fnctl with status %d", status );
+        rodsLogError( LOG_NOTICE, status, "failed to revert flags on fnctl" );
     }
 
     if ( newSock < 0 ) {
         const int status = SYS_SOCK_ACCEPT_ERR - errno;
         rodsLogError( LOG_NOTICE, status,
-                      "rsAcceptConn: accept error for socket %d, status = %d",
-                      svrComm->sock, status );
+                      "rsAcceptConn: accept error for socket %d",
+                      svrComm->sock );
         return newSock;
     }
     rodsSetSockOpt( newSock, svrComm->windowSize );
@@ -563,8 +563,7 @@ irods::error readVersion(
     free( inputStructBBuf.buf );
     if ( status < 0 ) {
         rodsLogError( LOG_NOTICE, status,
-                      "readVersion:unpackStruct error. status = %d",
-                      status );
+                      "readVersion:unpackStruct error." );
     }
 
     return CODE( status );
@@ -694,8 +693,8 @@ connectToRhost( rcComm_t *conn, int connectCnt, int reconnFlag ) {
                                           conn->windowSize, 1 );
     if ( conn->sock < 0 ) {
         rodsLogError( LOG_NOTICE, conn->sock,
-                      "connectToRhost: connect to host %s on port %d failed, status = %d",
-                      conn->host, conn->portNum, conn->sock );
+                      "connectToRhost: connect to host %s on port %d failed",
+                      conn->host, conn->portNum );
         return conn->sock;
     }
 
@@ -704,8 +703,8 @@ connectToRhost( rcComm_t *conn, int connectCnt, int reconnFlag ) {
 
     if ( status < 0 ) {
         rodsLogError( LOG_ERROR, status,
-                      "connectToRhost: sendStartupPack to %s failed, status = %d",
-                      conn->host, status );
+                      "connectToRhost: sendStartupPack to %s failed",
+                      conn->host );
         close( conn->sock );
         return status;
     }
@@ -756,8 +755,8 @@ connectToRhost( rcComm_t *conn, int connectCnt, int reconnFlag ) {
 
     if ( conn->svrVersion->status < 0 ) {
         rodsLogError( LOG_ERROR, conn->svrVersion->status,
-                      "connectToRhost: error returned from host %s status = %d",
-                      conn->host, conn->svrVersion->status );
+                      "connectToRhost: error returned from host %s",
+                      conn->host );
         if ( conn->svrVersion->status == SYS_EXCEED_CONNECT_CNT )
             rodsLog( LOG_ERROR,
                      "It is likely %s is a localhost but not recognized by this server. A line can be added to the server/config/irodsHost file to fix the problem", conn->host );
@@ -953,7 +952,7 @@ connectToRhostWithTout(struct sockaddr *sin ) {
                 }
                 /* Check the returned value */
                 if ( myval ) {
-                    rodsLog( LOG_NOTICE,
+                    rodsLog( LOG_DEBUG,
                              "connectToRhostWithTout: myval error, errno = %d",
                              myval );
                     timeoutCnt++;
@@ -1137,7 +1136,7 @@ sendStartupPack( rcComm_t *conn, int connectCnt, int reconnFlag ) {
                          "StartupPack_PI", RodsPackTable, 0, XML_PROT );
     if ( status < 0 ) {
         rodsLogError( LOG_NOTICE, status,
-                      "sendStartupPack: packStruct error, status = %d", status );
+                      "sendStartupPack: packStruct error" );
         return status;
     }
 
@@ -1356,8 +1355,7 @@ irods::error readReconMsg(
     clearBBuf( &inputStructBBuf );
     if ( status < 0 ) {
         rodsLogError( LOG_NOTICE,  status,
-                      "readReconMsg:unpackStruct error. status = %d",
-                      status );
+                      "readReconMsg:unpackStruct error." );
     }
 
     return CODE( status );
@@ -1400,8 +1398,7 @@ irods::error sendReconnMsg(
     freeBBuf( recon_buf );
     if ( !ret.ok() ) {
         rodsLogError( LOG_ERROR, status,
-                      "sendReconnMsg: sendRodsMsg of reconnect msg failed, status = %d",
-                      status );
+                      "sendReconnMsg: sendRodsMsg of reconnect msg failed" );
     }
 
     return CODE( status );

--- a/plugins/resources/CMakeLists.txt
+++ b/plugins/resources/CMakeLists.txt
@@ -32,6 +32,7 @@ set(IRODS_RESOURCE_PLUGIN_REPLICATION_SOURCES
   ${CMAKE_SOURCE_DIR}/plugins/resources/replication/irods_create_write_replicator.cpp
   ${CMAKE_SOURCE_DIR}/plugins/resources/replication/irods_object_oper.cpp
   ${CMAKE_SOURCE_DIR}/plugins/resources/replication/irods_repl_rebalance.cpp
+  ${CMAKE_SOURCE_DIR}/plugins/resources/replication/irods_repl_retry.cpp
   ${CMAKE_SOURCE_DIR}/plugins/resources/replication/irods_replicator.cpp
   ${CMAKE_SOURCE_DIR}/plugins/resources/replication/irods_unlink_replicator.cpp
   ${CMAKE_SOURCE_DIR}/plugins/resources/replication/librepl.cpp

--- a/plugins/resources/replication/irods_repl_rebalance.hpp
+++ b/plugins/resources/replication/irods_repl_rebalance.hpp
@@ -14,14 +14,14 @@ namespace irods {
 
     // throws irods::exception
     void update_out_of_date_replicas(
-        rsComm_t* _comm_ptr,
+        irods::plugin_context& _ctx,
         const std::vector<leaf_bundle_t>& _leaf_bundles,
         const int _batch_size,
         const std::string& resource_name);
 
     // throws irods::exception
     void create_missing_replicas(
-        rsComm_t* _comm_ptr,
+        irods::plugin_context& _ctx,
         const std::vector<leaf_bundle_t>& _leaf_bundles,
         const int _batch_size,
         const std::string& resource_name);

--- a/plugins/resources/replication/irods_repl_retry.cpp
+++ b/plugins/resources/replication/irods_repl_retry.cpp
@@ -1,0 +1,63 @@
+#include "irods_repl_retry.hpp"
+#include "irods_repl_types.hpp"
+#include "rsDataObjRepl.hpp"
+
+#include <boost/numeric/conversion/cast.hpp>
+#include <chrono>
+#include <string>
+#include <thread>
+
+// Replicates a data object and verifies that the bits are correct
+// Retry mechanism triggers based on config in repl context string
+int irods::data_obj_repl_with_retry(
+        irods::plugin_context& _ctx,
+        dataObjInp_t& dataObjInp ) {
+
+    transferStat_t* trans_stat{ nullptr };
+    auto status{ rsDataObjRepl( _ctx.comm(), &dataObjInp, &trans_stat ) };
+    if ( 0 == status ) {
+        free( trans_stat );
+        return status;
+    }
+
+    // Throw in the event that repl resource retry settings not set
+    auto retry_attempts{ irods::DEFAULT_RETRY_ATTEMPTS };
+    auto delay_in_seconds{ irods::DEFAULT_RETRY_FIRST_DELAY_IN_SECONDS };
+    auto backoff_multiplier{ irods::DEFAULT_RETRY_BACKOFF_MULTIPLIER };
+    irods::error err{ _ctx.prop_map().get< decltype( retry_attempts ) >
+                          ( irods::RETRY_ATTEMPTS_KW, retry_attempts ) };
+    if ( !err.ok() ) {
+        THROW( err.code(), err.result() );
+    }
+    err = _ctx.prop_map().get< decltype( delay_in_seconds ) >
+              ( irods::RETRY_FIRST_DELAY_IN_SECONDS_KW, delay_in_seconds );
+    if ( !err.ok() ) {
+        THROW( err.code(), err.result() );
+    }
+    err = _ctx.prop_map().get< decltype( backoff_multiplier ) >
+              ( irods::RETRY_BACKOFF_MULTIPLIER_KW, backoff_multiplier );
+    if ( !err.ok() ) {
+        THROW( err.code(), err.result() );
+    }
+
+    // Keep retrying until success or there are no more attempts left
+    try {
+        while ( status < 0 && retry_attempts-- > 0 ) {
+            std::this_thread::sleep_for( std::chrono::seconds( delay_in_seconds ) );
+            status = rsDataObjRepl( _ctx.comm(), &dataObjInp, &trans_stat );
+            if ( status < 0 && retry_attempts > 0 ) {
+                delay_in_seconds = boost::numeric_cast< decltype( delay_in_seconds ) >
+                                    ( delay_in_seconds * backoff_multiplier );
+            }
+        }
+    }
+    catch( const boost::bad_numeric_cast& e ) {
+        // Indicates that delay value is too large to store,
+        // so we should stop retrying (2^32 seconds > 136 years)
+        irods::error err = ERROR( USER_INPUT_OPTION_ERR, e.what() );
+        irods::log( err );
+    }
+
+    free( trans_stat );
+    return status;
+}

--- a/plugins/resources/replication/irods_repl_retry.hpp
+++ b/plugins/resources/replication/irods_repl_retry.hpp
@@ -1,0 +1,23 @@
+#ifndef _IRODS_REPL_RETRY_HPP_
+#define _IRODS_REPL_RETRY_HPP_
+
+#include "dataObjInpOut.h"
+#include "irods_plugin_context.hpp"
+#include <string>
+
+namespace irods {
+    // throws irods::exception
+    int data_obj_repl_with_retry(
+        irods::plugin_context& _ctx,
+        dataObjInp_t& dataObjInp );
+
+    const std::string RETRY_ATTEMPTS_KW{ "retry_attempts" };
+    const std::string RETRY_FIRST_DELAY_IN_SECONDS_KW{ "first_retry_delay_in_seconds" };
+    const std::string RETRY_BACKOFF_MULTIPLIER_KW{ "backoff_multiplier" };
+
+    const uint32_t DEFAULT_RETRY_ATTEMPTS{ 1 };
+    const uint32_t DEFAULT_RETRY_FIRST_DELAY_IN_SECONDS{ 1 };
+    const double DEFAULT_RETRY_BACKOFF_MULTIPLIER{ 1.0f };
+}
+
+#endif // _IRODS_REPL_RETRY_HPP_

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -7,6 +7,8 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
+from threading import Timer
 import time
 
 if sys.version_info < (2, 7):
@@ -14,6 +16,7 @@ if sys.version_info < (2, 7):
 else:
     import unittest
 
+from ..test.command import assert_command
 from ..configuration import IrodsConfig
 from ..controller import IrodsController
 from ..core_file import temporary_core_file, CoreFile
@@ -4098,6 +4101,546 @@ class Test_Resource_Replication(ChunkyDevTest, ResourceSuite, unittest.TestCase)
         self.assertEqual(num_up_to_date, 3*num_data_objects_to_use)
         self.assertEqual(num_out_of_date, 0)
         os.unlink(filename)
+
+@unittest.skipIf(False == test.settings.USE_MUNGEFS, "These tests require mungefs")
+class Test_Resource_Replication_With_Retry(ChunkyDevTest, ResourceSuite, unittest.TestCase):
+    def setUp(self):
+        irods_config = IrodsConfig()
+
+        with session.make_session_for_existing_admin() as admin_session:
+            self.munge_mount=tempfile.mkdtemp(prefix='munge_mount_')
+            self.munge_target=tempfile.mkdtemp(prefix='munge_target_')
+            assert_command('mungefs ' + self.munge_mount + ' -omodules=subdir,subdir=' + self.munge_target)
+
+            self.munge_resc = 'ufs1munge'
+            self.munge_passthru = 'pt1'
+            self.normal_vault = irods_config.irods_directory + '/vault2'
+
+            admin_session.assert_icommand("iadmin modresc demoResc name origResc", 'STDOUT_SINGLELINE', 'rename', input='yes\n')
+            admin_session.assert_icommand("iadmin mkresc demoResc replication", 'STDOUT_SINGLELINE', 'replication')
+            admin_session.assert_icommand('iadmin mkresc ' + self.munge_passthru + ' passthru', 'STDOUT_SINGLELINE', 'passthru')
+            admin_session.assert_icommand('iadmin mkresc pt2 passthru', 'STDOUT_SINGLELINE', 'passthru')
+            admin_session.assert_icommand('iadmin mkresc ' + self.munge_resc + ' unixfilesystem ' + test.settings.HOSTNAME_1 + ':' +
+                                          self.munge_mount, 'STDOUT_SINGLELINE', 'unixfilesystem')
+            admin_session.assert_icommand('iadmin mkresc ufs2 unixfilesystem ' + test.settings.HOSTNAME_2 + ':' +
+                                          self.normal_vault, 'STDOUT_SINGLELINE', 'unixfilesystem')
+            admin_session.assert_icommand('iadmin addchildtoresc ' + self.munge_passthru + ' ' + self.munge_resc)
+            admin_session.assert_icommand('iadmin addchildtoresc pt2 ufs2')
+            admin_session.assert_icommand('iadmin addchildtoresc demoResc ' + self.munge_passthru)
+            admin_session.assert_icommand('iadmin addchildtoresc demoResc pt2')
+
+            # Increase write on pt2 because could vote evenly with the 0.5 of pt1 due to locality of reference
+            admin_session.assert_icommand('iadmin modresc ' + self.munge_passthru + ' context "write=0.5"')
+            admin_session.assert_icommand('iadmin modresc pt2 context "write=3.0"')
+
+        # Get count of existing failures in the log
+        self.failure_message = 'Failed to replicate data object'
+        self.log_message_starting_location = lib.get_file_size_by_path(irods_config.server_log_path)
+
+        self.valid_scenarios = [
+            self.test_scenario(1, 1, 1, self.make_context()),
+            self.test_scenario(3, 1, 1, self.make_context('3')),
+            self.test_scenario(1, 3, 1, self.make_context(delay='3')),
+            self.test_scenario(1, 3, 1, self.make_context(delay='3')),
+            self.test_scenario(3, 2, 2, self.make_context('3', '2', '2')),
+            self.test_scenario(3, 2, 1.5, self.make_context('3', '2', '1.5'))
+            ]
+
+        self.invalid_scenarios = [
+            self.test_scenario(1, 1, 1, self.make_context('-2')),
+            self.test_scenario(1, 1, 1, self.make_context('2.0')),
+            self.test_scenario(1, 1, 1, self.make_context('one')),
+            self.test_scenario(1, 1, 1, self.make_context(delay='0')),
+            self.test_scenario(1, 1, 1, self.make_context(delay='-2')),
+            self.test_scenario(1, 1, 1, self.make_context(delay='2.0')),
+            self.test_scenario(1, 1, 1, self.make_context(delay='one')),
+            self.test_scenario(3, 2, 1, self.make_context('3', '2', '0')),
+            self.test_scenario(3, 2, 1, self.make_context('3', '2', '0.5')),
+            self.test_scenario(3, 2, 1, self.make_context('3', '2', '-2')),
+            self.test_scenario(3, 2, 1, self.make_context('3', '2', 'one'))
+            ]
+        super(Test_Resource_Replication_With_Retry, self).setUp()
+
+    def tearDown(self):
+        super(Test_Resource_Replication_With_Retry, self).tearDown()
+
+        # unmount mungefs and destroy directories
+        assert_command(['fusermount', '-u', self.munge_mount])
+        shutil.rmtree(self.munge_mount, ignore_errors=True)
+        shutil.rmtree(self.munge_target, ignore_errors=True)
+        shutil.rmtree(self.normal_vault, ignore_errors=True)
+
+        with session.make_session_for_existing_admin() as admin_session:
+            admin_session.assert_icommand("iadmin rmchildfromresc demoResc " + self.munge_passthru)
+            admin_session.assert_icommand("iadmin rmchildfromresc demoResc pt2")
+            admin_session.assert_icommand("iadmin rmchildfromresc " + self.munge_passthru + ' ' + self.munge_resc)
+            admin_session.assert_icommand("iadmin rmchildfromresc pt2 ufs2")
+            admin_session.assert_icommand("iadmin rmresc " + self.munge_resc)
+            admin_session.assert_icommand("iadmin rmresc ufs2")
+            admin_session.assert_icommand("iadmin rmresc " + self.munge_passthru)
+            admin_session.assert_icommand("iadmin rmresc pt2")
+            admin_session.assert_icommand("iadmin rmresc demoResc")
+            admin_session.assert_icommand("iadmin modresc origResc name demoResc", 'STDOUT_SINGLELINE', 'rename', input='yes\n')
+
+    # Nested class for containing test case information
+    class test_scenario:
+        def __init__(self, retries, delay, multiplier, context_string=None):
+            self.retries = retries
+            self.delay = delay
+            self.multiplier = multiplier
+            self.context_string = context_string
+
+        def munge_delay(self):
+            # No retries means no delay
+            if 0 == self.retries:
+                return 0
+
+            # Get total time over all retries
+            if self.multiplier == 1.0 or self.retries == 1:
+                # Since there is no multiplier, delay increases linearly
+                time_to_failure = self.delay * self.retries
+            else:
+                # Delay represented by geometric sequence
+                # Example for 3 retries:
+                #   First retry -> delay * multiplier^0
+                #   Second retry -> delay * multiplier^1
+                #   Third retry -> delay * multiplier^2
+                time_to_failure = 0
+                for i in range(0, self.retries): # range is non-inclusive at the top end because python
+                    time_to_failure += int(self.delay * pow(self.multiplier, i))
+
+            # Shave some time to ensure mungefsctl can restore filesystem for successful replication
+            return time_to_failure - 0.25
+
+    # Ensure that expected number of new failure messages appear in the log
+    def verify_new_failure_messages_in_log(self, expected_count, expected_message=None):
+        if not expected_message:
+            expected_message = self.failure_message
+
+        irods_config = IrodsConfig()
+        fail_message_count = lib.count_occurrences_of_string_in_log(
+                                  irods_config.server_log_path,
+                                  expected_message,
+                                  start_index=self.log_message_starting_location)
+        self.assertTrue(fail_message_count == expected_count,
+                        msg='counted:[{0}]; expected:[{1}]'.format(
+                            str(fail_message_count), str(expected_count)))
+        self.log_message_starting_location = lib.get_file_size_by_path(irods_config.server_log_path)
+
+    # Generate a context string for replication resource
+    @staticmethod
+    def make_context(retries=None, delay=None, multiplier=None):
+        context_string = ""
+        # Only generate for populated parameters
+        if retries:
+            context_string += 'retry_attempts={0};'.format(retries)
+        if delay:
+            context_string += 'first_retry_delay_in_seconds={0};'.format(delay)
+        if multiplier:
+            context_string += 'backoff_multiplier={0}'.format(multiplier)
+
+        # Empty string causes an error, so put none if using all defaults
+        if not context_string:
+            context_string = 'none=none'
+
+        return context_string
+
+    @staticmethod
+    def run_mungefsctl(operation, modifier=None):
+        mungefsctl_call = 'mungefsctl --operations ' + str(operation)
+        if modifier:
+            mungefsctl_call += ' ' + str(modifier)
+        assert_command(mungefsctl_call)
+
+    def run_rebalance_test(self, scenario, filename):
+        # Setup test and context string
+        filepath = lib.create_local_testfile(filename)
+        if scenario.context_string:
+            self.admin.assert_icommand('iadmin modresc demoResc context "{0}"'.format(scenario.context_string))
+
+        # Get wait time for mungefs to reset
+        wait_time = scenario.munge_delay()
+        self.assertTrue( wait_time > 0, msg='wait time for mungefs [{0}] <= 0'.format(wait_time))
+
+        # For each test, iput will fail to replicate; then we can run a rebalance
+        # Perform corrupt read (checksum) test
+        self.run_mungefsctl('read', '--corrupt_data')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message )
+        self.verify_new_failure_messages_in_log(scenario.retries + 1)
+        munge_thread = Timer(wait_time, self.run_mungefsctl, ['read'])
+        munge_thread.start()
+        self.admin.assert_icommand('iadmin modresc demoResc rebalance')
+        munge_thread.join()
+        self.admin.assert_icommand(['irm', '-f', filename])
+        self.verify_new_failure_messages_in_log(scenario.retries)
+
+        # Perform corrupt size test
+        self.run_mungefsctl('getattr', '--corrupt_size')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(scenario.retries + 1)
+        munge_thread = Timer(wait_time, self.run_mungefsctl, ['getattr'])
+        munge_thread.start()
+        self.admin.assert_icommand('iadmin modresc demoResc rebalance')
+        munge_thread.join()
+        self.admin.assert_icommand(['irm', '-f', filename])
+        self.verify_new_failure_messages_in_log(scenario.retries)
+
+        # Cleanup
+        os.unlink(filepath)
+
+    def run_iput_test(self, scenario, filename):
+        # Setup test and context string
+        filepath = lib.create_local_testfile(filename)
+        if scenario.context_string:
+            self.admin.assert_icommand('iadmin modresc demoResc context "{0}"'.format(scenario.context_string))
+
+        # Get wait time for mungefs to reset
+        wait_time = scenario.munge_delay()
+        self.assertTrue( wait_time > 0, msg='wait time for mungefs [{0}] <= 0'.format(wait_time))
+
+        # Perform corrupt read (checksum) test
+        self.run_mungefsctl('read', '--corrupt_data')
+        munge_thread = Timer(wait_time, self.run_mungefsctl, ['read'])
+        munge_thread.start()
+        self.admin.assert_icommand(['iput', '-K', filepath])
+        munge_thread.join()
+        self.admin.assert_icommand(['irm', '-f', filename])
+        self.verify_new_failure_messages_in_log(scenario.retries)
+
+        # Perform corrupt size test
+        self.run_mungefsctl('getattr', '--corrupt_size')
+        munge_thread = Timer(wait_time, self.run_mungefsctl, ['getattr'])
+        munge_thread.start()
+        self.admin.assert_icommand(['iput', '-K', filepath])
+        munge_thread.join()
+        self.admin.assert_icommand(['irm', '-f', filename])
+        self.verify_new_failure_messages_in_log(scenario.retries)
+
+        # Cleanup
+        os.unlink(filepath)
+
+    # Helper function to recreate replication node to ensure empty context string
+    def reset_repl_resource(self):
+        self.admin.assert_icommand("iadmin rmchildfromresc demoResc " + self.munge_passthru)
+        self.admin.assert_icommand("iadmin rmchildfromresc demoResc pt2")
+        self.admin.assert_icommand("iadmin rmresc demoResc")
+        self.admin.assert_icommand("iadmin mkresc demoResc replication", 'STDOUT_SINGLELINE', 'replication')
+        self.admin.assert_icommand('iadmin addchildtoresc demoResc ' + self.munge_passthru)
+        self.admin.assert_icommand('iadmin addchildtoresc demoResc pt2')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_iput_valid(self):
+        for scenario in self.valid_scenarios:
+            self.run_iput_test(scenario, 'test_repl_retry_iput_valid')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_iput_invalid(self):
+        for scenario in self.invalid_scenarios:
+            self.run_iput_test(scenario, 'test_repl_retry_iput_invalid')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_rebalance_valid(self):
+        for scenario in self.valid_scenarios:
+            self.run_rebalance_test(scenario, 'test_repl_retry_rebalance_valid')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_rebalance_invalid(self):
+        for scenario in self.invalid_scenarios:
+            self.run_rebalance_test(scenario, 'test_repl_retry_rebalance_invalid')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_iput_no_context(self):
+        self.reset_repl_resource()
+        self.run_iput_test(self.test_scenario(1, 1, 1), 'test_repl_retry_iput_no_context')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_rebalance_no_context(self):
+        self.reset_repl_resource()
+        self.run_rebalance_test(self.test_scenario(1, 1, 1), 'test_repl_retry_rebalance_no_context')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_iput_no_retries(self):
+        filename = "test_repl_retry_iput_no_retries"
+        filepath = lib.create_local_testfile(filename)
+        self.admin.assert_icommand('iadmin modresc demoResc context "{0}"'.format(self.make_context('0')))
+
+        # Perform corrupt read (checksum) test
+        self.run_mungefsctl('read', '--corrupt_data')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1)
+        self.run_mungefsctl('read')
+        self.admin.assert_icommand(['irm', '-f', filename])
+
+        # Perform corrupt size test
+        self.run_mungefsctl('getattr', '--corrupt_size')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1)
+        self.run_mungefsctl('getattr')
+
+        self.admin.assert_icommand(['irm', '-f', filename])
+        os.unlink(filepath)
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_rebalance_no_retries(self):
+        filename = "test_repl_retry_rebalance_no_retries"
+        filepath = lib.create_local_testfile(filename)
+        self.admin.assert_icommand('iadmin modresc demoResc context "{0}"'.format(self.make_context('0')))
+
+        # Perform corrupt read (checksum) test
+        self.run_mungefsctl('read', '--corrupt_data')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1)
+        self.admin.assert_icommand_fail('iadmin modresc demoResc rebalance', 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1)
+        self.run_mungefsctl('read')
+        self.admin.assert_icommand(['irm', '-f', filename])
+
+        # Perform corrupt size test
+        self.run_mungefsctl('getattr', '--corrupt_size')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1)
+        self.admin.assert_icommand_fail('iadmin modresc demoResc rebalance', 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1)
+        self.run_mungefsctl('getattr')
+
+        self.admin.assert_icommand(['irm', '-f', filename])
+        os.unlink(filepath)
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_multiplier_overflow(self):
+        filename = "test_repl_retry_iput_large_multiplier"
+        filepath = lib.create_local_testfile(filename)
+        large_number = pow(2, 32)
+        scenario = self.test_scenario(2, 1, large_number, self.make_context('2', '1', str(large_number)))
+        failure_message = 'bad numeric conversion'
+        self.admin.assert_icommand('iadmin modresc demoResc context "{0}"'.format(scenario.context_string))
+
+        self.run_mungefsctl('read', '--corrupt_data')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1, failure_message)
+        self.admin.assert_icommand_fail('iadmin modresc demoResc rebalance', 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1, failure_message)
+        self.run_mungefsctl('read')
+
+        self.admin.assert_icommand(['irm', '-f', filename])
+        os.unlink(filepath)
+
+    def test_irepl_over_existing_bad_replica__ticket_1705(self):
+        # local setup
+        filename = "reploverwritebad.txt"
+        filepath = lib.create_local_testfile(filename)
+        doublefile = "doublefile.txt"
+        lib.execute_command("cat %s %s > %s" % (filename, filename, doublefile), use_unsafe_shell=True)
+        doublesize = str(os.stat(doublefile).st_size)
+
+        self.admin.assert_icommand("ils -L " + filename, 'STDERR_SINGLELINE', "does not exist")
+        self.admin.assert_icommand("iput " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        # overwrite default repl with different data
+        self.admin.assert_icommand("iput -f %s %s" % (doublefile, filename))
+        # default resource should have replicated 2 clean copies
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " & " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " & " + filename])
+        # default resource should have replicated new double clean copies
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " " + doublesize + " ", " & " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " " + doublesize + " ", " & " + filename])
+        # test resource should not have doublesize file
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 2 " + self.testresc, " " + doublesize + " ", "  " + filename])
+        # replicate back onto test resource
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        # test resource should have new clean doublesize file
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 2 " + self.testresc, " " + doublesize + " ", " & " + filename])
+        # should not have a replica 3
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 3 ", " & " + filename])
+
+        # local cleanup
+        os.remove(filepath)
+
+    def test_irepl_over_existing_second_replica__ticket_1705(self):
+        # local setup
+        filename = "secondreplicatest.txt"
+        filepath = lib.create_local_testfile(filename)
+
+        self.admin.assert_icommand("ils -L " + filename, 'STDERR_SINGLELINE', "does not exist")
+        self.admin.assert_icommand("iput -R " + self.testresc + " " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        # replicate to default resource (default resource is replication)
+        self.admin.assert_icommand("irepl " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        # replicate overtop default resource (default resource is replication)
+        self.admin.assert_icommand("irepl " + filename)
+        # should not have a replica 3
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 3 ", " & " + filename])
+        # replicate overtop test resource
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        # should not have a replica 3
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 3 ", " & " + filename])
+
+        # local cleanup
+        os.remove(filepath)
+
+    def test_irepl_over_existing_third_replica__ticket_1705(self):
+        # local setup
+        filename = "thirdreplicatest.txt"
+        filepath = lib.create_local_testfile(filename)
+        hostname = lib.get_hostname()
+        hostuser = getpass.getuser()
+
+        self.admin.assert_icommand("iadmin mkresc thirdresc unixfilesystem %s:/tmp/%s/thirdrescVault" % (hostname, hostuser), 'STDOUT_SINGLELINE', "Creating")
+        self.admin.assert_icommand("ils -L " + filename, 'STDERR_SINGLELINE', "does not exist")
+        # put to default resource (creates 2 replicas, 0 and 1)
+        self.admin.assert_icommand("iput " + filename)
+        # replicate to test resource (creates replica 2)
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        # replicate to third resource (creates replica 3)
+        self.admin.assert_icommand("irepl -R thirdresc " + filename)
+        self.admin.assert_icommand("irepl " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        self.admin.assert_icommand("irepl -R thirdresc " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        # should not have a replica 4
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 4 ", " & " + filename])
+        # should not have a replica 5
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 5 ", " & " + filename])
+        self.admin.assert_icommand("irm -f " + filename)
+        self.admin.assert_icommand("iadmin rmresc thirdresc")
+
+        # local cleanup
+        os.remove(filepath)
+
+    def test_irepl_update_replicas(self):
+        # local setup
+        filename = "updatereplicasfile.txt"
+        filepath = lib.create_local_testfile(filename)
+        hostname = lib.get_hostname()
+        hostuser = getpass.getuser()
+        doublefile = "doublefile.txt"
+        lib.execute_command("cat %s %s > %s" % (filename, filename, doublefile), use_unsafe_shell=True)
+        doublesize = str(os.stat(doublefile).st_size)
+
+        self.admin.assert_icommand("iadmin mkresc thirdresc unixfilesystem %s:/tmp/%s/thirdrescVault" %
+                                           (hostname, hostuser), 'STDOUT_SINGLELINE', "Creating")
+        self.admin.assert_icommand("iadmin mkresc fourthresc unixfilesystem %s:/tmp/%s/fourthrescVault" %
+                                           (hostname, hostuser), 'STDOUT_SINGLELINE', "Creating")
+        self.admin.assert_icommand("ils -L " + filename, 'STDERR_SINGLELINE', "does not exist")
+        # put to default resource (creates two replicas, 0 and 1)
+        self.admin.assert_icommand("iput " + filename)
+        # replicate to test resource
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        # replicate to third resource
+        self.admin.assert_icommand("irepl -R thirdresc " + filename)
+        # replicate to fourth resource
+        self.admin.assert_icommand("irepl -R fourthresc " + filename)
+        # repave overtop test resource
+        self.admin.assert_icommand("iput -f -R " + self.testresc + " " + doublefile + " " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+
+        # should have dirty copies
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " & " + filename])
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " & " + filename])
+        # should have a clean copy
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 2 ", " & " + filename])
+        # should have dirty copies
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 3 ", " & " + filename])
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 4 ", " & " + filename])
+
+        self.admin.assert_icommand("irepl -U " + filename)
+
+        # should have dirty copies
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " & " + filename])
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " & " + filename])
+        # should have a clean copy
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 2 ", " & " + filename])
+        # should have a dirty copy
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 3 ", " & " + filename])
+        # should have a clean copy
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 4 ", " & " + filename])
+
+        self.admin.assert_icommand("irepl -aU " + filename)
+
+        # should have clean copies
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " & " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " & " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 2 ", " & " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 3 ", " & " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 4 ", " & " + filename])
+
+        self.admin.assert_icommand("irm -f " + filename)
+        self.admin.assert_icommand("iadmin rmresc thirdresc")
+        self.admin.assert_icommand("iadmin rmresc fourthresc")
+
+        # local cleanup
+        os.remove(filepath)
+        os.remove(doublefile)
+
+    def test_irm_specific_replica(self):
+        # should be listed 2x
+        self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', [" 0 ", " & " + self.testfile])
+        self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', [" 1 ", " & " + self.testfile])
+
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + self.testfile)
+        # should be listed a third time
+        self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', [" 2 ", " & " + self.testfile])
+        # Remove one of the original replicas
+        self.admin.assert_icommand("irm -n 1 " + self.testfile)
+        # replicas 0 and 2 should be there (replica 0 goes to ufs2)
+        self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', ["0 ", "ufs2", self.testfile])
+        self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', ["2 " + self.testresc, self.testfile])
+        # replica 1 should be gone
+        self.admin.assert_icommand_fail("ils -L " + self.testfile, 'STDOUT_SINGLELINE',
+                                                ["1 ", self.munge_resc, self.testfile])
+        # replica should not be in trash
+        trashpath = "/" + self.admin.zone_name + "/trash/home/" + self.admin.username + "/" + self.admin._session_id
+        self.admin.assert_icommand_fail("ils -L " + trashpath + "/" + self.testfile, 'STDOUT_SINGLELINE',
+                                                ["1 ", self.munge_resc, self.testfile])
+
+    def test_local_iput_with_force_and_destination_resource__ticket_1706(self):
+        # local setup
+        filename = "iputwithforceanddestination.txt"
+        filepath = lib.create_local_testfile(filename)
+        doublefile = "doublefile.txt"
+        lib.execute_command("cat %s %s > %s" % (filename, filename, doublefile), use_unsafe_shell=True)
+        doublesize = str(os.stat(doublefile).st_size)
+
+        self.admin.assert_icommand("ils -L " + filename, 'STDERR_SINGLELINE', "does not exist")
+        # put to default resource creates 2 replicas
+        self.admin.assert_icommand("iput " + filename)
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        # overwrite test repl with different data
+        self.admin.assert_icommand("iput -f -R %s %s %s" % (self.testresc, doublefile, filename))
+        # default resource should have dirty copies
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " " + filename])
+        # default resource should not have any doublesize files
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " " + doublesize + " ", " " + filename])
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " " + doublesize + " ", " " + filename])
+        # targeted resource should have new double clean copy
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 2 ", " " + doublesize + " ", "& " + filename])
+
+        # local cleanup
+        os.remove(filepath)
+        os.remove(doublefile)
+
+    @unittest.skip("no support for non-compound resources")
+    def test_iget_with_purgec(self):
+        pass
+
+    @unittest.skip("no support for non-compound resources")
+    def test_iput_with_purgec(self):
+        pass
+
+    @unittest.skip("no support for non-compound resources")
+    def test_irepl_with_purgec(self):
+        pass
+
+    @unittest.skip("EMPTY_RESC_PATH - no vault path for coordinating resources")
+    def test_ireg_as_rodsuser_in_vault(self):
+        pass
 
 class Test_Resource_MultiLayered(ChunkyDevTest, ResourceSuite, unittest.TestCase):
 


### PR DESCRIPTION
This change adds a configurable retry mechanism to the replication resource. The replication resources can be configured via 3 new settings in the context string of the resource. The retry applies when the replication from an iput or a replication rebalance fails. The default value for each setting is 1, which means a single retry after 1 second has passed.

Passed 4 test runs on Jenkins. Two of the runs hit #3689 for ub16-oracle. One run hit #3706 for topo-cen6-psql-resc-ssl.