### PR TITLE
[#3436] Add retry capability to replication resource

### DIFF
--- a/lib/core/src/sockComm.cpp
+++ b/lib/core/src/sockComm.cpp
@@ -303,7 +303,7 @@ sockOpenForInConn( rsComm_t *rsComm, int *portNum, char **addr, int proto ) {
     if ( sock < 0 ) {
         status = SYS_SOCK_OPEN_ERR - errno;
         rodsLogError( LOG_NOTICE, status,
-                      "sockOpenForInConn: open socket error. status = %d", status );
+                      "sockOpenForInConn: open socket error." );
         return status;
     }
 
@@ -410,19 +410,19 @@ rsAcceptConn( rsComm_t *svrComm ) {
     const int saved_socket_flags = fcntl( svrComm->sock, F_GETFL );
     int status = fcntl( svrComm->sock, F_SETFL, saved_socket_flags | O_NONBLOCK );
     if ( status < 0 ) {
-        rodsLogError( LOG_NOTICE, status, "failed to set flags with nonblock on fnctl with status %d", status );
+        rodsLogError( LOG_NOTICE, status, "failed to set flags with nonblock on fnctl" );
     }
     const int newSock = accept( svrComm->sock, ( struct sockaddr * ) &svrComm->remoteAddr, &len );
     status = fcntl( svrComm->sock, F_SETFL, saved_socket_flags );
     if ( status < 0 ) {
-        rodsLogError( LOG_NOTICE, status, "failed to revert flags on fnctl with status %d", status );
+        rodsLogError( LOG_NOTICE, status, "failed to revert flags on fnctl" );
     }
 
     if ( newSock < 0 ) {
         const int status = SYS_SOCK_ACCEPT_ERR - errno;
         rodsLogError( LOG_NOTICE, status,
-                      "rsAcceptConn: accept error for socket %d, status = %d",
-                      svrComm->sock, status );
+                      "rsAcceptConn: accept error for socket %d",
+                      svrComm->sock );
         return newSock;
     }
     rodsSetSockOpt( newSock, svrComm->windowSize );
@@ -563,8 +563,7 @@ irods::error readVersion(
     free( inputStructBBuf.buf );
     if ( status < 0 ) {
         rodsLogError( LOG_NOTICE, status,
-                      "readVersion:unpackStruct error. status = %d",
-                      status );
+                      "readVersion:unpackStruct error." );
     }
 
     return CODE( status );
@@ -694,8 +693,8 @@ connectToRhost( rcComm_t *conn, int connectCnt, int reconnFlag ) {
                                           conn->windowSize, 1 );
     if ( conn->sock < 0 ) {
         rodsLogError( LOG_NOTICE, conn->sock,
-                      "connectToRhost: connect to host %s on port %d failed, status = %d",
-                      conn->host, conn->portNum, conn->sock );
+                      "connectToRhost: connect to host %s on port %d failed",
+                      conn->host, conn->portNum );
         return conn->sock;
     }
 
@@ -704,8 +703,8 @@ connectToRhost( rcComm_t *conn, int connectCnt, int reconnFlag ) {
 
     if ( status < 0 ) {
         rodsLogError( LOG_ERROR, status,
-                      "connectToRhost: sendStartupPack to %s failed, status = %d",
-                      conn->host, status );
+                      "connectToRhost: sendStartupPack to %s failed",
+                      conn->host );
         close( conn->sock );
         return status;
     }
@@ -756,8 +755,8 @@ connectToRhost( rcComm_t *conn, int connectCnt, int reconnFlag ) {
 
     if ( conn->svrVersion->status < 0 ) {
         rodsLogError( LOG_ERROR, conn->svrVersion->status,
-                      "connectToRhost: error returned from host %s status = %d",
-                      conn->host, conn->svrVersion->status );
+                      "connectToRhost: error returned from host %s",
+                      conn->host );
         if ( conn->svrVersion->status == SYS_EXCEED_CONNECT_CNT )
             rodsLog( LOG_ERROR,
                      "It is likely %s is a localhost but not recognized by this server. A line can be added to the server/config/irodsHost file to fix the problem", conn->host );
@@ -953,7 +952,7 @@ connectToRhostWithTout(struct sockaddr *sin ) {
                 }
                 /* Check the returned value */
                 if ( myval ) {
-                    rodsLog( LOG_NOTICE,
+                    rodsLog( LOG_DEBUG,
                              "connectToRhostWithTout: myval error, errno = %d",
                              myval );
                     timeoutCnt++;
@@ -1137,7 +1136,7 @@ sendStartupPack( rcComm_t *conn, int connectCnt, int reconnFlag ) {
                          "StartupPack_PI", RodsPackTable, 0, XML_PROT );
     if ( status < 0 ) {
         rodsLogError( LOG_NOTICE, status,
-                      "sendStartupPack: packStruct error, status = %d", status );
+                      "sendStartupPack: packStruct error" );
         return status;
     }
 
@@ -1356,8 +1355,7 @@ irods::error readReconMsg(
     clearBBuf( &inputStructBBuf );
     if ( status < 0 ) {
         rodsLogError( LOG_NOTICE,  status,
-                      "readReconMsg:unpackStruct error. status = %d",
-                      status );
+                      "readReconMsg:unpackStruct error." );
     }
 
     return CODE( status );
@@ -1400,8 +1398,7 @@ irods::error sendReconnMsg(
     freeBBuf( recon_buf );
     if ( !ret.ok() ) {
         rodsLogError( LOG_ERROR, status,
-                      "sendReconnMsg: sendRodsMsg of reconnect msg failed, status = %d",
-                      status );
+                      "sendReconnMsg: sendRodsMsg of reconnect msg failed" );
     }
 
     return CODE( status );

--- a/plugins/resources/CMakeLists.txt
+++ b/plugins/resources/CMakeLists.txt
@@ -32,6 +32,7 @@ set(IRODS_RESOURCE_PLUGIN_REPLICATION_SOURCES
   ${CMAKE_SOURCE_DIR}/plugins/resources/replication/irods_create_write_replicator.cpp
   ${CMAKE_SOURCE_DIR}/plugins/resources/replication/irods_object_oper.cpp
   ${CMAKE_SOURCE_DIR}/plugins/resources/replication/irods_repl_rebalance.cpp
+  ${CMAKE_SOURCE_DIR}/plugins/resources/replication/irods_repl_retry.cpp
   ${CMAKE_SOURCE_DIR}/plugins/resources/replication/irods_replicator.cpp
   ${CMAKE_SOURCE_DIR}/plugins/resources/replication/irods_unlink_replicator.cpp
   ${CMAKE_SOURCE_DIR}/plugins/resources/replication/librepl.cpp

--- a/plugins/resources/replication/irods_repl_rebalance.cpp
+++ b/plugins/resources/replication/irods_repl_rebalance.cpp
@@ -3,9 +3,9 @@
 #include "irods_file_object.hpp"
 #include "irods_hierarchy_parser.hpp"
 #include "irods_virtual_path.hpp"
+#include "irods_repl_retry.hpp"
 #include "irods_repl_types.hpp"
 #include "icatHighLevelRoutines.hpp"
-#include "rsDataObjRepl.hpp"
 #include "dataObjRepl.h"
 #include "genQuery.h"
 #include "rsGenQuery.hpp"
@@ -16,14 +16,14 @@
 
 namespace {
     irods::error repl_for_rebalance(
-        rsComm_t*          _comm,
+        irods::plugin_context& _ctx,
         const std::string& _obj_path,
         const std::string& _current_resc,
         const std::string& _src_hier,
         const std::string& _dst_hier,
         const std::string& _src_resc,
         const std::string& _dst_resc,
-        int                _mode ) {
+        const int          _mode ) {
         // =-=-=-=-=-=-=-
         // generate a resource hierarchy that ends at this resource for pdmo
         irods::hierarchy_parser parser;
@@ -34,8 +34,7 @@ namespace {
         // =-=-=-=-=-=-=-
         // create a data obj input struct to call rsDataObjRepl which given
         // the _stage_sync_kw will either stage or sync the data object
-        dataObjInp_t data_obj_inp;
-        bzero( &data_obj_inp, sizeof( data_obj_inp ) );
+        dataObjInp_t data_obj_inp{};
         rstrcpy( data_obj_inp.objPath, _obj_path.c_str(), MAX_NAME_LEN );
         data_obj_inp.createMode = _mode;
         addKeyVal( &data_obj_inp.condInput, RESC_HIER_STR_KW,      _src_hier.c_str() );
@@ -45,17 +44,18 @@ namespace {
         addKeyVal( &data_obj_inp.condInput, IN_PDMO_KW,             sub_hier.c_str() );
         addKeyVal( &data_obj_inp.condInput, ADMIN_KW,              "" );
 
-        // =-=-=-=-=-=-=-
-        // process the actual call for replication
-        transferStat_t* trans_stat = NULL;
-        int repl_stat = rsDataObjRepl( _comm, &data_obj_inp, &trans_stat );
-        free( trans_stat );
-        if ( repl_stat < 0 ) {
-            std::stringstream msg;
-            msg << "Failed to replicate the data object ["
-                << _obj_path
-                << "]";
-            return ERROR( repl_stat, msg.str() );
+        try {
+            // =-=-=-=-=-=-=-
+            // process the actual call for replication
+            const auto status = data_obj_repl_with_retry( _ctx, data_obj_inp );
+            if ( status < 0 ) {
+                return ERROR( status,
+                              boost::format( "Failed to replicate the data object [%s]" ) %
+                              _obj_path );
+            }
+        }
+        catch( const irods::exception& e ) {
+            return irods::error( e );
         }
 
         return SUCCESS();
@@ -291,13 +291,13 @@ namespace {
 
     // throws irods::exception
     void proc_results_for_rebalance(
-        rsComm_t*                        _comm,
+        irods::plugin_context&           _ctx,
         const std::string&               _parent_resc_name,
         const std::string&               _child_resc_name,
         const size_t                     _bun_idx,
         const std::vector<leaf_bundle_t> _bundles,
         const dist_child_result_t&       _data_ids_to_replicate) {
-        if (!_comm) {
+        if (!_ctx.comm()) {
             THROW(SYS_INVALID_INPUT_PARAM,
                   boost::format("null comm pointer. resource [%s]. child resource [%s]. bundle index [%d]. bundles [%s]") %
                   _parent_resc_name %
@@ -317,10 +317,10 @@ namespace {
 
         irods::error first_rebalance_error = SUCCESS();
         for (auto data_id_to_replicate : _data_ids_to_replicate) {
-            const ReplicationSourceInfo source_info = get_source_data_object_attributes(_comm, data_id_to_replicate, _bundles);
+            const ReplicationSourceInfo source_info = get_source_data_object_attributes(_ctx.comm(), data_id_to_replicate, _bundles);
 
             // create a file object so we can resolve a valid hierarchy to which to replicate
-            irods::file_object_ptr f_ptr(new irods::file_object(_comm, source_info.object_path, "", "", 0, source_info.data_mode, 0));
+            irods::file_object_ptr f_ptr(new irods::file_object(_ctx.comm(), source_info.object_path, "", "", 0, source_info.data_mode, 0));
             // short circuit the magic re-repl
             {
                 irods::hierarchy_parser sub_parser;
@@ -362,7 +362,7 @@ namespace {
             std::string host_name;
             float vote = 0.0;
             const irods::error err_vote = dst_resc->call<const std::string*, const std::string*, irods::hierarchy_parser*, float*>(
-                _comm,
+                _ctx.comm(),
                 irods::RESOURCE_OP_RESOLVE_RESC_HIER,
                 f_ptr,
                 &irods::CREATE_OPERATION,
@@ -384,7 +384,7 @@ namespace {
             parser.str(dst_hier);
             rodsLog(LOG_NOTICE, "proc_results_for_rebalance: creating new replica for data id [%lld] from [%s] on [%s]", data_id_to_replicate, source_info.resource_hierarchy.c_str(), dst_hier.c_str());
             const irods::error err_rebalance = repl_for_rebalance(
-                _comm,
+                _ctx,
                 source_info.object_path,
                 _parent_resc_name,
                 source_info.resource_hierarchy,
@@ -399,19 +399,17 @@ namespace {
                 rodsLog(LOG_ERROR, "proc_results_for_rebalance: repl_for_rebalance failed. object path [%s] parent resc [%s] source hier [%s] dest hier [%s] root resc [%s] data mode [%d]",
                         source_info.object_path.c_str(), _parent_resc_name.c_str(), source_info.resource_hierarchy.c_str(), dst_hier.c_str(), root_resc.c_str(), source_info.data_mode);
                 irods::log(PASS(err_rebalance));
-                if (_comm->rError.len < MAX_ERROR_MESSAGES) {
-                    addRErrorMsg(&_comm->rError, err_rebalance.code(), err_rebalance.result().c_str());
+                if (_ctx.comm()->rError.len < MAX_ERROR_MESSAGES) {
+                    addRErrorMsg(&_ctx.comm()->rError, err_rebalance.code(), err_rebalance.result().c_str());
                 }
             }
         }
 
         if (!first_rebalance_error.ok()) {
             THROW(first_rebalance_error.code(),
-                  boost::format("failed to resolve resource plugin. child resc name [%s] parent resc [%s] bundle index [%d] bundles [%s]. rebalance message [%s]") %
+                  boost::format("proc_results_for_rebalance: repl_for_rebalance failed. child_resc [%s] parent resc [%s]. rebalance message [%s]") %
                   _child_resc_name %
                   _parent_resc_name %
-                  _bun_idx %
-                  leaf_bundles_to_string(_bundles) %
                   first_rebalance_error.result());
         }
     }
@@ -420,13 +418,13 @@ namespace {
 namespace irods {
     // throws irods::exception
     void update_out_of_date_replicas(
-        rsComm_t* _comm_ptr,
+        irods::plugin_context& _ctx,
         const std::vector<leaf_bundle_t>& _leaf_bundles,
         const int _batch_size,
         const std::string& _resource_name) {
 
         while (true) {
-            const std::vector<ReplicaAndRescId> replicas_to_update = get_out_of_date_replicas_batch(_comm_ptr, _leaf_bundles, _batch_size);
+            const std::vector<ReplicaAndRescId> replicas_to_update = get_out_of_date_replicas_batch(_ctx.comm(), _leaf_bundles, _batch_size);
             if (replicas_to_update.empty()) {
                 break;
             }
@@ -443,7 +441,7 @@ namespace irods {
                           replica_to_update.resource_id);
                 }
 
-                ReplicationSourceInfo source_info = get_source_data_object_attributes(_comm_ptr, replica_to_update.data_id, _leaf_bundles);
+                ReplicationSourceInfo source_info = get_source_data_object_attributes(_ctx.comm(), replica_to_update.data_id, _leaf_bundles);
                 hierarchy_parser hierarchy_parser;
                 const error err_parser = hierarchy_parser.set_string(source_info.resource_hierarchy);
                 if (!err_parser.ok()) {
@@ -468,7 +466,7 @@ namespace irods {
                         source_info.resource_hierarchy.c_str(),
                         destination_hierarchy.c_str());
                 const error err_repl = repl_for_rebalance(
-                    _comm_ptr,
+                    _ctx,
                     source_info.object_path,
                     _resource_name,
                     source_info.resource_hierarchy,
@@ -482,8 +480,8 @@ namespace irods {
                         first_error = err_repl;
                     }
                     const error error_to_log = PASS(err_repl);
-                    if (_comm_ptr->rError.len < MAX_ERROR_MESSAGES) {
-                        addRErrorMsg(&_comm_ptr->rError, error_to_log.code(), error_to_log.result().c_str());
+                    if (_ctx.comm()->rError.len < MAX_ERROR_MESSAGES) {
+                        addRErrorMsg(&_ctx.comm()->rError, error_to_log.code(), error_to_log.result().c_str());
                     }
                     rodsLog(LOG_ERROR,
                             "update_out_of_date_replicas: repl_for_rebalance failed with code [%ji] and message [%s]. object [%s] source hierarchy [%s] data id [%ji] destination repl num [%ji] destination hierarchy [%s]",
@@ -499,7 +497,7 @@ namespace irods {
 
     // throws irods::exception
     void create_missing_replicas(
-        rsComm_t* _comm_ptr,
+        irods::plugin_context& _ctx,
         const std::vector<leaf_bundle_t>& _leaf_bundles,
         const int _batch_size,
         const std::string& _resource_name) {
@@ -519,7 +517,7 @@ namespace irods {
                     break;
                 }
 
-                proc_results_for_rebalance(_comm_ptr, _resource_name, child_name, i, _leaf_bundles, data_ids_needing_new_replicas);
+                proc_results_for_rebalance(_ctx, _resource_name, child_name, i, _leaf_bundles, data_ids_needing_new_replicas);
             }
         }
     }

--- a/plugins/resources/replication/irods_repl_rebalance.hpp
+++ b/plugins/resources/replication/irods_repl_rebalance.hpp
@@ -14,14 +14,14 @@ namespace irods {
 
     // throws irods::exception
     void update_out_of_date_replicas(
-        rsComm_t* _comm_ptr,
+        irods::plugin_context& _ctx,
         const std::vector<leaf_bundle_t>& _leaf_bundles,
         const int _batch_size,
         const std::string& resource_name);
 
     // throws irods::exception
     void create_missing_replicas(
-        rsComm_t* _comm_ptr,
+        irods::plugin_context& _ctx,
         const std::vector<leaf_bundle_t>& _leaf_bundles,
         const int _batch_size,
         const std::string& resource_name);

--- a/plugins/resources/replication/irods_repl_retry.cpp
+++ b/plugins/resources/replication/irods_repl_retry.cpp
@@ -1,0 +1,63 @@
+#include "irods_repl_retry.hpp"
+#include "irods_repl_types.hpp"
+#include "rsDataObjRepl.hpp"
+
+#include <boost/numeric/conversion/cast.hpp>
+#include <chrono>
+#include <string>
+#include <thread>
+
+// Replicates a data object and verifies that the bits are correct
+// Retry mechanism triggers based on config in repl context string
+int irods::data_obj_repl_with_retry(
+        irods::plugin_context& _ctx,
+        dataObjInp_t& dataObjInp ) {
+
+    transferStat_t* trans_stat{ nullptr };
+    auto status{ rsDataObjRepl( _ctx.comm(), &dataObjInp, &trans_stat ) };
+    if ( 0 == status ) {
+        free( trans_stat );
+        return status;
+    }
+
+    // Throw in the event that repl resource retry settings not set
+    auto retry_attempts{ irods::DEFAULT_RETRY_ATTEMPTS };
+    auto delay_in_seconds{ irods::DEFAULT_RETRY_FIRST_DELAY_IN_SECONDS };
+    auto backoff_multiplier{ irods::DEFAULT_RETRY_BACKOFF_MULTIPLIER };
+    irods::error err{ _ctx.prop_map().get< decltype( retry_attempts ) >
+                          ( irods::RETRY_ATTEMPTS_KW, retry_attempts ) };
+    if ( !err.ok() ) {
+        THROW( err.code(), err.result() );
+    }
+    err = _ctx.prop_map().get< decltype( delay_in_seconds ) >
+              ( irods::RETRY_FIRST_DELAY_IN_SECONDS_KW, delay_in_seconds );
+    if ( !err.ok() ) {
+        THROW( err.code(), err.result() );
+    }
+    err = _ctx.prop_map().get< decltype( backoff_multiplier ) >
+              ( irods::RETRY_BACKOFF_MULTIPLIER_KW, backoff_multiplier );
+    if ( !err.ok() ) {
+        THROW( err.code(), err.result() );
+    }
+
+    // Keep retrying until success or there are no more attempts left
+    try {
+        while ( status < 0 && retry_attempts-- > 0 ) {
+            std::this_thread::sleep_for( std::chrono::seconds( delay_in_seconds ) );
+            status = rsDataObjRepl( _ctx.comm(), &dataObjInp, &trans_stat );
+            if ( status < 0 && retry_attempts > 0 ) {
+                delay_in_seconds = boost::numeric_cast< decltype( delay_in_seconds ) >
+                                    ( delay_in_seconds * backoff_multiplier );
+            }
+        }
+    }
+    catch( const boost::bad_numeric_cast& e ) {
+        // Indicates that delay value is too large to store,
+        // so we should stop retrying (2^32 seconds > 136 years)
+        irods::error err = ERROR( USER_INPUT_OPTION_ERR, e.what() );
+        irods::log( err );
+    }
+
+    free( trans_stat );
+    return status;
+}

--- a/plugins/resources/replication/irods_repl_retry.hpp
+++ b/plugins/resources/replication/irods_repl_retry.hpp
@@ -1,0 +1,23 @@
+#ifndef _IRODS_REPL_RETRY_HPP_
+#define _IRODS_REPL_RETRY_HPP_
+
+#include "dataObjInpOut.h"
+#include "irods_plugin_context.hpp"
+#include <string>
+
+namespace irods {
+    // throws irods::exception
+    int data_obj_repl_with_retry(
+        irods::plugin_context& _ctx,
+        dataObjInp_t& dataObjInp );
+
+    const std::string RETRY_ATTEMPTS_KW{ "retry_attempts" };
+    const std::string RETRY_FIRST_DELAY_IN_SECONDS_KW{ "first_retry_delay_in_seconds" };
+    const std::string RETRY_BACKOFF_MULTIPLIER_KW{ "backoff_multiplier" };
+
+    const uint32_t DEFAULT_RETRY_ATTEMPTS{ 1 };
+    const uint32_t DEFAULT_RETRY_FIRST_DELAY_IN_SECONDS{ 1 };
+    const double DEFAULT_RETRY_BACKOFF_MULTIPLIER{ 1.0f };
+}
+
+#endif // _IRODS_REPL_RETRY_HPP_

--- a/plugins/resources/replication/librepl.cpp
+++ b/plugins/resources/replication/librepl.cpp
@@ -5,10 +5,9 @@
 
 // =-=-=-=-=-=-=-
 // irods includes
+#include "icatHighLevelRoutines.hpp"
 #include "msParam.h"
 #include "rodsLog.h"
-#include "icatHighLevelRoutines.hpp"
-#include "dataObjRepl.h"
 
 // =-=-=-=-=-=-=-
 #include "irods_resource_plugin.hpp"
@@ -19,6 +18,7 @@
 #include "irods_resource_backport.hpp"
 #include "irods_plugin_base.hpp"
 #include "irods_stacktrace.hpp"
+#include "irods_repl_retry.hpp"
 #include "irods_repl_types.hpp"
 #include "irods_object_oper.hpp"
 #include "irods_replicator.hpp"
@@ -1735,8 +1735,8 @@ irods::error repl_file_rebalance(
     try {
         const int batch_size = get_rebalance_batch_size(_ctx);
         const std::vector<leaf_bundle_t> leaf_bundles = resc_mgr.gather_leaf_bundles_for_resc(resource_name);
-        irods::update_out_of_date_replicas(_ctx.comm(), leaf_bundles, batch_size, resource_name);
-        irods::create_missing_replicas(_ctx.comm(), leaf_bundles, batch_size, resource_name);
+        irods::update_out_of_date_replicas(_ctx, leaf_bundles, batch_size, resource_name);
+        irods::create_missing_replicas(_ctx, leaf_bundles, batch_size, resource_name);
     } catch (const irods::exception& e) {
         return irods::error(e);
     }
@@ -1799,49 +1799,120 @@ class repl_resource : public irods::resource {
             irods::resource(
                     _inst_name,
                     _context ) {
+
+                if ( _context.empty() ) {
+                    // Retry capability requires default values to be used if not set
+                    properties_.set< decltype( irods::DEFAULT_RETRY_ATTEMPTS ) >( irods::RETRY_ATTEMPTS_KW, irods::DEFAULT_RETRY_ATTEMPTS );
+                    properties_.set< decltype( irods::DEFAULT_RETRY_FIRST_DELAY_IN_SECONDS ) >( irods::RETRY_FIRST_DELAY_IN_SECONDS_KW, irods::DEFAULT_RETRY_FIRST_DELAY_IN_SECONDS );
+                    properties_.set< decltype( irods::DEFAULT_RETRY_BACKOFF_MULTIPLIER ) >( irods::RETRY_BACKOFF_MULTIPLIER_KW, irods::DEFAULT_RETRY_BACKOFF_MULTIPLIER );
+                    return;
+                }
+
                 irods::kvp_map_t kvp_map;
-                if ( !_context.empty() ) {
-                    irods::error ret = irods::parse_kvp_string(
-                            _context,
-                            kvp_map );
-                    if ( !ret.ok() ) {
-                        irods::log( PASS( ret ) );
+                irods::error ret = irods::parse_kvp_string( _context, kvp_map );
+                if ( !ret.ok() ) {
+                    irods::log( PASS( ret ) );
+                }
 
-                    }
-
-                    if ( kvp_map.find( NUM_REPL_KW ) != kvp_map.end() ) {
-                        try {
-                            // need to capture as int to test for <0 first
-                            int num_repl = boost::lexical_cast< int >( kvp_map[ NUM_REPL_KW ] );
-                            if(num_repl <= 0) {
-                                rodsLog(
-                                    LOG_ERROR,
-                                    "%s:%d - %s is <= 0",
-                                    __FUNCTION__,
-                                    __LINE__,
-                                    NUM_REPL_KW.c_str());
-                            }
-
-                            properties_.set< size_t >( NUM_REPL_KW, static_cast<size_t>(num_repl) );
+                if ( kvp_map.find( NUM_REPL_KW ) != kvp_map.end() ) {
+                    try {
+                        int num_repl = boost::lexical_cast< int >( kvp_map[ NUM_REPL_KW ] );
+                        if( num_repl <= 0 ) {
+                            irods::log( ERROR( SYS_INVALID_INPUT_PARAM,
+                                            boost::format( "%s:%d - [%s] is 0" ) %
+                                            __FUNCTION__ % __LINE__ %
+                                            NUM_REPL_KW.c_str() ) );
                         }
-                        catch ( const boost::bad_lexical_cast& ) {
-                            std::stringstream msg;
-                            msg << "failed to cast num_repl ["
-                                << kvp_map[ NUM_REPL_KW ]
-                                << "]";
-                            irods::log(
-                                    ERROR(
-                                        SYS_INVALID_INPUT_PARAM,
-                                        msg.str() ) );
+                        else {
+                            properties_.set< size_t >( NUM_REPL_KW, static_cast< size_t >( num_repl ) );
                         }
                     }
-
-                    if ( kvp_map.find( READ_KW ) != kvp_map.end() ) {
-                        properties_.set< std::string >( READ_KW, kvp_map[ READ_KW ] );
+                    catch ( const boost::bad_lexical_cast& ) {
+                        irods::log( ERROR( SYS_INVALID_INPUT_PARAM,
+                                        boost::format( "failed to cast [%s] to value [%s]" ) %
+                                        NUM_REPL_KW.c_str() %
+                                        kvp_map[ NUM_REPL_KW ] ) );
                     }
+                }
 
-                } // if !empty
+                auto retry_attempts = irods::DEFAULT_RETRY_ATTEMPTS;
+                if ( kvp_map.find( irods::RETRY_ATTEMPTS_KW ) != kvp_map.end() ) {
+                    try {
+                        // boost::lexical_cast does not raise errors on negatives when casting to unsigned
+                        const int int_retry_attempts = boost::lexical_cast< int >( kvp_map[ irods::RETRY_ATTEMPTS_KW ] );
+                        if ( int_retry_attempts < 0 ) {
+                            irods::log( ERROR( SYS_INVALID_INPUT_PARAM,
+                                           boost::format( "%s:%d - [%s] is < 0; using default value [%d]" ) %
+                                           __FUNCTION__ % __LINE__ %
+                                           irods::RETRY_ATTEMPTS_KW.c_str() %
+                                           irods::DEFAULT_RETRY_ATTEMPTS ) );
+                        }
+                        else {
+                            retry_attempts = static_cast< decltype( retry_attempts ) >( int_retry_attempts );
+                        }
+                    }
+                    catch ( const boost::bad_lexical_cast& ) {
+                        irods::log( ERROR( SYS_INVALID_INPUT_PARAM,
+                                        boost::format( "failed to cast [%s] to value [%s]; using default value [%d]" ) %
+                                        irods::RETRY_ATTEMPTS_KW.c_str() %
+                                        kvp_map[ irods::RETRY_ATTEMPTS_KW ] %
+                                        irods::DEFAULT_RETRY_ATTEMPTS ) );
+                    }
+                }
+                properties_.set< decltype( retry_attempts ) >( irods::RETRY_ATTEMPTS_KW, retry_attempts );
 
+                auto retry_delay_in_seconds = irods::DEFAULT_RETRY_FIRST_DELAY_IN_SECONDS;
+                if ( kvp_map.find( irods::RETRY_FIRST_DELAY_IN_SECONDS_KW ) != kvp_map.end() ) {
+                    try {
+                        // boost::lexical_cast does not raise errors on negatives when casting to unsigned
+                        const int int_retry_delay = boost::lexical_cast< int >( kvp_map[ irods::RETRY_FIRST_DELAY_IN_SECONDS_KW ] );
+                        if ( int_retry_delay <= 0 ) {
+                            irods::log( ERROR( SYS_INVALID_INPUT_PARAM,
+                                            boost::format( "%s:%d - [%s] is <= 0; using default value [%d]" ) %
+                                            __FUNCTION__ % __LINE__ %
+                                            irods::RETRY_FIRST_DELAY_IN_SECONDS_KW.c_str() %
+                                            irods::DEFAULT_RETRY_FIRST_DELAY_IN_SECONDS ) );
+                        }
+                        else {
+                            retry_delay_in_seconds = static_cast< decltype( retry_delay_in_seconds ) >( int_retry_delay );
+                        }
+                    }
+                    catch ( const boost::bad_lexical_cast& ) {
+                        irods::log( ERROR( SYS_INVALID_INPUT_PARAM,
+                                        boost::format( "failed to cast [%s] to value [%s]; using default value [%d]" ) %
+                                        irods::RETRY_BACKOFF_MULTIPLIER_KW.c_str() %
+                                        kvp_map[ irods::RETRY_FIRST_DELAY_IN_SECONDS_KW ] %
+                                        irods::DEFAULT_RETRY_FIRST_DELAY_IN_SECONDS ) );
+                    }
+                }
+                properties_.set< decltype( retry_delay_in_seconds ) >( irods::RETRY_FIRST_DELAY_IN_SECONDS_KW, retry_delay_in_seconds );
+
+                auto backoff_multiplier = irods::DEFAULT_RETRY_BACKOFF_MULTIPLIER;
+                if ( kvp_map.find( irods::RETRY_BACKOFF_MULTIPLIER_KW ) != kvp_map.end() ) {
+                    try {
+                        backoff_multiplier = boost::lexical_cast< decltype( backoff_multiplier ) >( kvp_map[ irods::RETRY_BACKOFF_MULTIPLIER_KW ] );
+                        if ( backoff_multiplier < 1 ) {
+                            irods::log( ERROR( SYS_INVALID_INPUT_PARAM,
+                                            boost::format( "%s:%d - [%s] is < 1; using default value [%f]" ) %
+                                            __FUNCTION__ % __LINE__ %
+                                            irods::RETRY_BACKOFF_MULTIPLIER_KW.c_str() %
+                                            irods::DEFAULT_RETRY_BACKOFF_MULTIPLIER ) );
+                            backoff_multiplier = irods::DEFAULT_RETRY_BACKOFF_MULTIPLIER;
+                        }
+                    }
+                    catch ( const boost::bad_lexical_cast& ) {
+                        irods::log( ERROR( SYS_INVALID_INPUT_PARAM,
+                                        boost::format( "failed to cast [%s] to value [%s]; using default value [%f]" ) %
+                                        irods::RETRY_BACKOFF_MULTIPLIER_KW.c_str() %
+                                        kvp_map[ irods::RETRY_BACKOFF_MULTIPLIER_KW ] %
+                                        irods::DEFAULT_RETRY_BACKOFF_MULTIPLIER ) );
+                    }
+                }
+                properties_.set< decltype( backoff_multiplier ) >( irods::RETRY_BACKOFF_MULTIPLIER_KW, backoff_multiplier );
+
+                if ( kvp_map.find( READ_KW ) != kvp_map.end() ) {
+                    properties_.set< std::string >( READ_KW, kvp_map[ READ_KW ] );
+                }
             } // ctor
 
         irods::error post_disconnect_maintenance_operation(

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -7,6 +7,8 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
+from threading import Timer
 import time
 
 if sys.version_info < (2, 7):
@@ -14,6 +16,7 @@ if sys.version_info < (2, 7):
 else:
     import unittest
 
+from ..test.command import assert_command
 from ..configuration import IrodsConfig
 from ..controller import IrodsController
 from ..core_file import temporary_core_file, CoreFile
@@ -4098,6 +4101,546 @@ class Test_Resource_Replication(ChunkyDevTest, ResourceSuite, unittest.TestCase)
         self.assertEqual(num_up_to_date, 3*num_data_objects_to_use)
         self.assertEqual(num_out_of_date, 0)
         os.unlink(filename)
+
+@unittest.skipIf(False == test.settings.USE_MUNGEFS, "These tests require mungefs")
+class Test_Resource_Replication_With_Retry(ChunkyDevTest, ResourceSuite, unittest.TestCase):
+    def setUp(self):
+        irods_config = IrodsConfig()
+
+        with session.make_session_for_existing_admin() as admin_session:
+            self.munge_mount=tempfile.mkdtemp(prefix='munge_mount_')
+            self.munge_target=tempfile.mkdtemp(prefix='munge_target_')
+            assert_command('mungefs ' + self.munge_mount + ' -omodules=subdir,subdir=' + self.munge_target)
+
+            self.munge_resc = 'ufs1munge'
+            self.munge_passthru = 'pt1'
+            self.normal_vault = irods_config.irods_directory + '/vault2'
+
+            admin_session.assert_icommand("iadmin modresc demoResc name origResc", 'STDOUT_SINGLELINE', 'rename', input='yes\n')
+            admin_session.assert_icommand("iadmin mkresc demoResc replication", 'STDOUT_SINGLELINE', 'replication')
+            admin_session.assert_icommand('iadmin mkresc ' + self.munge_passthru + ' passthru', 'STDOUT_SINGLELINE', 'passthru')
+            admin_session.assert_icommand('iadmin mkresc pt2 passthru', 'STDOUT_SINGLELINE', 'passthru')
+            admin_session.assert_icommand('iadmin mkresc ' + self.munge_resc + ' unixfilesystem ' + test.settings.HOSTNAME_1 + ':' +
+                                          self.munge_mount, 'STDOUT_SINGLELINE', 'unixfilesystem')
+            admin_session.assert_icommand('iadmin mkresc ufs2 unixfilesystem ' + test.settings.HOSTNAME_2 + ':' +
+                                          self.normal_vault, 'STDOUT_SINGLELINE', 'unixfilesystem')
+            admin_session.assert_icommand('iadmin addchildtoresc ' + self.munge_passthru + ' ' + self.munge_resc)
+            admin_session.assert_icommand('iadmin addchildtoresc pt2 ufs2')
+            admin_session.assert_icommand('iadmin addchildtoresc demoResc ' + self.munge_passthru)
+            admin_session.assert_icommand('iadmin addchildtoresc demoResc pt2')
+
+            # Increase write on pt2 because could vote evenly with the 0.5 of pt1 due to locality of reference
+            admin_session.assert_icommand('iadmin modresc ' + self.munge_passthru + ' context "write=0.5"')
+            admin_session.assert_icommand('iadmin modresc pt2 context "write=3.0"')
+
+        # Get count of existing failures in the log
+        self.failure_message = 'Failed to replicate data object'
+        self.log_message_starting_location = lib.get_file_size_by_path(irods_config.server_log_path)
+
+        self.valid_scenarios = [
+            self.test_scenario(1, 1, 1, self.make_context()),
+            self.test_scenario(3, 1, 1, self.make_context('3')),
+            self.test_scenario(1, 3, 1, self.make_context(delay='3')),
+            self.test_scenario(1, 3, 1, self.make_context(delay='3')),
+            self.test_scenario(3, 2, 2, self.make_context('3', '2', '2')),
+            self.test_scenario(3, 2, 1.5, self.make_context('3', '2', '1.5'))
+            ]
+
+        self.invalid_scenarios = [
+            self.test_scenario(1, 1, 1, self.make_context('-2')),
+            self.test_scenario(1, 1, 1, self.make_context('2.0')),
+            self.test_scenario(1, 1, 1, self.make_context('one')),
+            self.test_scenario(1, 1, 1, self.make_context(delay='0')),
+            self.test_scenario(1, 1, 1, self.make_context(delay='-2')),
+            self.test_scenario(1, 1, 1, self.make_context(delay='2.0')),
+            self.test_scenario(1, 1, 1, self.make_context(delay='one')),
+            self.test_scenario(3, 2, 1, self.make_context('3', '2', '0')),
+            self.test_scenario(3, 2, 1, self.make_context('3', '2', '0.5')),
+            self.test_scenario(3, 2, 1, self.make_context('3', '2', '-2')),
+            self.test_scenario(3, 2, 1, self.make_context('3', '2', 'one'))
+            ]
+        super(Test_Resource_Replication_With_Retry, self).setUp()
+
+    def tearDown(self):
+        super(Test_Resource_Replication_With_Retry, self).tearDown()
+
+        # unmount mungefs and destroy directories
+        assert_command(['fusermount', '-u', self.munge_mount])
+        shutil.rmtree(self.munge_mount, ignore_errors=True)
+        shutil.rmtree(self.munge_target, ignore_errors=True)
+        shutil.rmtree(self.normal_vault, ignore_errors=True)
+
+        with session.make_session_for_existing_admin() as admin_session:
+            admin_session.assert_icommand("iadmin rmchildfromresc demoResc " + self.munge_passthru)
+            admin_session.assert_icommand("iadmin rmchildfromresc demoResc pt2")
+            admin_session.assert_icommand("iadmin rmchildfromresc " + self.munge_passthru + ' ' + self.munge_resc)
+            admin_session.assert_icommand("iadmin rmchildfromresc pt2 ufs2")
+            admin_session.assert_icommand("iadmin rmresc " + self.munge_resc)
+            admin_session.assert_icommand("iadmin rmresc ufs2")
+            admin_session.assert_icommand("iadmin rmresc " + self.munge_passthru)
+            admin_session.assert_icommand("iadmin rmresc pt2")
+            admin_session.assert_icommand("iadmin rmresc demoResc")
+            admin_session.assert_icommand("iadmin modresc origResc name demoResc", 'STDOUT_SINGLELINE', 'rename', input='yes\n')
+
+    # Nested class for containing test case information
+    class test_scenario:
+        def __init__(self, retries, delay, multiplier, context_string=None):
+            self.retries = retries
+            self.delay = delay
+            self.multiplier = multiplier
+            self.context_string = context_string
+
+        def munge_delay(self):
+            # No retries means no delay
+            if 0 == self.retries:
+                return 0
+
+            # Get total time over all retries
+            if self.multiplier == 1.0 or self.retries == 1:
+                # Since there is no multiplier, delay increases linearly
+                time_to_failure = self.delay * self.retries
+            else:
+                # Delay represented by geometric sequence
+                # Example for 3 retries:
+                #   First retry -> delay * multiplier^0
+                #   Second retry -> delay * multiplier^1
+                #   Third retry -> delay * multiplier^2
+                time_to_failure = 0
+                for i in range(0, self.retries): # range is non-inclusive at the top end because python
+                    time_to_failure += int(self.delay * pow(self.multiplier, i))
+
+            # Shave some time to ensure mungefsctl can restore filesystem for successful replication
+            return time_to_failure - 0.25
+
+    # Ensure that expected number of new failure messages appear in the log
+    def verify_new_failure_messages_in_log(self, expected_count, expected_message=None):
+        if not expected_message:
+            expected_message = self.failure_message
+
+        irods_config = IrodsConfig()
+        fail_message_count = lib.count_occurrences_of_string_in_log(
+                                  irods_config.server_log_path,
+                                  expected_message,
+                                  start_index=self.log_message_starting_location)
+        self.assertTrue(fail_message_count == expected_count,
+                        msg='counted:[{0}]; expected:[{1}]'.format(
+                            str(fail_message_count), str(expected_count)))
+        self.log_message_starting_location = lib.get_file_size_by_path(irods_config.server_log_path)
+
+    # Generate a context string for replication resource
+    @staticmethod
+    def make_context(retries=None, delay=None, multiplier=None):
+        context_string = ""
+        # Only generate for populated parameters
+        if retries:
+            context_string += 'retry_attempts={0};'.format(retries)
+        if delay:
+            context_string += 'first_retry_delay_in_seconds={0};'.format(delay)
+        if multiplier:
+            context_string += 'backoff_multiplier={0}'.format(multiplier)
+
+        # Empty string causes an error, so put none if using all defaults
+        if not context_string:
+            context_string = 'none=none'
+
+        return context_string
+
+    @staticmethod
+    def run_mungefsctl(operation, modifier=None):
+        mungefsctl_call = 'mungefsctl --operations ' + str(operation)
+        if modifier:
+            mungefsctl_call += ' ' + str(modifier)
+        assert_command(mungefsctl_call)
+
+    def run_rebalance_test(self, scenario, filename):
+        # Setup test and context string
+        filepath = lib.create_local_testfile(filename)
+        if scenario.context_string:
+            self.admin.assert_icommand('iadmin modresc demoResc context "{0}"'.format(scenario.context_string))
+
+        # Get wait time for mungefs to reset
+        wait_time = scenario.munge_delay()
+        self.assertTrue( wait_time > 0, msg='wait time for mungefs [{0}] <= 0'.format(wait_time))
+
+        # For each test, iput will fail to replicate; then we can run a rebalance
+        # Perform corrupt read (checksum) test
+        self.run_mungefsctl('read', '--corrupt_data')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message )
+        self.verify_new_failure_messages_in_log(scenario.retries + 1)
+        munge_thread = Timer(wait_time, self.run_mungefsctl, ['read'])
+        munge_thread.start()
+        self.admin.assert_icommand('iadmin modresc demoResc rebalance')
+        munge_thread.join()
+        self.admin.assert_icommand(['irm', '-f', filename])
+        self.verify_new_failure_messages_in_log(scenario.retries)
+
+        # Perform corrupt size test
+        self.run_mungefsctl('getattr', '--corrupt_size')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(scenario.retries + 1)
+        munge_thread = Timer(wait_time, self.run_mungefsctl, ['getattr'])
+        munge_thread.start()
+        self.admin.assert_icommand('iadmin modresc demoResc rebalance')
+        munge_thread.join()
+        self.admin.assert_icommand(['irm', '-f', filename])
+        self.verify_new_failure_messages_in_log(scenario.retries)
+
+        # Cleanup
+        os.unlink(filepath)
+
+    def run_iput_test(self, scenario, filename):
+        # Setup test and context string
+        filepath = lib.create_local_testfile(filename)
+        if scenario.context_string:
+            self.admin.assert_icommand('iadmin modresc demoResc context "{0}"'.format(scenario.context_string))
+
+        # Get wait time for mungefs to reset
+        wait_time = scenario.munge_delay()
+        self.assertTrue( wait_time > 0, msg='wait time for mungefs [{0}] <= 0'.format(wait_time))
+
+        # Perform corrupt read (checksum) test
+        self.run_mungefsctl('read', '--corrupt_data')
+        munge_thread = Timer(wait_time, self.run_mungefsctl, ['read'])
+        munge_thread.start()
+        self.admin.assert_icommand(['iput', '-K', filepath])
+        munge_thread.join()
+        self.admin.assert_icommand(['irm', '-f', filename])
+        self.verify_new_failure_messages_in_log(scenario.retries)
+
+        # Perform corrupt size test
+        self.run_mungefsctl('getattr', '--corrupt_size')
+        munge_thread = Timer(wait_time, self.run_mungefsctl, ['getattr'])
+        munge_thread.start()
+        self.admin.assert_icommand(['iput', '-K', filepath])
+        munge_thread.join()
+        self.admin.assert_icommand(['irm', '-f', filename])
+        self.verify_new_failure_messages_in_log(scenario.retries)
+
+        # Cleanup
+        os.unlink(filepath)
+
+    # Helper function to recreate replication node to ensure empty context string
+    def reset_repl_resource(self):
+        self.admin.assert_icommand("iadmin rmchildfromresc demoResc " + self.munge_passthru)
+        self.admin.assert_icommand("iadmin rmchildfromresc demoResc pt2")
+        self.admin.assert_icommand("iadmin rmresc demoResc")
+        self.admin.assert_icommand("iadmin mkresc demoResc replication", 'STDOUT_SINGLELINE', 'replication')
+        self.admin.assert_icommand('iadmin addchildtoresc demoResc ' + self.munge_passthru)
+        self.admin.assert_icommand('iadmin addchildtoresc demoResc pt2')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_iput_valid(self):
+        for scenario in self.valid_scenarios:
+            self.run_iput_test(scenario, 'test_repl_retry_iput_valid')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_iput_invalid(self):
+        for scenario in self.invalid_scenarios:
+            self.run_iput_test(scenario, 'test_repl_retry_iput_invalid')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_rebalance_valid(self):
+        for scenario in self.valid_scenarios:
+            self.run_rebalance_test(scenario, 'test_repl_retry_rebalance_valid')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_rebalance_invalid(self):
+        for scenario in self.invalid_scenarios:
+            self.run_rebalance_test(scenario, 'test_repl_retry_rebalance_invalid')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_iput_no_context(self):
+        self.reset_repl_resource()
+        self.run_iput_test(self.test_scenario(1, 1, 1), 'test_repl_retry_iput_no_context')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_rebalance_no_context(self):
+        self.reset_repl_resource()
+        self.run_rebalance_test(self.test_scenario(1, 1, 1), 'test_repl_retry_rebalance_no_context')
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_iput_no_retries(self):
+        filename = "test_repl_retry_iput_no_retries"
+        filepath = lib.create_local_testfile(filename)
+        self.admin.assert_icommand('iadmin modresc demoResc context "{0}"'.format(self.make_context('0')))
+
+        # Perform corrupt read (checksum) test
+        self.run_mungefsctl('read', '--corrupt_data')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1)
+        self.run_mungefsctl('read')
+        self.admin.assert_icommand(['irm', '-f', filename])
+
+        # Perform corrupt size test
+        self.run_mungefsctl('getattr', '--corrupt_size')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1)
+        self.run_mungefsctl('getattr')
+
+        self.admin.assert_icommand(['irm', '-f', filename])
+        os.unlink(filepath)
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_rebalance_no_retries(self):
+        filename = "test_repl_retry_rebalance_no_retries"
+        filepath = lib.create_local_testfile(filename)
+        self.admin.assert_icommand('iadmin modresc demoResc context "{0}"'.format(self.make_context('0')))
+
+        # Perform corrupt read (checksum) test
+        self.run_mungefsctl('read', '--corrupt_data')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1)
+        self.admin.assert_icommand_fail('iadmin modresc demoResc rebalance', 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1)
+        self.run_mungefsctl('read')
+        self.admin.assert_icommand(['irm', '-f', filename])
+
+        # Perform corrupt size test
+        self.run_mungefsctl('getattr', '--corrupt_size')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1)
+        self.admin.assert_icommand_fail('iadmin modresc demoResc rebalance', 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1)
+        self.run_mungefsctl('getattr')
+
+        self.admin.assert_icommand(['irm', '-f', filename])
+        os.unlink(filepath)
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing: Reads server log")
+    def test_repl_retry_multiplier_overflow(self):
+        filename = "test_repl_retry_iput_large_multiplier"
+        filepath = lib.create_local_testfile(filename)
+        large_number = pow(2, 32)
+        scenario = self.test_scenario(2, 1, large_number, self.make_context('2', '1', str(large_number)))
+        failure_message = 'bad numeric conversion'
+        self.admin.assert_icommand('iadmin modresc demoResc context "{0}"'.format(scenario.context_string))
+
+        self.run_mungefsctl('read', '--corrupt_data')
+        self.admin.assert_icommand_fail(['iput', '-K', filepath], 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1, failure_message)
+        self.admin.assert_icommand_fail('iadmin modresc demoResc rebalance', 'STDOUT_SINGLELINE', self.failure_message)
+        self.verify_new_failure_messages_in_log(1, failure_message)
+        self.run_mungefsctl('read')
+
+        self.admin.assert_icommand(['irm', '-f', filename])
+        os.unlink(filepath)
+
+    def test_irepl_over_existing_bad_replica__ticket_1705(self):
+        # local setup
+        filename = "reploverwritebad.txt"
+        filepath = lib.create_local_testfile(filename)
+        doublefile = "doublefile.txt"
+        lib.execute_command("cat %s %s > %s" % (filename, filename, doublefile), use_unsafe_shell=True)
+        doublesize = str(os.stat(doublefile).st_size)
+
+        self.admin.assert_icommand("ils -L " + filename, 'STDERR_SINGLELINE', "does not exist")
+        self.admin.assert_icommand("iput " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        # overwrite default repl with different data
+        self.admin.assert_icommand("iput -f %s %s" % (doublefile, filename))
+        # default resource should have replicated 2 clean copies
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " & " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " & " + filename])
+        # default resource should have replicated new double clean copies
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " " + doublesize + " ", " & " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " " + doublesize + " ", " & " + filename])
+        # test resource should not have doublesize file
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 2 " + self.testresc, " " + doublesize + " ", "  " + filename])
+        # replicate back onto test resource
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        # test resource should have new clean doublesize file
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 2 " + self.testresc, " " + doublesize + " ", " & " + filename])
+        # should not have a replica 3
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 3 ", " & " + filename])
+
+        # local cleanup
+        os.remove(filepath)
+
+    def test_irepl_over_existing_second_replica__ticket_1705(self):
+        # local setup
+        filename = "secondreplicatest.txt"
+        filepath = lib.create_local_testfile(filename)
+
+        self.admin.assert_icommand("ils -L " + filename, 'STDERR_SINGLELINE', "does not exist")
+        self.admin.assert_icommand("iput -R " + self.testresc + " " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        # replicate to default resource (default resource is replication)
+        self.admin.assert_icommand("irepl " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        # replicate overtop default resource (default resource is replication)
+        self.admin.assert_icommand("irepl " + filename)
+        # should not have a replica 3
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 3 ", " & " + filename])
+        # replicate overtop test resource
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        # should not have a replica 3
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 3 ", " & " + filename])
+
+        # local cleanup
+        os.remove(filepath)
+
+    def test_irepl_over_existing_third_replica__ticket_1705(self):
+        # local setup
+        filename = "thirdreplicatest.txt"
+        filepath = lib.create_local_testfile(filename)
+        hostname = lib.get_hostname()
+        hostuser = getpass.getuser()
+
+        self.admin.assert_icommand("iadmin mkresc thirdresc unixfilesystem %s:/tmp/%s/thirdrescVault" % (hostname, hostuser), 'STDOUT_SINGLELINE', "Creating")
+        self.admin.assert_icommand("ils -L " + filename, 'STDERR_SINGLELINE', "does not exist")
+        # put to default resource (creates 2 replicas, 0 and 1)
+        self.admin.assert_icommand("iput " + filename)
+        # replicate to test resource (creates replica 2)
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        # replicate to third resource (creates replica 3)
+        self.admin.assert_icommand("irepl -R thirdresc " + filename)
+        self.admin.assert_icommand("irepl " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        self.admin.assert_icommand("irepl -R thirdresc " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        # should not have a replica 4
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 4 ", " & " + filename])
+        # should not have a replica 5
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 5 ", " & " + filename])
+        self.admin.assert_icommand("irm -f " + filename)
+        self.admin.assert_icommand("iadmin rmresc thirdresc")
+
+        # local cleanup
+        os.remove(filepath)
+
+    def test_irepl_update_replicas(self):
+        # local setup
+        filename = "updatereplicasfile.txt"
+        filepath = lib.create_local_testfile(filename)
+        hostname = lib.get_hostname()
+        hostuser = getpass.getuser()
+        doublefile = "doublefile.txt"
+        lib.execute_command("cat %s %s > %s" % (filename, filename, doublefile), use_unsafe_shell=True)
+        doublesize = str(os.stat(doublefile).st_size)
+
+        self.admin.assert_icommand("iadmin mkresc thirdresc unixfilesystem %s:/tmp/%s/thirdrescVault" %
+                                           (hostname, hostuser), 'STDOUT_SINGLELINE', "Creating")
+        self.admin.assert_icommand("iadmin mkresc fourthresc unixfilesystem %s:/tmp/%s/fourthrescVault" %
+                                           (hostname, hostuser), 'STDOUT_SINGLELINE', "Creating")
+        self.admin.assert_icommand("ils -L " + filename, 'STDERR_SINGLELINE', "does not exist")
+        # put to default resource (creates two replicas, 0 and 1)
+        self.admin.assert_icommand("iput " + filename)
+        # replicate to test resource
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        # replicate to third resource
+        self.admin.assert_icommand("irepl -R thirdresc " + filename)
+        # replicate to fourth resource
+        self.admin.assert_icommand("irepl -R fourthresc " + filename)
+        # repave overtop test resource
+        self.admin.assert_icommand("iput -f -R " + self.testresc + " " + doublefile + " " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+
+        # should have dirty copies
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " & " + filename])
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " & " + filename])
+        # should have a clean copy
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 2 ", " & " + filename])
+        # should have dirty copies
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 3 ", " & " + filename])
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 4 ", " & " + filename])
+
+        self.admin.assert_icommand("irepl -U " + filename)
+
+        # should have dirty copies
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " & " + filename])
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " & " + filename])
+        # should have a clean copy
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 2 ", " & " + filename])
+        # should have a dirty copy
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 3 ", " & " + filename])
+        # should have a clean copy
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 4 ", " & " + filename])
+
+        self.admin.assert_icommand("irepl -aU " + filename)
+
+        # should have clean copies
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " & " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " & " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 2 ", " & " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 3 ", " & " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 4 ", " & " + filename])
+
+        self.admin.assert_icommand("irm -f " + filename)
+        self.admin.assert_icommand("iadmin rmresc thirdresc")
+        self.admin.assert_icommand("iadmin rmresc fourthresc")
+
+        # local cleanup
+        os.remove(filepath)
+        os.remove(doublefile)
+
+    def test_irm_specific_replica(self):
+        # should be listed 2x
+        self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', [" 0 ", " & " + self.testfile])
+        self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', [" 1 ", " & " + self.testfile])
+
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + self.testfile)
+        # should be listed a third time
+        self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', [" 2 ", " & " + self.testfile])
+        # Remove one of the original replicas
+        self.admin.assert_icommand("irm -n 1 " + self.testfile)
+        # replicas 0 and 2 should be there (replica 0 goes to ufs2)
+        self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', ["0 ", "ufs2", self.testfile])
+        self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', ["2 " + self.testresc, self.testfile])
+        # replica 1 should be gone
+        self.admin.assert_icommand_fail("ils -L " + self.testfile, 'STDOUT_SINGLELINE',
+                                                ["1 ", self.munge_resc, self.testfile])
+        # replica should not be in trash
+        trashpath = "/" + self.admin.zone_name + "/trash/home/" + self.admin.username + "/" + self.admin._session_id
+        self.admin.assert_icommand_fail("ils -L " + trashpath + "/" + self.testfile, 'STDOUT_SINGLELINE',
+                                                ["1 ", self.munge_resc, self.testfile])
+
+    def test_local_iput_with_force_and_destination_resource__ticket_1706(self):
+        # local setup
+        filename = "iputwithforceanddestination.txt"
+        filepath = lib.create_local_testfile(filename)
+        doublefile = "doublefile.txt"
+        lib.execute_command("cat %s %s > %s" % (filename, filename, doublefile), use_unsafe_shell=True)
+        doublesize = str(os.stat(doublefile).st_size)
+
+        self.admin.assert_icommand("ils -L " + filename, 'STDERR_SINGLELINE', "does not exist")
+        # put to default resource creates 2 replicas
+        self.admin.assert_icommand("iput " + filename)
+        self.admin.assert_icommand("irepl -R " + self.testresc + " " + filename)
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', filename)
+        # overwrite test repl with different data
+        self.admin.assert_icommand("iput -f -R %s %s %s" % (self.testresc, doublefile, filename))
+        # default resource should have dirty copies
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " " + filename])
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " " + filename])
+        # default resource should not have any doublesize files
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " " + doublesize + " ", " " + filename])
+        self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 1 ", " " + doublesize + " ", " " + filename])
+        # targeted resource should have new double clean copy
+        self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', [" 2 ", " " + doublesize + " ", "& " + filename])
+
+        # local cleanup
+        os.remove(filepath)
+        os.remove(doublefile)
+
+    @unittest.skip("no support for non-compound resources")
+    def test_iget_with_purgec(self):
+        pass
+
+    @unittest.skip("no support for non-compound resources")
+    def test_iput_with_purgec(self):
+        pass
+
+    @unittest.skip("no support for non-compound resources")
+    def test_irepl_with_purgec(self):
+        pass
+
+    @unittest.skip("EMPTY_RESC_PATH - no vault path for coordinating resources")
+    def test_ireg_as_rodsuser_in_vault(self):
+        pass
 
 class Test_Resource_MultiLayered(ChunkyDevTest, ResourceSuite, unittest.TestCase):
 


### PR DESCRIPTION
This change adds a configurable retry mechanism to the replication resource. The replication resources can be configured via 3 new settings in the context string of the resource. The retry applies when the replication from an iput or a replication rebalance fails. The default value for each setting is 1, which means a single retry after 1 second has passed.

Cherry-picked changes from master. Jenkins tests passed.