### PR TITLE
[#3419] Fix iscan for resource hierarchies

### DIFF
--- a/tests/pydevtest/test_iscan.py
+++ b/tests/pydevtest/test_iscan.py
@@ -16,15 +16,19 @@ import lib
 class Test_iScan(ResourceBase, unittest.TestCase):
 
     def setUp(self):
+        super(Test_iScan, self).setUp()
         self.dirname1 = 'dir_3681-1'
         self.dirname2 = 'dir_3681-2'
         lib.create_directory_of_small_files(self.dirname1,2)
         lib.create_directory_of_small_files(self.dirname2,2)
-        super(Test_iScan, self).setUp()
+        self.admin.assert_icommand(['iadmin', 'mkresc', 'pt', 'passthru'], 'STDOUT_SINGLELINE', 'passthru')
+        self.admin.assert_icommand(['iadmin', 'addchildtoresc', 'pt', self.testresc])
 
     def tearDown(self):
         shutil.rmtree(os.path.abspath(self.dirname1), ignore_errors=True)
         shutil.rmtree(os.path.abspath(self.dirname2), ignore_errors=True)
+        self.admin.assert_icommand(['iadmin', 'rmchildfromresc', 'pt', self.testresc])
+        self.admin.assert_icommand(['iadmin', 'rmresc', 'pt'])
         super(Test_iScan, self).tearDown()
 
     @unittest.skipIf(configuration.TOPOLOGY_FROM_RESOURCE_SERVER, 'Skip for topology testing from resource server: Reads Vault')


### PR DESCRIPTION
Running iscan against a data path which resides on a resource in a hierarchy will result in failure, even if the file is registered in iRODS. In 4.1.x, the resource associated with the data object in the catalog is the root resource, which is not necessarily the storage resource. The query fails because the root resource is not associated with any particular hostname, which is needed to determine if the path is associated with any data objects in iRODS.

This changes chkObjExist to perform three steps:

1. Get all hierarchies for the given data path.
2. Get all resource names for the given hostname.
3. Compare the leaf nodes of each hierarchy to all the resources. If a match is found, the data path exists on the given hostname, and this combination of information in the catalog indicates that the file is registered in iRODS.

--
Passed CI tests.