### PR TITLE
[#3904] Generate new child list for each repl (master)

### DIFF
--- a/plugins/resources/replication/librepl.cpp
+++ b/plugins/resources/replication/librepl.cpp
@@ -1341,38 +1341,30 @@ irods::error replCreateChildReplList(
     irods::plugin_context& _ctx,
     const redirect_map_t& _redirect_map,
     const std::string     _child_list_prop ) {
-    irods::error result = SUCCESS();
-    irods::error ret;
-
-    // Check for an existing child list property. If it exists assume it is correct and do nothing.
-    // This assumes that redirect always resolves to the same child. Is that ok? - hcj
+    // loop over all of the children in the map except the first (selected) and add them to a vector
     child_list_t repl_vector;
-    ret = _ctx.prop_map().get<child_list_t>( _child_list_prop, repl_vector );
-    if ( !ret.ok() ) {
-
-        // loop over all of the children in the map except the first (selected) and add them to a vector
-        redirect_map_t::const_iterator it = _redirect_map.begin();
-        for ( ++it; it != _redirect_map.end(); ++it ) {
-            // JMC - need to consider the vote here as if it is 0 the child
-            //       is down and should not get a replica
-            std::string hier;
-            it->second.str( hier );
-            if ( it->first > 0 ) {
-                irods::hierarchy_parser parser = it->second;
-                repl_vector.push_back( parser );
-            }
-        }
-
-        // add the resulting vector as a property of the resource
-        irods::error ret = _ctx.prop_map().set<child_list_t>( _child_list_prop, repl_vector );
-        if ( !ret.ok() ) {
-            std::stringstream msg;
-            msg << __FUNCTION__;
-            msg << " - Failed to store the repl child list as a property.";
-            result = PASSMSG( msg.str(), ret );
+    redirect_map_t::const_iterator it = _redirect_map.begin();
+    for ( ++it; it != _redirect_map.end(); ++it ) {
+        // JMC - need to consider the vote here as if it is 0 the child
+        //       is down and should not get a replica
+        std::string hier;
+        it->second.str( hier );
+        if ( it->first > 0 ) {
+            irods::hierarchy_parser parser = it->second;
+            repl_vector.push_back( parser );
         }
     }
-    return result;
+
+    // add the resulting vector as a property of the resource
+    irods::error ret = _ctx.prop_map().set<child_list_t>( _child_list_prop, repl_vector );
+    if ( !ret.ok() ) {
+        return PASSMSG(
+                   (boost::format(
+                    "[%s] - Failed to store the repl child list as a property.") %
+                    __FUNCTION__).str(), ret );
+    }
+
+    return SUCCESS();
 }
 
 /// @brief honor the read context string keyword if present

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -71,6 +71,30 @@ class Test_Resource_RandomWithinReplication(ResourceSuite, ChunkyDevTest, unitte
         shutil.rmtree(irods_config.irods_directory + "/unixB1Vault", ignore_errors=True)
         shutil.rmtree(irods_config.irods_directory + "/unixAVault", ignore_errors=True)
 
+    def test_redirect_map_regeneration__3904(self):
+        # Setup
+        filecount = 50
+        dirname = 'test_redirect_map_regeneration__3904'
+        lib.create_directory_of_small_files(dirname, filecount)
+
+        self.admin.assert_icommand(['iput', '-r', dirname])
+
+        # Count the number of recipients of replicas
+        hier_ctr = {}
+        stdout,_,_ = self.admin.run_icommand(['ils', '-l', dirname])
+        lines = stdout.splitlines()
+        # Check all lines but the first one
+        for line in lines[1:]:
+            res = line.split()
+            hier_ctr[res[2]] = 'found_it'
+
+        # Ensure that a different set of replication targets resulted at least once
+        self.assertTrue(len(hier_ctr) == 3, msg="only %d resources received replicas, expected 3" % len(hier_ctr))
+
+        # Cleanup
+        self.admin.assert_icommand(['irm', '-rf', dirname])
+        shutil.rmtree(dirname, ignore_errors=True)
+
     @unittest.skip("EMPTY_RESC_PATH - no vault path for coordinating resources")
     def test_ireg_as_rodsuser_in_vault(self):
         pass


### PR DESCRIPTION
The redirect map for the operation replication in the replication resource was being re-used over a single connection via a check for an existing property map value.

This change removes the check so that the redirect map is re-generated for each replication.

(adapted from SHA: 1b758c2)

---
Passed CI tests