### PR TITLE
Significantly enlarge objectMap hashtable to speed up rule caching.

### DIFF
--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/cache.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/cache.cpp
@@ -36,7 +36,7 @@ Cache *copyCache( unsigned char **p, size_t size, Cache *ptr ) {
 
     MK_POINTER( &( ecopy->address ) );
     MK_POINTER( &( ecopy->pointers ) );
-    Hashtable *objectMap = newHashTable( 100 );
+    Hashtable *objectMap = newHashTable( size / 40 );
 
     MK_PTR( RuleSet, coreRuleSet );
     ecopy->coreRuleSetStatus = COMPRESSED;


### PR DESCRIPTION
See https://github.com/irods/irods/issues/3932