### PR TITLE
Remove double increment for loop counter in rodsMonPerfLog

### DIFF
--- a/server/re/src/reIn2p3SysRule.cpp
+++ b/server/re/src/reIn2p3SysRule.cpp
@@ -152,7 +152,6 @@ int rodsMonPerfLog( char *serverName, char *resc, char *output, ruleExecInfo_t *
         if ( rc4 != 0 ) {
             rodsLog( LOG_ERROR, "msiServerMonPerf: unable to register the status metadata for the resource %s", resc_tokens[index].c_str() );
         }
-        index += 1;
     }
 
     clearGenQueryInp( &genQueryInp );


### PR DESCRIPTION
Hi,

The loop counter `index` is double incremented, leading to discard half of the metrics update.

The issue appeared in 4.1.0 with commit c4d070d .

Regards,
Marco
