### PR TITLE
[#3932] More size checking in RE cache copying (4-2-stable)

### DIFF
--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/cache.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/cache.cpp
@@ -36,7 +36,7 @@ Cache *copyCache( unsigned char **p, size_t size, Cache *ptr ) {
 
     MK_POINTER( &( ecopy->address ) );
     MK_POINTER( &( ecopy->pointers ) );
-    Hashtable *objectMap = newHashTable( 100 );
+    Hashtable *objectMap = newHashTable( size / 40 );
 
     MK_PTR( RuleSet, coreRuleSet );
     ecopy->coreRuleSetStatus = COMPRESSED;


### PR DESCRIPTION
Adds a size checking guard at the front of copyCache in order to ensure a hashtable size that is greater than 0. Also adds some explanation for the calculation being done for the hashtable.

(cherry-picked from SHA: b496659)

---
Passed CI tests.