### PR TITLE
[#3928] Error when root dir used with vault paths (4-2-stable)

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -537,6 +537,17 @@ _resolveHostName(rsComm_t* _rsComm, const char* _hostAddress) {
     return 0;
 }
 
+// Returns success if path is not root; otherwise, generates an error
+irods::error
+verify_non_root_vault_path(irods::plugin_context& _ctx, const std::string& path) {
+    if (0 == path.compare("/")) {
+        const std::string error_message = "root directory cannot be used as vault path.";
+        addRErrorMsg(&_ctx.comm()->rError, 0, error_message.c_str());
+        return ERROR(CAT_INVALID_RESOURCE_VAULT_PATH, error_message.c_str() );
+    }
+    return SUCCESS();
+}
+
 // =-=-=-=-=-=-=-
 //
 irods::error _childIsValid(
@@ -4050,6 +4061,12 @@ irods::error db_reg_resc_op(
         // =-=-=-=-=-=-=-
         // JMC - backport 4597
         _resolveHostName( _ctx.comm(), resc_input[irods::RESOURCE_LOCATION].c_str());
+    }
+
+    // Root dir is not a valid vault path
+    ret = verify_non_root_vault_path(_ctx, resc_input[irods::RESOURCE_PATH]);
+    if (!ret.ok()) {
+        return PASS(ret);
     }
 
     getNowStr( myTime );
@@ -8448,6 +8465,12 @@ irods::error db_mod_resc_op(
     }
 
     if ( strcmp( _option, "path" ) == 0 ) {
+        // Root dir is not a valid vault path
+        ret = verify_non_root_vault_path(_ctx, std::string(_option_value));
+        if (!ret.ok()) {
+            return PASS(ret);
+        }
+
         if ( logSQL != 0 ) {
             rodsLog( LOG_SQL, "chlModResc SQL 10" );
         }

--- a/plugins/microservices/administration/msi_update_unixfilesystem_resource_free_space/libmsi_update_unixfilesystem_resource_free_space.cpp
+++ b/plugins/microservices/administration/msi_update_unixfilesystem_resource_free_space/libmsi_update_unixfilesystem_resource_free_space.cpp
@@ -16,33 +16,33 @@ extern irods::resource_manager resc_mgr;
 int
 msi_update_unixfilesystem_resource_free_space(msParam_t *resource_name_msparam, ruleExecInfo_t *rei) {
     if (rei == NULL) {
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: input rei is NULL");
+        rodsLog(LOG_ERROR, "[%s]: input rei is NULL", __FUNCTION__);
         return SYS_INTERNAL_NULL_INPUT_ERR;
     }
 
     if (resource_name_msparam == NULL) {
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: resource_name_msparam is NULL");
+        rodsLog(LOG_ERROR, "[%s]: resource_name_msparam is NULL", __FUNCTION__);
         return SYS_INTERNAL_NULL_INPUT_ERR;
     }
     if (resource_name_msparam->type == NULL) {
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: resource_name_msparam->type is NULL");
+        rodsLog(LOG_ERROR, "[%s]: resource_name_msparam->type is NULL", __FUNCTION__);
         return SYS_INTERNAL_NULL_INPUT_ERR;
     }
     if (strcmp(resource_name_msparam->type, STR_MS_T)) {
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: first argument should be STR_MS_T, was [%s]", resource_name_msparam->type);
+        rodsLog(LOG_ERROR, "[%s]: first argument should be STR_MS_T, was [%s]", __FUNCTION__, resource_name_msparam->type);
         return USER_PARAM_TYPE_ERR;
     }
 
     const char* resource_name_cstring = static_cast<char*>(resource_name_msparam->inOutStruct);
     if (resource_name_cstring == NULL) {
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: input resource_name_msparam->inOutStruct is NULL");
+        rodsLog(LOG_ERROR, "[%s]: input resource_name_msparam->inOutStruct is NULL", __FUNCTION__);
         return SYS_INTERNAL_NULL_INPUT_ERR;
     }
 
     irods::resource_ptr resource_ptr;
     const irods::error resource_manager_resolve_error = resc_mgr.resolve(resource_name_cstring, resource_ptr );
     if (!resource_manager_resolve_error.ok()) {
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: failed to resolve resource [%s]", resource_name_cstring);
+        rodsLog(LOG_ERROR, "[%s]: failed to resolve resource [%s]", __FUNCTION__, resource_name_cstring);
         irods::log(resource_manager_resolve_error);
         return resource_manager_resolve_error.status();
     }
@@ -50,7 +50,7 @@ msi_update_unixfilesystem_resource_free_space(msParam_t *resource_name_msparam, 
     std::string resource_type_unnormalized;
     const irods::error get_resource_type_error = resource_ptr->get_property<std::string>(irods::RESOURCE_TYPE, resource_type_unnormalized);
     if (!get_resource_type_error.ok()) {
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: failed to get resource type for [%s]", resource_name_cstring);
+        rodsLog(LOG_ERROR, "[%s]: failed to get resource type for [%s]", __FUNCTION__, resource_name_cstring);
         irods::log(get_resource_type_error);
         return get_resource_type_error.status();
     }
@@ -63,31 +63,38 @@ msi_update_unixfilesystem_resource_free_space(msParam_t *resource_name_msparam, 
     std::string resource_vault_path;
     const irods::error get_resource_vault_path_error = resource_ptr->get_property<std::string>(irods::RESOURCE_PATH, resource_vault_path);
     if (!get_resource_vault_path_error.ok()) {
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: failed to get resource path for [%s]", resource_name_cstring);
+        rodsLog(LOG_ERROR, "[%s]: failed to get resource path for [%s]", __FUNCTION__, resource_name_cstring);
         irods::log(get_resource_vault_path_error);
         return get_resource_vault_path_error.status();
     }
 
-    boost::filesystem::path path_to_stat(resource_vault_path);
+    boost::filesystem::path path_to_stat{resource_vault_path};
+    const auto absolute_vault_path{boost::filesystem::absolute(path_to_stat)};
     while(!boost::filesystem::exists(path_to_stat)) {
-        rodsLog(LOG_NOTICE, "msi_update_unixfilesystem_resource_free_space: path to stat [%s] for resource [%s] doesn't exist, moving to parent", path_to_stat.string().c_str(), resource_name_cstring);
+        rodsLog(LOG_NOTICE, "[%s]: path to stat [%s] for resource [%s] doesn't exist, moving to parent", __FUNCTION__, path_to_stat.string().c_str(), resource_name_cstring);
         path_to_stat = path_to_stat.parent_path();
         if (path_to_stat.empty()) {
-            rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: could not find existing path from vault path [%s] for resource [%s]", resource_vault_path.c_str(), resource_name_cstring);
+            rodsLog(LOG_ERROR, "[%s]: could not find existing path from vault path [%s] for resource [%s]", __FUNCTION__, resource_vault_path.c_str(), resource_name_cstring);
             return SYS_INVALID_RESC_INPUT;
         }
+    }
+
+    // Using the root directory as a vault path is bad - do not allow it to be used for updating free space
+    if (absolute_vault_path.root_path() == path_to_stat) {
+        rodsLog(LOG_ERROR, "[%s]: could not find existing non-root path from vault path [%s] for resource [%s]", __FUNCTION__, resource_vault_path.c_str(), resource_name_cstring);
+        return SYS_INVALID_RESC_INPUT;
     }
 
     struct statvfs statvfs_buf;
     const int statvfs_ret = statvfs(path_to_stat.string().c_str(), &statvfs_buf);
     if (statvfs_ret != 0) {
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: statvfs() of [%s] for resource [%s] failed with return %d and errno %d", path_to_stat.string().c_str(), resource_name_cstring, statvfs_ret, errno);
+        rodsLog(LOG_ERROR, "[%s]: statvfs() of [%s] for resource [%s] failed with return %d and errno %d", __FUNCTION__, path_to_stat.string().c_str(), resource_name_cstring, statvfs_ret, errno);
         return SYS_INVALID_RESC_INPUT;
     }
 
     uintmax_t free_space_in_bytes;
     if (statvfs_buf.f_bavail > ULONG_MAX / statvfs_buf.f_frsize) {
-        rodsLog(LOG_NOTICE, "msi_update_unixfilesystem_resource_free_space: statvfs() of resource [%s] reports free space in excess of ULONG_MAX f_bavail %ju f_frsize %ju failed with return %d and errno %d", resource_name_cstring, static_cast<uintmax_t>(statvfs_buf.f_bavail), static_cast<uintmax_t>(statvfs_buf.f_frsize));
+        rodsLog(LOG_NOTICE, "[%s]: statvfs() of resource [%s] reports free space in excess of ULONG_MAX f_bavail %ju f_frsize %ju failed with return %d and errno %d", __FUNCTION__, resource_name_cstring, static_cast<uintmax_t>(statvfs_buf.f_bavail), static_cast<uintmax_t>(statvfs_buf.f_frsize));
         free_space_in_bytes = ULONG_MAX;
     } else {
         free_space_in_bytes = statvfs_buf.f_bavail * statvfs_buf.f_frsize;
@@ -95,7 +102,7 @@ msi_update_unixfilesystem_resource_free_space(msParam_t *resource_name_msparam, 
     const std::string free_space_in_bytes_string = boost::lexical_cast<std::string>(free_space_in_bytes);
 
     if (rei->rsComm == NULL) {
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: input rei->rsComm is NULL");
+        rodsLog(LOG_ERROR, "[%s]: input rei->rsComm is NULL", __FUNCTION__);
         return SYS_INTERNAL_NULL_INPUT_ERR;
     }
 
@@ -111,7 +118,7 @@ msi_update_unixfilesystem_resource_free_space(msParam_t *resource_name_msparam, 
     rodsEnv service_account_environment;
     const int getRodsEnv_ret = getRodsEnv(&service_account_environment);
     if (getRodsEnv_ret < 0) {
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: getRodsEnv failure [%d]", getRodsEnv_ret);
+        rodsLog(LOG_ERROR, "[%s]: getRodsEnv failure [%d]", __FUNCTION__, getRodsEnv_ret);
         return getRodsEnv_ret;
     }
 
@@ -122,14 +129,14 @@ msi_update_unixfilesystem_resource_free_space(msParam_t *resource_name_msparam, 
     if (admin_connection == NULL) {
         char *mySubName = NULL;
         const char *myName = rodsErrorName(errMsg.status, &mySubName);
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: rcConnect failure [%s] [%s] [%d] [%s]",
+        rodsLog(LOG_ERROR, "[%s]: rcConnect failure [%s] [%s] [%d] [%s]", __FUNCTION__,
                 myName, mySubName, errMsg.status, errMsg.msg);
         return errMsg.status;
     }
 
     const int clientLogin_ret = clientLogin(admin_connection);
     if (clientLogin_ret != 0) {
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: clientLogin failure [%d]", clientLogin_ret);
+        rodsLog(LOG_ERROR, "[%s]: clientLogin failure [%d]", __FUNCTION__, clientLogin_ret);
         return clientLogin_ret;
     }
 
@@ -137,7 +144,7 @@ msi_update_unixfilesystem_resource_free_space(msParam_t *resource_name_msparam, 
     rcDisconnect(admin_connection);
     if (rcGeneralAdmin_ret < 0) {
         printErrorStack(admin_connection->rError);
-        rodsLog(LOG_ERROR, "msi_update_unixfilesystem_resource_free_space: rcGeneralAdmin failure [%d]", rcGeneralAdmin_ret);
+        rodsLog(LOG_ERROR, "[%s]: rcGeneralAdmin failure [%d]", __FUNCTION__, rcGeneralAdmin_ret);
     }
     return rcGeneralAdmin_ret;
 }

--- a/scripts/irods/test/test_iadmin.py
+++ b/scripts/irods/test/test_iadmin.py
@@ -1303,3 +1303,56 @@ class Test_Iadmin(resource_suite.ResourceBase, unittest.TestCase):
         self.admin.assert_icommand('iadmin rmresc pt0')
         self.admin.assert_icommand('iadmin rmresc pt1')
 
+class Test_Iadmin_Resources(resource_suite.ResourceBase, unittest.TestCase):
+
+    def setUp(self):
+        self.resc_name = 'warningresc'
+        self.host_warning_message = 'Warning, resource host address \'localhost\' will not work properly'
+        self.vault_error_message = 'ERROR: rcGeneralAdmin failed with error -813000 CAT_INVALID_RESOURCE_VAULT_PATH'
+        self.vault_warning_message = 'root directory cannot be used as vault path.'
+
+        # Ensure vault does not exist so the stat fails
+        self.good_vault = tempfile.mkdtemp()
+        shutil.rmtree(self.good_vault)
+
+        with session.make_session_for_existing_admin() as admin_session:
+            # Make resource with good host and vault path
+            admin_session.assert_icommand(['iadmin', 'mkresc', self.resc_name, 'unixfilesystem',
+                                           '{0}:{1}'.format(lib.get_hostname(), self.good_vault)],
+                                          'STDOUT_SINGLELINE', self.resc_name)
+        super(Test_Iadmin_Resources, self).setUp()
+
+    def tearDown(self):
+        with session.make_session_for_existing_admin() as admin_session:
+            admin_session.run_icommand(['iadmin', 'rmresc', self.resc_name])
+        super(Test_Iadmin_Resources, self).tearDown()
+
+    def test_mkresc_host_path_warning_messages(self):
+        # Make resc with localhost and root vault
+        self.admin.assert_icommand(['iadmin', 'rmresc', self.resc_name])
+        stdout,stderr,rc = self.admin.run_icommand(['iadmin', 'mkresc', self.resc_name, 'unixfilesystem', 'localhost:/'])
+        # Should produce warnings and errors
+        self.assertTrue(0 != rc)
+        self.assertTrue(self.vault_error_message in stderr)
+        self.assertTrue(self.vault_warning_message in stdout)
+        self.assertTrue(self.host_warning_message in stdout)
+        # Should fail to create resource
+        self.admin.assert_icommand_fail('ilsresc', 'STDOUT_SINGLELINE', self.resc_name)
+
+        # Make resc with good vault path and localhost and ensure it is created
+        self.admin.assert_icommand(['iadmin', 'mkresc', self.resc_name, 'unixfilesystem', 'localhost:' + self.good_vault],
+                                   'STDOUT_SINGLELINE', self.host_warning_message)
+        self.admin.assert_icommand('ilsresc', 'STDOUT_SINGLELINE', self.resc_name)
+
+    def test_modresc_host_path_warning_messages(self):
+        # Change host to localhost and ensure that it was changed (check for warning)
+        self.admin.assert_icommand(['iadmin', 'modresc', self.resc_name, 'host', 'localhost'], 'STDOUT_SINGLELINE', self.host_warning_message)
+        self.admin.assert_icommand(['ilsresc', '-l', self.resc_name], 'STDOUT_SINGLELINE', 'location: localhost')
+
+        # Change vault to root and check for errors/warnings
+        stdout,stderr,rc = self.admin.run_icommand(['iadmin', 'modresc', self.resc_name, 'path', '/'])
+        self.assertTrue(0 != rc)
+        self.assertTrue(self.vault_error_message in stderr)
+        self.assertTrue(self.vault_warning_message in stdout)
+        # Changing vault should have failed, so make sure it has not changed
+        self.admin.assert_icommand(['ilsresc', '-l', self.resc_name], 'STDOUT_SINGLELINE', 'vault: ' + self.good_vault)


### PR DESCRIPTION
When msi_update_unixfilesystem_resource_free_space() updates the free space on a non-existent vault path (or one that boost::filesystem interprets as non-existent), it checks the parent directories of the resource vault path until it finds one that exists, even if it is the root directory ('/' on UNIX systems).

Root directory should not be used as a vault path. An error is now produced if the vault path is set to root directory. Additionally, the root path should not be used in updating the free space on a resource. This change causes msi_update_unixfilesystem_resource_free_space() to log an error and exit if the path_to_stat becomes the root directory because this gives misleading information about the free space on a resource.

(cherry-picked from SHA: 4a2cf90)

---
[CI tests passed](http://172.25.14.125:8080/view/2.%20Personal/job/irods-build-and-test-workflow/950/)