### PR TITLE
[#3855] Add dataMode in dataObjectInfo for ibun -x (master)

### DIFF
--- a/lib/core/include/rodsGenQueryNames.h
+++ b/lib/core/include/rodsGenQueryNames.h
@@ -61,6 +61,7 @@ columnName_t columnNames[] = {
     { COL_DATA_VERSION,     "DATA_VERSION", },
     { COL_DATA_TYPE_NAME,   "DATA_TYPE_NAME", },
     { COL_DATA_SIZE,        "DATA_SIZE", },
+    { COL_DATA_MODE,        "DATA_MODE", },
     { COL_D_RESC_NAME,      "DATA_RESC_NAME", },
     { COL_D_RESC_HIER,      "DATA_RESC_HIER", },
     { COL_D_DATA_PATH,      "DATA_PATH", },

--- a/server/api/include/rsStructFileExtAndReg.hpp
+++ b/server/api/include/rsStructFileExtAndReg.hpp
@@ -2,19 +2,16 @@
 #define RS_STRUCT_FILE_EXT_AND_REG_HPP
 
 #include "rcConnect.h"
-#include "rodsGenQuery.h"
-#include "rodsType.h"
 #include "objStat.h"
-#include "bulkDataObjPut.h"
 #include "structFileExtAndReg.h"
 
-int rsStructFileExtAndReg( rsComm_t *rsComm, structFileExtAndRegInp_t *structFileExtAndRegInp );
-int chkCollForExtAndReg( rsComm_t *rsComm, char *collection, rodsObjStat_t **rodsObjStatOut );
-int regUnbunSubfiles( rsComm_t *rsComm, const char *_resc_name, const char* rescHier, char *collection, char *phyBunDir, int flags, genQueryOut_t *attriArray );
-int regSubfile( rsComm_t *rsComm, const char *_resc_name, const char* rescHier, char *subObjPath, char *subfilePath, rodsLong_t dataSize, int flags );
-int addRenamedPhyFile( char *subObjPath, char *oldFileName, char *newFileName, renamedPhyFiles_t *renamedPhyFiles );
-int postProcRenamedPhyFiles( renamedPhyFiles_t *renamedPhyFiles, int regStatus );
-int cleanupBulkRegFiles( rsComm_t *rsComm, genQueryOut_t *bulkDataObjRegInp );
-int postProcBulkPut( rsComm_t *rsComm, genQueryOut_t *bulkDataObjRegInp, genQueryOut_t *bulkDataObjRegOut );
+int rsStructFileExtAndReg(
+    rsComm_t *rsComm,
+    structFileExtAndRegInp_t *structFileExtAndRegInp );
+
+int chkCollForExtAndReg(
+    rsComm_t *rsComm,
+    char *collection,
+    rodsObjStat_t **rodsObjStatOut );
 
 #endif

--- a/server/api/src/rsBulkDataObjPut.cpp
+++ b/server/api/src/rsBulkDataObjPut.cpp
@@ -65,6 +65,29 @@ bulkRegSubfile( rsComm_t *rsComm, const char*, const std::string& rescHier,
                 renamedPhyFiles_t *renamedPhyFiles );
 
 int
+addRenamedPhyFile(
+    char *subObjPath,
+    char *oldFileName,
+    char *newFileName,
+    renamedPhyFiles_t *renamedPhyFiles );
+
+int
+cleanupBulkRegFiles(
+    rsComm_t *rsComm,
+    genQueryOut_t *bulkDataObjRegInp );
+
+int
+postProcBulkPut(
+    rsComm_t *rsComm,
+    genQueryOut_t *bulkDataObjRegInp,
+    genQueryOut_t *bulkDataObjRegOut );
+
+int
+postProcRenamedPhyFiles(
+    renamedPhyFiles_t *renamedPhyFiles,
+    int regStatus );
+
+int
 rsBulkDataObjPut( rsComm_t *rsComm, bulkOprInp_t *bulkOprInp,
                   bytesBuf_t *bulkOprInpBBuf ) {
     int status;
@@ -388,8 +411,8 @@ bulkRegUnbunSubfiles( rsComm_t *rsComm, const char *_resc_name, const std::strin
         if ( status1 < 0 ) {
             status = status1;
             rodsLog( LOG_ERROR,
-                     "regUnbunSubfiles: rsBulkDataObjReg error for %s. stat = %d",
-                     collection, status1 );
+                     "%s: rsBulkDataObjReg error for %s. stat = %d",
+                     __FUNCTION__, collection, status1 );
             cleanupBulkRegFiles( rsComm, &bulkDataObjRegInp );
         }
         postProcRenamedPhyFiles( &renamedPhyFiles, status );
@@ -416,8 +439,8 @@ _bulkRegUnbunSubfiles( rsComm_t *rsComm, const char *_resc_name, const std::stri
     path srcDirPath( phyBunDir );
     if ( !exists( srcDirPath ) || !is_directory( srcDirPath ) ) {
         rodsLog( LOG_ERROR,
-                 "regUnbunphySubfiles: opendir error for %s, errno = %d",
-                 phyBunDir, errno );
+                 "%s: opendir error for %s, errno = %d",
+                 __FUNCTION__, phyBunDir, errno );
         return UNIX_FILE_OPENDIR_ERR - errno;
     }
     bzero( &dataObjInp, sizeof( dataObjInp ) );
@@ -429,8 +452,8 @@ _bulkRegUnbunSubfiles( rsComm_t *rsComm, const char *_resc_name, const std::stri
 
         if ( !exists( p ) ) {
             rodsLog( LOG_ERROR,
-                     "regUnbunphySubfiles: stat error for %s, errno = %d",
-                     subfilePath, errno );
+                     "%s: stat error for %s, errno = %d",
+                     __FUNCTION__, subfilePath, errno );
             savedStatus = UNIX_FILE_STAT_ERR - errno;
             unlink( subfilePath );
             continue;
@@ -443,8 +466,8 @@ _bulkRegUnbunSubfiles( rsComm_t *rsComm, const char *_resc_name, const std::stri
             status = rsMkCollR( rsComm, "/", subObjPath );
             if ( status < 0 ) {
                 rodsLog( LOG_ERROR,
-                         "regUnbunSubfiles: rsMkCollR of %s error. status = %d",
-                         subObjPath, status );
+                         "%s: rsMkCollR of %s error. status = %d",
+                         __FUNCTION__, subObjPath, status );
                 savedStatus = status;
                 continue;
             }
@@ -453,8 +476,8 @@ _bulkRegUnbunSubfiles( rsComm_t *rsComm, const char *_resc_name, const std::stri
                                             renamedPhyFiles, attriArray );
             if ( status < 0 ) {
                 rodsLog( LOG_ERROR,
-                         "regUnbunSubfiles: regUnbunSubfiles of %s error. status=%d",
-                         subObjPath, status );
+                         "%s: _bulkRegUnbunSubfiles of %s error. status=%d",
+                         __FUNCTION__, subObjPath, status );
                 savedStatus = status;
                 continue;
             }
@@ -469,8 +492,8 @@ _bulkRegUnbunSubfiles( rsComm_t *rsComm, const char *_resc_name, const std::stri
             unlink( subfilePath );
             if ( status < 0 ) {
                 rodsLog( LOG_ERROR,
-                         "regUnbunSubfiles:bulkProcAndRegSubfile of %s err.stat=%d",
-                         subObjPath, status );
+                         "%s:bulkProcAndRegSubfile of %s err.stat=%d",
+                         __FUNCTION__, subObjPath, status );
                 savedStatus = status;
                 continue;
             }


### PR DESCRIPTION
Fixes a bug where attempting to replicate files extracted from a bundle in a rebalance operation would fail with a BAD_LEXICAL_CAST due to a missing DATA_MODE column. Struct file extraction and registration now includes data mode in the data object information when registering subfiles.

Many dependencies between rsBulkDataObjPut and rsStructFileExtAndReg were not needed, so they were removed as appropriate. Some formatting cleanup at the tops of the files as well.

---
[CI tests passed.](http://172.25.14.125:8080/view/2.%20Personal/job/irods-build-and-test-workflow/984/)