### PR TITLE
[#3853] Use known strings in obsolete columns

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -919,74 +919,6 @@ static int _delColl( rsComm_t *rsComm, collInfo_t *collInfo ) {
 
 } // _delColl
 
-// Modifies a given resource name in all resource hierarchies (i.e for all objects)
-// gets called after a resource has been modified (iadmin modresc <oldname> name <newname>)
-static int _modRescInHierarchies( const std::string& old_resc, const std::string& new_resc ) {
-    char update_sql[MAX_SQL_SIZE];
-    int status = 0;
-    const char *sep = irods::hierarchy_parser::delimiter().c_str();
-    std::string std_conf_str;        // to store value of STANDARD_CONFORMING_STRINGS
-
-#if ORA_ICAT
-    // =-=-=-=-=-=-=-
-    // Oracle
-    snprintf( update_sql, MAX_SQL_SIZE,
-              "update r_data_main set resc_hier = regexp_replace(resc_hier, '(^|(.+%s))%s($|(%s.+))', '\\1%s\\3')",
-              sep, old_resc.c_str(), sep, new_resc.c_str() );
-
-
-#elif MY_ICAT
-    // =-=-=-=-=-=-=-
-    // MySQL
-    snprintf( update_sql, MAX_SQL_SIZE,
-              "update R_DATA_MAIN set resc_hier = PREG_REPLACE('/(^|(.+%s))%s($|(%s.+))/', '$1%s$3', resc_hier);",
-              sep, old_resc.c_str(), sep, new_resc.c_str() );
-#else
-    // =-=-=-=-=-=-=-
-    // PostgreSQL
-    // Get STANDARD_CONFORMING_STRINGS setting to determine if backslashes in regex must be escaped
-    irods::error ret = irods::get_catalog_property<std::string>( irods::STANDARD_CONFORMING_STRINGS, std_conf_str );
-    if ( !ret.ok() ) {
-        rodsLog( LOG_ERROR, "%s", ret.result().c_str() );
-    }
-
-    // =-=-=-=-=-=-=-
-    // Regex will look in r_data_main.resc_hier
-    // for occurrences of old_resc with either nothing or the separator (and some stuff) on each side
-    // and replace them with new_resc, e.g:
-    // regexp_replace(resc_hier, '(^|(.+;))OLD_RESC($|(;.+))', '\1NEW_RESC\3')
-    // Backslashes must be escaped in older versions of Postgres
-
-    if ( std_conf_str == "on" ) {
-        // Default since Postgres 9.1
-        snprintf( update_sql, MAX_SQL_SIZE,
-                  "update r_data_main set resc_hier = regexp_replace(resc_hier, '(^|(.+%s))%s($|(%s.+))', '\\1%s\\3');",
-                  sep, old_resc.c_str(), sep, new_resc.c_str() );
-    }
-    else {
-        // Older versions
-        snprintf( update_sql, MAX_SQL_SIZE,
-                  "update r_data_main set resc_hier = regexp_replace(resc_hier, '(^|(.+%s))%s($|(%s.+))', '\\\\1%s\\\\3');",
-                  sep, old_resc.c_str(), sep, new_resc.c_str() );
-    }
-
-#endif
-    // =-=-=-=-=-=-=-
-    // SQL update
-    status = cmlExecuteNoAnswerSql( update_sql, &icss );
-
-    // =-=-=-=-=-=-=-
-    // Log error. Rollback is done in calling function
-    if ( status < 0 && status != CAT_SUCCESS_BUT_WITH_NO_INFO ) {
-        std::stringstream ss;
-        ss << "_modRescInHierarchies: cmlExecuteNoAnswerSql update failure, status = " << status;
-        irods::log( LOG_NOTICE, ss.str() );
-        // _rollback("_modRescInHierarchies");
-    }
-
-    return status;
-}
-
 // =-=-=-=-=-=-=-
 // local function to delegate the response
 // verification to an authentication plugin
@@ -2516,7 +2448,6 @@ irods::error db_mod_data_obj_meta_op(
         std::stringstream repl_stream;
         repl_stream << _data_obj_info->replNum;
         rodsLong_t resc_id = 0;
-        std::string resc_hier;
         {
             std::vector<std::string> bindVars;
             bindVars.push_back( id_stream.str() );
@@ -2773,12 +2704,14 @@ irods::error db_reg_data_obj_op(
     cllBindVars[15] = myTime;
     cllBindVars[16] = data_expiry_ts;
     cllBindVars[17] = "EMPTY_RESC_NAME";
-    cllBindVarCount = 18;
+    cllBindVars[18] = "EMPTY_RESC_HIER";
+    cllBindVars[19] = "EMPTY_RESC_GROUP_NAME";
+    cllBindVarCount = 20;
     if ( logSQL != 0 ) {
         rodsLog( LOG_SQL, "chlRegDataObj SQL 6" );
     }
     status =  cmlExecuteNoAnswerSql(
-                  "insert into R_DATA_MAIN (data_id, coll_id, data_name, data_repl_num, data_version, data_type_name, data_size, resc_id, data_path, data_owner_name, data_owner_zone, data_is_dirty, data_checksum, data_mode, create_ts, modify_ts, data_expiry_ts, resc_name) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                  "insert into R_DATA_MAIN (data_id, coll_id, data_name, data_repl_num, data_version, data_type_name, data_size, resc_id, data_path, data_owner_name, data_owner_zone, data_is_dirty, data_checksum, data_mode, create_ts, modify_ts, data_expiry_ts, resc_name, resc_hier, resc_group_name) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                   &icss );
     if ( status != 0 ) {
         rodsLog( LOG_NOTICE,
@@ -14088,83 +14021,6 @@ irods::error db_specific_query_op(
 
 } // db_specific_query_op
 
-irods::error db_substitute_resource_hierarchies_op(
-    irods::plugin_context& _ctx,
-    const char*            _old_hier,
-    const char*            _new_hier ) {
-    // =-=-=-=-=-=-=-
-    // check the context
-    irods::error ret = _ctx.valid();
-    if ( !ret.ok() ) {
-        return PASS( ret );
-    }
-
-    // =-=-=-=-=-=-=-
-    // get a postgres object from the context
-    /*irods::postgres_object_ptr pg;
-    ret = make_db_ptr( _ctx.fco(), pg );
-    if ( !ret.ok() ) {
-        return PASS( ret );
-
-    }*/
-
-    // =-=-=-=-=-=-=-
-    // extract the icss property
-//        icatSessionStruct icss;
-//        _ctx.prop_map().get< icatSessionStruct >( ICSS_PROP, icss );
-    int status = 0;
-    char old_hier_partial[MAX_NAME_LEN];
-    irods::sql_logger logger( "chlSubstituteResourceHierarchies", logSQL );
-
-    logger.log();
-
-    // =-=-=-=-=-=-=-
-    // Sanity and permission checks
-    if ( !icss.status ) {
-        return ERROR( CATALOG_NOT_CONNECTED, "catalog not connected" );
-    }
-    if ( !_old_hier || !_new_hier ) {
-        return ERROR( SYS_INTERNAL_NULL_INPUT_ERR, "null parameter" );
-    }
-    if ( _ctx.comm()->clientUser.authInfo.authFlag < LOCAL_PRIV_USER_AUTH || _ctx.comm()->proxyUser.authInfo.authFlag < LOCAL_PRIV_USER_AUTH ) {
-        return ERROR( CAT_INSUFFICIENT_PRIVILEGE_LEVEL, "insufficient privilege" );
-    }
-
-    // =-=-=-=-=-=-=-
-    // String to match partial hierarchies
-    snprintf( old_hier_partial, MAX_NAME_LEN, "%s%s%%", _old_hier, irods::hierarchy_parser::delimiter().c_str() );
-
-    // =-=-=-=-=-=-=-
-    // Update r_data_main
-    cllBindVars[cllBindVarCount++] = ( char* )_new_hier;
-    cllBindVars[cllBindVarCount++] = ( char* )_old_hier;
-    cllBindVars[cllBindVarCount++] = ( char* )_old_hier;
-    cllBindVars[cllBindVarCount++] = old_hier_partial;
-#if ORA_ICAT // Oracle
-    status = cmlExecuteNoAnswerSql( "update R_DATA_MAIN set resc_hier = ? || substr(resc_hier, (length(?)+1)) where resc_hier = ? or resc_hier like ?", &icss );
-#else // Postgres and MySQL
-    status = cmlExecuteNoAnswerSql( "update R_DATA_MAIN set resc_hier = ? || substring(resc_hier from (char_length(?)+1)) where resc_hier = ? or resc_hier like ?", &icss );
-#endif
-
-    // Nothing was modified
-    if ( status == CAT_SUCCESS_BUT_WITH_NO_INFO ) {
-        return SUCCESS();
-    }
-
-    // =-=-=-=-=-=-=-
-    // Roll back if error
-    if ( status < 0 ) {
-        std::stringstream ss;
-        ss << "chlSubstituteResourceHierarchies: cmlExecuteNoAnswerSql update failure " << status;
-        irods::log( LOG_NOTICE, ss.str() );
-        _rollback( "chlSubstituteResourceHierarchies" );
-        return ERROR( status, "update failure" );
-    }
-
-    return SUCCESS();
-
-} // db_substitute_resource_hierarchies_op
-
 irods::error db_get_distinct_data_obj_count_on_resource_op(
     irods::plugin_context& _ctx,
     const char*            _resc_name,
@@ -15815,10 +15671,6 @@ irods::database* plugin_factory(
         DATABASE_OP_GEN_QUERY_TICKET_SETUP,
         function<error(plugin_context&,const char*,const char*)>(
             db_gen_query_ticket_setup_op ) );
-    pg->add_operation<const char*,const char*>(
-        DATABASE_OP_SUBSTITUTE_RESOURCE_HIERARCHIES,
-        function<error(plugin_context&,const char*,const char*)>(
-            db_substitute_resource_hierarchies_op ) );
     pg->add_operation<const char*,long long*>(
         DATABASE_OP_GET_DISTINCT_DATA_OBJ_COUNT_ON_RESOURCE,
         function<error(plugin_context&,const char*,long long*)>(

--- a/scripts/irods/test/test_iadmin.py
+++ b/scripts/irods/test/test_iadmin.py
@@ -1364,3 +1364,71 @@ class Test_Iadmin_Resources(resource_suite.ResourceBase, unittest.TestCase):
         # Changing vault should have failed, so make sure it has not changed
         self.admin.assert_icommand(['ilsresc', '-l', self.resc_name], 'STDOUT_SINGLELINE', 'vault: ' + self.good_vault)
 
+class Test_Iadmin_Queries(resource_suite.ResourceBase, unittest.TestCase):
+
+    def setUp(self):
+        super(Test_Iadmin_Queries, self).setUp()
+
+    def tearDown(self):
+        super(Test_Iadmin_Queries, self).tearDown()
+
+    def test_add_and_remove_specific_query(self):
+        # setup
+        test_file = 'test_specific_query_file'
+        lib.make_file(test_file, 500)
+        specific_query = 'SELECT data_name FROM R_DATA_MAIN WHERE DATA_NAME = \'{}\';'.format(test_file)
+        query_name = 'test_asq'
+
+        # Make specific query and run before it returns any results
+        self.admin.assert_icommand(['iadmin', 'asq', specific_query, query_name])
+        self.admin.assert_icommand(['iquest', '--sql', 'ls'], 'STDOUT', query_name)
+        self.admin.assert_icommand(['iquest', '--sql', query_name], 'STDOUT', 'No rows found')
+
+        # Run specific query after results can be found
+        self.admin.assert_icommand(['iput', test_file])
+        self.admin.assert_icommand(['iquest', '--sql', query_name], 'STDOUT', test_file)
+
+        # Make sure specific query can be removed
+        self.admin.assert_icommand(['iadmin', 'rsq', query_name])
+        self.admin.assert_icommand_fail(['iquest', '--sql', 'ls'], 'STDOUT', query_name)
+        self.admin.assert_icommand(['iquest', '--sql', query_name], 'STDERR', 'CAT_UNKNOWN_SPECIFIC_QUERY')
+
+        # cleanup
+        self.admin.assert_icommand(['irm', '-f', test_file])
+        os.unlink(test_file)
+
+    def test_add_non_unique_specific_query(self):
+        specific_query = 'select * from r_data_main;'
+        query_name = 'unique_asq'
+
+        # Add specific query and confirm
+        self.admin.assert_icommand(['iadmin', 'asq', specific_query, query_name])
+        self.admin.assert_icommand(['iquest', '--sql', 'ls'], 'STDOUT', query_name)
+
+        # Try adding specific query with same name
+        _,out,_=self.admin.assert_icommand(['iadmin', 'asq', specific_query, query_name], 'STDERR', 'CAT_INVALID_ARGUMENT')
+        self.assertTrue('Alias is not unique' in out)
+        self.admin.assert_icommand(['iadmin', 'rsq', query_name])
+
+    def test_unused_r_data_main_columns(self):
+        # setup
+        test_file = 'test_unused_r_data_main_columns_file'
+        column_dict = {'resc_name': 'EMPTY_RESC_NAME',
+                       'resc_hier': 'EMPTY_RESC_HIER',
+                       'resc_group_name': 'EMPTY_RESC_GROUP_NAME'}
+        specific_query = 'SELECT {0} FROM R_DATA_MAIN WHERE data_name = \'{1}\';'.format(', '.join([key for key in column_dict.keys()]), test_file)
+        query_name = 'unused_columns_asq'
+        lib.make_file(test_file, 500)
+
+        # Run query and verify that output matches expected values for columns
+        self.admin.assert_icommand(['iput', test_file])
+        self.admin.assert_icommand(['iadmin', 'asq', specific_query, query_name])
+        self.admin.assert_icommand(['iquest', '--sql', 'ls'], 'STDOUT', query_name)
+        out,_,_=self.admin.run_icommand(['iquest', '--sql', query_name])
+        for key in column_dict.keys():
+            self.assertTrue(column_dict[key] in out)
+
+        # teardown
+        self.admin.assert_icommand(['iadmin', 'rsq', query_name])
+        self.admin.assert_icommand(['irm', '-f', test_file])
+        os.unlink(test_file)

--- a/server/core/include/irods_database_constants.hpp
+++ b/server/core/include/irods_database_constants.hpp
@@ -104,7 +104,6 @@ namespace irods {
     const std::string DATABASE_OP_MOD_TICKET( "database_mod_ticket" );
     const std::string DATABASE_OP_UPDATE_PAM_PASSWORD( "database_update_pam_password" );
 
-    const std::string DATABASE_OP_SUBSTITUTE_RESOURCE_HIERARCHIES( "database_substitute_resource_hierarchies" );
     const std::string DATABASE_OP_GET_DISTINCT_DATA_OBJS_MISSING_FROM_CHILD_GIVEN_PARENT( "database_get_distinct_data_objs_missing_from_child_given_parent" );
     const std::string DATABASE_OP_GET_DISTINCT_DATA_OBJ_COUNT_ON_RESOURCE( "database_get_distinct_data_obj_count_on_resource" );
     const std::string DATABASE_OP_GET_HIERARCHY_FOR_RESC( "database_get_hierarchy_for_resc" );

--- a/server/icat/include/icatHighLevelRoutines.hpp
+++ b/server/icat/include/icatHighLevelRoutines.hpp
@@ -187,8 +187,6 @@ int chlUpdateIrodsPamPassword( rsComm_t *rsComm, const char *userName,
                                int timeToLive, const char *testTime,
                                char **irodsPassword );
 
-int chlSubstituteResourceHierarchies( rsComm_t *rsComm, const char *old_hier, const char *new_hier );
-
 /// =-=-=-=-=-=-=-
 /// @brief typedefs and prototype for query used for rebalancing operation
 typedef std::vector< rodsLong_t > dist_child_result_t;

--- a/server/icat/src/icatHighLevelRoutines.cpp
+++ b/server/icat/src/icatHighLevelRoutines.cpp
@@ -4229,62 +4229,6 @@ int chlSpecificQuery(
 
 } // chlSpecificQuery
 
-
-// =-=-=-=-=-=-=-
-// chlSubstituteResourceHierarchies - Given an old resource hierarchy string and a new one,
-// replaces all r_data_main.resc_hier rows that match the old string with the new one.
-int chlSubstituteResourceHierarchies(
-    rsComm_t*   _comm,
-    const char* _old_hier,
-    const char* _new_hier ) {
-    // =-=-=-=-=-=-=-
-    // call factory for database object
-    irods::database_object_ptr db_obj_ptr;
-    irods::error ret = irods::database_factory(
-                           database_plugin_type,
-                           db_obj_ptr );
-    if ( !ret.ok() ) {
-        irods::log( PASS( ret ) );
-        return ret.code();
-    }
-
-    // =-=-=-=-=-=-=-
-    // resolve a plugin for that object
-    irods::plugin_ptr db_plug_ptr;
-    ret = db_obj_ptr->resolve(
-              irods::DATABASE_INTERFACE,
-              db_plug_ptr );
-    if ( !ret.ok() ) {
-        irods::log(
-            PASSMSG(
-                "failed to resolve database interface",
-                ret ) );
-        return ret.code();
-    }
-
-    // =-=-=-=-=-=-=-
-    // cast plugin and object to db and fco for call
-    irods::first_class_object_ptr ptr = boost::dynamic_pointer_cast <
-                                        irods::first_class_object > ( db_obj_ptr );
-    irods::database_ptr           db = boost::dynamic_pointer_cast <
-                                       irods::database > ( db_plug_ptr );
-
-    // =-=-=-=-=-=-=-
-    // call the operation on the plugin
-    ret = db->call <
-          const char*,
-          const char* > (
-              _comm,
-              irods::DATABASE_OP_SUBSTITUTE_RESOURCE_HIERARCHIES,
-              ptr,
-              _old_hier,
-              _new_hier );
-
-    return ret.code();
-
-} // chlSubstituteResourceHierarchies
-
-
 /// =-=-=-=-=-=-=-
 /// @brief return the distinct object count of a resource in a hierarchy
 int chlGetDistinctDataObjCountOnResource(


### PR DESCRIPTION
Obsolete columns in R_DATA_MAIN have inconsistent empty values. This change uses well-defined values (EMPTY_*) in a few unused columns for all new data objects registered in iRODS. Replicas made of said data objects will contain the same garbage information. Any data objects or replicas registered before this change will have the out of date information (pre-4.2) or empty values (as of 4.2).

resc_hier and resc_name do not actually store the resc_hier or resc_name anymore, so any code related to repaving these has been removed. Nothing that was removed is in use anymore.

---
[Passed CI](http://172.25.14.125:8080/view/2.%20Personal/job/irods-build-and-test-workflow/1053/) before rebase. Running again.