### PR TITLE
[#3853] Use known strings in obsolete columns

### DIFF
--- a/server/core/include/irods_database_constants.hpp
+++ b/server/core/include/irods_database_constants.hpp
@@ -104,7 +104,6 @@ namespace irods {
     const std::string DATABASE_OP_MOD_TICKET( "database_mod_ticket" );
     const std::string DATABASE_OP_UPDATE_PAM_PASSWORD( "database_update_pam_password" );
 
-    const std::string DATABASE_OP_SUBSTITUTE_RESOURCE_HIERARCHIES( "database_substitute_resource_hierarchies" );
     const std::string DATABASE_OP_GET_DISTINCT_DATA_OBJS_MISSING_FROM_CHILD_GIVEN_PARENT( "database_get_distinct_data_objs_missing_from_child_given_parent" );
     const std::string DATABASE_OP_GET_DISTINCT_DATA_OBJ_COUNT_ON_RESOURCE( "database_get_distinct_data_obj_count_on_resource" );
     const std::string DATABASE_OP_GET_HIERARCHY_FOR_RESC( "database_get_hierarchy_for_resc" );

--- a/server/icat/include/icatHighLevelRoutines.hpp
+++ b/server/icat/include/icatHighLevelRoutines.hpp
@@ -187,8 +187,6 @@ int chlUpdateIrodsPamPassword( rsComm_t *rsComm, const char *userName,
                                int timeToLive, const char *testTime,
                                char **irodsPassword );
 
-int chlSubstituteResourceHierarchies( rsComm_t *rsComm, const char *old_hier, const char *new_hier );
-
 /// =-=-=-=-=-=-=-
 /// @brief typedefs and prototype for query used for rebalancing operation
 typedef std::vector< rodsLong_t > dist_child_result_t;

--- a/server/icat/src/icatHighLevelRoutines.cpp
+++ b/server/icat/src/icatHighLevelRoutines.cpp
@@ -4229,62 +4229,6 @@ int chlSpecificQuery(
 
 } // chlSpecificQuery
 
-
-// =-=-=-=-=-=-=-
-// chlSubstituteResourceHierarchies - Given an old resource hierarchy string and a new one,
-// replaces all r_data_main.resc_hier rows that match the old string with the new one.
-int chlSubstituteResourceHierarchies(
-    rsComm_t*   _comm,
-    const char* _old_hier,
-    const char* _new_hier ) {
-    // =-=-=-=-=-=-=-
-    // call factory for database object
-    irods::database_object_ptr db_obj_ptr;
-    irods::error ret = irods::database_factory(
-                           database_plugin_type,
-                           db_obj_ptr );
-    if ( !ret.ok() ) {
-        irods::log( PASS( ret ) );
-        return ret.code();
-    }
-
-    // =-=-=-=-=-=-=-
-    // resolve a plugin for that object
-    irods::plugin_ptr db_plug_ptr;
-    ret = db_obj_ptr->resolve(
-              irods::DATABASE_INTERFACE,
-              db_plug_ptr );
-    if ( !ret.ok() ) {
-        irods::log(
-            PASSMSG(
-                "failed to resolve database interface",
-                ret ) );
-        return ret.code();
-    }
-
-    // =-=-=-=-=-=-=-
-    // cast plugin and object to db and fco for call
-    irods::first_class_object_ptr ptr = boost::dynamic_pointer_cast <
-                                        irods::first_class_object > ( db_obj_ptr );
-    irods::database_ptr           db = boost::dynamic_pointer_cast <
-                                       irods::database > ( db_plug_ptr );
-
-    // =-=-=-=-=-=-=-
-    // call the operation on the plugin
-    ret = db->call <
-          const char*,
-          const char* > (
-              _comm,
-              irods::DATABASE_OP_SUBSTITUTE_RESOURCE_HIERARCHIES,
-              ptr,
-              _old_hier,
-              _new_hier );
-
-    return ret.code();
-
-} // chlSubstituteResourceHierarchies
-
-
 /// =-=-=-=-=-=-=-
 /// @brief return the distinct object count of a resource in a hierarchy
 int chlGetDistinctDataObjCountOnResource(


### PR DESCRIPTION
Obsolete columns in R_DATA_MAIN have inconsistent empty values. This change uses well-defined values (EMPTY_*) in a few unused columns for all new data objects registered in iRODS. Replicas made of said data objects will contain the same garbage information. Any data objects or replicas registered before this change will have the out of date information (pre-4.2) or empty values (as of 4.2).

resc_hier and resc_name do not actually store the resc_hier or resc_name anymore, so any code related to repaving these has been removed. Nothing that was removed is in use anymore.

(cherry-picked from SHA: 334fa63)

---
[CI tests running](http://172.25.14.125:8080/view/2.%20Personal/job/irods-build-and-test-workflow/1062/flowGraphTable/).