### PR TITLE
[#3940] Various error handling where there was none (master)

### DIFF
--- a/plugins/auth/pam/libpam.cpp
+++ b/plugins/auth/pam/libpam.cpp
@@ -245,8 +245,11 @@ irods::error pam_auth_client_request(
         // copy over the resulting irods pam pasword
         // and cache the result in our auth object
         ptr->request_result( req_out->result_ );
-        obfSavePw( 0, 0, 0, req_out->result_ );
+        status = obfSavePw( 0, 0, 0, req_out->result_ );
         free( req_out );
+        if (status < 0) {
+            return ERROR(status, "obfSavePw failed");
+        }
         return SUCCESS();
 
     }
@@ -420,7 +423,10 @@ irods::error pam_auth_agent_request(
     // request the resulting irods password after the handshake
     char password_out[ MAX_NAME_LEN ];
     char* pw_ptr = &password_out[0];
-    chlUpdateIrodsPamPassword( _ctx.comm(), const_cast< char* >( user_name.c_str() ), ttl, NULL, &pw_ptr );
+    status = chlUpdateIrodsPamPassword( _ctx.comm(), const_cast< char* >( user_name.c_str() ), ttl, NULL, &pw_ptr );
+    if (status < 0) {
+        return ERROR(status, "failed updating iRODS pam password");
+    }
 
     // =-=-=-=-=-=-=-
     // set the result for communication back to the client

--- a/plugins/database/src/general_query.cpp
+++ b/plugins/database/src/general_query.cpp
@@ -2054,7 +2054,6 @@ checkCondInputAccess( genQueryInp_t genQueryInp, int statementNum,
                       icatSessionStruct *icss, int continueFlag ) {
     int i, nCols;
     int userIx = -1, zoneIx = -1, accessIx = -1, dataIx = -1, collIx = -1;
-    int status;
     std::string zoneName;
 
     static char prevDataId[LONG_NAME_LEN];
@@ -2123,6 +2122,7 @@ checkCondInputAccess( genQueryInp_t genQueryInp, int statementNum,
         return CAT_INVALID_ARGUMENT;
     }
 
+    int status{};
     if ( dataIx >= 0 ) {
         if ( continueFlag == 1 ) {
             if ( strcmp( prevDataId,
@@ -2167,13 +2167,14 @@ checkCondInputAccess( genQueryInp_t genQueryInp, int statementNum,
         else {
             zoneName = genQueryInp.condInput.value[zoneIx];
         }
-        cmlCheckDirId(
+        status = cmlCheckDirId(
             icss->stmtPtr[statementNum]->resultValue[collIx],
             genQueryInp.condInput.value[userIx],
             ( char* )zoneName.c_str(),
             genQueryInp.condInput.value[accessIx], icss );
+        prevStatus = status;
     }
-    return 0;
+    return status;
 }
 
 /* Save some pre-provided parameters if msiAclPolicy is STRICT.

--- a/server/api/src/rsChkObjPermAndStat.cpp
+++ b/server/api/src/rsChkObjPermAndStat.cpp
@@ -256,24 +256,29 @@ chkCollForBundleOpr( rsComm_t *rsComm,
         }
 
         /* handle what's left */
-        if ( curCollEnt != NULL ) {
-            if ( curCopyGood == False ) {
-                status = replDataObjForBundle( rsComm, curCollEnt->collName,
-                                               curCollEnt->dataName, resource, curCollEnt->resc_hier, resc_hier, 0, NULL );
-                freeCollEntForChkColl( curCollEnt );
-                if ( status < 0 ) {
-                    rodsLog( LOG_ERROR,
-                             "chkCollForBundleOpr:%s does not have a good copy in %s",
-                             chkObjPermAndStatInp->objPath, resource );
+        if (NULL != curCollEnt) {
+            if (False == curCopyGood) {
+                status = replDataObjForBundle(rsComm,
+                                              curCollEnt->collName,
+                                              curCollEnt->dataName,
+                                              resource,
+                                              curCollEnt->resc_hier,
+                                              resc_hier,
+                                              0,
+                                              NULL);
+                freeCollEntForChkColl(curCollEnt);
+                if (status < 0) {
+                    const auto err{ERROR(status,
+                                         (boost::format("[%s] does not have a good copy in [%s]") %
+                                          chkObjPermAndStatInp->objPath % resource).str().c_str())};
+                    irods::log(err);
                 }
             }
             else {
-                freeCollEntForChkColl( curCollEnt );
+                freeCollEntForChkColl(curCollEnt);
             }
         }
-
-        rsCloseCollection( rsComm, &handleInx );
-
+        rsCloseCollection(rsComm, &handleInx);
         return 0;
     } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         return SYS_NO_RCAT_SERVER_ERR;

--- a/server/api/src/rsDataObjPhymv.cpp
+++ b/server/api/src/rsDataObjPhymv.cpp
@@ -272,18 +272,19 @@ rsDataObjPhymv( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
         return status;
     }
 
-
-    initReiWithDataObjInp(
-	    &rei,
-		rsComm,
-		dataObjInp );
-    applyRule(
-        "acSetMultiReplPerResc",
-        NULL,
-        &rei,
-        NO_SAVE_REI );
+    initReiWithDataObjInp(&rei, rsComm, dataObjInp);
+    status = applyRule("acSetMultiReplPerResc", NULL, &rei, NO_SAVE_REI);
     clearKeyVal(rei.condInputData);
     free(rei.condInputData);
+    if (status < 0) {
+        if (rei.status < 0) {
+            status = rei.status;
+        }
+        const auto err{ERROR(status, "acSetMultiReplPerResc failed")};
+        irods::log(err);
+        return status;
+    }
+
     if ( strcmp( rei.statusStr, MULTI_COPIES_PER_RESC ) == 0 ) {
         multiCopyFlag = 1;
     }

--- a/server/api/src/rsDataObjPut.cpp
+++ b/server/api/src/rsDataObjPut.cpp
@@ -236,12 +236,15 @@ _rsDataObjPut( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
             clearKeyVal( &replDataObjInp.condInput );
         }
     }
-    else if ( allFlag == 1 ) {
-        rsDataObjRepl( rsComm, &replDataObjInp, &transStat );
-        if ( transStat != NULL ) {
-            free( transStat );
+    else if (1 == allFlag) {
+        status = rsDataObjRepl(rsComm, &replDataObjInp, &transStat);
+        free(transStat);
+        clearKeyVal(&replDataObjInp.condInput);
+        if (status < 0) {
+            const auto err{ERROR(status, "rsDataObjRepl failed")};
+            irods::log(err);
+            return err.code();
         }
-        clearKeyVal( &replDataObjInp.condInput );
     }
 
     /* already send the client the status */

--- a/server/api/src/rsDataObjRepl.cpp
+++ b/server/api/src/rsDataObjRepl.cpp
@@ -254,10 +254,19 @@ _rsDataObjRepl(
         accessPerm = ACCESS_READ_OBJECT;
     }
 
-    initReiWithDataObjInp( &rei, rsComm, dataObjInp );
-    applyRule( "acSetMultiReplPerResc", NULL, &rei, NO_SAVE_REI );
+    initReiWithDataObjInp(&rei, rsComm, dataObjInp);
+    status = applyRule("acSetMultiReplPerResc", NULL, &rei, NO_SAVE_REI);
     clearKeyVal(rei.condInputData);
     free(rei.condInputData);
+    if (status < 0) {
+        if (rei.status < 0) {
+            status = rei.status;
+        }
+        const auto err{ERROR(status, "acSetMultiReplPerResc failed")};
+        irods::log(err);
+        return err.code();
+    }
+
     if ( strcmp( rei.statusStr, MULTI_COPIES_PER_RESC ) == 0 ) {
         multiCopyFlag = 1;
     }

--- a/server/api/src/rsRmColl.cpp
+++ b/server/api/src/rsRmColl.cpp
@@ -179,10 +179,18 @@ _rsRmCollRecur( rsComm_t *rsComm, collInp_t *rmCollInp,
                 getValByKey( &rmCollInp->condInput, RMTRASH_KW ) == NULL &&
                 getValByKey( &rmCollInp->condInput, ADMIN_RMTRASH_KW ) == NULL ) {
             initReiWithDataObjInp( &rei, rsComm, NULL );
-            applyRule( "acTrashPolicy", NULL, &rei, NO_SAVE_REI );
+            status = applyRule("acTrashPolicy", NULL, &rei, NO_SAVE_REI);
             clearKeyVal(rei.condInputData);
             free(rei.condInputData);
-            if ( NO_TRASH_CAN != rei.status ) {
+            if (status < 0) {
+                if (rei.status < 0) {
+                    status = rei.status;
+                }
+                const auto err{ERROR(status, "acTrashPolicy failed")};
+                irods::log(err);
+                return err.code();
+            }
+            if (NO_TRASH_CAN != rei.status) {
                 status = rsMvCollToTrash( rsComm, rmCollInp );
                 if ( status >= 0 && collOprStat != NULL ) {
                     if ( *collOprStat == NULL ) {

--- a/server/api/src/rsRuleExecDel.cpp
+++ b/server/api/src/rsRuleExecDel.cpp
@@ -131,10 +131,11 @@ int _rsRuleExecDel( rsComm_t *rsComm, ruleExecDelInp_t *ruleExecDelInp ) {
                      "_rsRuleExecDel: chlDelRuleExec only in ICAT host" );
             return SYS_NO_RCAT_SERVER_ERR;
         } else {
-            rodsLog(
-                LOG_ERROR,
-                "role not supported [%s]",
-                svc_role.c_str() );
+            const auto err{ERROR(SYS_SERVICE_ROLE_NOT_SUPPORTED,
+                                 (boost::format("role not supported [%s]") %
+                                  svc_role.c_str()).str().c_str())};
+            irods::log(err);
+            return err.code();
         }
     }
 
@@ -199,10 +200,11 @@ int _rsRuleExecDel( rsComm_t *rsComm, ruleExecDelInp_t *ruleExecDelInp ) {
                      "_rsRuleExecDel: chlDelRuleExec only in ICAT host" );
             return SYS_NO_RCAT_SERVER_ERR;
         } else {
-            rodsLog(
-                LOG_ERROR,
-                "role not supported [%s]",
-                svc_role.c_str() );
+            const auto err{ERROR(SYS_SERVICE_ROLE_NOT_SUPPORTED,
+                                 (boost::format("role not supported [%s]") %
+                                  svc_role.c_str()).str().c_str())};
+            irods::log(err);
+            return err.code();
         }
     }
     status = unlink( reiFilePath->value );
@@ -240,7 +242,10 @@ int _rsRuleExecDel( rsComm_t *rsComm, ruleExecDelInp_t *ruleExecDelInp ) {
             snprintf( errMsg, sizeof errMsg,
                       "rei file: %s",
                       reiFilePath->value );
-            addRErrorMsg( &rsComm->rError, 1, errMsg );
+            i = addRErrorMsg( &rsComm->rError, 1, errMsg );
+            if (i < 0) {
+                irods::log(ERROR(i, "addRErrorMsg failed"));
+            }
             if ( status == 0 ) {
                 /* return this error if no other error occurred */
                 status = unlinkStatus;
@@ -255,10 +260,10 @@ int _rsRuleExecDel( rsComm_t *rsComm, ruleExecDelInp_t *ruleExecDelInp ) {
                  "_rsRuleExecDel: chlDelRuleExec only in ICAT host" );
         return SYS_NO_RCAT_SERVER_ERR;
     } else {
-        rodsLog(
-            LOG_ERROR,
-            "role not supported [%s]",
-            svc_role.c_str() );
-        return SYS_SERVICE_ROLE_NOT_SUPPORTED;
+        const auto err{ERROR(SYS_SERVICE_ROLE_NOT_SUPPORTED,
+                             (boost::format("role not supported [%s]") %
+                              svc_role.c_str()).str().c_str())};
+        irods::log(err);
+        return err.code();
     }
 }

--- a/server/core/include/initServer.hpp
+++ b/server/core/include/initServer.hpp
@@ -50,7 +50,7 @@ chkAllowedUser( const char *userName, const char *rodsZone );
 int
 setRsCommFromRodsEnv( rsComm_t *rsComm );
 int
-queAgentProc( agentProc_t *agentProc, agentProc_t **agentProcHead,
+queueAgentProc( agentProc_t *agentProc, agentProc_t **agentProcHead,
               irodsPosition_t position );
 int
 purgeLockFileDir( int chkLockFlag );

--- a/server/core/include/rodsConnect.h
+++ b/server/core/include/rodsConnect.h
@@ -90,21 +90,21 @@ extern "C" {
 #endif
 
 int
-queAddr( rodsServerHost_t *rodsServerHost, char *myHostName );
+queueAddr( rodsServerHost_t *rodsServerHost, char *myHostName );
 int
-queHostName( rodsServerHost_t *rodsServerHost, const char *myHostName, int topFlag );
+queueHostName( rodsServerHost_t *rodsServerHost, const char *myHostName, int topFlag );
 int
-queRodsServerHost( rodsServerHost_t **rodsServerHostHead,
+queueRodsServerHost( rodsServerHost_t **rodsServerHostHead,
                    rodsServerHost_t *myRodsServerHost );
 rodsServerHost_t *
 mkServerHost( char *myHostAddr, char *zoneName );
 int
-queZone( const char *zoneName, int portNum, rodsServerHost_t *masterServerHost,
+queueZone( const char *zoneName, int portNum, rodsServerHost_t *masterServerHost,
          rodsServerHost_t *slaveServerHost );
 int
 matchHostConfig( rodsServerHost_t *myRodsServerHost );
 int
-queConfigName( rodsServerHost_t *configServerHost,
+queueConfigName( rodsServerHost_t *configServerHost,
                rodsServerHost_t *myRodsServerHost );
 int
 getAndConnRcatHost( rsComm_t *rsComm, int rcatType, const char *rcatZoneHint,

--- a/server/core/src/irods_resource_redirect.cpp
+++ b/server/core/src/irods_resource_redirect.cpp
@@ -628,6 +628,9 @@ namespace irods {
                             key_word,
                             oper,
                             _out_hier );
+            if (!ret.ok()) {
+                return PASSMSG("Failed to resolve resource hierarchy", ret);
+            }
 
             // make sure the desired hierarchy is in the linked list
             // otherwise get data object info list again,
@@ -709,7 +712,6 @@ namespace irods {
                           create_resc_name.c_str(),
                           _data_obj_inp,
                           _out_hier );
-
             }
             else {
                 // =-=-=-=-=-=-=-
@@ -720,6 +722,9 @@ namespace irods {
                           create_resc_name.c_str(),
                           _data_obj_inp,
                           _out_hier );
+            }
+            if (!ret.ok()) {
+                return PASSMSG("Failed to resolve resource hierarchy", ret);
             }
 
             // make sure the desired hierarchy is in the linked list

--- a/server/core/src/irods_server_control_plane.cpp
+++ b/server/core/src/irods_server_control_plane.cpp
@@ -1120,7 +1120,6 @@ namespace irods {
         boost::optional<const std::string&> encryption_algorithm;
         buffer_crypt::array_t shared_secret;
         try {
-            get_server_property<const int>(port_prop_);
             num_hash_rounds = get_server_property<const int>(CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS_KW);
             encryption_algorithm.reset(get_server_property<const std::string>(CFG_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM_KW));
             const auto& key = get_server_property<const std::string>(CFG_SERVER_CONTROL_PLANE_KEY);

--- a/server/core/src/physPath.cpp
+++ b/server/core/src/physPath.cpp
@@ -827,11 +827,19 @@ syncDataObjPhyPathS( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
         dataObjInp_t myDdataObjInp;
         memset( &myDdataObjInp, 0, sizeof( myDdataObjInp ) );
         rstrcpy( myDdataObjInp.objPath, dataObjInfo->objPath, MAX_NAME_LEN );
-        getFilePathName( rsComm, dataObjInfo, &myDdataObjInp );
+        status = getFilePathName(rsComm, dataObjInfo, &myDdataObjInp);
     }
     else {
-        getFilePathName( rsComm, dataObjInfo, dataObjInp );
+        status = getFilePathName(rsComm, dataObjInfo, dataObjInp);
     }
+
+    if (status < 0) { 
+        const auto err{ERROR(status,
+                             (boost::format("getFilePathName err for [%s]") %
+                              dataObjInfo->objPath).str().c_str())};
+        irods::log(err);
+        return err.code();
+    }   
 
     if ( strcmp( fileRenameInp.oldFileName, dataObjInfo->filePath ) == 0 ) {
         return 0;

--- a/server/core/src/rodsServer.cpp
+++ b/server/core/src/rodsServer.cpp
@@ -959,7 +959,7 @@ queConnectedAgentProc( int childPid, agentProc_t *connReq,
 
     boost::unique_lock< boost::mutex > con_agent_lock( ConnectedAgentMutex );
 
-    queAgentProc( connReq, agentProcHead, TOP_POS );
+    queueAgentProc( connReq, agentProcHead, TOP_POS );
 
     con_agent_lock.unlock();
 
@@ -1282,7 +1282,7 @@ addConnReqToQue( rsComm_t *rsComm, int sock ) {
 
     myConnReq->sock = sock;
     myConnReq->remoteAddr = rsComm->remoteAddr;
-    queAgentProc( myConnReq, &ConnReqHead, BOTTOM_POS );
+    queueAgentProc( myConnReq, &ConnReqHead, BOTTOM_POS );
 
     ReadReqCond.notify_all(); // NOTE:: check all vs one
     read_req_lock.unlock();
@@ -1412,7 +1412,7 @@ readWorkerTask() {
             rodsLog( LOG_ERROR, "readWorkerTask - readStartupPack failed. %d", ret.code() );
             sendVersion( net_obj, ret.code(), 0, NULL, 0 );
             boost::unique_lock<boost::mutex> bad_req_lock( BadReqMutex );
-            queAgentProc( myConnReq, &BadReqHead, TOP_POS );
+            queueAgentProc( myConnReq, &BadReqHead, TOP_POS );
             bad_req_lock.unlock();
             mySockClose( newSock );
         }
@@ -1457,7 +1457,7 @@ readWorkerTask() {
 
             boost::unique_lock< boost::mutex > spwn_req_lock( SpawnReqCondMutex );
 
-            queAgentProc( myConnReq, &SpawnReqHead, BOTTOM_POS );
+            queueAgentProc( myConnReq, &SpawnReqHead, BOTTOM_POS );
 
             SpawnReqCond.notify_all(); // NOTE:: look into notify_one vs notify_all
 


### PR DESCRIPTION
Partial rework of 3ad667c

Instead of removing references to the unused variables, usage was actually implemented (mostly error checking and logging).

---
[Passed CI tests.](http://172.25.14.125:8080/job/irods-build-and-test-workflow/1095/) This change is for master only. A little less rodsLog and que and a little more irods::log and queue, as well.