### PR TITLE
[#3941] Add test for delay queue batch processing (master)

### DIFF
--- a/server/core/src/reServerLib.cpp
+++ b/server/core/src/reServerLib.cpp
@@ -221,9 +221,15 @@ getNextQueuedRuleExec( genQueryOut_t **inGenQueryOut,
         exeTimeStr = &exeTime->value[exeTime->len * i];
         ruleExecIdStr =  &ruleExecId->value[ruleExecId->len * i];
 
-        if ( ( jobType & RE_FAILED_STATUS ) == 0 &&
-                strcmp( exeStatusStr, RE_FAILED ) == 0 ) {
-            /* failed request */
+        // jobType indicates the type of jobs being executed on the queue
+        if (0 != (jobType & RE_FAILED_STATUS) &&
+            0 != strcmp(exeStatusStr, RE_FAILED)) {
+            // Only processing failed execution requests
+            continue;
+        }
+        else if (0 == (jobType & RE_FAILED_STATUS) &&
+                 0 == strcmp(exeStatusStr, RE_FAILED)) {
+            // Not processing failed execution requests
             continue;
         }
         else if ( atoi( exeTimeStr ) > time( 0 ) ) {


### PR DESCRIPTION
Test ensures that all queued jobs are processed if they can be in the rule engine server execution timeframe.

Also includes fix for double rule exec in delay queue.

---
[CI tests passed.](http://172.25.14.125:8080/view/2.%20Personal/job/irods-build-and-test-workflow/1137/) Do not merge until #3942 is merged.