### PR TITLE
[#3991] Set spOption everywhere (4-1-stable)

### DIFF
--- a/iRODS/clients/icommands/src/iapitest.cpp
+++ b/iRODS/clients/icommands/src/iapitest.cpp
@@ -30,13 +30,20 @@ typedef struct {
     otherOut_t _other;
 } helloOut_t;
 
-void usage();
-
 int
-main( int, char** ) {
+main( int, char** argv ) {
 
     signal( SIGPIPE, SIG_IGN );
 
+    if (NULL != argv && NULL != argv[0]) {
+        /* set SP_OPTION to argv[0] so it can be passed to server */
+        char child[MAX_NAME_LEN], parent[MAX_NAME_LEN];
+        *child = '\0';
+        splitPathByKey(argv[0], parent, MAX_NAME_LEN, child, MAX_NAME_LEN, '/');
+        if (*child != '\0') {
+            mySetenvStr(SP_OPTION, child);
+        }
+    }
 
     rodsEnv myEnv;
     int status = getRodsEnv( &myEnv );

--- a/iRODS/clients/icommands/src/izonereport.cpp
+++ b/iRODS/clients/icommands/src/izonereport.cpp
@@ -39,7 +39,7 @@ void usage() {
 }
 
 int
-main( int _argc, char** ) {
+main( int _argc, char** argv ) {
 
     signal( SIGPIPE, SIG_IGN );
 
@@ -48,8 +48,20 @@ main( int _argc, char** ) {
         return 0;
     }
 
+    rodsArguments_t myRodsArgs;
+    char* optStr = "h";
+    int status = parseCmdLineOpt(_argc, argv, optStr, 0, &myRodsArgs);
+    if (status) {
+        printf("Use -h for help.\n");
+        exit(1);
+    }
+    if (True == myRodsArgs.help) {
+        usage();
+        exit(0);
+    }
+
     rodsEnv myEnv;
-    int status = getRodsEnv( &myEnv );
+    status = getRodsEnv( &myEnv );
     if ( status < 0 ) {
         rodsLogError( LOG_ERROR, status, "main: getRodsEnv error. " );
         exit( 1 );

--- a/plugins/resources/replication/librepl.cpp
+++ b/plugins/resources/replication/librepl.cpp
@@ -270,10 +270,10 @@ extern "C" {
         child_list_t child_list;
         ret = _ctx.prop_map().get<child_list_t>( CHILD_LIST_PROP, child_list );
         if ( !ret.ok() ) {
-            return PASSMSG(
-                       (boost::format(
-                        "[%s] - Failed to get child list for replication.") %
-                        __FUNCTION__).str(), ret );
+            irods::log(PASSMSG( (boost::format(
+                       "[%s] - Failed to get child list for replication.") %
+                       __FUNCTION__).str(), ret ));
+            return SUCCESS();
         }
 
         // get the root resource name as well as the child hierarchy string


### PR DESCRIPTION
spOption is the environment variable that the server checks to identify connected client. This variable should be set for all the icommands. izonereport, iapitest, and iclienthints do not set this environment variable. In the case of izonereport and iclienthints, the -h flag was actually not supported at all, despite claiming to have support.

(cherry-picked from irods/irods_client_icommands SHA: 008b5343e086e452cbf62173d94fc4f8fbafd05a)

Also reverts failing when failing to find the child list when replicating create/write, where before it returned with success.

---
[CI tests passed.](http://172.25.14.125:8080/view/2.%20Personal/job/irods-build-and-test-workflow/1206/)