### PR TITLE
[#4040] remove calls to determine username/groupname (master)

### DIFF
--- a/server/core/src/physPath.cpp
+++ b/server/core/src/physPath.cpp
@@ -1328,11 +1328,9 @@ rodsLong_t
 getFileMetadataFromVault( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo )
 
 {
-    static char fname[] = "getFileMetadataFromVault";
     rodsStat_t *myStat = NULL;
     int status;
     rodsLong_t mysize;
-    char name_buf[NAME_LEN];
     char sstr_buf[SHORT_STR_LEN];
     char time_buf[TIME_LEN];
 
@@ -1349,24 +1347,6 @@ getFileMetadataFromVault( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo )
         free( myStat );
         return ( rodsLong_t ) SYS_PATH_IS_NOT_A_FILE;
     }
-
-    status = getUnixUsername( myStat->st_uid, name_buf, NAME_LEN );
-    if ( status ) {
-        rodsLog( LOG_ERROR, "%s: could not retrieve username for uid %d",
-                 fname, myStat->st_uid );
-        free( myStat );
-        return status;
-    }
-    addKeyVal( &dataObjInfo->condInput, FILE_OWNER_KW, name_buf );
-
-    status = getUnixGroupname( myStat->st_gid, name_buf, NAME_LEN );
-    if ( status ) {
-        rodsLog( LOG_ERROR, "%s: could not retrieve groupname for gid %d",
-                 fname, myStat->st_gid );
-        free( myStat );
-        return status;
-    }
-    addKeyVal( &dataObjInfo->condInput, FILE_GROUP_KW, name_buf );
 
     snprintf( sstr_buf, SHORT_STR_LEN, "%u", myStat->st_uid );
     addKeyVal( &dataObjInfo->condInput, FILE_UID_KW, sstr_buf );


### PR DESCRIPTION
These two calls were populating a data structure and then never used.

If the username and groupname need to be determined later, the uid/gid
are still being recorded.