### PR TITLE
[#4066] Add data size/modify KWs in rsPhyPathReg

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -2693,6 +2693,10 @@ irods::error db_reg_data_obj_op(
     snprintf( dataSizeNum, MAX_NAME_LEN, "%lld", _data_obj_info->dataSize );
     getNowStr( myTime );
 
+    if (0 == strcmp(_data_obj_info->dataModify, "")) {
+        strcpy(_data_obj_info->dataModify, myTime);
+    }
+
     std::string resc_id_str = boost::lexical_cast<std::string>(_data_obj_info->rescId);
     cllBindVars[0] = dataIdNum;
     cllBindVars[1] = collIdNum;
@@ -2709,7 +2713,7 @@ irods::error db_reg_data_obj_op(
     cllBindVars[12] = _data_obj_info->chksum;
     cllBindVars[13] = _data_obj_info->dataMode;
     cllBindVars[14] = myTime;
-    cllBindVars[15] = myTime;
+    cllBindVars[15] = _data_obj_info->dataModify;
     cllBindVars[16] = data_expiry_ts;
     cllBindVars[17] = "EMPTY_RESC_NAME";
     cllBindVars[18] = "EMPTY_RESC_HIER";


### PR DESCRIPTION
Added support for data size and modify keywords in dataObjInp for rsPhyPathReg. This allows the client to pass DATA_SIZE_KW and DATA_MODIFY_KW to specify the size and modify time of the data object
being registered.

---
[CI tests passed.](http://172.25.14.125:8080/view/2.%20Personal/job/irods-build-and-test-workflow/1292/)