### PR TITLE
[#4066] Add data size/modify KWs in rsPhyPathReg (master)

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -2685,6 +2685,10 @@ irods::error db_reg_data_obj_op(
     snprintf( dataSizeNum, MAX_NAME_LEN, "%lld", _data_obj_info->dataSize );
     getNowStr( myTime );
 
+    if (0 == strcmp(_data_obj_info->dataModify, "")) {
+        strcpy(_data_obj_info->dataModify, myTime);
+    }
+
     std::string resc_id_str = boost::lexical_cast<std::string>(_data_obj_info->rescId);
     cllBindVars[0] = dataIdNum;
     cllBindVars[1] = collIdNum;
@@ -2701,7 +2705,7 @@ irods::error db_reg_data_obj_op(
     cllBindVars[12] = _data_obj_info->chksum;
     cllBindVars[13] = _data_obj_info->dataMode;
     cllBindVars[14] = myTime;
-    cllBindVars[15] = myTime;
+    cllBindVars[15] = _data_obj_info->dataModify;
     cllBindVars[16] = data_expiry_ts;
     cllBindVars[17] = "EMPTY_RESC_NAME";
     cllBindVars[18] = "EMPTY_RESC_HIER";

--- a/server/api/src/rsPhyPathReg.cpp
+++ b/server/api/src/rsPhyPathReg.cpp
@@ -43,6 +43,8 @@
 #include "irods_resource_redirect.hpp"
 #include "irods_hierarchy_parser.hpp"
 
+#include "boost/lexical_cast.hpp"
+
 // =-=-=-=-=-=-=-
 // stl includes
 #include <iostream>
@@ -520,6 +522,17 @@ filePathReg( rsComm_t *rsComm, dataObjInp_t *phyPathRegInp, const char *_resc_na
         irods::log(PASS(ret));
     }
 
+    const auto data_size_str{getValByKey(&phyPathRegInp->condInput, DATA_SIZE_KW)};
+    try {
+        if (NULL != data_size_str) {
+            dataObjInfo.dataSize = boost::lexical_cast<decltype(dataObjInfo.dataSize)>(data_size_str);
+        }
+    }
+    catch (boost::bad_lexical_cast&) {
+        rodsLog(LOG_ERROR, "[%s] - bad_lexical_cast for dataSize [%s]; setting to 0", __FUNCTION__, data_size_str);
+        dataObjInfo.dataSize = 0;
+    }
+
     if ( dataObjInfo.dataSize <= 0 &&
             ( dataObjInfo.dataSize = getFileMetadataFromVault( rsComm, &dataObjInfo ) ) < 0 &&
             dataObjInfo.dataSize != UNKNOWN_FILE_SZ ) {
@@ -529,6 +542,11 @@ filePathReg( rsComm_t *rsComm, dataObjInp_t *phyPathRegInp, const char *_resc_na
                  dataObjInfo.objPath, status );
         clearKeyVal( &dataObjInfo.condInput );
         return status;
+    }
+
+    const auto data_modify_str{getValByKey(&phyPathRegInp->condInput, DATA_MODIFY_KW)};
+    if (NULL != data_modify_str) {
+        strcpy(dataObjInfo.dataModify, data_modify_str);
     }
 
     if ( ( getValByKey( &phyPathRegInp->condInput, REG_CHKSUM_KW ) != NULL ) ||


### PR DESCRIPTION
Added support for data size and modify keywords in dataObjInp for rsPhyPathReg. This allows the client to pass DATA_SIZE_KW and DATA_MODIFY_KW to specify the size and modify time of the data object
being registered.

(cherry-picked from SHA: e24dfb6412a26f60623fff541acada666db05b28)

---
[CI tests running.](http://172.25.14.125:8080/view/2.%20Personal/job/irods-build-and-test-workflow/1295/)