### PR TITLE
[#4066] Skip redirect in reg with size KW (4-2-stable)

### DIFF
--- a/server/api/src/rsPhyPathReg.cpp
+++ b/server/api/src/rsPhyPathReg.cpp
@@ -272,7 +272,9 @@ irsPhyPathReg( rsComm_t *rsComm, dataObjInp_t *phyPathRegInp ) {
     rstrcpy( addr.hostAddr, location.c_str(), LONG_NAME_LEN );
     remoteFlag = resolveHost( &addr, &rodsServerHost );
 
-    if ( remoteFlag == LOCAL_HOST ) {
+    // We do not need to redirect if we do not need to stat the file which is to be registered
+    const auto size_kw{getValByKey(&phyPathRegInp->condInput, DATA_SIZE_KW)};
+    if ( size_kw || remoteFlag == LOCAL_HOST ) {
         irods::hierarchy_parser p;
         p.set_string(hier);
         std::string leaf_resc;
@@ -525,18 +527,20 @@ filePathReg( rsComm_t *rsComm, dataObjInp_t *phyPathRegInp, const char *_resc_na
         irods::log(PASS(ret));
     }
 
-    const auto data_size_str{getValByKey(&phyPathRegInp->condInput, DATA_SIZE_KW)};
+    auto data_size_str{getValByKey(&phyPathRegInp->condInput, DATA_SIZE_KW)};
     try {
-        if (NULL != data_size_str) {
+        if (data_size_str) {
             dataObjInfo.dataSize = boost::lexical_cast<decltype(dataObjInfo.dataSize)>(data_size_str);
         }
     }
     catch (boost::bad_lexical_cast&) {
         rodsLog(LOG_ERROR, "[%s] - bad_lexical_cast for dataSize [%s]; setting to 0", __FUNCTION__, data_size_str);
         dataObjInfo.dataSize = 0;
+        data_size_str = nullptr;
     }
 
-    if ( dataObjInfo.dataSize <= 0 &&
+    if ( nullptr == data_size_str &&
+         dataObjInfo.dataSize <= 0 &&
             ( dataObjInfo.dataSize = getFileMetadataFromVault( rsComm, &dataObjInfo ) ) < 0 &&
             dataObjInfo.dataSize != UNKNOWN_FILE_SZ ) {
         status = ( int ) dataObjInfo.dataSize;


### PR DESCRIPTION
When the size KW is provided in the call to rsPhyPathReg, there is no need to stat the file. As such, there is no need to redirect to the remote server at all. This also resolves an issue with stat'ing 0-length files even in the presence of the size KW.

---
[CI tests passed.](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1327/)