### PR TITLE
[#3906] Skip delay with output param test for PREP (4-2-stable)

### DIFF
--- a/scripts/irods/test/test_native_rule_engine_plugin.py
+++ b/scripts/irods/test/test_native_rule_engine_plugin.py
@@ -292,6 +292,7 @@ OUTPUT ruleExecOut
         irodsctl.restart()
 
     @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'Skip for topology testing from resource server: reads server log')
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Delete this line on resolution of #4094')
     def test_delay_block_with_output_param__3906(self):
         irodsctl = IrodsController()
         server_config_filename = paths.server_config_path()


### PR DESCRIPTION
Skips test added in commit for python rule engine plugin:
c553f66

---
CI tests running [for native REP](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1349/) and [python REP](http://172.25.14.63:8080/job/rule-engine-plugin-python-build-test-workflow/92/)