### PR TITLE
[#4029] Clean up dir created in test_iscan setUp (4-2-stable)

### DIFF
--- a/scripts/irods/test/test_iscan.py
+++ b/scripts/irods/test/test_iscan.py
@@ -29,6 +29,7 @@ class Test_iScan(ResourceBase, unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(os.path.abspath(self.dirname1), ignore_errors=True)
         shutil.rmtree(os.path.abspath(self.dirname2), ignore_errors=True)
+        shutil.rmtree(os.path.abspath(self.dirname3), ignore_errors=True)
         self.admin.assert_icommand(['iadmin', 'rmchildfromresc', 'pt', self.testresc])
         self.admin.assert_icommand(['iadmin', 'rmresc', 'pt'])
         super(Test_iScan, self).tearDown()


### PR DESCRIPTION
An extra dir has been created in the setUp step of test_iscan but was not being cleaned up in tearDown.

---
[CI tests passed](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1319/)