### PR TITLE
[#4100] Add zone checking to rsGetHostForGet/Put (4-1-stable)

### DIFF
--- a/iRODS/server/api/src/rsGetHostForPut.cpp
+++ b/iRODS/server/api/src/rsGetHostForPut.cpp
@@ -24,41 +24,55 @@ int rsGetHostForPut(
     rsComm_t*     rsComm,
     dataObjInp_t* dataObjInp,
     char **       outHost ) {
-    // =-=-=-=-=-=-=-
-    // working on the "home zone", determine if we need to redirect to a different
-    // server in this zone for this operation.  if there is a RESC_HIER_STR_KW then
-    // we know that the redirection decision has already been made
-    std::string       hier;
-    if ( getValByKey( &dataObjInp->condInput, RESC_HIER_STR_KW ) == NULL ) {
-        irods::error ret = irods::resolve_resource_hierarchy( irods::CREATE_OPERATION, rsComm,
-                           dataObjInp, hier );
-        if ( !ret.ok() ) {
-            std::stringstream msg;
-            msg << __FUNCTION__;
-            msg << " :: failed in irods::resolve_resource_hierarchy for [";
-            msg << dataObjInp->objPath << "]";
-            irods::log( PASSMSG( msg.str(), ret ) );
-            return ret.code();
+    rodsServerHost_t *rodsServerHost;
+    const int remoteFlag = getAndConnRemoteZone(rsComm, dataObjInp, &rodsServerHost, REMOTE_OPEN);
+    if (remoteFlag < 0) {
+        return remoteFlag;
+    }
+    else if (REMOTE_HOST == remoteFlag) {
+        const int status = rcGetHostForPut(rodsServerHost->conn, dataObjInp, outHost);
+        if (status < 0) {
+            return status;
         }
+    }
+    else {
         // =-=-=-=-=-=-=-
-        // we resolved the redirect and have a host, set the hier str for subsequent
-        // api calls, etc.
-        addKeyVal( &dataObjInp->condInput, RESC_HIER_STR_KW, hier.c_str() );
+        // working on the "home zone", determine if we need to redirect to a different
+        // server in this zone for this operation.  if there is a RESC_HIER_STR_KW then
+        // we know that the redirection decision has already been made
+        std::string       hier;
+        if ( getValByKey( &dataObjInp->condInput, RESC_HIER_STR_KW ) == NULL ) {
+            irods::error ret = irods::resolve_resource_hierarchy( irods::CREATE_OPERATION, rsComm,
+                               dataObjInp, hier );
+            if ( !ret.ok() ) {
+                std::stringstream msg;
+                msg << __FUNCTION__;
+                msg << " :: failed in irods::resolve_resource_hierarchy for [";
+                msg << dataObjInp->objPath << "]";
+                irods::log( PASSMSG( msg.str(), ret ) );
+                return ret.code();
+            }
+            // =-=-=-=-=-=-=-
+            // we resolved the redirect and have a host, set the hier str for subsequent
+            // api calls, etc.
+            addKeyVal( &dataObjInp->condInput, RESC_HIER_STR_KW, hier.c_str() );
 
-    } // if keyword
+        } // if keyword
 
-    // =-=-=-=-=-=-=-
-    // extract the host location from the resource hierarchy
-    std::string location;
-    irods::error ret = irods::get_loc_for_hier_string( hier, location );
-    if ( !ret.ok() ) {
-        irods::log( PASSMSG( "rsGetHostForPut - failed in get_loc_for_hier_string", ret ) );
-        return -1;
+        // =-=-=-=-=-=-=-
+        // extract the host location from the resource hierarchy
+        std::string location;
+        irods::error ret = irods::get_loc_for_hier_string( hier, location );
+        if ( !ret.ok() ) {
+            irods::log( PASSMSG( "rsGetHostForPut - failed in get_loc_for_hier_string", ret ) );
+            return -1;
+        }
+
+        // =-=-=-=-=-=-=-
+        // set the out variable
+        *outHost = strdup( location.c_str() );
     }
 
-    // =-=-=-=-=-=-=-
-    // set the out variable
-    *outHost = strdup( location.c_str() );
     return 0;
 
 }


### PR DESCRIPTION
rsGetHostForGet and rsGetHostForPut need to make sure they are connected to the correct zone before attempting any operation. If a resource hierarchy is involved, the operation will fail because
the target could be on a remote zone with a resource heirarchy which differs from the connected zone (or worse - one which doesn't differ and data is pulled/put from/to the wrong zone).

---
[CI tests passed](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1369/) (minus ub16 - investigating)

Discussion point: How would one go about adding a test for this change? I thought about making a microservice for the API calls because by my estimation this is not used internally in iRODS.