### PR TITLE
[#4100] Add zone checking to rsGetHostForGet/Put (master)

### DIFF
--- a/server/api/src/rsGetHostForGet.cpp
+++ b/server/api/src/rsGetHostForGet.cpp
@@ -29,48 +29,61 @@ int rsGetHostForGet(
     rsComm_t*     rsComm,
     dataObjInp_t* dataObjInp,
     char**        outHost ) {
-    // =-=-=-=-=-=-=-
-    // default behavior
-    *outHost = strdup( THIS_ADDRESS );
-
-    // =-=-=-=-=-=-=-
-    // working on the "home zone", determine if we need to redirect to a different
-    // server in this zone for this operation.  if there is a RESC_HIER_STR_KW then
-    // we know that the redirection decision has already been made
-    if ( isColl( rsComm, dataObjInp->objPath, NULL ) < 0 ) {
-        std::string       hier;
-        if ( getValByKey( &dataObjInp->condInput, RESC_HIER_STR_KW ) == NULL ) {
-            irods::error ret = irods::resolve_resource_hierarchy( irods::OPEN_OPERATION, rsComm,
-                               dataObjInp, hier );
-            if ( !ret.ok() ) {
-                std::stringstream msg;
-                msg << __FUNCTION__;
-                msg << " :: failed in irods::resolve_resource_hierarchy for [";
-                msg << dataObjInp->objPath << "]";
-                irods::log( PASSMSG( msg.str(), ret ) );
-                return ret.code();
-            }
-            // =-=-=-=-=-=-=-
-            // we resolved the redirect and have a host, set the hier str for subsequent
-            // api calls, etc.
-            addKeyVal( &dataObjInp->condInput, RESC_HIER_STR_KW, hier.c_str() );
-
-        } // if keyword
-
-        // =-=-=-=-=-=-=-
-        // extract the host location from the resource hierarchy
-        std::string location;
-        irods::error ret = irods::get_loc_for_hier_string( hier, location );
-        if ( !ret.ok() ) {
-            irods::log( PASSMSG( "rsGetHostForGet - failed in get_loc_for_hier_string", ret ) );
-            return -1;
+    rodsServerHost_t *rodsServerHost;
+    const int remoteFlag = getAndConnRemoteZone(rsComm, dataObjInp, &rodsServerHost, REMOTE_OPEN);
+    if (remoteFlag < 0) {
+        return remoteFlag;
+    }
+    else if (REMOTE_HOST == remoteFlag) {
+        const int status = rcGetHostForGet(rodsServerHost->conn, dataObjInp, outHost);
+        if (status < 0) {
+            return status;
         }
+    }
+    else {
+        // =-=-=-=-=-=-=-
+        // default behavior
+        *outHost = strdup( THIS_ADDRESS );
 
         // =-=-=-=-=-=-=-
-        // set the out variable
-        *outHost = strdup( location.c_str() );
+        // working on the "home zone", determine if we need to redirect to a different
+        // server in this zone for this operation.  if there is a RESC_HIER_STR_KW then
+        // we know that the redirection decision has already been made
+        if ( isColl( rsComm, dataObjInp->objPath, NULL ) < 0 ) {
+            std::string       hier;
+            if ( getValByKey( &dataObjInp->condInput, RESC_HIER_STR_KW ) == NULL ) {
+                irods::error ret = irods::resolve_resource_hierarchy( irods::OPEN_OPERATION, rsComm,
+                                   dataObjInp, hier );
+                if ( !ret.ok() ) {
+                    std::stringstream msg;
+                    msg << __FUNCTION__;
+                    msg << " :: failed in irods::resolve_resource_hierarchy for [";
+                    msg << dataObjInp->objPath << "]";
+                    irods::log( PASSMSG( msg.str(), ret ) );
+                    return ret.code();
+                }
+                // =-=-=-=-=-=-=-
+                // we resolved the redirect and have a host, set the hier str for subsequent
+                // api calls, etc.
+                addKeyVal( &dataObjInp->condInput, RESC_HIER_STR_KW, hier.c_str() );
 
-    } // if not a collection
+            } // if keyword
+
+            // =-=-=-=-=-=-=-
+            // extract the host location from the resource hierarchy
+            std::string location;
+            irods::error ret = irods::get_loc_for_hier_string( hier, location );
+            if ( !ret.ok() ) {
+                irods::log( PASSMSG( "rsGetHostForGet - failed in get_loc_for_hier_string", ret ) );
+                return -1;
+            }
+
+            // =-=-=-=-=-=-=-
+            // set the out variable
+            *outHost = strdup( location.c_str() );
+
+        } // if not a collection
+    }
 
     return 0;
 

--- a/server/api/src/rsGetHostForPut.cpp
+++ b/server/api/src/rsGetHostForPut.cpp
@@ -25,41 +25,55 @@ int rsGetHostForPut(
     rsComm_t*     rsComm,
     dataObjInp_t* dataObjInp,
     char **       outHost ) {
-    // =-=-=-=-=-=-=-
-    // working on the "home zone", determine if we need to redirect to a different
-    // server in this zone for this operation.  if there is a RESC_HIER_STR_KW then
-    // we know that the redirection decision has already been made
-    std::string       hier;
-    if ( getValByKey( &dataObjInp->condInput, RESC_HIER_STR_KW ) == NULL ) {
-        irods::error ret = irods::resolve_resource_hierarchy( irods::CREATE_OPERATION, rsComm,
-                           dataObjInp, hier );
-        if ( !ret.ok() ) {
-            std::stringstream msg;
-            msg << __FUNCTION__;
-            msg << " :: failed in irods::resolve_resource_hierarchy for [";
-            msg << dataObjInp->objPath << "]";
-            irods::log( PASSMSG( msg.str(), ret ) );
-            return ret.code();
+    rodsServerHost_t *rodsServerHost;
+    const int remoteFlag = getAndConnRemoteZone(rsComm, dataObjInp, &rodsServerHost, REMOTE_OPEN);
+    if (remoteFlag < 0) {
+        return remoteFlag;
+    }
+    else if (REMOTE_HOST == remoteFlag) {
+        const int status = rcGetHostForPut(rodsServerHost->conn, dataObjInp, outHost);
+        if (status < 0) {
+            return status;
         }
+    }
+    else {
         // =-=-=-=-=-=-=-
-        // we resolved the redirect and have a host, set the hier str for subsequent
-        // api calls, etc.
-        addKeyVal( &dataObjInp->condInput, RESC_HIER_STR_KW, hier.c_str() );
+        // working on the "home zone", determine if we need to redirect to a different
+        // server in this zone for this operation.  if there is a RESC_HIER_STR_KW then
+        // we know that the redirection decision has already been made
+        std::string       hier;
+        if ( getValByKey( &dataObjInp->condInput, RESC_HIER_STR_KW ) == NULL ) {
+            irods::error ret = irods::resolve_resource_hierarchy( irods::CREATE_OPERATION, rsComm,
+                               dataObjInp, hier );
+            if ( !ret.ok() ) {
+                std::stringstream msg;
+                msg << __FUNCTION__;
+                msg << " :: failed in irods::resolve_resource_hierarchy for [";
+                msg << dataObjInp->objPath << "]";
+                irods::log( PASSMSG( msg.str(), ret ) );
+                return ret.code();
+            }
+            // =-=-=-=-=-=-=-
+            // we resolved the redirect and have a host, set the hier str for subsequent
+            // api calls, etc.
+            addKeyVal( &dataObjInp->condInput, RESC_HIER_STR_KW, hier.c_str() );
 
-    } // if keyword
+        } // if keyword
 
-    // =-=-=-=-=-=-=-
-    // extract the host location from the resource hierarchy
-    std::string location;
-    irods::error ret = irods::get_loc_for_hier_string( hier, location );
-    if ( !ret.ok() ) {
-        irods::log( PASSMSG( "rsGetHostForPut - failed in get_loc_for_hier_string", ret ) );
-        return -1;
+        // =-=-=-=-=-=-=-
+        // extract the host location from the resource hierarchy
+        std::string location;
+        irods::error ret = irods::get_loc_for_hier_string( hier, location );
+        if ( !ret.ok() ) {
+            irods::log( PASSMSG( "rsGetHostForPut - failed in get_loc_for_hier_string", ret ) );
+            return -1;
+        }
+
+        // =-=-=-=-=-=-=-
+        // set the out variable
+        *outHost = strdup( location.c_str() );
     }
 
-    // =-=-=-=-=-=-=-
-    // set the out variable
-    *outHost = strdup( location.c_str() );
     return 0;
 
 }


### PR DESCRIPTION
rsGetHostForGet and rsGetHostForPut need to make sure they are connected to the correct zone before attempting any operation. If a resource hierarchy is involved, the operation will fail because
the target could be on a remote zone with a resource heirarchy which differs from the connected zone (or worse - one which doesn't differ and data is pulled/put from/to the wrong zone).

(cherry-picked from SHA: eec41ba84bde5687f8fa83acbd377c41fcdfa821)

---
[CI tests running](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1404/)