### PR TITLE
[#3862] Updated code to call cllFreeStatement consistently.

### DIFF
--- a/plugins/database/include/low_level_odbc.hpp
+++ b/plugins/database/include/low_level_odbc.hpp
@@ -31,7 +31,7 @@ int cllExecSqlWithResult( icatSessionStruct *icss, int *stmtNum, const char *sql
 int cllExecSqlWithResultBV( icatSessionStruct *icss, int *stmtNum, const char *sql,
                             std::vector<std::string> &bindVars );
 int cllGetRow( icatSessionStruct *icss, int statementNumber );
-int cllFreeStatement( icatSessionStruct *icss, int statementNumber );
+int cllFreeStatement( icatSessionStruct *icss, int& statementNumber );
 int cllNextValueString( const char *itemName, char *outString, int maxSize );
 int cllCurrentValueString( const char *itemName, char *outString, int maxSize );
 int cllGetRowCount( icatSessionStruct *icss, int statementNumber );

--- a/plugins/database/include/mid_level.hpp
+++ b/plugins/database/include/mid_level.hpp
@@ -15,6 +15,8 @@
 #include <vector>
 #include <string>
 
+const int UNINITIALIZED_STATEMENT_NUMBER = -1;
+
 int cmlOpen( icatSessionStruct *icss );
 
 int cmlClose( icatSessionStruct *icss );

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -1471,7 +1471,7 @@ int _modInheritance( int inheritFlag, int recursiveFlag, const char *collIdStr, 
 int setOverQuota( rsComm_t *rsComm ) {
     int status;
     int rowsFound;
-    int statementNum;
+    int statementNum = UNINITIALIZED_STATEMENT_NUMBER;
     char myTime[50];
 
     /* For each defined group limit (if any), get a total usage on that
@@ -1558,6 +1558,8 @@ int setOverQuota( rsComm_t *rsComm ) {
         }
     }
 
+    cmlFreeStatement(statementNum, &icss);
+
     /* Handle group quotas on resources */
     if ( logSQL != 0 ) {
         rodsLog( LOG_SQL, "setOverQuota SQL 5" );
@@ -1588,6 +1590,7 @@ int setOverQuota( rsComm_t *rsComm ) {
             status2 = 0;
         }
         if ( status2 != 0 ) {
+            cmlFreeStatement(statementNum, &icss);
             return status2;
         }
     }
@@ -1595,8 +1598,11 @@ int setOverQuota( rsComm_t *rsComm ) {
         status = 0;
     }
     if ( status != 0 ) {
+        cmlFreeStatement(statementNum, &icss);
         return status;
     }
+
+    cmlFreeStatement(statementNum, &icss);
 
     /* Handle group quotas on total usage */
 #if ORA_ICAT
@@ -1645,6 +1651,7 @@ int setOverQuota( rsComm_t *rsComm ) {
             status2 = 0;
         }
         if ( status2 != 0 ) {
+            cmlFreeStatement(statementNum, &icss);
             return status2;
         }
     }
@@ -1652,6 +1659,7 @@ int setOverQuota( rsComm_t *rsComm ) {
         status = 0;
     }
     if ( status != 0 ) {
+        cmlFreeStatement(statementNum, &icss);
         return status;
     }
 
@@ -1660,6 +1668,7 @@ int setOverQuota( rsComm_t *rsComm ) {
        for each user into R_QUOTA_MAIN.  For now tho, this is not done and
        perhaps shouldn't be, to keep it a little less complicated. */
 
+    cmlFreeStatement(statementNum, &icss);
     return status;
 }
 
@@ -2865,7 +2874,7 @@ irods::error db_reg_replica_op(
     char tSQL[MAX_SQL_SIZE];
     char *cVal[30];
     int i;
-    int statementNumber;
+    int statementNumber = UNINITIALIZED_STATEMENT_NUMBER;
     int nextReplNum;
     char nextRepl[30];
     char theColls[] = "data_id, \
@@ -5996,7 +6005,7 @@ irods::error db_simple_query_op_vector(
     // extract the icss property
 //        icatSessionStruct icss;
 //        _ctx.prop_map().get< icatSessionStruct >( ICSS_PROP, icss );
-    int stmtNum, status, nCols, i, needToGet, didGet;
+    int stmtNum = UNINITIALIZED_STATEMENT_NUMBER, status, nCols, i, needToGet, didGet;
     int rowSize;
     int rows;
     int OK;
@@ -6155,6 +6164,7 @@ irods::error db_simple_query_op_vector(
                          "chlSimpleQuery cmlGetFirstRowFromSqlBV failure %d",
                          status );
             }
+            cmlFreeStatement(stmtNum, &icss);
             return ERROR( status, "cmlGetFirstRowFromSqlBV failure" );
         }
         didGet = 1;
@@ -6177,6 +6187,7 @@ irods::error db_simple_query_op_vector(
                     }
                     return CODE( 0 );
                 }
+                cmlFreeStatement(stmtNum, &icss);
                 return ERROR( status, "cmlGetNextRowFromStatement failed" );
             }
             if ( status < 0 ) {
@@ -6229,6 +6240,7 @@ irods::error db_simple_query_op_vector(
         }
     }
 
+    cmlFreeStatement(stmtNum, &icss);
     return SUCCESS();
 
 } // db_simple_query_op
@@ -12797,7 +12809,7 @@ irods::error db_check_quota_op(
        group per-resource, and group global.
     */
     int status;
-    int statementNum;
+    int statementNum = UNINITIALIZED_STATEMENT_NUMBER;
 
     char mySQL[] = "select distinct QM.user_id, QM.resc_id, QM.quota_limit, QM.quota_over from R_QUOTA_MAIN QM, R_USER_MAIN UM, R_RESC_MAIN RM, R_USER_GROUP UG, R_USER_MAIN UM2 where ( (QM.user_id = UM.user_id and UM.user_name = ?) or (QM.user_id = UG.group_user_id and UM2.user_name = ? and UG.user_id = UM2.user_id) ) and ((QM.resc_id = RM.resc_id and RM.resc_name = ?) or QM.resc_id = '0') order by quota_over desc";
 
@@ -12816,6 +12828,7 @@ irods::error db_check_quota_op(
         rodsLog( LOG_NOTICE,
                  "chlCheckQuota - CAT_SUCCESS_BUT_WITH_NO_INFO" );
         *_quota_status = QUOTA_UNRESTRICTED;
+        cmlFreeStatement(statementNum, &icss);
         return SUCCESS();
     }
 
@@ -12823,10 +12836,12 @@ irods::error db_check_quota_op(
         rodsLog( LOG_NOTICE,
                  "chlCheckQuota - CAT_NO_ROWS_FOUND" );
         *_quota_status = QUOTA_UNRESTRICTED;
+        cmlFreeStatement(statementNum, &icss);
         return SUCCESS();
     }
 
     if ( status != 0 ) {
+        cmlFreeStatement(statementNum, &icss);
         return ERROR( status, "check quota failed" );
     }
 
@@ -13824,7 +13839,7 @@ irods::error db_specific_query_op(
 
     char combinedSQL[MAX_SQL_SIZE];
 
-    int status, statementNum;
+    int status, statementNum = UNINITIALIZED_STATEMENT_NUMBER;
     int numOfCols;
     int attriTextLen;
     int totalLen;
@@ -13902,6 +13917,7 @@ irods::error db_specific_query_op(
                          "chlSpecificQuery cmlGetFirstRowFromSql failure %d",
                          status );
             }
+            cmlFreeStatement(statementNum, &icss);
             return ERROR( status, "cmlGetFirstRowFromSql failure" );
         }
 
@@ -13934,6 +13950,7 @@ irods::error db_specific_query_op(
                 return SUCCESS();
             }
             if ( status < 0 ) {
+                cmlFreeStatement(statementNum, &icss);
                 return ERROR( status, "failed to get next row" );
             }
         }
@@ -13963,6 +13980,7 @@ irods::error db_specific_query_op(
             for ( j = 0; j < numOfCols; j++ ) {
                 tResult = ( char * ) malloc( totalLen );
                 if ( tResult == NULL ) {
+                    cmlFreeStatement(statementNum, &icss);
                     return ERROR( SYS_MALLOC_ERR, "malloc error" );
                 }
                 memset( tResult, 0, totalLen );
@@ -13990,6 +14008,7 @@ irods::error db_specific_query_op(
                 int k;
                 tResult = ( char * ) malloc( totalLen );
                 if ( tResult == NULL ) {
+                    cmlFreeStatement(statementNum, &icss);
                     return ERROR( SYS_MALLOC_ERR, "failed to allocate result" );
                 }
                 memset( tResult, 0, totalLen );
@@ -14077,11 +14096,13 @@ irods::error db_get_distinct_data_obj_count_on_resource_op(
                      &statement_num,
                      0, &icss );
     if ( status != 0 ) {
+        cmlFreeStatement(statement_num, &icss);
         return ERROR( status, "cmlGetFirstRowFromSql failed" );
     }
 
     ( *_count ) = atol( icss.stmtPtr[ statement_num ]->resultValue[0] );
 
+    cmlFreeStatement(statement_num, &icss);
     return SUCCESS();
 
 } // db_get_distinct_data_obj_count_on_resource_op
@@ -14169,6 +14190,7 @@ irods::error db_get_distinct_data_objs_missing_from_child_given_parent_op(
         }
 
         if ( status != 0 ) {
+            cmlFreeStatement(statement_num, &icss);
             return ERROR( status, "failed to get a row" );
         }
 

--- a/plugins/database/src/general_query.cpp
+++ b/plugins/database/src/general_query.cpp
@@ -2241,7 +2241,7 @@ int chl_gen_query_access_control_setup_impl(
     char combinedSQL[MAX_SQL_SIZE_GQ];
     char countSQL[MAX_SQL_SIZE_GQ]; /* For Oracle, sql to get the count */
 
-    int status, statementNum;
+    int status, statementNum = UNINITIALIZED_STATEMENT_NUMBER;
     int numOfCols;
     int attriTextLen;
     int totalLen;

--- a/plugins/database/src/low_level_odbc.cpp
+++ b/plugins/database/src/low_level_odbc.cpp
@@ -575,7 +575,10 @@ cllExecSqlWithResult( icatSessionStruct *icss, int *stmtNum, const char *sql ) {
         return -1;
     }
 
-    int statementNumber = -1;
+    // Issue 3862:  Set stmtNum to -1 and in cllFreeStatement if the stmtNum is negative do nothing
+    *stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
+
+    int statementNumber = UNINITIALIZED_STATEMENT_NUMBER;
     for ( int i = 0; i < MAX_NUM_OF_CONCURRENT_STMTS && statementNumber < 0; i++ ) {
         if ( icss->stmtPtr[i] == 0 ) {
             statementNumber = i;
@@ -588,7 +591,10 @@ cllExecSqlWithResult( icatSessionStruct *icss, int *stmtNum, const char *sql ) {
     }
 
     icatStmtStrct * myStatement = ( icatStmtStrct * )malloc( sizeof( icatStmtStrct ) );
+    memset( myStatement, 0, sizeof( icatStmtStrct ) );
+
     icss->stmtPtr[statementNumber] = myStatement;
+    *stmtNum = statementNumber;
 
     myStatement->stmtPtr = hstmt;
 
@@ -673,6 +679,7 @@ cllExecSqlWithResult( icatSessionStruct *icss, int *stmtNum, const char *sql ) {
         /*      printf("columnLength[%d]=%d\n",i,columnLength[i]); */
 
         myStatement->resultValue[i] = ( char* )malloc( ( int )columnLength[i] );
+        memset( myStatement->resultValue[i], 0, (int)columnLength[i] );
 
         strcpy( ( char * )myStatement->resultValue[i], "" );
 
@@ -688,6 +695,7 @@ cllExecSqlWithResult( icatSessionStruct *icss, int *stmtNum, const char *sql ) {
 
 
         myStatement->resultColName[i] = ( char* )malloc( ( int )columnLength[i] );
+        memset( myStatement->resultColName[i], 0, (int)columnLength[i] );
 
 #ifdef ORA_ICAT
         //oracle prints column names (which are case-insensitive) in upper case,
@@ -700,7 +708,6 @@ cllExecSqlWithResult( icatSessionStruct *icss, int *stmtNum, const char *sql ) {
 
     }
 
-    *stmtNum = statementNumber;
     return 0;
 }
 
@@ -742,7 +749,10 @@ cllExecSqlWithResultBV(
         return -1;
     }
 
-    int statementNumber = -1;
+    // Issue 3862:  Set stmtNum to -1 and in cllFreeStatement if the stmtNum is negative do nothing
+    *stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
+
+    int statementNumber = UNINITIALIZED_STATEMENT_NUMBER;
     for ( int i = 0; i < MAX_NUM_OF_CONCURRENT_STMTS && statementNumber < 0; i++ ) {
         if ( icss->stmtPtr[i] == 0 ) {
             statementNumber = i;
@@ -755,7 +765,10 @@ cllExecSqlWithResultBV(
     }
 
     icatStmtStrct * myStatement = ( icatStmtStrct * )malloc( sizeof( icatStmtStrct ) );
+    memset( myStatement, 0, sizeof( icatStmtStrct ) );
     icss->stmtPtr[statementNumber] = myStatement;
+
+    *stmtNum = statementNumber;
 
     myStatement->stmtPtr = hstmt;
 
@@ -852,6 +865,7 @@ cllExecSqlWithResultBV(
         /*      printf("columnLength[%d]=%d\n",i,columnLength[i]); */
 
         myStatement->resultValue[i] = ( char* )malloc( ( int )columnLength[i] );
+        memset( myStatement->resultValue[i], 0, (int)columnLength[i] );
 
         myStatement->resultValue[i][0] = '\0';
         // =-=-=-=-=-=-=-
@@ -867,6 +881,7 @@ cllExecSqlWithResultBV(
 
 
         myStatement->resultColName[i] = ( char* )malloc( ( int )columnLength[i] );
+        memset( myStatement->resultColName[i], 0, (int)columnLength[i] );
 #ifdef ORA_ICAT
         //oracle prints column names (which are case-insensitive) in upper case,
         //so to remain consistent with postgres and mysql, we convert them to lower case.
@@ -877,7 +892,7 @@ cllExecSqlWithResultBV(
         strncpy( myStatement->resultColName[i], ( char * )colName, columnLength[i] );
 
     }
-    *stmtNum = statementNumber;
+
     return 0;
 }
 
@@ -954,10 +969,20 @@ cllCurrentValueString( const char *itemName, char *outString, int maxSize ) {
    corresponding resultValue array.
 */
 int
-cllFreeStatement( icatSessionStruct *icss, int statementNumber ) {
+cllFreeStatement( icatSessionStruct *icss, int& statementNumber ) {
+
+    // Issue 3862 - Statement number is set to negative until it is 
+    // created.  When the statement is freed it is again set to negative.
+    // Do not free when statementNumber is negative.  If this is called twice 
+    // by a client, after the first call the statementNumber will be negative
+    // and nothing will be done.
+    if (statementNumber < 0) {
+        return 0;
+    }
 
     icatStmtStrct * myStatement = icss->stmtPtr[statementNumber];
     if ( myStatement == NULL ) { /* already freed */
+        statementNumber = UNINITIALIZED_STATEMENT_NUMBER;
         return 0;
     }
 
@@ -965,12 +990,13 @@ cllFreeStatement( icatSessionStruct *icss, int statementNumber ) {
 
     SQLRETURN stat = SQLFreeHandle( SQL_HANDLE_STMT, myStatement->stmtPtr );
     if ( stat != SQL_SUCCESS ) {
+        statementNumber = UNINITIALIZED_STATEMENT_NUMBER;
         rodsLog( LOG_ERROR, "cllFreeStatement SQLFreeHandle for statement error: %d", stat );
     }
 
     free( myStatement );
-
     icss->stmtPtr[statementNumber] = NULL; /* indicate that the statement is free */
+    statementNumber = UNINITIALIZED_STATEMENT_NUMBER;
 
     return 0;
 }
@@ -985,10 +1011,10 @@ _cllFreeStatementColumns( icatSessionStruct *icss, int statementNumber ) {
     icatStmtStrct * myStatement = icss->stmtPtr[statementNumber];
 
     for ( int i = 0; i < myStatement->numOfCols; i++ ) {
-        free( myStatement->resultValue[i] );
+	free( myStatement->resultValue[i] );
         myStatement->resultValue[i] = NULL;
-        free( myStatement->resultColName[i] );
-        myStatement->resultColName[i] = NULL;
+	free( myStatement->resultColName[i] );
+	myStatement->resultColName[i] = NULL;
     }
     return 0;
 }

--- a/plugins/database/src/mid_level_routines.cpp
+++ b/plugins/database/src/mid_level_routines.cpp
@@ -165,7 +165,7 @@ int cmlGetOneRowFromSqlBV( const char *sql,
                            int numOfCols,
                            std::vector<std::string> &bindVars,
                            icatSessionStruct *icss ) {
-    int stmtNum;
+    int stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
     char updatedSql[MAX_SQL_SIZE + 1];
 
 //TODO: this should be a function, probably inside low-level icat
@@ -185,6 +185,7 @@ int cmlGetOneRowFromSqlBV( const char *sql,
     int status = cllExecSqlWithResultBV( icss, &stmtNum, updatedSql,
                                          bindVars );
     if ( status != 0 ) {
+        cllFreeStatement(icss, stmtNum);
         if ( status <= CAT_ENV_ERR ) {
             return status;    /* already an iRODS error code */
         }
@@ -214,7 +215,7 @@ int cmlGetOneRowFromSql( const char *sql,
                          int cValSize[],
                          int numOfCols,
                          icatSessionStruct *icss ) {
-    int i, j, stmtNum;
+    int i, j, stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
     char updatedSql[MAX_SQL_SIZE + 1];
 
 //TODO: this should be a function, probably inside low-level icat
@@ -236,6 +237,7 @@ int cmlGetOneRowFromSql( const char *sql,
     i = cllExecSqlWithResultBV( icss, &stmtNum, updatedSql,
                                 emptyBindVars );
     if ( i != 0 ) {
+        cllFreeStatement( icss, stmtNum );
         if ( i <= CAT_ENV_ERR ) {
             return ( i );   /* already an iRODS error code */
         }
@@ -267,7 +269,7 @@ int cmlGetOneRowFromSqlV2( const char *sql,
                            int maxCols,
                            std::vector<std::string> &bindVars,
                            icatSessionStruct *icss ) {
-    int i, j, stmtNum;
+    int i, j, stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
     char updatedSql[MAX_SQL_SIZE + 1];
 
 //TODO: this should be a function, probably inside low-level icat
@@ -289,6 +291,7 @@ int cmlGetOneRowFromSqlV2( const char *sql,
                                 bindVars );
 
     if ( i != 0 ) {
+        cllFreeStatement( icss, stmtNum ); 
         if ( i <= CAT_ENV_ERR ) {
             return ( i );   /* already an iRODS error code */
         }
@@ -319,7 +322,7 @@ int cmlGetOneRowFromSqlV3( const char *sql,
                            int cValSize[],
                            int numOfCols,
                            icatSessionStruct *icss ) {
-    int i, j, stmtNum;
+    int i, j, stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
     char updatedSql[MAX_SQL_SIZE + 1];
 
 //TODO: this should be a function, probably inside low-level icat
@@ -340,6 +343,7 @@ int cmlGetOneRowFromSqlV3( const char *sql,
     i = cllExecSqlWithResult( icss, &stmtNum, updatedSql );
 
     if ( i != 0 ) {
+        cllFreeStatement( icss, stmtNum );
         if ( i <= CAT_ENV_ERR ) {
             return ( i );   /* already an iRODS error code */
         }
@@ -370,7 +374,8 @@ int cmlFreeStatement( int statementNumber, icatSessionStruct *icss ) {
     return i;
 }
 
-
+/*
+ * caller must free on success */
 int cmlGetFirstRowFromSql( const char *sql,
                            int *statement,
                            int skipCount,
@@ -379,7 +384,8 @@ int cmlGetFirstRowFromSql( const char *sql,
     int i = cllExecSqlWithResult( icss, statement, sql );
 
     if ( i != 0 ) {
-        *statement = 0;
+        cllFreeStatement( icss, *statement );
+        *statement = UNINITIALIZED_STATEMENT_NUMBER;
         if ( i <= CAT_ENV_ERR ) {
             return ( i );   /* already an iRODS error code */
         }
@@ -392,12 +398,12 @@ int cmlGetFirstRowFromSql( const char *sql,
             i = cllGetRow( icss, *statement );
             if ( i != 0 )  {
                 cllFreeStatement( icss, *statement );
-                *statement = 0;
+                *statement = UNINITIALIZED_STATEMENT_NUMBER;
                 return CAT_GET_ROW_ERR;
             }
             if ( icss->stmtPtr[*statement]->numOfCols == 0 ) {
                 cllFreeStatement( icss, *statement );
-                *statement = 0;
+                *statement = UNINITIALIZED_STATEMENT_NUMBER;
                 return CAT_NO_ROWS_FOUND;
             }
         }
@@ -407,25 +413,26 @@ int cmlGetFirstRowFromSql( const char *sql,
     i = cllGetRow( icss, *statement );
     if ( i != 0 )  {
         cllFreeStatement( icss, *statement );
-        *statement = 0;
+        *statement = UNINITIALIZED_STATEMENT_NUMBER;
         return CAT_GET_ROW_ERR;
     }
     if ( icss->stmtPtr[*statement]->numOfCols == 0 ) {
         cllFreeStatement( icss, *statement );
-        *statement = 0;
+        *statement = UNINITIALIZED_STATEMENT_NUMBER;
         return CAT_NO_ROWS_FOUND;
     }
 
     return 0;
 }
 
-/* with bind-variables */
+/* with bind-variables 
+ * caller must free on success */
 int cmlGetFirstRowFromSqlBV( const char *sql,
                              std::vector<std::string> &bindVars,
                              int *statement,
                              icatSessionStruct *icss ) {
     if ( int status = cllExecSqlWithResultBV( icss, statement, sql, bindVars ) ) {
-        *statement = 0;
+        *statement = UNINITIALIZED_STATEMENT_NUMBER;
         if ( status <= CAT_ENV_ERR ) {
             return status;    /* already an iRODS error code */
         }
@@ -433,17 +440,19 @@ int cmlGetFirstRowFromSqlBV( const char *sql,
     }
     if ( cllGetRow( icss, *statement ) ) {
         cllFreeStatement( icss, *statement );
-        *statement = 0;
+        *statement = UNINITIALIZED_STATEMENT_NUMBER;
         return CAT_GET_ROW_ERR;
     }
     if ( icss->stmtPtr[*statement]->numOfCols == 0 ) {
         cllFreeStatement( icss, *statement );
-        *statement = 0;
+        *statement = UNINITIALIZED_STATEMENT_NUMBER;
         return CAT_NO_ROWS_FOUND;
     }
     return 0;
 }
 
+/*
+ * caller must free on success */
 int cmlGetNextRowFromStatement( int stmtNum,
                                 icatSessionStruct *icss ) {
 
@@ -506,7 +515,7 @@ int cmlGetMultiRowStringValuesFromSql( const char *sql,
                                        std::vector<std::string> &bindVars,
                                        icatSessionStruct *icss ) {
 
-    int i, j, stmtNum;
+    int i, j, stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
     int tsg; /* total strings gotten */
     char *pString;
 
@@ -516,6 +525,7 @@ int cmlGetMultiRowStringValuesFromSql( const char *sql,
 
     i = cllExecSqlWithResultBV( icss, &stmtNum, sql, bindVars );
     if ( i != 0 ) {
+        cllFreeStatement( icss, stmtNum );
         if ( i <= CAT_ENV_ERR ) {
             return ( i );   /* already an iRODS error code */
         }
@@ -550,6 +560,7 @@ int cmlGetMultiRowStringValuesFromSql( const char *sql,
             }
         }
     }
+    cllFreeStatement( icss, stmtNum );
     return 0;
 }
 
@@ -1186,7 +1197,7 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
                             const char *userName, const char *userZone,
                             icatSessionStruct *icss ) {
     int status;
-    int stmtNum;
+    int stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
     int hostOK = 0;
     int userOK = 0;
     int groupOK = 0;
@@ -1206,6 +1217,7 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
     }
     else {
         if ( status != 0 ) {
+            cllFreeStatement(icss, stmtNum);
             return status;
         }
     }
@@ -1218,12 +1230,15 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
         }
         status = cmlGetNextRowFromStatement( stmtNum, icss );
         if ( status != 0 && status != CAT_NO_ROWS_FOUND ) {
+            cllFreeStatement(icss, stmtNum);
             return status;
         }
     }
     if ( hostOK == 0 ) {
+        cllFreeStatement(icss, stmtNum);
         return CAT_TICKET_HOST_EXCLUDED;
     }
+    cllFreeStatement(icss, stmtNum);
 
     /* Now check on user restrictions */
     if ( logSQL_CML != 0 ) {
@@ -1235,10 +1250,12 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
                  "select user_name from R_TICKET_ALLOWED_USERS where ticket_id=?",
                  bindVars,  &stmtNum, icss );
     if ( status == CAT_NO_ROWS_FOUND ) {
+        cllFreeStatement(icss, stmtNum);
         userOK = 1;
     }
     else {
         if ( status != 0 ) {
+            cllFreeStatement(icss, stmtNum);
             return status;
         }
     }
@@ -1261,12 +1278,15 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
         }
         status = cmlGetNextRowFromStatement( stmtNum, icss );
         if ( status != 0 && status != CAT_NO_ROWS_FOUND ) {
+            cllFreeStatement(icss, stmtNum);
             return status;
         }
     }
     if ( userOK == 0 ) {
+        cllFreeStatement(icss, stmtNum);
         return CAT_TICKET_USER_EXCLUDED;
     }
+    cllFreeStatement(icss, stmtNum);
 
     /* Now check on group restrictions */
     if ( logSQL_CML != 0 ) {
@@ -1282,6 +1302,7 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
     }
     else {
         if ( status != 0 ) {
+            cllFreeStatement(icss, stmtNum);
             return status;
         }
     }
@@ -1295,12 +1316,15 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
         }
         status = cmlGetNextRowFromStatement( stmtNum, icss );
         if ( status != 0 && status != CAT_NO_ROWS_FOUND ) {
+            cllFreeStatement(icss, stmtNum);
             return status;
         }
     }
     if ( groupOK == 0 ) {
+        cllFreeStatement(icss, stmtNum);
         return CAT_TICKET_GROUP_EXCLUDED;
     }
+    cllFreeStatement(icss, stmtNum);
     return 0;
 }
 

--- a/scripts/irods/test/test_iadmin.py
+++ b/scripts/irods/test/test_iadmin.py
@@ -1433,3 +1433,66 @@ class Test_Iadmin_Queries(resource_suite.ResourceBase, unittest.TestCase):
         self.admin.assert_icommand(['iadmin', 'rsq', query_name])
         self.admin.assert_icommand(['irm', '-f', test_file])
         os.unlink(test_file)
+
+class Test_Issue3862(resource_suite.ResourceBase, unittest.TestCase):
+
+    def setUp(self):
+        super(Test_Issue3862, self).setUp()
+
+        output = commands.getstatusoutput("hostname")
+        hostname = output[1]
+
+        # =-=-=-=-=-=-=-
+        # STANDUP
+        self.admin.assert_icommand("iadmin mkresc repl replication", 'STDOUT_SINGLELINE', "Creating")
+
+        self.admin.assert_icommand("iadmin mkresc leaf_a unixfilesystem " + hostname +
+                                   ":/tmp/irods/pydevtest_leaf_a", 'STDOUT_SINGLELINE', "Creating")  # unix
+        self.admin.assert_icommand("iadmin mkresc leaf_b unixfilesystem " + hostname +
+                                   ":/tmp/irods/pydevtest_leaf_b", 'STDOUT_SINGLELINE', "Creating")  # unix
+
+        # =-=-=-=-=-=-=-
+        # place data into the leaf_a
+        test_dir = 'issue3862'
+        num_files = 400
+        if not os.path.isdir(test_dir):
+            os.mkdir(test_dir)
+        for i in range(num_files):
+            filename = test_dir + '/file_' + str(i)
+            lib.create_local_testfile(filename)
+
+        with session.make_session_for_existing_admin() as admin_session:
+
+            # add files to leaf_a
+            admin_session.run_icommand(['iput', '-r', '-R', 'leaf_a', test_dir])
+
+            # now connect leaves to repl
+            admin_session.run_icommand(['iadmin', 'addchildtoresc', 'repl', 'leaf_a'])
+            admin_session.run_icommand(['iadmin', 'addchildtoresc', 'repl', 'leaf_b'])
+
+    def tearDown(self):
+
+        super(Test_Issue3862, self).tearDown()
+
+        test_dir = 'issue3862'
+
+        with session.make_session_for_existing_admin() as admin_session:
+
+            admin_session.run_icommand(['irm', '-rf', test_dir])
+
+            admin_session.run_icommand(['iadmin', 'rmchildfromresc', 'repl', 'leaf_a'])
+            admin_session.run_icommand(['iadmin', 'rmchildfromresc', 'repl', 'leaf_b'])
+
+            admin_session.run_icommand(['iadmin', 'rmresc', 'leaf_b'])
+            admin_session.run_icommand(['iadmin', 'rmresc', 'leaf_a'])
+            admin_session.run_icommand(['iadmin', 'rmresc', 'repl'])
+
+    # Issue 3862:  test that CAT_STATEMENT_TABLE_FULL is not encountered during parallel rebalance
+    def test_rebalance__ticket_3862(self):
+
+        # =-=-=-=-=-=-=-
+        # call two separate rebalances, the first in background
+        # prior to fix the second would generate a CAT_STATEMENT_TABLE_FULL error
+        subprocess.Popen(["iadmin", "modresc",  "repl", "rebalance"])
+        self.admin.assert_icommand("iadmin modresc repl rebalance")
+


### PR DESCRIPTION
- Added test cases.
- Initialized memsets in DB structs because on a cllFreeStatement call
  pointers are freed and these pointers are sometimes not allocated
  (specifically when an error cllFreeStatement() is called after a DB
  error.

- This has passed CI.