### PR TITLE
[#4119] Honor DATA_SIZE_KW in rsRegReplica (4-2-stable)

### DIFF
--- a/server/api/src/rsPhyPathReg.cpp
+++ b/server/api/src/rsPhyPathReg.cpp
@@ -496,6 +496,11 @@ filePathRegRepl( rsComm_t *rsComm, dataObjInp_t *phyPathRegInp, char *filePath,
                            ADMIN_KW ) != NULL ) {
         addKeyVal( &regReplicaInp.condInput, ADMIN_KW, "" );
     }
+    // Data size can be passed via DATA_SIZE_KW to save a stat later
+    const auto data_size_str = getValByKey(&phyPathRegInp->condInput, DATA_SIZE_KW);
+    if (nullptr != data_size_str) {
+        addKeyVal(&regReplicaInp.condInput, DATA_SIZE_KW, data_size_str);
+    }
     status = rsRegReplica( rsComm, &regReplicaInp );
     clearKeyVal( &regReplicaInp.condInput );
     freeAllDataObjInfo( dataObjInfoHead );


### PR DESCRIPTION
rsRegReplica was not honoring DATA_SIZE_KW which means it had to do a stat for every registration. This change adds handling for the DATA_SIZE_KW when registering a data object as a replica.

(cherry-picked from SHA: 18c3df2fd230b11503b599224b0eaa755614c936)

---

[CI tests passed](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1428/)