### PR TITLE
[#3862] Updated code to call cllFreeStatement consistently.

### DIFF
--- a/plugins/database/include/low_level_odbc.hpp
+++ b/plugins/database/include/low_level_odbc.hpp
@@ -43,7 +43,7 @@ int cllExecSqlWithResult( icatSessionStruct *icss, int *stmtNum, const char *sql
 int cllExecSqlWithResultBV( icatSessionStruct *icss, int *stmtNum, const char *sql,
                             std::vector<std::string> &bindVars );
 int cllGetRow( icatSessionStruct *icss, int statementNumber );
-int cllFreeStatement( icatSessionStruct *icss, int statementNumber );
+int cllFreeStatement( icatSessionStruct *icss, int& statementNumber );
 int cllNextValueString( const char *itemName, char *outString, int maxSize );
 extern "C" int cllTest( const char *userArg, const char *pwArg );
 int cllCurrentValueString( const char *itemName, char *outString, int maxSize );

--- a/plugins/database/include/low_level_oracle.hpp
+++ b/plugins/database/include/low_level_oracle.hpp
@@ -28,7 +28,7 @@ int cllExecSqlWithResult( icatSessionStruct *icss, int *stmtNum, const char *sql
 int cllExecSqlWithResultBV( icatSessionStruct *icss, int *stmtNum, const char *sql,
                             std::vector<std::string> &bindVars );
 int cllGetRow( icatSessionStruct *icss, int statementNumber );
-int cllFreeStatement( icatSessionStruct *icss, int statementNumber );
+int cllFreeStatement( icatSessionStruct *icss, int& statementNumber );
 int cllNextValueString( const char *itemName, char *outString, int maxSize );
 extern "C" int cllTest( const char *userArg, const char *pwArg );
 int cllCurrentValueString( const char *itemName, char *outString, int maxSize );

--- a/plugins/database/include/mid_level.hpp
+++ b/plugins/database/include/mid_level.hpp
@@ -15,6 +15,8 @@
 #include <vector>
 #include <string>
 
+const int UNINITIALIZED_STATEMENT_NUMBER = -1;
+
 int cmlOpen( icatSessionStruct *icss );
 
 int cmlClose( icatSessionStruct *icss );

--- a/plugins/database/src/general_query.cpp
+++ b/plugins/database/src/general_query.cpp
@@ -2181,7 +2181,7 @@ extern "C" int chl_gen_query_impl(
     char combinedSQL[MAX_SQL_SIZE_GQ];
     char countSQL[MAX_SQL_SIZE_GQ]; /* For Oracle, sql to get the count */
 
-    int status, statementNum;
+    int status, statementNum = UNINITIALIZED_STATEMENT_NUMBER;
     int numOfCols;
     int attriTextLen;
     int totalLen;

--- a/plugins/database/src/mid_level_routines.cpp
+++ b/plugins/database/src/mid_level_routines.cpp
@@ -165,7 +165,7 @@ int cmlGetOneRowFromSqlBV( const char *sql,
                            int numOfCols,
                            std::vector<std::string> &bindVars,
                            icatSessionStruct *icss ) {
-    int stmtNum;
+    int stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
     char updatedSql[MAX_SQL_SIZE + 1];
 
 //TODO: this should be a function, probably inside low-level icat
@@ -185,6 +185,7 @@ int cmlGetOneRowFromSqlBV( const char *sql,
     int status = cllExecSqlWithResultBV( icss, &stmtNum, updatedSql,
                                          bindVars );
     if ( status != 0 ) {
+        cllFreeStatement(icss, stmtNum);
         if ( status <= CAT_ENV_ERR ) {
             return status;    /* already an iRODS error code */
         }
@@ -214,7 +215,7 @@ int cmlGetOneRowFromSql( const char *sql,
                          int cValSize[],
                          int numOfCols,
                          icatSessionStruct *icss ) {
-    int i, j, stmtNum;
+    int i, j, stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
     char updatedSql[MAX_SQL_SIZE + 1];
 
 //TODO: this should be a function, probably inside low-level icat
@@ -236,6 +237,7 @@ int cmlGetOneRowFromSql( const char *sql,
     i = cllExecSqlWithResultBV( icss, &stmtNum, updatedSql,
                                 emptyBindVars );
     if ( i != 0 ) {
+        cllFreeStatement( icss, stmtNum );
         if ( i <= CAT_ENV_ERR ) {
             return ( i );   /* already an iRODS error code */
         }
@@ -267,7 +269,7 @@ int cmlGetOneRowFromSqlV2( const char *sql,
                            int maxCols,
                            std::vector<std::string> &bindVars,
                            icatSessionStruct *icss ) {
-    int i, j, stmtNum;
+    int i, j, stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
     char updatedSql[MAX_SQL_SIZE + 1];
 
 //TODO: this should be a function, probably inside low-level icat
@@ -289,6 +291,7 @@ int cmlGetOneRowFromSqlV2( const char *sql,
                                 bindVars );
 
     if ( i != 0 ) {
+        cllFreeStatement( icss, stmtNum );
         if ( i <= CAT_ENV_ERR ) {
             return ( i );   /* already an iRODS error code */
         }
@@ -319,7 +322,7 @@ int cmlGetOneRowFromSqlV3( const char *sql,
                            int cValSize[],
                            int numOfCols,
                            icatSessionStruct *icss ) {
-    int i, j, stmtNum;
+    int i, j, stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
     char updatedSql[MAX_SQL_SIZE + 1];
 
 //TODO: this should be a function, probably inside low-level icat
@@ -340,6 +343,7 @@ int cmlGetOneRowFromSqlV3( const char *sql,
     i = cllExecSqlWithResult( icss, &stmtNum, updatedSql );
 
     if ( i != 0 ) {
+        cllFreeStatement( icss, stmtNum );
         if ( i <= CAT_ENV_ERR ) {
             return ( i );   /* already an iRODS error code */
         }
@@ -370,7 +374,8 @@ int cmlFreeStatement( int statementNumber, icatSessionStruct *icss ) {
     return i;
 }
 
-
+/*
+ * caller must free on success */
 int cmlGetFirstRowFromSql( const char *sql,
                            int *statement,
                            int skipCount,
@@ -379,7 +384,8 @@ int cmlGetFirstRowFromSql( const char *sql,
     int i = cllExecSqlWithResult( icss, statement, sql );
 
     if ( i != 0 ) {
-        *statement = 0;
+        cllFreeStatement( icss, *statement );
+        *statement = UNINITIALIZED_STATEMENT_NUMBER;
         if ( i <= CAT_ENV_ERR ) {
             return ( i );   /* already an iRODS error code */
         }
@@ -392,12 +398,12 @@ int cmlGetFirstRowFromSql( const char *sql,
             i = cllGetRow( icss, *statement );
             if ( i != 0 )  {
                 cllFreeStatement( icss, *statement );
-                *statement = 0;
+                *statement = UNINITIALIZED_STATEMENT_NUMBER;
                 return CAT_GET_ROW_ERR;
             }
             if ( icss->stmtPtr[*statement]->numOfCols == 0 ) {
                 i = cllFreeStatement( icss, *statement );
-                *statement = 0;
+                *statement = UNINITIALIZED_STATEMENT_NUMBER;
                 return CAT_NO_ROWS_FOUND;
             }
         }
@@ -407,25 +413,27 @@ int cmlGetFirstRowFromSql( const char *sql,
     i = cllGetRow( icss, *statement );
     if ( i != 0 )  {
         cllFreeStatement( icss, *statement );
-        *statement = 0;
+        *statement = UNINITIALIZED_STATEMENT_NUMBER;
         return CAT_GET_ROW_ERR;
     }
     if ( icss->stmtPtr[*statement]->numOfCols == 0 ) {
         i = cllFreeStatement( icss, *statement );
-        *statement = 0;
+        *statement = UNINITIALIZED_STATEMENT_NUMBER;
         return CAT_NO_ROWS_FOUND;
     }
 
     return 0;
 }
 
-/* with bind-variables */
+/* with bind-variables 
+ * caller must free on success*/
 int cmlGetFirstRowFromSqlBV( const char *sql,
                              std::vector<std::string> &bindVars,
                              int *statement,
                              icatSessionStruct *icss ) {
     if ( int status = cllExecSqlWithResultBV( icss, statement, sql, bindVars ) ) {
-        *statement = 0;
+        cllFreeStatement( icss, *statement );
+        *statement = UNINITIALIZED_STATEMENT_NUMBER;
         if ( status <= CAT_ENV_ERR ) {
             return status;    /* already an iRODS error code */
         }
@@ -433,17 +441,19 @@ int cmlGetFirstRowFromSqlBV( const char *sql,
     }
     if ( cllGetRow( icss, *statement ) ) {
         cllFreeStatement( icss, *statement );
-        *statement = 0;
+        *statement = UNINITIALIZED_STATEMENT_NUMBER;
         return CAT_GET_ROW_ERR;
     }
     if ( icss->stmtPtr[*statement]->numOfCols == 0 ) {
         cllFreeStatement( icss, *statement );
-        *statement = 0;
+        *statement = UNINITIALIZED_STATEMENT_NUMBER;
         return CAT_NO_ROWS_FOUND;
     }
     return 0;
 }
 
+/*
+ * caller must free on success*/
 int cmlGetNextRowFromStatement( int stmtNum,
                                 icatSessionStruct *icss ) {
     int i;
@@ -508,7 +518,7 @@ int cmlGetMultiRowStringValuesFromSql( const char *sql,
                                        std::vector<std::string> &bindVars,
                                        icatSessionStruct *icss ) {
 
-    int i, j, stmtNum;
+    int i, j, stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
     int tsg; /* total strings gotten */
     char *pString;
 
@@ -518,6 +528,7 @@ int cmlGetMultiRowStringValuesFromSql( const char *sql,
 
     i = cllExecSqlWithResultBV( icss, &stmtNum, sql, bindVars );
     if ( i != 0 ) {
+        cllFreeStatement( icss, stmtNum );
         if ( i <= CAT_ENV_ERR ) {
             return ( i );   /* already an iRODS error code */
         }
@@ -552,6 +563,7 @@ int cmlGetMultiRowStringValuesFromSql( const char *sql,
             }
         }
     }
+    cllFreeStatement( icss, stmtNum );
     return 0;
 }
 
@@ -1189,7 +1201,7 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
                             const char *userName, const char *userZone,
                             icatSessionStruct *icss ) {
     int status;
-    int stmtNum;
+    int stmtNum = UNINITIALIZED_STATEMENT_NUMBER;
     int hostOK = 0;
     int userOK = 0;
     int groupOK = 0;
@@ -1209,6 +1221,7 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
     }
     else {
         if ( status != 0 ) {
+            cllFreeStatement(icss, stmtNum);
             return status;
         }
     }
@@ -1221,12 +1234,15 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
         }
         status = cmlGetNextRowFromStatement( stmtNum, icss );
         if ( status != 0 && status != CAT_NO_ROWS_FOUND ) {
+            cllFreeStatement(icss, stmtNum);
             return status;
         }
     }
     if ( hostOK == 0 ) {
+        cllFreeStatement(icss, stmtNum);
         return CAT_TICKET_HOST_EXCLUDED;
     }
+    cllFreeStatement(icss, stmtNum);
 
     /* Now check on user restrictions */
     if ( logSQL_CML != 0 ) {
@@ -1238,10 +1254,12 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
                  "select user_name from R_TICKET_ALLOWED_USERS where ticket_id=?",
                  bindVars,  &stmtNum, icss );
     if ( status == CAT_NO_ROWS_FOUND ) {
+        cllFreeStatement(icss, stmtNum);
         userOK = 1;
     }
     else {
         if ( status != 0 ) {
+            cllFreeStatement(icss, stmtNum);
             return status;
         }
     }
@@ -1264,12 +1282,15 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
         }
         status = cmlGetNextRowFromStatement( stmtNum, icss );
         if ( status != 0 && status != CAT_NO_ROWS_FOUND ) {
+            cllFreeStatement(icss, stmtNum);
             return status;
         }
     }
     if ( userOK == 0 ) {
+        cllFreeStatement(icss, stmtNum);
         return CAT_TICKET_USER_EXCLUDED;
     }
+    cllFreeStatement(icss, stmtNum);
 
     /* Now check on group restrictions */
     if ( logSQL_CML != 0 ) {
@@ -1285,6 +1306,7 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
     }
     else {
         if ( status != 0 ) {
+            cllFreeStatement(icss, stmtNum);
             return status;
         }
     }
@@ -1298,12 +1320,15 @@ cmlCheckTicketRestrictions( const char *ticketId, const char *ticketHost,
         }
         status = cmlGetNextRowFromStatement( stmtNum, icss );
         if ( status != 0 && status != CAT_NO_ROWS_FOUND ) {
+            cllFreeStatement(icss, stmtNum);
             return status;
         }
     }
     if ( groupOK == 0 ) {
+        cllFreeStatement(icss, stmtNum);
         return CAT_TICKET_GROUP_EXCLUDED;
-    }
+    }     
+    cllFreeStatement(icss, stmtNum);
     return 0;
 }
 

--- a/tests/pydevtest/test_iadmin.py
+++ b/tests/pydevtest/test_iadmin.py
@@ -1381,3 +1381,66 @@ class Test_Iadmin_Resources(resource_suite.ResourceBase, unittest.TestCase):
         self.assertTrue(self.vault_warning_message in stdout)
         # Changing vault should have failed, so make sure it has not changed
         self.admin.assert_icommand(['ilsresc', '-l', self.resc_name], 'STDOUT_SINGLELINE', 'vault: ' + self.good_vault)
+
+class Test_Issue3862(resource_suite.ResourceBase, unittest.TestCase):
+
+    def setUp(self):
+        super(Test_Issue3862, self).setUp()
+
+        output = commands.getstatusoutput("hostname")
+        hostname = output[1]
+
+        # =-=-=-=-=-=-=-
+        # STANDUP
+        self.admin.assert_icommand("iadmin mkresc repl replication", 'STDOUT_SINGLELINE', "Creating")
+
+        self.admin.assert_icommand("iadmin mkresc leaf_a unixfilesystem " + hostname +
+                                   ":/tmp/irods/pydevtest_leaf_a", 'STDOUT_SINGLELINE', "Creating")  # unix
+        self.admin.assert_icommand("iadmin mkresc leaf_b unixfilesystem " + hostname +
+                                   ":/tmp/irods/pydevtest_leaf_b", 'STDOUT_SINGLELINE', "Creating")  # unix
+
+        # =-=-=-=-=-=-=-
+        # place data into the leaf_a
+        test_dir = 'issue3862'
+        num_files = 400
+        if not os.path.isdir(test_dir):
+            os.mkdir(test_dir)
+        for i in range(num_files):
+            filename = test_dir + '/file_' + str(i)
+            lib.create_local_testfile(filename)
+
+        with lib.make_session_for_existing_admin() as admin_session:
+
+            # add files to leaf_a
+            admin_session.run_icommand(['iput', '-r', '-R', 'leaf_a', test_dir])
+
+            # now connect leaves to repl
+            admin_session.run_icommand(['iadmin', 'addchildtoresc', 'repl', 'leaf_a'])
+            admin_session.run_icommand(['iadmin', 'addchildtoresc', 'repl', 'leaf_b'])
+
+    def tearDown(self):
+
+        super(Test_Issue3862, self).tearDown()
+
+        test_dir = 'issue3862'
+
+        with lib.make_session_for_existing_admin() as admin_session:
+
+            admin_session.run_icommand(['irm', '-rf', test_dir])
+
+            admin_session.run_icommand(['iadmin', 'rmchildfromresc', 'repl', 'leaf_a'])
+            admin_session.run_icommand(['iadmin', 'rmchildfromresc', 'repl', 'leaf_b'])
+
+            admin_session.run_icommand(['iadmin', 'rmresc', 'leaf_b'])
+            admin_session.run_icommand(['iadmin', 'rmresc', 'leaf_a'])
+            admin_session.run_icommand(['iadmin', 'rmresc', 'repl'])
+
+    # Issue 3862:  test that CAT_STATEMENT_TABLE_FULL is not encountered during parallel rebalance
+    def test_rebalance__ticket_3862(self):
+
+        # =-=-=-=-=-=-=-
+        # call two separate rebalances, the first in background
+        # prior to fix the second would generate a CAT_STATEMENT_TABLE_FULL error
+        subprocess.Popen(["iadmin", "modresc",  "repl", "rebalance"])
+        self.admin.assert_icommand("iadmin modresc repl rebalance")
+


### PR DESCRIPTION
- Added test cases.
- Initialized memsets in DB structs because on a cllFreeStatement call
  pointers are freed and these pointers are sometimes not allocated
  (specifically when an error cllFreeStatement() is called after a DB
  error.
- Do not free statements if they were not created and allow cllFreeStatement to be called multiple
  times without adverse effects.
   - Initialized all references to statementNumber to -1.
   - When cllFreeStatement is called, if statementNumber is negative do nothing.
   - Once freed set the statementNumber to -1.