### PR TITLE
[4089] Updated code to handle quotas

### DIFF
--- a/lib/core/include/rodsErrorTable.h
+++ b/lib/core/include/rodsErrorTable.h
@@ -217,6 +217,7 @@ NEW_ERROR(SYS_SOCK_WRITE_ERR,                          -161000)
 NEW_ERROR(SYS_SOCK_CONNECT_ERR,                        -162000)
 NEW_ERROR(SYS_OPERATION_IN_PROGRESS,                   -163000)
 NEW_ERROR(SYS_REPLICA_DOES_NOT_EXIST,                  -164000)
+NEW_ERROR(SYS_RESC_QUOTA_EXCEEDED_ON_REPLICATION,      -165000)
 /** @} */
 
 /* 300,000 - 499,000 - user input type error */

--- a/plugins/resources/replication/irods_repl_retry.cpp
+++ b/plugins/resources/replication/irods_repl_retry.cpp
@@ -15,7 +15,7 @@ int irods::data_obj_repl_with_retry(
 
     transferStat_t* trans_stat{ nullptr };
     auto status{ rsDataObjRepl( _ctx.comm(), &dataObjInp, &trans_stat ) };
-    if ( 0 == status ) {
+    if ( 0 == status || SYS_RESC_QUOTA_EXCEEDED_ON_REPLICATION == status ) {
         free( trans_stat );
         return status;
     }

--- a/scripts/irods/test/rule_texts_for_tests.py
+++ b/scripts/irods/test/rule_texts_for_tests.py
@@ -27,6 +27,25 @@ acAclPolicy {
     ON($userNameClient == "quickshare") { }
 }
 '''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Quota_Issue4089'] = {}
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Quota_Issue4089'] ['test_quota_default_replication_node_put_failure'] = '''
+acSetRescSchemeForCreate{
+    msiSetDefaultResc('repl', 'forced');
+}
+acRescQuotaPolicy {msiSetRescQuotaPolicy("on"); }
+'''
+
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Quota_Issue4089'] ['test_quota_default_replication_node_repl_failure'] = '''
+acSetRescSchemeForCreate{
+    msiSetDefaultResc('repl', 'forced');
+}
+acRescQuotaPolicy {msiSetRescQuotaPolicy("on"); }
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Quota_Issue4089'] ['others'] = '''
+acRescQuotaPolicy {msiSetRescQuotaPolicy("on"); }
+'''
+
+
 
 #===== Test_ICommands_File_Operations =====
 

--- a/scripts/irods/test/test_iadmin.py
+++ b/scripts/irods/test/test_iadmin.py
@@ -1521,3 +1521,302 @@ class Test_Issue3862(resource_suite.ResourceBase, unittest.TestCase):
         check_and_remove_rebalance_visibility_metadata(10); # try 10 times
         # fire parallel rebalance
         self.admin.assert_icommand("iadmin modresc repl rebalance")
+
+class Test_Quota_Issue4089(resource_suite.ResourceBase, unittest.TestCase):
+
+    plugin_name = IrodsConfig().default_rule_engine_plugin
+    class_name = 'Test_Quota_Issue4089'
+
+    def setUp(self):
+        super(Test_Quota_Issue4089, self).setUp()
+
+        output = commands.getstatusoutput("hostname")
+        hostname = output[1]
+
+        # =-=-=-=-=-=-=-
+        # STANDUP
+        self.admin.assert_icommand('iadmin mkresc repl replication', 'STDOUT_SINGLELINE', 'Creating')
+
+        self.admin.assert_icommand(['iadmin', 'mkresc', 'pt_a', 'passthru', '', 'write=1.0;read=1.0'], 'STDOUT_SINGLELINE', 'Creating')
+        self.admin.assert_icommand(['iadmin', 'mkresc', 'pt_b', 'passthru', '', 'write=.9;read=1.0'], 'STDOUT_SINGLELINE', 'Creating')
+        self.admin.assert_icommand(['iadmin', 'mkresc', 'pt_c', 'passthru', '', 'write=.9;read=1.0'], 'STDOUT_SINGLELINE', 'Creating')
+
+        self.admin.assert_icommand('iadmin mkresc leaf_a unixfilesystem ' + hostname +
+                                   ':/tmp/irods/pydevtest_leaf_a', 'STDOUT_SINGLELINE', 'Creating')  # unix
+        self.admin.assert_icommand('iadmin mkresc leaf_b unixfilesystem ' + hostname +
+                                   ':/tmp/irods/pydevtest_leaf_b', 'STDOUT_SINGLELINE', 'Creating')  # unix
+        self.admin.assert_icommand('iadmin mkresc leaf_c unixfilesystem ' + hostname +
+                                   ':/tmp/irods/pydevtest_leaf_c', 'STDOUT_SINGLELINE', 'Creating')  # unix
+        self.admin.assert_icommand('iadmin mkresc standalone_resc unixfilesystem ' + hostname +
+                                   ':/tmp/irods/pydevtest_standalone_resc', 'STDOUT_SINGLELINE', 'Creating')  # unix
+
+
+        # now connect the tree
+        self.admin.assert_icommand(['iadmin', 'addchildtoresc', 'repl', 'pt_a'])
+        self.admin.assert_icommand(['iadmin', 'addchildtoresc', 'repl', 'pt_b'])
+        self.admin.assert_icommand(['iadmin', 'addchildtoresc', 'repl', 'pt_c'])
+        self.admin.assert_icommand(['iadmin', 'addchildtoresc', 'pt_a', 'leaf_a'])
+        self.admin.assert_icommand(['iadmin', 'addchildtoresc', 'pt_b', 'leaf_b'])
+        self.admin.assert_icommand(['iadmin', 'addchildtoresc', 'pt_c', 'leaf_c'])
+
+        # add low quotas on another user to make sure it doesn't impact the user under test
+        self.admin.assert_icommand(['iadmin', 'suq', self.user1.username, 'demoResc', '50'])
+        self.admin.assert_icommand(['iadmin', 'suq', self.user1.username, 'leaf_a', '50'])
+        self.admin.assert_icommand(['iadmin', 'suq', self.user1.username, 'leaf_b', '50'])
+        self.admin.assert_icommand(['iadmin', 'suq', self.user1.username, 'leaf_c', '50'])
+        self.admin.assert_icommand(['iadmin', 'suq', self.user1.username, 'total', '50'])
+
+        # add higher total quota on user and make sure this doesn't impact the lower quotas
+        self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'total', '20000'])
+
+        self.admin.assert_icommand('iadmin cu')
+
+    def tearDown(self):
+
+        super(Test_Quota_Issue4089, self).tearDown()
+
+        with session.make_session_for_existing_admin() as admin_session:
+
+            admin_session.run_icommand(['iadmin', 'rmchildfromresc', 'repl', 'pt_a'])
+            admin_session.run_icommand(['iadmin', 'rmchildfromresc', 'repl', 'pt_b'])
+            admin_session.run_icommand(['iadmin', 'rmchildfromresc', 'repl', 'pt_c'])
+            admin_session.run_icommand(['iadmin', 'rmchildfromresc', 'pt_a', 'leaf_a'])
+            admin_session.run_icommand(['iadmin', 'rmchildfromresc', 'pt_b', 'leaf_b'])
+            admin_session.run_icommand(['iadmin', 'rmchildfromresc', 'pt_c', 'leaf_c'])
+
+            admin_session.run_icommand(['iadmin', 'rmresc', 'leaf_a'])
+            admin_session.run_icommand(['iadmin', 'rmresc', 'leaf_b'])
+            admin_session.run_icommand(['iadmin', 'rmresc', 'leaf_c'])
+            admin_session.run_icommand(['iadmin', 'rmresc', 'pt_a'])
+            admin_session.run_icommand(['iadmin', 'rmresc', 'pt_b'])
+            admin_session.run_icommand(['iadmin', 'rmresc', 'pt_c'])
+            admin_session.run_icommand(['iadmin', 'rmresc', 'repl'])
+            admin_session.run_icommand(['iadmin', 'rmresc', 'standalone_resc'])
+
+    def test_quota_default_standalone_resource(self):
+
+        test_file = '2kfile'
+        lib.make_file(test_file, 2000)
+
+        # enable quota
+        with temporary_core_file() as core:
+            core.add_rule(rule_texts[self.plugin_name][self.class_name]['others'])
+
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'demoResc', '3000'])
+            self.admin.assert_icommand('iadmin cu')
+
+            # first put should pass
+            self.user0.assert_icommand('iput %s f1' % test_file)
+            self.admin.assert_icommand('iadmin cu')
+
+            # second put should fail due to quota
+            self.user0.assert_icommand('iput %s f2' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+            # test a put when we are already over quota
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'demoResc', '1000'])
+            self.admin.assert_icommand('iadmin cu')
+            self.user0.assert_icommand('iput %s f3' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+    def test_quota_selected_standalone_resource(self):
+
+        test_file = '2kfile'
+        lib.make_file(test_file, 2000)
+
+        # enable quota
+        with temporary_core_file() as core:
+            core.add_rule(rule_texts[self.plugin_name][self.class_name]['others'])
+
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'standalone_resc', '3000'])
+            self.admin.assert_icommand('iadmin cu')
+
+            # first put should pass
+            self.user0.assert_icommand('iput -R standalone_resc %s f1' % test_file)
+            self.admin.assert_icommand('iadmin cu')
+
+            # second put should fail due to quota
+            self.user0.assert_icommand('iput -R standalone_resc %s f2' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+            # test a put when we are already over quota
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'standalone_resc', '1000'])
+            self.admin.assert_icommand('iadmin cu')
+            self.user0.assert_icommand('iput -R standalone_resc %s f3' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+
+    def test_quota_default_replication_node_put_failure(self):
+
+        test_file = '2kfile'
+        lib.make_file(test_file, 2000)
+
+        # enable quota
+        with temporary_core_file() as core:
+            core.add_rule(rule_texts[self.plugin_name][self.class_name][inspect.currentframe().f_code.co_name])
+
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_a', '3000'])
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_b', '10000'])
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_c', '10000'])
+            self.admin.assert_icommand('iadmin cu')
+
+            # first put should pass
+            self.user0.assert_icommand('iput %s f1' % test_file)
+            self.admin.assert_icommand('iadmin cu')
+
+            # make sure object and two replicas exist
+            self.user0.assert_icommand('ils -l f1', 'STDOUT_MULTILINE', ['repl;pt_a;leaf_a', 'repl;pt_b;leaf_b','repl;pt_c;leaf_c'])
+
+            # second put should fail due to quota
+            self.user0.assert_icommand('iput %s f2' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+            # test a put when we are already over quota
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_a', '1000'])
+            self.admin.assert_icommand('iadmin cu')
+            self.user0.assert_icommand('iput %s f3' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+
+    def test_quota_default_replication_node_repl_failure(self):
+
+        test_file = '2kfile'
+        lib.make_file(test_file, 2000)
+
+        # set the default resource to repl and enable quota
+        with temporary_core_file() as core:
+            core.add_rule(rule_texts[self.plugin_name][self.class_name][inspect.currentframe().f_code.co_name])
+
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_a', '10000'])
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_b', '5000'])
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_c', '3000'])
+            self.admin.assert_icommand('iadmin cu')
+
+            # restart the server to reread the new core.re
+            IrodsController().restart()
+
+            # first put should pass
+            self.user0.assert_icommand('iput %s f1' % test_file)
+            self.admin.assert_icommand('iadmin cu')
+
+            # make sure the object and two replicas exist
+            self.user0.assert_icommand('ils -l f1', 'STDOUT_MULTILINE', ['repl;pt_a;leaf_a', 'repl;pt_b;leaf_b','repl;pt_c;leaf_c'])
+
+            # second put should fail to replicate to leaf_c
+            self.user0.assert_icommand('iput %s f2' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED_ON_REPLICATION')
+
+            # make sure the object and one replica exists
+            self.user0.assert_icommand('ils -l f2', 'STDOUT_MULTILINE', ['repl;pt_a;leaf_a', 'repl;pt_b;leaf_b'])
+
+            # third put should fail to replicate to leaf_b or leaf_c (also tests already over quota case)
+            self.user0.assert_icommand('iput %s f3' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED_ON_REPLICATION')
+
+            # make sure the one object exists
+            self.user0.assert_icommand('ils -l f3', 'STDOUT_MULTILINE', ['repl;pt_a;leaf_a'])
+
+
+    def test_quota_selected_replication_node_put_failure(self):
+
+        test_file = '2kfile'
+        lib.make_file(test_file, 2000)
+
+        # enable quota
+        with temporary_core_file() as core:
+            core.add_rule(rule_texts[self.plugin_name][self.class_name]['others'])
+
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_a', '3000'])
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_b', '10000'])
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_c', '10000'])
+            self.admin.assert_icommand('iadmin cu')
+
+            # first put should pass
+            self.user0.assert_icommand('iput -R repl %s f1' % test_file)
+            self.admin.assert_icommand('iadmin cu')
+
+            # make sure object and two replicas exist
+            self.user0.assert_icommand('ils -l f1', 'STDOUT_MULTILINE', ['repl;pt_a;leaf_a', 'repl;pt_b;leaf_b','repl;pt_c;leaf_c'])
+
+            # second put should fail due to quota
+            self.user0.assert_icommand('iput -R repl %s f2' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+            # test a put when we are already over quota
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_a', '1000'])
+            self.admin.assert_icommand('iadmin cu')
+            self.user0.assert_icommand('iput -R repl %s f3' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+    def test_total_quota_repl_node_put_failure(self):
+
+        test_file = '2kfile'
+        lib.make_file(test_file, 2000)
+
+        # enable quota
+        with temporary_core_file() as core:
+            core.add_rule(rule_texts[self.plugin_name][self.class_name]['others'])
+
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'total', '7000'])
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_a', '20000'])
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_b', '20000'])
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'leaf_c', '20000'])
+            self.admin.assert_icommand('iadmin cu')
+
+            # first put should pass
+            self.user0.assert_icommand('iput -R repl %s f1' % test_file)
+            self.admin.assert_icommand('iadmin cu')
+
+            # second put should fail due to total quota
+            self.user0.assert_icommand('iput -R repl %s f2' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+            # test a put when we are already over quota
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'total', '1000'])
+            self.admin.assert_icommand('iadmin cu')
+            self.user0.assert_icommand('iput -R repl %s f3' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+
+    def test_total_quota_standalone_resource_put_failure(self):
+
+        test_file = '2kfile'
+        lib.make_file(test_file, 2000)
+
+        # enable quota
+        with temporary_core_file() as core:
+            core.add_rule(rule_texts[self.plugin_name][self.class_name]['others'])
+
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'total', '3000'])
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'standalone_resc', '20000'])
+            self.admin.assert_icommand('iadmin cu')
+
+            # first put should pass
+            self.user0.assert_icommand('iput -R standalone_resc %s f1' % test_file)
+            self.admin.assert_icommand('iadmin cu')
+
+            # second put should fail due to total quota
+            self.user0.assert_icommand('iput -R demoResc %s f2' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+            # test a put when we are already over quota
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'total', '1000'])
+            self.admin.assert_icommand('iadmin cu')
+            self.user0.assert_icommand('iput -R demoResc %s f3' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+
+    def test_total_quota_put_on_different_resources(self):
+
+        test_file = '2kfile'
+        lib.make_file(test_file, 2000)
+
+        # enable quota
+        with temporary_core_file() as core:
+            core.add_rule(rule_texts[self.plugin_name][self.class_name]['others'])
+
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'total', '3000'])
+            self.admin.assert_icommand('iadmin cu')
+
+            # first put should pass
+            self.user0.assert_icommand('iput -R standalone_resc %s f1' % test_file)
+            self.admin.assert_icommand('iadmin cu')
+
+            # second put should fail as we've reached total quota
+            self.user0.assert_icommand('iput -R demoResc %s f2' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+            # test a put when we are already over quota
+            self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'total', '1000'])
+            self.admin.assert_icommand('iadmin cu')
+            self.user0.assert_icommand('iput -R demoResc %s f3' % test_file, 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+
+    def test_setting_quota_on_coordinating_resource_fails(self):
+
+        self.admin.assert_icommand(['iadmin', 'suq', self.user0.username, 'repl', '3000'], 'STDERR_SINGLELINE', 'SYS_INVALID_INPUT_PARAM')
+

--- a/server/api/include/rsGetRescQuota.hpp
+++ b/server/api/include/rsGetRescQuota.hpp
@@ -9,11 +9,11 @@
 int rsGetRescQuota( rsComm_t *rsComm, getRescQuotaInp_t *getRescQuotaInp, rescQuota_t **rescQuota );
 int _rsGetRescQuota( rsComm_t *rsComm, getRescQuotaInp_t *getRescQuotaInp, rescQuota_t **rescQuota );
 int getQuotaByResc( rsComm_t *rsComm, char *userName, char *rescName, genQueryOut_t **genQueryOut );
-int queRescQuota( rescQuota_t **rescQuota, genQueryOut_t *genQueryOut );
+int queueRescQuota( rescQuota_t **rescQuota, char *targetRescName, genQueryOut_t *genQueryOut );
 int fillRescQuotaStruct( rescQuota_t *rescQuota, char *tmpQuotaLimit, char *tmpQuotaOver, char *tmpRescName, char *tmpQuotaRescId, char *tmpQuotaUserId );
 int updatequotaOverrun( const char *_resc_hier, rodsLong_t dataSize, int flags );
 int chkRescQuotaPolicy( rsComm_t *rsComm );
-int setRescQuota(rsComm_t* comm_handle, const char* obj_path, const char* resc_name, rodsLong_t data_size);
+int setRescQuota(rsComm_t* comm_handle, const char* obj_path, const char* resc_hier, rodsLong_t data_size);
 
 
 #endif

--- a/server/api/src/rsDataObjCreate.cpp
+++ b/server/api/src/rsDataObjCreate.cpp
@@ -657,15 +657,5 @@ int getRescForCreate(
         _resc_name = rei.rescName;
     }
 
-    status = setRescQuota(
-                 _comm,
-                 _obj_inp->objPath,
-                 _resc_name.c_str(),
-                 _obj_inp->dataSize );
-    if( status == SYS_RESC_QUOTA_EXCEEDED ) {
-        return SYS_RESC_QUOTA_EXCEEDED;
-    }
-
-
     return 0;
 }

--- a/server/core/src/irods_resource_redirect.cpp
+++ b/server/core/src/irods_resource_redirect.cpp
@@ -438,63 +438,54 @@ namespace irods {
     }
 
     int apply_policy_for_create_operation(
-	rsComm_t*     _comm,
-	dataObjInp_t* _obj_inp,
-	std::string&  _resc_name ) {
+        rsComm_t*     _comm,
+        dataObjInp_t* _obj_inp,
+        std::string&  _resc_name ) {
 
-	/* query rcat for resource info and sort it */
-	ruleExecInfo_t rei;
-	initReiWithDataObjInp( &rei, _comm, _obj_inp );
+        /* query rcat for resource info and sort it */
+        ruleExecInfo_t rei;
+        initReiWithDataObjInp( &rei, _comm, _obj_inp );
 
-	int status = 0;
-	if ( _obj_inp->oprType == REPLICATE_OPR ) {
-	    status = applyRule( "acSetRescSchemeForRepl", NULL, &rei, NO_SAVE_REI );
-	}
-	else {
-	    status = applyRule( "acSetRescSchemeForCreate", NULL, &rei, NO_SAVE_REI );
-	}
-    clearKeyVal(rei.condInputData);
-    free(rei.condInputData);
+        int status = 0;
+        if ( _obj_inp->oprType == REPLICATE_OPR ) {
+            status = applyRule( "acSetRescSchemeForRepl", NULL, &rei, NO_SAVE_REI );
+        }
+        else {
+            status = applyRule( "acSetRescSchemeForCreate", NULL, &rei, NO_SAVE_REI );
+        }
 
-	    if ( status < 0 ) {
+        // get resource name
+        if ( !strlen( rei.rescName ) ) {
+            irods::error set_err = irods::set_default_resource(
+                    _comm,
+                    "", "",
+                    &_obj_inp->condInput,
+                    _resc_name );
+            if ( !set_err.ok() ) {
+                irods::log( PASS( set_err ) );
+                return SYS_INVALID_RESC_INPUT;
+            }
+        }
+        else {
+            _resc_name = rei.rescName;
+        }
+
+        clearKeyVal(rei.condInputData);
+        free(rei.condInputData);
+
+        if ( status < 0 ) {
 		    if ( rei.status < 0 ) {
 			    status = rei.status;
 		    }
 
 		    rodsLog(
-				    LOG_NOTICE,
+				    LOG_ERROR,
 				    "getRescForCreate:acSetRescSchemeForCreate error for %s,status=%d",
 				    _obj_inp->objPath,
 				    status );
 
 		    return status;
 	    }
-
-	    // get resource name
-	    if ( !strlen( rei.rescName ) ) {
-		 irods::error set_err = irods::set_default_resource(
-				    _comm,
-				    "", "",
-				    &_obj_inp->condInput,
-				    _resc_name );
-		    if ( !set_err.ok() ) {
-			    irods::log( PASS( set_err ) );
-			    return SYS_INVALID_RESC_INPUT;
-		    }
-	    }
-	    else {
-		    _resc_name = rei.rescName;
-	    }
-
-	    status = setRescQuota(
-			    _comm,
-			    _obj_inp->objPath,
-			    _resc_name.c_str(),
-			    _obj_inp->dataSize );
-	    if( status == SYS_RESC_QUOTA_EXCEEDED ) {
-		    return SYS_RESC_QUOTA_EXCEEDED;
-	    }
-
 
 	    return 0;
     }
@@ -673,7 +664,6 @@ namespace irods {
             /////////////////////////
             /////////////////////////
 
-
             return ret;
 
         }
@@ -765,6 +755,15 @@ namespace irods {
             }
             /////////////////////////
             /////////////////////////
+            status = setRescQuota(
+                    _comm,
+                    _data_obj_inp->objPath,
+                    _out_hier.c_str(),
+                    _data_obj_inp->dataSize );
+
+            if( status == SYS_RESC_QUOTA_EXCEEDED ) {
+                return ERROR(SYS_RESC_QUOTA_EXCEEDED, "quota exceeded");
+            }
 
             return ret;
 


### PR DESCRIPTION
[#4089] Update code to handle quotas (passed test)

1.  Moved the quota check to resolve_resource_hierarchy as the full
hierarch needs to be known to properly check for quota issues.

2.  Send the resource to the reoutine that does the quota check.

3.  When checking quotas on resource, filter out all quotas on other
resources.

4.  Create new error code when a put succeeds but replication fails due
to quota exceeded.

5.  Do not perform retry logic when replication fails due to quota
issue.

6.  Provide an error to the user if she attempts to set a quota on a
coordinating resource.

Note:  Quotas on coordinating resources have no effect.  Error added for this case.