### PR TITLE
[4089] Updated code to handle quotas

### DIFF
--- a/lib/core/include/rodsErrorTable.h
+++ b/lib/core/include/rodsErrorTable.h
@@ -217,6 +217,7 @@ NEW_ERROR(SYS_SOCK_WRITE_ERR,                          -161000)
 NEW_ERROR(SYS_SOCK_CONNECT_ERR,                        -162000)
 NEW_ERROR(SYS_OPERATION_IN_PROGRESS,                   -163000)
 NEW_ERROR(SYS_REPLICA_DOES_NOT_EXIST,                  -164000)
+NEW_ERROR(SYS_RESC_QUOTA_EXCEEDED_ON_REPLICATION,      -165000)
 /** @} */
 
 /* 300,000 - 499,000 - user input type error */

--- a/plugins/resources/replication/irods_repl_retry.cpp
+++ b/plugins/resources/replication/irods_repl_retry.cpp
@@ -15,7 +15,7 @@ int irods::data_obj_repl_with_retry(
 
     transferStat_t* trans_stat{ nullptr };
     auto status{ rsDataObjRepl( _ctx.comm(), &dataObjInp, &trans_stat ) };
-    if ( 0 == status ) {
+    if ( 0 == status || SYS_RESC_QUOTA_EXCEEDED_ON_REPLICATION == status ) {
         free( trans_stat );
         return status;
     }

--- a/scripts/irods/test/rule_texts_for_tests.py
+++ b/scripts/irods/test/rule_texts_for_tests.py
@@ -27,6 +27,25 @@ acAclPolicy {
     ON($userNameClient == "quickshare") { }
 }
 '''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Quota_Issue4089'] = {}
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Quota_Issue4089'] ['test_quota_default_replication_node_put_failure'] = '''
+acSetRescSchemeForCreate{
+    msiSetDefaultResc('repl', 'forced');
+}
+acRescQuotaPolicy {msiSetRescQuotaPolicy("on"); }
+'''
+
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Quota_Issue4089'] ['test_quota_default_replication_node_repl_failure'] = '''
+acSetRescSchemeForCreate{
+    msiSetDefaultResc('repl', 'forced');
+}
+acRescQuotaPolicy {msiSetRescQuotaPolicy("on"); }
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Quota_Issue4089'] ['others'] = '''
+acRescQuotaPolicy {msiSetRescQuotaPolicy("on"); }
+'''
+
+
 
 #===== Test_ICommands_File_Operations =====
 

--- a/server/api/include/rsGetRescQuota.hpp
+++ b/server/api/include/rsGetRescQuota.hpp
@@ -9,11 +9,11 @@
 int rsGetRescQuota( rsComm_t *rsComm, getRescQuotaInp_t *getRescQuotaInp, rescQuota_t **rescQuota );
 int _rsGetRescQuota( rsComm_t *rsComm, getRescQuotaInp_t *getRescQuotaInp, rescQuota_t **rescQuota );
 int getQuotaByResc( rsComm_t *rsComm, char *userName, char *rescName, genQueryOut_t **genQueryOut );
-int queRescQuota( rescQuota_t **rescQuota, genQueryOut_t *genQueryOut );
+int queueRescQuota( rescQuota_t **rescQuota, char *targetRescName, genQueryOut_t *genQueryOut );
 int fillRescQuotaStruct( rescQuota_t *rescQuota, char *tmpQuotaLimit, char *tmpQuotaOver, char *tmpRescName, char *tmpQuotaRescId, char *tmpQuotaUserId );
 int updatequotaOverrun( const char *_resc_hier, rodsLong_t dataSize, int flags );
 int chkRescQuotaPolicy( rsComm_t *rsComm );
-int setRescQuota(rsComm_t* comm_handle, const char* obj_path, const char* resc_name, rodsLong_t data_size);
+int setRescQuota(rsComm_t* comm_handle, const char* obj_path, const char* resc_hier, rodsLong_t data_size);
 
 
 #endif

--- a/server/api/src/rsDataObjCreate.cpp
+++ b/server/api/src/rsDataObjCreate.cpp
@@ -657,15 +657,5 @@ int getRescForCreate(
         _resc_name = rei.rescName;
     }
 
-    status = setRescQuota(
-                 _comm,
-                 _obj_inp->objPath,
-                 _resc_name.c_str(),
-                 _obj_inp->dataSize );
-    if( status == SYS_RESC_QUOTA_EXCEEDED ) {
-        return SYS_RESC_QUOTA_EXCEEDED;
-    }
-
-
     return 0;
 }

--- a/server/api/src/rsDataObjRepl.cpp
+++ b/server/api/src/rsDataObjRepl.cpp
@@ -39,6 +39,7 @@
 #include "rsFileStageToCache.hpp"
 #include "rsFileSyncToArch.hpp"
 #include "rsUnbunAndRegPhyBunfile.hpp"
+#include "rsGetRescQuota.hpp"
 
 #include "irods_resource_backport.hpp"
 #include "irods_resource_redirect.hpp"
@@ -166,7 +167,7 @@ rsDataObjRepl( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
     if ( !tmp_dest_resc.empty() ) {
         addKeyVal( &dataObjInp->condInput, DEST_RESC_NAME_KW, tmp_dest_resc.c_str() );
     }
-
+    
     // =-=-=-=-=-=-=-
     // performing a local replication
     *transStat = ( transferStat_t* )malloc( sizeof( transferStat_t ) );
@@ -231,6 +232,7 @@ _rsDataObjRepl(
     dataObjInp_t *dataObjInp,
     transferStat_t *transStat,
     dataObjInfo_t *outDataObjInfo ) {
+
     int status;
     dataObjInfo_t *dataObjInfoHead = NULL;
     dataObjInfo_t *oldDataObjInfoHead = NULL;
@@ -293,6 +295,7 @@ _rsDataObjRepl(
 
     char* resc_hier = getValByKey( &dataObjInp->condInput, RESC_HIER_STR_KW );
     char* dest_hier = getValByKey( &dataObjInp->condInput, DEST_RESC_HIER_STR_KW );
+
     const bool update_requested = (getValByKey(&dataObjInp->condInput, UPDATE_REPL_KW) != nullptr);
     bool update_replica = update_requested;
 
@@ -336,6 +339,18 @@ _rsDataObjRepl(
         // to correctly determine if an update needs to take place or not.
         update_replica = irods::is_hier_in_obj_info_list(dest_hier, dataObjInfoHead);
     }
+
+    status = setRescQuota(
+                 rsComm,
+                 dataObjInp->objPath,
+                 dest_hier,
+                 dataObjInp->dataSize );
+
+    if( status == SYS_RESC_QUOTA_EXCEEDED ) {
+        return SYS_RESC_QUOTA_EXCEEDED_ON_REPLICATION;
+    }
+
+   
 
     // If [dest_hier] is not null, then the replica matching [dest_hier] will appear
     // at the head of the list. The list it appears in is determined by whether it is
@@ -667,7 +682,6 @@ _rsDataObjReplS(
     int l1descInx;
     openedDataObjInp_t dataObjCloseInp;
     dataObjInfo_t *myDestDataObjInfo = NULL;
-
     l1descInx = dataObjOpenForRepl( rsComm, dataObjInp, srcDataObjInfo,
                                     _root_resc_name, destDataObjInfo, updateFlag );
     if ( l1descInx < 0 ) {


### PR DESCRIPTION
[#4089] Update code to handle quotas (passed test)

1.  Moved the quota check to resolve_resource_hierarchy as the full
hierarch needs to be known to properly check for quota issues.

2.  Send the resource to the reoutine that does the quota check.

3.  When checking quotas on resource, filter out all quotas on other
resources.

4.  Create new error code when a put succeeds but replication fails due
to quota exceeded.

5.  Do not perform retry logic when replication fails due to quota
issue.

6.  Provide an error to the user if she attempts to set a quota on a
coordinating resource.

Note:  Quotas on coordinating resources have no effect.  Updated output on iadmin suq indicating this.