### PR TITLE
[#4099] Prevent file_modified on non-write ops (4-1-stable)

### DIFF
--- a/iRODS/lib/core/include/rodsKeyWdDef.h
+++ b/iRODS/lib/core/include/rodsKeyWdDef.h
@@ -91,6 +91,7 @@
 /* DATA_SIZE_KW already defined */
 #define NUM_THREADS_KW   	"numThreads" /* a msKeyValStr keyword */
 #define OPR_TYPE_KW   		"oprType" /* a msKeyValStr keyword */
+#define OPEN_TYPE_KW   		"openType"
 #define COLL_FLAGS_KW  		"collFlags" /* a msKeyValStr keyword */
 #define TRANSLATED_PATH_KW	"translatedPath"  /* the path translated */
 #define NO_TRANSLATE_LINKPT_KW	"noTranslateMntpt"  /* don't translate mntpt */

--- a/iRODS/server/api/src/rsDataObjClose.cpp
+++ b/iRODS/server/api/src/rsDataObjClose.cpp
@@ -288,6 +288,11 @@ _rsDataObjClose(
     l1descInx = dataObjCloseInp->l1descInx;
     l3descInx = L1desc[l1descInx].l3descInx;
 
+    memset( &regParam, 0, sizeof( regParam ) );
+    std::stringstream open_type;
+    open_type << L1desc[l1descInx].openType;
+    addKeyVal(&regParam, OPEN_TYPE_KW, open_type.str().c_str());
+
     if ( l3descInx > 2 ) {
         /* it could be -ive for parallel I/O */
         status = l3Close( rsComm, l1descInx );
@@ -435,7 +440,6 @@ _rsDataObjClose(
         }
     }
 
-    memset( &regParam, 0, sizeof( regParam ) );
     if ( L1desc[l1descInx].oprType == PHYMV_DEST ) {
         /* a phymv */
         destDataObjInfo = L1desc[l1descInx].dataObjInfo;
@@ -551,6 +555,10 @@ _rsDataObjClose(
             if ( pdmo_kw ) {
                 addKeyVal( &regReplicaInp.condInput, IN_PDMO_KW, pdmo_kw );
             }
+            // Store openType in key/val in case a hop occurs
+            std::stringstream open_type;
+            open_type << L1desc[l1descInx].openType;
+            addKeyVal(&regReplicaInp.condInput, OPEN_TYPE_KW, open_type.str().c_str());
 
             status = rsRegReplica( rsComm, &regReplicaInp );
             clearKeyVal( &regReplicaInp.condInput );

--- a/iRODS/server/api/src/rsDataObjCreate.cpp
+++ b/iRODS/server/api/src/rsDataObjCreate.cpp
@@ -185,8 +185,10 @@ rsDataObjCreate( rsComm_t *rsComm, dataObjInp_t *dataObjInp ) {
         /* use L1desc[l1descInx].replStatus & OPEN_EXISTING_COPY instead */
         /* newly created. take out FORCE_FLAG since it could be used by put */
         /* rmKeyVal (&dataObjInp->condInput, FORCE_FLAG_KW); */
+        std::stringstream open_type;
+        open_type << CREATE_TYPE;
+        addKeyVal(&dataObjInp->condInput, OPEN_TYPE_KW, open_type.str().c_str());
         l1descInx = _rsDataObjCreate( rsComm, dataObjInp );
-
     }
     else if ( rodsObjStatOut->specColl != NULL &&
               rodsObjStatOut->objType == UNKNOWN_OBJ_T ) {
@@ -236,6 +238,9 @@ rsDataObjCreate( rsComm_t *rsComm, dataObjInp_t *dataObjInp ) {
             parser.set_string( hier );
             parser.first_resc( top_resc );
             addKeyVal( &dataObjInp->condInput, DEST_RESC_NAME_KW, top_resc.c_str() );
+            std::stringstream open_type;
+            open_type << OPEN_FOR_WRITE_TYPE;
+            addKeyVal(&dataObjInp->condInput, OPEN_TYPE_KW, open_type.str().c_str());
             l1descInx = _rsDataObjOpen( rsComm, dataObjInp );
 
         }

--- a/iRODS/server/api/src/rsDataObjRepl.cpp
+++ b/iRODS/server/api/src/rsDataObjRepl.cpp
@@ -731,6 +731,8 @@ dataObjOpenForRepl(
         // set a open operation
         op_name = irods::WRITE_OPERATION;
 
+        L1desc[destL1descInx].openType = OPEN_FOR_WRITE_TYPE;
+
         /* update an existing copy */
         if ( inpDestDataObjInfo == NULL || inpDestDataObjInfo->dataId <= 0 ) {
             rodsLog( LOG_ERROR, "dataObjOpenForRepl: dataId of %s copy to be updated not defined",
@@ -759,6 +761,8 @@ dataObjOpenForRepl(
         // =-=-=-=-=-=-=-
         // set a creation operation
         op_name = irods::CREATE_OPERATION;
+
+        L1desc[destL1descInx].openType = CREATE_TYPE;
 
         initDataObjInfoForRepl( myDestDataObjInfo, srcDataObjInfo, _resc_name );
         replStatus = srcDataObjInfo->replStatus;

--- a/iRODS/server/api/src/rsStructFileExtAndReg.cpp
+++ b/iRODS/server/api/src/rsStructFileExtAndReg.cpp
@@ -484,6 +484,9 @@ regSubfile( rsComm_t *rsComm, const char *_resc_name, const char* rescHier,
                 rsComm,
                 &dataObjInfo ) );
 
+        std::stringstream open_type;
+        open_type << CREATE_TYPE;
+        addKeyVal((keyValPair_t*)&file_obj->cond_input(), OPEN_TYPE_KW, open_type.str().c_str());
         irods::error ret = fileModified( rsComm, file_obj );
         if ( !ret.ok() ) {
             std::stringstream msg;

--- a/iRODS/server/core/src/objDesc.cpp
+++ b/iRODS/server/core/src/objDesc.cpp
@@ -170,6 +170,11 @@ fillL1desc( int l1descInx, dataObjInp_t *dataObjInp,
         rstrcpy( L1desc[l1descInx].in_pdmo, "", MAX_NAME_LEN );
     }
 
+    char* open_type = getValByKey(condInput, OPEN_TYPE_KW);
+    if (open_type) {
+        L1desc[l1descInx].openType = std::atoi(open_type);
+    }
+
     if ( dataObjInp != NULL ) {
         /* always repl the .dataObjInp */
         L1desc[l1descInx].dataObjInp = ( dataObjInp_t* )malloc( sizeof( dataObjInp_t ) );

--- a/plugins/resources/replication/irods_repl_types.hpp
+++ b/plugins/resources/replication/irods_repl_types.hpp
@@ -26,7 +26,5 @@ typedef std::multimap<float, irods::hierarchy_parser, child_comp> redirect_map_t
 // define some constants
 const std::string CHILD_LIST_PROP = "child_list";
 const std::string OBJECT_LIST_PROP = "object_list";
-const std::string HIERARCHY_PROP = "hierarchy";
-const std::string OPERATION_TYPE_PROP = "operation_type";
 
 #endif // _IRODS_REPL_TYPES_HPP_

--- a/tests/pydevtest/test_iadmin.py
+++ b/tests/pydevtest/test_iadmin.py
@@ -1284,7 +1284,7 @@ acSetNumThreads() {
 
             debug_message = 'DEBUG: loading impostor resource for [{0}] of type [{1}] with context [] and load_plugin message'.format(name_of_bogus_resource, name_of_missing_plugin)
             debug_message_count = lib.count_occurrences_of_string_in_log('server', debug_message, start_index=initial_size_of_server_log)
-            assert 1 == debug_message_count, debug_message_count
+            self.assertTrue(1 == debug_message_count, msg='Found {} messages in log but expected 1'.format(debug_message_count))
 
         self.admin.assert_icommand(['iadmin', 'rmresc', name_of_bogus_resource])
         lib.restart_irods_server()

--- a/tests/pydevtest/test_resource_types.py
+++ b/tests/pydevtest/test_resource_types.py
@@ -1,5 +1,6 @@
 import commands
 import getpass
+import hashlib
 import os
 import psutil
 import re
@@ -25,6 +26,11 @@ def statvfs_path_or_parent(path):
         path = os.path.dirname(path)
     return os.statvfs(path)
 
+def assert_number_of_replicas(admin_session, logical_path, data_obj_name, replica_count):
+    for i in range(0, replica_count):
+        admin_session.assert_icommand(['ils', '-l', logical_path], 'STDOUT_SINGLELINE', [' {} '.format(str(i)), ' & ', data_obj_name])
+    admin_session.assert_icommand_fail(['ils', '-l', logical_path], 'STDOUT_SINGLELINE', [' {} '.format(str(replica_count + 1)), data_obj_name])
+
 class Test_Resource_RandomWithinReplication(ResourceSuite, ChunkyDevTest, unittest.TestCase):
 
     def setUp(self):
@@ -42,6 +48,7 @@ class Test_Resource_RandomWithinReplication(ResourceSuite, ChunkyDevTest, unitte
             admin_session.assert_icommand("iadmin addchildtoresc demoResc unixA")
             admin_session.assert_icommand("iadmin addchildtoresc rrResc unixB1")
             admin_session.assert_icommand("iadmin addchildtoresc rrResc unixB2")
+            self.child_replication_count = 2
         super(Test_Resource_RandomWithinReplication, self).setUp()
 
     def tearDown(self):
@@ -60,6 +67,65 @@ class Test_Resource_RandomWithinReplication(ResourceSuite, ChunkyDevTest, unitte
         shutil.rmtree(lib.get_irods_top_level_dir() + "/unixB2Vault", ignore_errors=True)
         shutil.rmtree(lib.get_irods_top_level_dir() + "/unixB1Vault", ignore_errors=True)
         shutil.rmtree(lib.get_irods_top_level_dir() + "/unixAVault", ignore_errors=True)
+
+    def test_ichksum_no_file_modified_under_replication__4099(self):
+        filename = 'test_ichksum_no_file_modified_under_replication__4099'
+        filepath = lib.create_local_testfile(filename)
+        with open(filepath, 'r') as f:
+            original_checksum = hashlib.sha256(f.read()).digest().encode("base64").strip()
+
+        # put file into iRODS and clean up local
+        self.admin.assert_icommand(['iput', '-K', filepath, filename])
+        os.unlink(filename)
+        self.admin.assert_icommand(['ils', '-L', filename], 'STDOUT_SINGLELINE', "sha2:" + original_checksum)
+
+        # corrupt data in replica 0
+        _,out,_ = self.admin.assert_icommand(['iquest', '''"select DATA_RESC_HIER where DATA_NAME = '{0}' and DATA_REPL_NUM = '0'"'''.format(filename)], 'STDOUT_SINGLELINE', 'DATA_RESC_HIER')
+        replica_0_resc = out.splitlines()[0].split()[-1].split(';')[-1]
+        phypath_for_data_obj = os.path.join(lib.get_vault_session_path(self.admin, replica_0_resc), filename)
+        with open(phypath_for_data_obj, 'w') as f:
+            f.write("corrupting the data")
+        with open(phypath_for_data_obj, 'r') as f:
+            new_checksum = hashlib.sha256(f.read()).digest().encode("base64").strip()
+
+        # forcibly re-calculate corrupted checksum and ensure that original checksum was not overwritten
+        self.admin.assert_icommand(['ichksum', '-f', '-n0', filename], 'STDOUT_SINGLELINE', 'Total checksum performed = 1, Failed checksum = 0')
+        self.admin.assert_icommand(['ils', '-L', filename], 'STDOUT_SINGLELINE', "sha2:" + new_checksum)
+        self.admin.assert_icommand(['ils', '-L', filename], 'STDOUT_SINGLELINE', "sha2:" + original_checksum)
+
+        # forcibly re-calculate all checksums and ensure that original checksum was not changed
+        self.admin.assert_icommand(['ichksum', '-f', '-a', filename], 'STDOUT_SINGLELINE', 'Total checksum performed = 1, Failed checksum = 0')
+        self.admin.assert_icommand(['ils', '-L', filename], 'STDOUT_SINGLELINE', "sha2:" + new_checksum)
+        self.admin.assert_icommand(['ils', '-L', filename], 'STDOUT_SINGLELINE', "sha2:" + original_checksum)
+
+        #cleanup
+        self.admin.assert_icommand(['irm', '-f', filename])
+
+    def test_ibun_creation_to_replication(self):
+        collection_name = 'bundle_me'
+        tar_name = 'bundle.tar'
+        filename = 'test_ibun_creation_to_replication'
+        copy_filename = filename + '_copy'
+        test_data_obj_path = os.path.join(collection_name, filename)
+        test_data_obj_copy_path = os.path.join(collection_name, copy_filename)
+
+        # put file into iRODS and make a copy on a non-replicating resource
+        filepath = lib.create_local_testfile(filename)
+        self.admin.assert_icommand(['imkdir', collection_name])
+        self.admin.assert_icommand(['iput', filepath, test_data_obj_path])
+        os.unlink(filepath)
+        self.admin.assert_icommand(['icp', '-R', 'pydevtest_TestResc', test_data_obj_path, test_data_obj_copy_path])
+
+        # bundle the collection and ensure that it and its contents replicated properly
+        self.admin.assert_icommand(['ibun', '-c', tar_name, collection_name])
+        assert_number_of_replicas(self.admin, tar_name, tar_name, self.child_replication_count)
+        assert_number_of_replicas(self.admin, test_data_obj_path, filename, self.child_replication_count)
+        self.admin.assert_icommand(['ils', '-l', test_data_obj_copy_path], 'STDOUT_SINGLELINE', [' 0 ', 'pydevtest_TestResc', ' & ', copy_filename])
+        assert_number_of_replicas(self.admin, test_data_obj_copy_path, copy_filename, self.child_replication_count + 1)
+
+        # cleanup
+        self.admin.assert_icommand(['irm', '-r', '-f', collection_name])
+        self.admin.assert_icommand(['irm', '-f', tar_name])
 
     def test_redirect_map_regeneration__3904(self):
         # Setup
@@ -1694,6 +1760,31 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
             admin_session.assert_icommand("iadmin modresc origResc name demoResc", 'STDOUT_SINGLELINE', 'rename', stdin_string='yes\n')
         shutil.rmtree(lib.get_irods_top_level_dir() + "/archiveRescVault", ignore_errors=True)
         shutil.rmtree("rm -rf " + lib.get_irods_top_level_dir() + "/cacheRescVault", ignore_errors=True)
+
+    def test_ichksum_no_file_modified_under_compound__4085(self):
+        filename = 'test_ichksum_no_file_modified_in_compound__4085'
+        filepath = lib.create_local_testfile(filename)
+        with open(filepath, 'r') as f:
+            original_checksum = hashlib.sha256(f.read()).digest().encode("base64").strip()
+
+        self.admin.assert_icommand(['iput', '-K', filepath, filename])
+        os.unlink(filename)
+        self.admin.assert_icommand(['ils', '-L', filename], 'STDOUT_SINGLELINE', 'archiveResc')
+
+        phypath_for_data_obj = os.path.join(lib.get_vault_session_path(self.admin, 'archiveResc'), filename)
+        original_archive_mtime = str(os.stat(phypath_for_data_obj).st_mtime)
+
+        # trim cache replica
+        self.admin.assert_icommand(['itrim', '-n0', '-N1', filename], 'STDOUT_SINGLELINE', "files trimmed")
+
+        # run ichksum on data object, which will replicate to cache
+        self.admin.assert_icommand(['ichksum', '-f', filename], 'STDOUT_SINGLELINE', 'Total checksum performed = 1, Failed checksum = 0')
+        self.admin.assert_icommand(['ils', '-L', filename], 'STDOUT_SINGLELINE', "sha2:" + original_checksum)
+
+        self.assertTrue(str(os.stat(phypath_for_data_obj).st_mtime) == original_archive_mtime, msg='Archive mtime changed after ichksum - not good!')
+
+        #cleanup
+        self.admin.assert_icommand(['irm', '-f', filename])
 
     def test_irsync__2976(self):
         filename = "test_irsync__2976.txt"
@@ -3524,6 +3615,7 @@ class Test_Resource_Replication(ChunkyDevTest, ResourceSuite, unittest.TestCase)
             admin_session.assert_icommand("iadmin addchildtoresc demoResc unix1Resc")
             admin_session.assert_icommand("iadmin addchildtoresc demoResc unix2Resc")
             admin_session.assert_icommand("iadmin addchildtoresc demoResc unix3Resc")
+            self.child_replication_count = 3
         super(Test_Resource_Replication, self).setUp()
 
     def tearDown(self):
@@ -3540,6 +3632,65 @@ class Test_Resource_Replication(ChunkyDevTest, ResourceSuite, unittest.TestCase)
         shutil.rmtree(lib.get_irods_top_level_dir() + "/unix1RescVault", ignore_errors=True)
         shutil.rmtree(lib.get_irods_top_level_dir() + "/unix2RescVault", ignore_errors=True)
         shutil.rmtree(lib.get_irods_top_level_dir() + "/unix3RescVault", ignore_errors=True)
+
+    def test_ichksum_no_file_modified_under_replication__4099(self):
+        filename = 'test_ichksum_no_file_modified_under_replication__4099'
+        filepath = lib.create_local_testfile(filename)
+        with open(filepath, 'r') as f:
+            original_checksum = hashlib.sha256(f.read()).digest().encode("base64").strip()
+
+        # put file into iRODS and clean up local
+        self.admin.assert_icommand(['iput', '-K', filepath, filename])
+        os.unlink(filename)
+        self.admin.assert_icommand(['ils', '-L', filename], 'STDOUT_SINGLELINE', "sha2:" + original_checksum)
+
+        # corrupt data in replica 0
+        _,out,_ = self.admin.assert_icommand(['iquest', '''"select DATA_RESC_HIER where DATA_NAME = '{0}' and DATA_REPL_NUM = '0'"'''.format(filename)], 'STDOUT_SINGLELINE', 'DATA_RESC_HIER')
+        replica_0_resc = out.splitlines()[0].split()[-1].split(';')[-1]
+        phypath_for_data_obj = os.path.join(lib.get_vault_session_path(self.admin, replica_0_resc), filename)
+        with open(phypath_for_data_obj, 'w') as f:
+            f.write("corrupting the data")
+        with open(phypath_for_data_obj, 'r') as f:
+            new_checksum = hashlib.sha256(f.read()).digest().encode("base64").strip()
+
+        # forcibly re-calculate corrupted checksum and ensure that original checksum was not overwritten
+        self.admin.assert_icommand(['ichksum', '-f', '-n0', filename], 'STDOUT_SINGLELINE', 'Total checksum performed = 1, Failed checksum = 0')
+        self.admin.assert_icommand(['ils', '-L', filename], 'STDOUT_SINGLELINE', "sha2:" + new_checksum)
+        self.admin.assert_icommand(['ils', '-L', filename], 'STDOUT_SINGLELINE', "sha2:" + original_checksum)
+
+        # forcibly re-calculate all checksums and ensure that original checksum was not changed
+        self.admin.assert_icommand(['ichksum', '-f', '-a', filename], 'STDOUT_SINGLELINE', 'Total checksum performed = 1, Failed checksum = 0')
+        self.admin.assert_icommand(['ils', '-L', filename], 'STDOUT_SINGLELINE', "sha2:" + new_checksum)
+        self.admin.assert_icommand(['ils', '-L', filename], 'STDOUT_SINGLELINE', "sha2:" + original_checksum)
+
+        #cleanup
+        self.admin.assert_icommand(['irm', '-f', filename])
+
+    def test_ibun_creation_to_replication(self):
+        collection_name = 'bundle_me'
+        tar_name = 'bundle.tar'
+        filename = 'test_ibun_creation_to_replication'
+        copy_filename = filename + '_copy'
+        test_data_obj_path = os.path.join(collection_name, filename)
+        test_data_obj_copy_path = os.path.join(collection_name, copy_filename)
+
+        # put file into iRODS and make a copy on a non-replicating resource
+        filepath = lib.create_local_testfile(filename)
+        self.admin.assert_icommand(['imkdir', collection_name])
+        self.admin.assert_icommand(['iput', filepath, test_data_obj_path])
+        os.unlink(filepath)
+        self.admin.assert_icommand(['icp', '-R', 'pydevtest_TestResc', test_data_obj_path, test_data_obj_copy_path])
+
+        # bundle the collection and ensure that it and its contents replicated properly
+        self.admin.assert_icommand(['ibun', '-c', tar_name, collection_name])
+        assert_number_of_replicas(self.admin, tar_name, tar_name, self.child_replication_count)
+        assert_number_of_replicas(self.admin, test_data_obj_path, filename, self.child_replication_count)
+        self.admin.assert_icommand(['ils', '-l', test_data_obj_copy_path], 'STDOUT_SINGLELINE', [' 0 ', 'pydevtest_TestResc', ' & ', copy_filename])
+        assert_number_of_replicas(self.admin, test_data_obj_copy_path, copy_filename, self.child_replication_count + 1)
+
+        # cleanup
+        self.admin.assert_icommand(['irm', '-r', '-f', collection_name])
+        self.admin.assert_icommand(['irm', '-f', tar_name])
 
     def test_open_write_close_for_repl__3909(self):
         # Create local test file of a certain expected size
@@ -3970,6 +4121,18 @@ OUTPUT ruleExecOut
         self.admin.assert_icommand(['itrim', '-Snewchild', '-r', '/tempZone'], 'STDOUT_SINGLELINE', 'Total size trimmed')
         self.admin.assert_icommand(['iadmin','rmresc','newchild'])
 
+    def update_specific_replica_for_data_objs_in_repl_hier(self, name_pair_list, repl_num=0):
+        # determine which resource has replica 0
+        _,out,_ = self.admin.assert_icommand(['iquest', "select DATA_RESC_HIER where DATA_NAME = '{0}' and DATA_REPL_NUM = '{1}'".format(name_pair_list[0][0], repl_num)], 'STDOUT_SINGLELINE', 'DATA_RESC_HIER')
+        replica_0_resc = out.splitlines()[0].split()[-1].split(';')[-1]
+        # remove from replication hierarchy
+        self.admin.assert_icommand(['iadmin', 'rmchildfromresc', 'demoResc', replica_0_resc])
+        # update all the replica 0's
+        for (data_obj_name, filename) in name_pair_list:
+            self.admin.assert_icommand(['iput', '-R', replica_0_resc, '-f', '-n', str(repl_num), filename, data_obj_name])
+        # restore to replication hierarchy
+        self.admin.assert_icommand(['iadmin', 'addchildtoresc', 'demoResc', replica_0_resc])
+
     def test_rebalance_different_sized_replicas__3486(self):
         filename = 'test_rebalance_different_sized_replicas__3486'
         large_file_size = 40000000
@@ -3977,7 +4140,7 @@ OUTPUT ruleExecOut
         self.admin.assert_icommand(['iput', filename])
         small_file_size = 20000
         lib.make_file(filename, small_file_size)
-        self.admin.assert_icommand(['iput', '-f', '-n', '0', filename])
+        self.update_specific_replica_for_data_objs_in_repl_hier([(filename, filename)])
         self.admin.assert_icommand(['ils', '-l'], 'STDOUT_SINGLELINE', [filename, str(large_file_size)])
         self.admin.assert_icommand(['ils', '-l'], 'STDOUT_SINGLELINE', [filename, str(small_file_size)])
         self.admin.assert_icommand(['iadmin', 'modresc', 'demoResc', 'rebalance'])
@@ -3989,7 +4152,7 @@ OUTPUT ruleExecOut
         file_size = 400
         lib.make_file(filename, file_size)
         self.admin.assert_icommand(['iput', filename])
-        self.admin.assert_icommand(['iput', '-f', '-n', '0', filename])
+        self.update_specific_replica_for_data_objs_in_repl_hier([(filename, filename)])
         initial_log_size = lib.get_log_size('server')
         self.admin.assert_icommand(['iadmin', 'modresc', 'demoResc', 'rebalance'])
         data_id = lib.get_data_id(self.admin, self.admin.session_collection, filename)


### PR DESCRIPTION
This change restricts when fileModified is called in rsModDataObjMeta. This should prevent replication (in the case of replication or compound hierarchies) on any non-write/create operation.

The replication resource has been modified such that the child replication list is generated at the time of fileModified instead of in resolve resource hierarchy. This ensures that the replication list is made available to the machine doing the replication as the property map may not be populated from machine to machine.

---
[CI tests passed](http://172.25.14.63:8080/job/test-ub14-oracle/1651/testReport/). Topo tests pending.