### PR TITLE
[3883] Updated code for zero length files

### DIFF
--- a/server/api/src/rsDataObjClose.cpp
+++ b/server/api/src/rsDataObjClose.cpp
@@ -362,7 +362,7 @@ _rsDataObjClose(
 
     /* note that bytesWritten only indicates whether the file has been written
      * to. Not necessarily the size of the file */
-    if ( L1desc[l1descInx].bytesWritten <= 0 &&
+    if ( L1desc[l1descInx].bytesWritten < 0 &&
             L1desc[l1descInx].oprType != REPLICATE_DEST &&
             L1desc[l1descInx].oprType != PHYMV_DEST &&
             L1desc[l1descInx].oprType != COPY_DEST ) {

--- a/server/api/src/rsDataObjPut.cpp
+++ b/server/api/src/rsDataObjPut.cpp
@@ -369,29 +369,6 @@ _l3DataPutSingleBuf( rsComm_t *rsComm, int l1descInx, dataObjInp_t *dataObjInp,
             L1desc[l1descInx].bytesWritten = bytesWritten;
         }
 
-        // special case of zero length files, trigger the fileModified
-        // operation for execution of coordinating resource logic
-        if ( 0 == dataObjInp->dataSize ) {
-            irods::file_object_ptr file_obj(
-                new irods::file_object(
-                    rsComm,
-                    myDataObjInfo ) );
-
-            char* pdmo_kw = getValByKey( &myDataObjInfo->condInput, IN_PDMO_KW );
-            if ( pdmo_kw != NULL ) {
-                file_obj->in_pdmo( pdmo_kw );
-            }
-            irods::error ret = fileModified( rsComm, file_obj );
-            if ( !ret.ok() ) {
-                std::stringstream msg;
-                msg << "fileModified failed for [";
-                msg << myDataObjInfo->objPath;
-                msg << "]";
-                ret = PASSMSG( msg.str(), ret );
-                irods::log( ret );
-                status = ret.code();
-            }
-        }
     }
 
     L1desc[l1descInx].dataSize = dataObjInp->dataSize;

--- a/server/core/src/objDesc.cpp
+++ b/server/core/src/objDesc.cpp
@@ -156,6 +156,10 @@ fillL1desc( int l1descInx, dataObjInp_t *dataObjInp,
     keyValPair_t *condInput;
     char *tmpPtr;
 
+    // Initialize the bytesWritten to -1 rather than 0.  If this is negative then we
+    // know no bytes have been written.  This is so that zero length files can be handled
+    // similarly to non-zero length files.
+    L1desc[l1descInx].bytesWritten = -1;
 
     char* resc_hier = getValByKey( &dataObjInp->condInput, RESC_HIER_STR_KW );
     if ( dataObjInfo->rescHier[0] == '\0' && resc_hier ) {


### PR DESCRIPTION
[#3883] Updated the code to treat zero length files the same as non-zero length
files.  The iput with --purgec and -k option now works the same for
both.