### PR TITLE
[#4099] Prevent file_modified on non-write ops (4-2-stable)

### DIFF
--- a/lib/core/include/rodsKeyWdDef.h
+++ b/lib/core/include/rodsKeyWdDef.h
@@ -91,6 +91,7 @@
 /* DATA_SIZE_KW already defined */
 #define NUM_THREADS_KW   	"numThreads" /* a msKeyValStr keyword */
 #define OPR_TYPE_KW   		"oprType" /* a msKeyValStr keyword */
+#define OPEN_TYPE_KW        "openType"
 #define COLL_FLAGS_KW  		"collFlags" /* a msKeyValStr keyword */
 #define TRANSLATED_PATH_KW	"translatedPath"  /* the path translated */
 #define NO_TRANSLATE_LINKPT_KW	"noTranslateMntpt"  /* don't translate mntpt */

--- a/plugins/resources/replication/irods_repl_types.hpp
+++ b/plugins/resources/replication/irods_repl_types.hpp
@@ -26,7 +26,5 @@ typedef std::multimap<float, irods::hierarchy_parser, child_comp> redirect_map_t
 // define some constants
 const std::string CHILD_LIST_PROP{"child_list"};
 const std::string OBJECT_LIST_PROP{"object_list"};
-const std::string HIERARCHY_PROP{"hierarchy"};
-const std::string OPERATION_TYPE_PROP{"operation_type"};
 
 #endif // _IRODS_REPL_TYPES_HPP_

--- a/scripts/irods/test/test_iadmin.py
+++ b/scripts/irods/test/test_iadmin.py
@@ -1215,7 +1215,7 @@ class Test_Iadmin(resource_suite.ResourceBase, unittest.TestCase):
 
             debug_message = 'DEBUG: loading impostor resource for [{0}] of type [{1}] with context [] and load_plugin message'.format(name_of_bogus_resource, name_of_missing_plugin)
             debug_message_count = lib.count_occurrences_of_string_in_log(irods_config.server_log_path, debug_message, start_index=initial_size_of_server_log)
-            assert 1 == debug_message_count, debug_message_count
+            self.assertTrue(1 == debug_message_count, msg='Found {} messages in log but expected 1'.format(debug_message_count))
 
         self.admin.assert_icommand(['iadmin', 'rmresc', name_of_bogus_resource])
         IrodsController().restart()

--- a/server/api/src/rsDataObjClose.cpp
+++ b/server/api/src/rsDataObjClose.cpp
@@ -302,6 +302,9 @@ _rsDataObjClose(
     l1descInx = dataObjCloseInp->l1descInx;
     l3descInx = L1desc[l1descInx].l3descInx;
 
+    // Store openType in key/val in case a hop occurs
+    addKeyVal(&regParam, OPEN_TYPE_KW, std::to_string(L1desc[l1descInx].openType).c_str());
+
     if ( l3descInx > 2 ) {
         /* it could be -ive for parallel I/O */
         status = l3Close( rsComm, l1descInx );
@@ -580,6 +583,8 @@ _rsDataObjClose(
             if ( pdmo_kw ) {
                 addKeyVal( &regReplicaInp.condInput, IN_PDMO_KW, pdmo_kw );
             }
+            // Store openType in key/val in case a hop occurs
+            addKeyVal(&regReplicaInp.condInput, OPEN_TYPE_KW, std::to_string(L1desc[l1descInx].openType).c_str());
 
             status = rsRegReplica( rsComm, &regReplicaInp );
             clearKeyVal( &regReplicaInp.condInput );

--- a/server/api/src/rsDataObjCreate.cpp
+++ b/server/api/src/rsDataObjCreate.cpp
@@ -182,7 +182,6 @@ rsDataObjCreate( rsComm_t *rsComm, dataObjInp_t *dataObjInp ) {
         return SYS_COLL_LINK_PATH_ERR;
     }
 
-
     if ( rodsObjStatOut  == NULL                     ||
             ( rodsObjStatOut->objType  == UNKNOWN_OBJ_T &&
               rodsObjStatOut->specColl == NULL ) ) {
@@ -190,6 +189,7 @@ rsDataObjCreate( rsComm_t *rsComm, dataObjInp_t *dataObjInp ) {
         /* use L1desc[l1descInx].replStatus & OPEN_EXISTING_COPY instead */
         /* newly created. take out FORCE_FLAG since it could be used by put */
         /* rmKeyVal (&dataObjInp->condInput, FORCE_FLAG_KW); */
+        addKeyVal(&dataObjInp->condInput, OPEN_TYPE_KW, std::to_string(CREATE_TYPE).c_str());
         l1descInx = _rsDataObjCreate( rsComm, dataObjInp );
 
     }
@@ -241,6 +241,7 @@ rsDataObjCreate( rsComm_t *rsComm, dataObjInp_t *dataObjInp ) {
             parser.set_string( hier );
             parser.first_resc( top_resc );
             addKeyVal( &dataObjInp->condInput, DEST_RESC_NAME_KW, top_resc.c_str() );
+            addKeyVal(&dataObjInp->condInput, OPEN_TYPE_KW, std::to_string(OPEN_FOR_WRITE_TYPE).c_str());
             l1descInx = rsDataObjOpen( rsComm, dataObjInp );
 
         }
@@ -430,7 +431,6 @@ _rsDataObjCreateWithResc(
         status = 0;
     }
     else {
-
         status = dataObjCreateAndReg( rsComm, l1descInx );
     }
 

--- a/server/api/src/rsDataObjRepl.cpp
+++ b/server/api/src/rsDataObjRepl.cpp
@@ -794,6 +794,8 @@ dataObjOpenForRepl(
         // set a open operation
         op_name = irods::WRITE_OPERATION;
 
+        L1desc[destL1descInx].openType = OPEN_FOR_WRITE_TYPE;
+
         /* update an existing copy */
         if ( inpDestDataObjInfo == NULL || inpDestDataObjInfo->dataId <= 0 ) {
             rodsLog( LOG_ERROR, "dataObjOpenForRepl: dataId of %s copy to be updated not defined",
@@ -822,6 +824,8 @@ dataObjOpenForRepl(
         // =-=-=-=-=-=-=-
         // set a creation operation
         op_name = irods::CREATE_OPERATION;
+
+        L1desc[destL1descInx].openType = CREATE_TYPE;
 
         initDataObjInfoForRepl( myDestDataObjInfo, srcDataObjInfo, _root_resc_name );
         replStatus = srcDataObjInfo->replStatus;

--- a/server/api/src/rsModDataObjMeta.cpp
+++ b/server/api/src/rsModDataObjMeta.cpp
@@ -14,6 +14,8 @@
 #include "irods_stacktrace.hpp"
 #include "irods_configuration_keywords.hpp"
 
+#include "boost/format.hpp"
+
 int _call_file_modified_for_modification(
     rsComm_t*         rsComm,
     modDataObjMeta_t* modDataObjMetaInp );
@@ -54,11 +56,19 @@ rsModDataObjMeta( rsComm_t *rsComm, modDataObjMeta_t *modDataObjMetaInp ) {
         }
     }
     else {
+        // Add IN_REPL_KW to prevent replication on the redirected server (the provider)
+        addKeyVal( modDataObjMetaInp->regParam, IN_REPL_KW, "" );
         status = rcModDataObjMeta( rodsServerHost->conn, modDataObjMetaInp );
+        // Remove the keyword as we will want to replicate on this server (the consumer)
+        rmKeyVal(modDataObjMetaInp->regParam, IN_REPL_KW);
     }
 
     if ( status >= 0 ) {
-        status = _call_file_modified_for_modification( rsComm, modDataObjMetaInp );
+        const auto open_type = getValByKey(modDataObjMetaInp->regParam, OPEN_TYPE_KW);
+        if (!getValByKey(modDataObjMetaInp->regParam, IN_REPL_KW) && open_type &&
+            (OPEN_FOR_WRITE_TYPE == std::atoi(open_type) || CREATE_TYPE == std::atoi(open_type))) {
+            status = _call_file_modified_for_modification( rsComm, modDataObjMetaInp );
+        }
     }
 
     return status;
@@ -242,7 +252,11 @@ int _call_file_modified_for_modification(
             char* pdmo_kw = getValByKey( regParam, IN_PDMO_KW );
             if ( pdmo_kw != NULL ) {
                 file_obj->in_pdmo( pdmo_kw );
+            }
 
+            const auto open_type{getValByKey(regParam, OPEN_TYPE_KW)};
+            if (open_type) {
+                addKeyVal((keyValPair_t*)&file_obj->cond_input(), OPEN_TYPE_KW, open_type);
             }
 
             irods::error ret = fileModified( rsComm, file_obj );
@@ -262,34 +276,45 @@ int _call_file_modified_for_modification(
         freeAllDataObjInfo( dataObjInfoHead );
     }
     else {
-        irods::file_object_ptr file_obj(
-            new irods::file_object(
-                rsComm,
-                dataObjInfo ) );
+        // Construct file_obj twice because ctor gives some info that factory does not
+        irods::file_object_ptr file_obj(new irods::file_object(rsComm, dataObjInfo));
 
-        char* admin_kw = getValByKey( regParam, ADMIN_KW );
-        if ( admin_kw != NULL ) {
-            addKeyVal( (keyValPair_t*)&file_obj->cond_input(), ADMIN_KW, "" );
+        // Need to pass along admin keyword here to ensure replicas can be managed
+        dataObjInp_t dataObjInp{};
+        rstrcpy(dataObjInp.objPath, dataObjInfo->objPath, MAX_NAME_LEN);
+        if (getValByKey(regParam, ADMIN_KW)) {
+            addKeyVal(&dataObjInp.condInput, ADMIN_KW, "");
         }
 
-        char* pdmo_kw = getValByKey( regParam, IN_PDMO_KW );
-        if ( pdmo_kw != NULL ) {
-            file_obj->in_pdmo( pdmo_kw );
+        // Use temporary as file_object_factory overwrites dataObjInfo pointer
+        dataObjInfo_t* tmpDataObjInfo{};
+        auto ret{file_object_factory(rsComm, &dataObjInp, file_obj, &tmpDataObjInfo)};
+        if (!ret.ok()) {
+            irods::log(ret);
+            return ret.code();
         }
-        irods::error ret = fileModified( rsComm, file_obj );
-        if ( !ret.ok() ) {
-            std::stringstream msg;
-            msg << __FUNCTION__;
-            msg << " - Failed to signal the resource that the data object \"";
-            msg << dataObjInfo->objPath;
-            msg << "\" was modified.";
-            ret = PASSMSG( msg.str(), ret );
-            irods::log( ret );
+        // Factory overwrites rescHier with the resource which holds replica 0 - put it back
+        file_obj->resc_hier(dataObjInfo->rescHier);
+
+        if (getValByKey(regParam, ADMIN_KW)) {
+            addKeyVal((keyValPair_t*)&file_obj->cond_input(), ADMIN_KW, "");
+        }
+        const auto pdmo_kw{getValByKey(regParam, IN_PDMO_KW)};
+        if (pdmo_kw) {
+            file_obj->in_pdmo(pdmo_kw);
+        }
+        const auto open_type{getValByKey(regParam, OPEN_TYPE_KW)};
+        if (open_type) {
+            addKeyVal((keyValPair_t*)&file_obj->cond_input(), OPEN_TYPE_KW, open_type);
+        }
+        ret = fileModified(rsComm, file_obj);
+        if (!ret.ok()) {
+            irods::log(PASSMSG((boost::format(
+                       "[%s] - Failed to signal the resource that the data object \"%s\"") %
+                       __FUNCTION__ % dataObjInfo->objPath).str(), ret));
             status = ret.code();
         }
-
     }
 
     return status;
-
 }

--- a/server/api/src/rsRegReplica.cpp
+++ b/server/api/src/rsRegReplica.cpp
@@ -220,7 +220,11 @@ rsRegReplica( rsComm_t *rsComm, regReplica_t *regReplicaInp ) {
         }
     }
     else {
+        // Add IN_REPL_KW to prevent replication on the redirected server (the provider)
+        addKeyVal(&regReplicaInp->condInput, IN_REPL_KW, "" );
         status = rcRegReplica( rodsServerHost->conn, regReplicaInp );
+        // Remove the keyword as we will want to replicate on this server (the consumer)
+        rmKeyVal(&regReplicaInp->condInput, IN_REPL_KW);
         if ( status >= 0 ) {
             regReplicaInp->destDataObjInfo->replNum = status;
         }
@@ -237,7 +241,9 @@ rsRegReplica( rsComm_t *rsComm, regReplica_t *regReplicaInp ) {
              return _e.code();
         }
 
-        status = _call_file_modified_for_replica( rsComm, regReplicaInp );
+        if (!getValByKey(&regReplicaInp->condInput, IN_REPL_KW)) {
+            status = _call_file_modified_for_replica( rsComm, regReplicaInp );
+        }
     }
 
     return status;
@@ -323,7 +329,10 @@ int _call_file_modified_for_replica(
     if ( admin_kw != NULL ) {
         addKeyVal( (keyValPair_t*)&file_obj->cond_input(), ADMIN_KW, "" );;
     }
-
+    const auto open_type{getValByKey(&regReplicaInp->condInput, OPEN_TYPE_KW)};
+    if (open_type) {
+        addKeyVal((keyValPair_t*)&file_obj->cond_input(), OPEN_TYPE_KW, open_type);
+    }
     irods::error ret = fileModified( rsComm, file_obj );
     if ( !ret.ok() ) {
         std::stringstream msg;

--- a/server/api/src/rsStructFileExtAndReg.cpp
+++ b/server/api/src/rsStructFileExtAndReg.cpp
@@ -512,6 +512,8 @@ regSubfile( rsComm_t *rsComm, const dataObjInfo_t& _dataObjInfo,
                 rsComm,
                 &dataObjInfo ) );
 
+        addKeyVal( (keyValPair_t*)&file_obj->cond_input(), OPEN_TYPE_KW, std::to_string(CREATE_TYPE).c_str() );
+
         irods::error ret = fileModified( rsComm, file_obj );
         if ( !ret.ok() ) {
             std::stringstream msg;

--- a/server/core/src/objDesc.cpp
+++ b/server/core/src/objDesc.cpp
@@ -172,6 +172,11 @@ fillL1desc( int l1descInx, dataObjInp_t *dataObjInp,
         rstrcpy( L1desc[l1descInx].in_pdmo, "", MAX_NAME_LEN );
     }
 
+    const auto open_type{getValByKey(condInput, OPEN_TYPE_KW)};
+    if (open_type) {
+        L1desc[l1descInx].openType = std::atoi(open_type);
+    }
+
     if ( dataObjInp != NULL ) {
         /* always repl the .dataObjInp */
         L1desc[l1descInx].dataObjInp = ( dataObjInp_t* )malloc( sizeof( dataObjInp_t ) );

--- a/server/drivers/src/fileDriver.cpp
+++ b/server/drivers/src/fileDriver.cpp
@@ -713,7 +713,7 @@ irods::error fileModified(
         else {
 
             // =-=-=-=-=-=-=-
-            // make the call to the "open" interface
+            // make the call to the "modified" interface
             resc = boost::dynamic_pointer_cast< irods::resource >( ptr );
             ret  = resc->call( _comm, irods::RESOURCE_OP_MODIFIED, _object );
             if ( !ret.ok() ) {


### PR DESCRIPTION
This change restricts when fileModified is called in rsModDataObjMeta. This should prevent replication (in the case of replication or compound hierarchies) on any non-write/create operation.

The replication resource has been modified such that the child replication list is generated at the time of fileModified instead of in resolve resource hierarchy. This ensures that the replication list is made available to the machine doing the replication as the property map may not be populated from machine to machine.

Adapted from 0290c78

---

[CI tests passed](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1593/)