### PR TITLE
[#858] specify RSA key size on generation (4-1-stable)

### DIFF
--- a/tests/pydevtest/resource_suite.py
+++ b/tests/pydevtest/resource_suite.py
@@ -258,7 +258,7 @@ class ResourceSuite(ResourceBase):
     ###################
     @unittest.skipIf(configuration.RUN_IN_TOPOLOGY, "Skip for Topology Testing")
     def test_ssl_iput_with_rods_env(self):
-        lib.run_command('openssl genrsa -out server.key')
+        lib.run_command('openssl genrsa -out server.key 1024')
         lib.run_command('openssl req -batch -new -key server.key -out server.csr')
         lib.run_command('openssl req -batch -new -x509 -key server.key -out chain.pem -days 365')
         lib.run_command('openssl dhparam -2 -out dhparams.pem 1024')  # normally 2048, but smaller size here for speed
@@ -298,7 +298,7 @@ class ResourceSuite(ResourceBase):
         # set up client and server side for ssl handshake
 
         # server side certificate setup
-        os.system("openssl genrsa -out server.key 2> /dev/null")
+        os.system("openssl genrsa -out server.key 1024 2> /dev/null")
         os.system("openssl req -batch -new -key server.key -out server.csr")
         os.system("openssl req -batch -new -x509 -key server.key -out server.crt -days 365")
         os.system("mv server.crt chain.pem")

--- a/tests/pydevtest/test_auth.py
+++ b/tests/pydevtest/test_auth.py
@@ -69,7 +69,7 @@ class Test_Auth(resource_suite.ResourceBase, unittest.TestCase):
 
     @unittest.skipIf(configuration.TOPOLOGY_FROM_RESOURCE_SERVER or configuration.USE_SSL, 'Topo from resource or SSL')
     def test_authentication_PAM_without_negotiation(self):
-        lib.run_command('openssl genrsa -out server.key')
+        lib.run_command('openssl genrsa -out server.key 1024')
         lib.run_command('openssl req -batch -new -key server.key -out server.csr')
         lib.run_command('openssl req -batch -new -x509 -key server.key -out chain.pem -days 365')
         lib.run_command('openssl dhparam -2 -out dhparams.pem 1024')  # normally 2048, but smaller size here for speed
@@ -117,7 +117,7 @@ class Test_Auth(resource_suite.ResourceBase, unittest.TestCase):
 
     @unittest.skipIf(configuration.TOPOLOGY_FROM_RESOURCE_SERVER or configuration.USE_SSL, 'Topo from resource or SSL')
     def test_authentication_PAM_with_server_params(self):
-        lib.run_command('openssl genrsa -out server.key')
+        lib.run_command('openssl genrsa -out server.key 1024')
         lib.run_command('openssl req -batch -new -key server.key -out server.csr')
         lib.run_command('openssl req -batch -new -x509 -key server.key -out chain.pem -days 365')
         lib.run_command('openssl dhparam -2 -out dhparams.pem 1024')  # normally 2048, but smaller size here for speed


### PR DESCRIPTION
Added to address #3939

(adapted from SHA: afebf9b1ae420f44d38e6d6c5da366cd11ae98d7)

---
[CI tests running](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1601/)