### PR TITLE
[#4144] Added support to allow clients to manually update the mtime of collections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,6 +603,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_resource_plugin.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_resource_plugin_impostor.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_resource_redirect.cpp
+  ${CMAKE_SOURCE_DIR}/server/core/src/irods_rs_comm_query.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_server_api_table.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_server_globals.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_server_negotiation.cpp

--- a/cmake/development_library.cmake
+++ b/cmake/development_library.cmake
@@ -452,6 +452,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/core/include/irodsReServer.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irodsXmsgServer.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_api_calling_functions.hpp
+  ${CMAKE_SOURCE_DIR}/server/core/include/irods_at_scope_exit.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_collection_object.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_data_object.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_database_constants.hpp
@@ -478,6 +479,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_resource_plugin_impostor.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_resource_redirect.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_resource_types.hpp
+  ${CMAKE_SOURCE_DIR}/server/core/include/irods_rs_comm_query.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_server_api_call.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_server_api_table.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_server_control_plane.hpp

--- a/lib/core/include/rodsKeyWdDef.h
+++ b/lib/core/include/rodsKeyWdDef.h
@@ -66,6 +66,7 @@
 #define COLLECTION_TYPE_KW    "collectionType"
 #define COLLECTION_INFO1_KW    "collectionInfo1"
 #define COLLECTION_INFO2_KW    "collectionInfo2"
+#define COLLECTION_MTIME_KW    "collectionMtime"
 #define SEL_OBJ_TYPE_KW    "selObjType"
 #define STRUCT_FILE_OPR_KW    	"structFileOpr"
 #define ALL_MS_PARAM_KW    	"allMsParam"

--- a/server/api/src/rsModColl.cpp
+++ b/server/api/src/rsModColl.cpp
@@ -78,18 +78,22 @@ _rsModColl( rsComm_t *rsComm, collInp_t *modCollInp ) {
 
         rstrcpy( collInfo.collName, modCollInp->collName, MAX_NAME_LEN );
 
-        if ( ( tmpStr = getValByKey( &modCollInp->condInput,
-                                     COLLECTION_TYPE_KW ) ) != NULL ) {
-            rstrcpy( collInfo.collType, tmpStr, NAME_LEN );
+        if ((tmpStr = getValByKey(&modCollInp->condInput, COLLECTION_TYPE_KW))) {
+            rstrcpy(collInfo.collType, tmpStr, NAME_LEN);
         }
-        if ( ( tmpStr = getValByKey( &modCollInp->condInput,
-                                     COLLECTION_INFO1_KW ) ) != NULL ) {
-            rstrcpy( collInfo.collInfo1, tmpStr, MAX_NAME_LEN );
+
+        if ((tmpStr = getValByKey(&modCollInp->condInput, COLLECTION_INFO1_KW))) {
+            rstrcpy(collInfo.collInfo1, tmpStr, MAX_NAME_LEN);
         }
-        if ( ( tmpStr = getValByKey( &modCollInp->condInput,
-                                     COLLECTION_INFO2_KW ) ) != NULL ) {
-            rstrcpy( collInfo.collInfo2, tmpStr, MAX_NAME_LEN );
+
+        if ((tmpStr = getValByKey(&modCollInp->condInput, COLLECTION_INFO2_KW))) {
+            rstrcpy(collInfo.collInfo2, tmpStr, MAX_NAME_LEN);
         }
+
+        if ((tmpStr = getValByKey(&modCollInp->condInput, COLLECTION_MTIME_KW))) {
+            rstrcpy(collInfo.collModify, tmpStr, TIME_LEN);
+        }
+
         /**  June 1 2009 for pre-post processing rule hooks **/
         rei2.coi = &collInfo;
         i =  applyRule( "acPreProcForModifyCollMeta", NULL, &rei2, NO_SAVE_REI );

--- a/server/core/include/irods_rs_comm_query.hpp
+++ b/server/core/include/irods_rs_comm_query.hpp
@@ -1,0 +1,14 @@
+#ifndef IRODS_RS_COMM_QUERY_HPP
+#define IRODS_RS_COMM_QUERY_HPP
+
+#include "rcConnect.h"
+
+namespace irods {
+
+bool is_privileged_client(const rsComm_t& _comm) noexcept;
+
+bool is_privileged_proxy(const rsComm_t& _comm) noexcept;
+
+} // namespace irods
+
+#endif // IRODS_RS_COMM_QUERY_HPP

--- a/server/core/src/irods_rs_comm_query.cpp
+++ b/server/core/src/irods_rs_comm_query.cpp
@@ -1,0 +1,16 @@
+#include "irods_rs_comm_query.hpp"
+
+namespace irods {
+
+bool is_privileged_client(const rsComm_t& _comm) noexcept
+{
+    return LOCAL_PRIV_USER_AUTH == _comm.clientUser.authInfo.authFlag;
+}
+
+bool is_privileged_proxy(const rsComm_t& _comm) noexcept
+{
+    return LOCAL_PRIV_USER_AUTH == _comm.proxyUser.authInfo.authFlag;
+}
+
+} // namespace irods
+


### PR DESCRIPTION
- Modified db_mod_coll_op function to also accept a timestamp from the client.
- Adjusted server-side code to allow setting the r_coll_main.modify_ts column of the ICAT database.
- Modified db_mod_coll_op to allow elevating privileges.
- Added missing irods_at_scope_exit header to irods-dev package.
- Created new server-side library for rsComm_t queries.

[Passed CI](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1650/)

**This branch passing in CI only indicates that the code change did not break existing behavior.**