### PR TITLE
[#4144] Added support to allow clients to manually update the mtime of collections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -600,6 +600,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_resource_plugin.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_resource_plugin_impostor.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_resource_redirect.cpp
+  ${CMAKE_SOURCE_DIR}/server/core/src/irods_rs_comm_query.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_server_api_table.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_server_globals.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_server_negotiation.cpp

--- a/cmake/development_library.cmake
+++ b/cmake/development_library.cmake
@@ -452,6 +452,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/core/include/irodsReServer.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irodsXmsgServer.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_api_calling_functions.hpp
+  ${CMAKE_SOURCE_DIR}/server/core/include/irods_at_scope_exit.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_collection_object.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_data_object.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_database_constants.hpp
@@ -476,6 +477,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_resource_plugin_impostor.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_resource_redirect.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_resource_types.hpp
+  ${CMAKE_SOURCE_DIR}/server/core/include/irods_rs_comm_query.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_server_api_call.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_server_api_table.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_server_control_plane.hpp

--- a/lib/core/include/rodsKeyWdDef.h
+++ b/lib/core/include/rodsKeyWdDef.h
@@ -66,6 +66,7 @@
 #define COLLECTION_TYPE_KW    "collectionType"
 #define COLLECTION_INFO1_KW    "collectionInfo1"
 #define COLLECTION_INFO2_KW    "collectionInfo2"
+#define COLLECTION_MTIME_KW    "collectionMtime"
 #define SEL_OBJ_TYPE_KW    "selObjType"
 #define STRUCT_FILE_OPR_KW    	"structFileOpr"
 #define ALL_MS_PARAM_KW    	"allMsParam"

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -29,6 +29,7 @@
 #include "irods_server_properties.hpp"
 #include "irods_resource_manager.hpp"
 #include "irods_virtual_path.hpp"
+#include "irods_rs_comm_query.hpp"
 #include "modAccessControl.h"
 #include "checksum.hpp"
 
@@ -5132,17 +5133,30 @@ irods::error db_mod_coll_op(
             addRErrorMsg( &_ctx.comm()->rError, 0, errMsg.str().c_str() );
             return ERROR( CAT_UNKNOWN_COLLECTION, "unknown collection" );
         }
+
         if ( iVal == CAT_NO_ACCESS_PERMISSION ) {
-            std::stringstream errMsg;
-            errMsg << "no permission to update collection '" << _coll_info->collName << "'";
-            addRErrorMsg( &_ctx.comm()->rError, 0, errMsg.str().c_str() );
-            return  ERROR( CAT_NO_ACCESS_PERMISSION, "no permission" );
+            // Allows elevation of privileges (e.g. irods_rule_engine_plugin-update_collection_mtime).
+            if (irods::is_privileged_client(*_ctx.comm())) {
+                iVal = 0;
+            }
+            else {
+                std::stringstream errMsg;
+                errMsg << "no permission to update collection '" << _coll_info->collName << "'";
+                addRErrorMsg( &_ctx.comm()->rError, 0, errMsg.str().c_str() );
+                return ERROR( CAT_NO_ACCESS_PERMISSION, "no permission" );
+            }
         }
-        return ERROR( iVal, "cmlCheckDir failed" );
+
+        // If client privileges are elevated, then iVal must be checked again because
+        // it could have been modified (e.g. irods_rule_engine_plugin-update_collection_mtime).
+        if (iVal < 0) {
+            return ERROR( iVal, "cmlCheckDir failed" );
+        }
     }
 
     std::string tSQL( "update R_COLL_MAIN set " );
     count = 0;
+
     if ( strlen( _coll_info->collType ) > 0 ) {
         if ( strcmp( _coll_info->collType, "NULL_SPECIAL_VALUE" ) == 0 ) {
             /* A special value to indicate NULL */
@@ -5154,6 +5168,7 @@ irods::error db_mod_coll_op(
         tSQL += "coll_type=? ";
         count++;
     }
+
     if ( strlen( _coll_info->collInfo1 ) > 0 ) {
         if ( strcmp( _coll_info->collInfo1, "NULL_SPECIAL_VALUE" ) == 0 ) {
             /* A special value to indicate NULL */
@@ -5168,6 +5183,7 @@ irods::error db_mod_coll_op(
         tSQL += "coll_info1=? ";
         count++;
     }
+
     if ( strlen( _coll_info->collInfo2 ) > 0 ) {
         if ( strcmp( _coll_info->collInfo2, "NULL_SPECIAL_VALUE" ) == 0 ) {
             /* A special value to indicate NULL */
@@ -5182,13 +5198,28 @@ irods::error db_mod_coll_op(
         tSQL += "coll_info2=? ";
         count++;
     }
+
+    if (strlen(_coll_info->collModify) > 0) {
+        cllBindVars[cllBindVarCount++] = _coll_info->collModify;
+
+        if (count > 0) {
+            tSQL += ',';
+        }
+
+        ++count;
+    }
+    else {
+        tSQL += ',';
+        getNowStr( myTime );
+        cllBindVars[cllBindVarCount++] = myTime;
+    }
+
     if ( count == 0 ) {
         return ERROR( CAT_INVALID_ARGUMENT, "count is 0" );
     }
-    getNowStr( myTime );
-    cllBindVars[cllBindVarCount++] = myTime;
+
     cllBindVars[cllBindVarCount++] = _coll_info->collName;
-    tSQL += ", modify_ts=? where coll_name=?";
+    tSQL += " modify_ts=? where coll_name=?";
 
     if ( logSQL != 0 ) {
         rodsLog( LOG_SQL, "chlModColl SQL 1" );

--- a/server/api/src/rsModColl.cpp
+++ b/server/api/src/rsModColl.cpp
@@ -78,18 +78,22 @@ _rsModColl( rsComm_t *rsComm, collInp_t *modCollInp ) {
 
         rstrcpy( collInfo.collName, modCollInp->collName, MAX_NAME_LEN );
 
-        if ( ( tmpStr = getValByKey( &modCollInp->condInput,
-                                     COLLECTION_TYPE_KW ) ) != NULL ) {
-            rstrcpy( collInfo.collType, tmpStr, NAME_LEN );
+        if ((tmpStr = getValByKey(&modCollInp->condInput, COLLECTION_TYPE_KW))) {
+            rstrcpy(collInfo.collType, tmpStr, NAME_LEN);
         }
-        if ( ( tmpStr = getValByKey( &modCollInp->condInput,
-                                     COLLECTION_INFO1_KW ) ) != NULL ) {
-            rstrcpy( collInfo.collInfo1, tmpStr, MAX_NAME_LEN );
+
+        if ((tmpStr = getValByKey(&modCollInp->condInput, COLLECTION_INFO1_KW))) {
+            rstrcpy(collInfo.collInfo1, tmpStr, MAX_NAME_LEN);
         }
-        if ( ( tmpStr = getValByKey( &modCollInp->condInput,
-                                     COLLECTION_INFO2_KW ) ) != NULL ) {
-            rstrcpy( collInfo.collInfo2, tmpStr, MAX_NAME_LEN );
+
+        if ((tmpStr = getValByKey(&modCollInp->condInput, COLLECTION_INFO2_KW))) {
+            rstrcpy(collInfo.collInfo2, tmpStr, MAX_NAME_LEN);
         }
+
+        if ((tmpStr = getValByKey(&modCollInp->condInput, COLLECTION_MTIME_KW))) {
+            rstrcpy(collInfo.collModify, tmpStr, TIME_LEN);
+        }
+
         /**  June 1 2009 for pre-post processing rule hooks **/
         rei2.coi = &collInfo;
         i =  applyRule( "acPreProcForModifyCollMeta", NULL, &rei2, NO_SAVE_REI );

--- a/server/core/include/irods_rs_comm_query.hpp
+++ b/server/core/include/irods_rs_comm_query.hpp
@@ -1,0 +1,14 @@
+#ifndef IRODS_RS_COMM_QUERY_HPP
+#define IRODS_RS_COMM_QUERY_HPP
+
+#include "rcConnect.h"
+
+namespace irods {
+
+bool is_privileged_client(const rsComm_t& _comm) noexcept;
+
+bool is_privileged_proxy(const rsComm_t& _comm) noexcept;
+
+} // namespace irods
+
+#endif // IRODS_RS_COMM_QUERY_HPP

--- a/server/core/src/irods_rs_comm_query.cpp
+++ b/server/core/src/irods_rs_comm_query.cpp
@@ -1,0 +1,16 @@
+#include "irods_rs_comm_query.hpp"
+
+namespace irods {
+
+bool is_privileged_client(const rsComm_t& _comm) noexcept
+{
+    return LOCAL_PRIV_USER_AUTH == _comm.clientUser.authInfo.authFlag;
+}
+
+bool is_privileged_proxy(const rsComm_t& _comm) noexcept
+{
+    return LOCAL_PRIV_USER_AUTH == _comm.proxyUser.authInfo.authFlag;
+}
+
+} // namespace irods
+


### PR DESCRIPTION
- Modified db_mod_coll_op function to also accept a timestamp from the client.
- Adjusted server-side code to allow setting the r_coll_main.modify_ts column of the ICAT database.
- Modified db_mod_coll_op to allow elevating privileges.
- Added missing irods_at_scope_exit header to irods-dev package.
- Created new server-side library for rsComm_t queries.

[Passed CI](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1651/)

**This branch passing in CI only indicates that the code change did not break existing behavior.**