### PR TITLE
[#1805] wrote tests for PREP genquery iterators

### DIFF
--- a/scripts/irods/core_file.py
+++ b/scripts/irods/core_file.py
@@ -22,6 +22,16 @@ class CoreFile:
             raise IrodsError('unsupported rule engine for testing: {0}'.format(self.plugin_name))
         self.filepath = os.path.join(irods_config.core_re_directory, filename)
 
+    def prepend_to_imports(self, rule_text):
+
+        if not(isinstance(rule_text,str)) or not rule_text : return
+
+        if self.plugin_name == PYTHON_RULE_ENGINE_PLUGIN_NAME:
+            rule_text = rule_text.lstrip() + ("\n" if rule_text[-1:] != "\n" else "")
+            lib.prepend_string_to_file(rule_text, self.filepath)
+        else:
+            raise IrodsError('core rulebase cannot contain imports unless Python RE plugin installed')
+
     def add_rule(self, rule_text):
         if self.plugin_name == IRODS_RULE_LANGUAGE_RULE_ENGINE_PLUGIN_NAME:
             lib.prepend_string_to_file(rule_text, self.filepath)

--- a/scripts/irods/test/test_iput_options.py
+++ b/scripts/irods/test/test_iput_options.py
@@ -2,6 +2,7 @@ import os
 import re
 import stat
 import sys
+import shutil
 import ustrings
 import commands
 
@@ -11,15 +12,19 @@ else:
     import unittest
 
 from .resource_suite import ResourceBase
+from ..configuration import IrodsConfig
 from .. import lib
 from . import session
 
 class Test_iPut_Options(ResourceBase, unittest.TestCase):
 
     def setUp(self):
+        self.new_paths = []
         super(Test_iPut_Options, self).setUp()
 
     def tearDown(self):
+        for abs_path in self.new_paths:
+            shutil.rmtree(abs_path, ignore_errors = True)
         super(Test_iPut_Options, self).tearDown()
 
     def test_iput_options(self):
@@ -62,8 +67,18 @@ class Test_iPut_Options(ResourceBase, unittest.TestCase):
         self.admin.assert_icommand('imeta ls -d ' + self.admin.session_collection + '/file', 'STDOUT_SINGLELINE', 'units: u1')
 
     def test_iput_recursive_with_period__issue_2010(self):
-        self.user0.assert_icommand(['iput', '-r', './'], 'STDOUT_SINGLELINE', ustrings.recurse_ok_string())
-        self.user0.assert_icommand_fail('ils -l', 'STDOUT_SINGLELINE', '/.')
+        try:
+            new_dir = 'dir_for_test_iput_recursive_with_period_2010'
+            home_dir = IrodsConfig().irods_directory
+            save_dir = os.getcwd()
+            os.chdir(home_dir)
+            lib.make_deep_local_tmp_dir(new_dir, depth=5, files_per_level=30, file_size=57)
+            self.new_paths.append(os.path.abspath(new_dir))
+            os.chdir(new_dir)
+            self.user0.assert_icommand(['iput', '-r', './'], 'STDOUT_SINGLELINE', ustrings.recurse_ok_string())
+            self.user0.assert_icommand_fail('ils -l', 'STDOUT_SINGLELINE', '/.')
+        finally:
+            os.chdir(save_dir)
 
     def test_iput_checksum_zero_length_file__issue_3275(self):
         filename = 'test_iput_checksum_zero_length_file__issue_3275'

--- a/scripts/irods/test/test_prep_genquery_iterator.py
+++ b/scripts/irods/test/test_prep_genquery_iterator.py
@@ -1,0 +1,510 @@
+from __future__ import print_function
+import os
+import re
+import sys
+
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    import unittest2 as unittest
+
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+from textwrap import dedent as D_
+from .. import lib
+from ..configuration import IrodsConfig
+from ..controller import IrodsController
+from . import resource_suite
+from ..core_file import temporary_core_file
+from ..paths import (config_directory as irods_config_dir,
+                     server_config_path)
+
+#             Constants
+
+GENQUERY_MODULE_BASENAME = 'genquery.py'
+
+Allow_Intensive_Memory_Use = False
+
+#  -------------
+#  This function will be necessary until PREP tests are separate from the irods core repository:
+
+def genquery_module_available():
+
+    global Allow_Intensive_Memory_Use
+    class EmptyModule(Exception): pass
+
+    IRODS_CONFIG_DIR =  irods_config_dir()
+
+    genquery_module_path = os.path.join( IRODS_CONFIG_DIR,  GENQUERY_MODULE_BASENAME)
+    file_description = " module file '{}'".format (genquery_module_path)
+
+    useable = False
+
+    if not os.path.isfile( genquery_module_path ):
+        print ("Not finding " + file_description ,file=sys.stderr)
+    else:
+        try:
+            with open(genquery_module_path,'rt') as f:
+                if not len(f.readline()) > 0:
+                    raise EmptyModule
+        except IOError:
+            print ("No read permissions on " + file_description ,file=sys.stderr)
+        except EmptyModule:
+            print ("Null content in " + file_description ,file=sys.stderr)
+        except Exception:
+            print ("Unknown Error in accessing " + file_description ,file=sys.stderr)
+        else:
+            useable = True
+            idx = -1
+            #--> try import genquery module so that we can test optimally according to configuration
+            try:
+                sys.path.insert(0,IRODS_CONFIG_DIR)
+                import genquery
+                if getattr(genquery,'AUTO_FREE_QUERIES',None) is True:
+                    Allow_Intensive_Memory_Use = True
+                idx =  sys.path.index(IRODS_CONFIG_DIR)
+            except ImportError: # not fatal, past versions were only importable via PREP
+                pass
+            except ValueError:
+                idx = -1
+            finally: #-- clean up module load path
+                if idx >= 0:
+                    cfg_dir = sys.path.pop(idx)
+                    if cfg_dir != IRODS_CONFIG_DIR:
+                        raise RuntimeError("Python module load path couldn't be restored")
+
+    if not useable:
+        print (" --- Not running genquery iterator tests --- " ,file=sys.stderr)
+
+    return useable
+
+
+@contextmanager
+def generateRuleFile(names_list=None, **kw):
+
+    if names_list is None:
+        names_list=kw.pop('names_list', [])
+
+    f = NamedTemporaryFile(mode='wt', dir='.', suffix='.r', delete=False, **kw)
+
+    try:
+        if isinstance(names_list,list):
+            names_list.append(f.name)
+        yield f
+
+    finally:
+        f.close()
+
+
+class Test_Genquery_Iterator(resource_suite.ResourceBase, unittest.TestCase):
+
+    plugin_name = IrodsConfig().default_rule_engine_plugin
+
+    full_test = genquery_module_available()
+
+    def setUp(self):
+
+        super(Test_Genquery_Iterator, self).setUp()
+
+        self.to_unlink = []
+
+        # ------- set up variables specific to this group of tests
+
+        self.dir_for_coll = 'testColn'
+
+        self.bundled_coll = self.dir_for_coll + '.tar'
+
+        self.assertFalse(os.path.exists(self.dir_for_coll))
+        self.assertFalse(os.path.exists(self.bundled_coll))
+
+        self.test_dir_path = os.path.abspath(self.dir_for_coll)
+        self.test_tar_path = os.path.abspath(self.bundled_coll)
+
+        self.server_config_path = server_config_path()
+
+        self.test_admin_coll_path = ("/" + self.admin.zone_name +
+                                     "/home/" + self.admin.username +
+                                     "/" + os.path.split(self.test_dir_path)[-1] )
+
+
+    # remove the next line when msiGetMoreRows always returns an accurate value for continueInx
+    @unittest.skipIf(Allow_Intensive_Memory_Use, 'Replace nested multiples-of-256 pending rsGenQuery continueInx fix')
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for python REP')
+    def test_multiples_256(self):
+
+        if not self.full_test : return
+        lib.create_directory_of_small_files(self.dir_for_coll,512)
+        lib.execute_command ('tar -cf {} {}'.format(self.bundled_coll, self.dir_for_coll))
+        self.admin.assert_icommand('icd')
+        self.admin.assert_icommand('iput -f {}'.format(self.bundled_coll))
+        self.admin.assert_icommand('ibun -x {} .'.format(self.bundled_coll))
+
+        IrodsController().stop()
+
+        with temporary_core_file() as core:
+
+            core.prepend_to_imports( 'from genquery import *')
+
+            core.add_rule(D_('''\
+                def my_rule_256(rule_args, callback, rei):
+                    n=0
+                    coll = rule_args[0]
+                    for z1 in paged_iterator("DATA_NAME", "COLL_NAME = '{}'".format(coll), # 512 objects
+                                           AS_LIST, callback):
+                        for z2 in z1: n += 1
+                    rule_args[0] = str(n)
+                '''))
+
+            IrodsController().start()
+
+            rule_file = ""
+            with generateRuleFile( names_list = self.to_unlink, **{'prefix':"test_mult256_"} ) as f:
+                rule_file = f.name
+                print(D_('''\
+                def main(rule_args,callback,rei):
+                    TestCollection = global_vars['*testcollection'][1:-1]
+                    retval = callback.my_rule_256(TestCollection);
+                    result = retval['arguments'][0]
+                    callback.writeLine("stdout", "multiples of 256 test: {}".format(result))
+                input *testcollection=$""
+                output ruleExecOut
+                '''), file=f, end='')
+
+            run_irule = ("irule -F {} \*testcollection=\"'{}'\""
+                                              ).format(rule_file, self.test_admin_coll_path,)
+
+            self.admin.assert_icommand(run_irule, 'STDOUT_SINGLELINE', r'\s{}$'.format(512), use_regex=True)
+
+            IrodsController().stop()
+
+        IrodsController().start()
+
+
+    #=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#
+
+    # This test passed on the command-line and behaves well, but temporarily removing from CI . -DWM 2018/11
+
+    # Remove the next line when msiGetMoreRows always returns an accurate value for continueInx
+    @unittest.skipUnless(Allow_Intensive_Memory_Use, 'Skip nested multiples-of-256 pending rsGenQuery continueInx fix')
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for python REP')
+    def test_multiples_256_nested(self):
+
+        if not self.full_test : return
+
+        lib.create_directory_of_small_files(self.dir_for_coll,912)
+        lib.execute_command('''sh -c "cd '{}' && rm ? ?? 1[0123]? 14[0123]"'''.format(self.dir_for_coll))
+        lib.execute_command ('tar -cf {} {}'.format(self.bundled_coll, self.dir_for_coll))
+        self.admin.assert_icommand('icd')
+        self.admin.assert_icommand('iput -f {}'.format(self.bundled_coll))
+        self.admin.assert_icommand('ibun -x {} .'.format(self.bundled_coll))
+
+        IrodsController().stop()
+
+        with temporary_core_file() as core:
+
+            core.prepend_to_imports( 'from genquery import *') # import all names to core that are exported by genquery.py
+
+            # with collection containing 144..911 inclusive
+            core.add_rule(D_('''\
+                def my_rule_256_nested(rule_args, callback, rei):
+                    n=0
+                    coll = rule_args[0]
+                    for x1 in row_iterator("DATA_NAME",
+                                           "COLL_NAME = '{}' and DATA_NAME < '4'".format(coll), # 256 objects
+                                           AS_LIST, callback):
+                        for y1 in row_iterator("DATA_NAME",
+                                           "COLL_NAME = '{}' and DATA_NAME like '91_'".format(coll), # 2 objects
+                                           AS_LIST, callback):
+                            for z1 in paged_iterator("DATA_NAME",
+                                                   "COLL_NAME = '{}' and DATA_NAME >= '4'".format(coll), # 512 objects
+                                                   AS_LIST, callback):
+                                for z2 in z1: n += 1
+                    rule_args[0] = str(n)
+                '''))
+
+            IrodsController().start()
+
+            rule_file = ""
+            with generateRuleFile( names_list = self.to_unlink, **{'prefix':"test_mult256_n_"} ) as f:
+                rule_file = f.name
+                print(D_('''\
+                def main(rule_args,callback,rei):
+                    TestCollection = global_vars['*testcollection'][1:-1]
+                    retval = callback.my_rule_256_nested(TestCollection);
+                    result = retval['arguments'][0]
+                    # import os
+                    # with open("/run/shm/thing."+str(os.getpid()),"wt") as f:
+                    #   f.write('result = {!r}'.format(result)+chr(10))
+                    callback.writeLine("stdout", "multiples of 256 test: {}".format(result))
+                input *testcollection=$""
+                output ruleExecOut
+                '''), file=f, end='')
+
+            run_irule = ("irule -F {} \*testcollection=\"'{}'\"" # will loop 256 * 2 * 512 iters
+                                              ).format(rule_file, self.test_admin_coll_path,)
+
+            self.admin.assert_icommand(run_irule, 'STDOUT_SINGLELINE', r'\s{}$'.format(512*2*256), use_regex=True)
+
+            IrodsController().stop()
+
+        IrodsController().start()
+
+    #=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#=-=-=-=-=-#
+
+    # This test passed on the command-line and behaves well, but temporarily removing from CI . -DWM 2018/11
+
+    # remove the next line when msiGetMoreRows always returns an accurate value for continueInx
+    @unittest.skipUnless(Allow_Intensive_Memory_Use, 'Skip nested paged iterators pending rsGenQuery continueInx fix')
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for python REP')
+    def test_nested_paged_iterators(self):
+
+        if not self.full_test : return
+
+        lib.create_directory_of_small_files(self.dir_for_coll,1000)
+        lib.execute_command ('tar -cf {} {}'.format(self.bundled_coll, self.dir_for_coll))
+        self.admin.assert_icommand('icd')
+        self.admin.assert_icommand('iput -f {}'.format(self.bundled_coll))
+        self.admin.assert_icommand('ibun -x {} .'.format(self.bundled_coll))
+
+        rule_file = ""
+
+        with generateRuleFile( names_list = self.to_unlink, **{'prefix':"qenquery_nest_paged"} ) as f:
+            rule_file = f.name
+            print(D_(
+            '''\
+            def main(rule_args,callback,rei):
+                collect = global_vars['*testcollection'][1:-1]
+                from genquery import row_iterator, paged_iterator, AS_LIST
+
+                cond1 = "DATA_NAME like '1__' || like '2__' || like '3__' "
+                cond2 = "DATA_NAME like '1' || like '2' "
+                cond3 = "DATA_NAME like '7__' || like '8__' || like '9__' "
+
+                condString1 = "COLL_NAME = '{}' and {}".format(collect,cond1)
+                condString2 = "COLL_NAME = '{}' and {}".format(collect,cond2)
+                condString3 = "COLL_NAME = '{}' and {}".format(collect,cond3)
+
+                num_lines = 0
+                for x_rows in paged_iterator( "order_asc(DATA_NAME)",condString1, AS_LIST,callback):
+                    for x in x_rows:
+                        for y in row_iterator( "order_asc(DATA_NAME)", condString2, AS_LIST,callback):
+                            for z_rows in paged_iterator( "order_asc(DATA_NAME)",condString3, AS_LIST,callback):
+                                for z in z_rows:
+                                    output_line = x[0] + y[0] + z[0]
+                                    num_lines += 1
+                                    callback.writeLine('stdout', output_line)
+                callback.writeLine('stderr', str(num_lines))
+
+
+            INPUT  *testcollection=$""
+            OUTPUT ruleExecOut
+            '''), file=f, end='')
+
+        command2run = ("irule -F " + rule_file + " " +
+                       "\*testcollection=\"'{}'\"").format(self.test_admin_coll_path)
+
+        out, err, _ = self.admin.run_icommand( command2run )
+        self.assertEqual( err.strip(), str( 2 * 300 ** 2 ))
+        nestedQueryError = None
+        old_i = 0
+        ## -- assert monotonic number sequence
+        for i in map (int, (line for line in out.split("\n") if line.strip()) ):
+            if nestedQueryError is None:
+                nestedQueryError = False
+            if i <= old_i : nestedQueryError = True
+            old_i = i
+        self.assertIsNotNone(nestedQueryError)
+        self.assertFalse(nestedQueryError)
+
+
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for python REP')
+    def test_with_modified_rulebase_off_boundary(self):
+
+        if self.full_test:
+            IrodsController().stop()
+            with lib.file_backed_up (self.server_config_path):
+                self.boundary_with_size(512 + 7 * 8 * 9, self.modify_rulebase_and_tst, pre_start = True)
+            IrodsController().start()
+
+
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for python REP')
+    def test_with_modified_rulebase_on_boundary(self):
+
+        if self.full_test:
+            IrodsController().stop()
+            with lib.file_backed_up (self.server_config_path):
+                #IrodsController().start()
+                self.boundary_with_size(512 + 7 * 8 * 9, self.modify_rulebase_and_tst, pre_start = True)
+                #IrodsController().stop()  # -- done internally by above call
+            IrodsController().start()
+
+
+    def boundary_with_size(self, N, func, pre_start = False):
+
+        if pre_start:
+            IrodsController().start() # -- for cases where Native REP was inserted to svr config
+
+        lib.create_directory_of_small_files(self.dir_for_coll,N)
+        lib.execute_command ('tar -cvf {} {}'.format(self.bundled_coll, self.dir_for_coll))
+        self.admin.assert_icommand('icd')
+        self.admin.assert_icommand('iput -f {}'.format(self.bundled_coll))
+        self.admin.assert_icommand('ibun -x {} .'.format(self.bundled_coll))
+
+        if func.__name__ == 'modify_rulebase_and_tst':
+            self.admin.assert_icommand('ichmod -r read {} {}' .format( self.user0.username, self.dir_for_coll ))
+
+        IrodsController().stop() # -- in preparation for core rule-base changes
+
+        func(N)
+
+
+    def create_py_rulefile_and_tst(self,N):
+
+        with temporary_core_file() as core:
+
+            core.prepend_to_imports( 'from genquery import test_python_RE_genquery_iterators' )
+
+            rule_file = ""
+
+            with generateRuleFile( names_list = self.to_unlink, **{'prefix':"test_core_py_mods_with_pyrule"} ) as f:
+
+                rule_file = f.name
+
+                rule_string = D_('''\
+                                 def main(rule_args,callback,rei):
+                                     a = "%s/%%" # collection  plus Sql match pattern
+                                     b = global_vars['*rpi'][1:-1]  # rows_per_iter
+                                     c = ""      # empty string (no verbose log dump)
+                                     rpi = global_vars['*rpi'][1:-1]
+                                     nobj = global_vars['*nobj'][1:-1]
+                                     #callback.writeLine('serverLog', '*nobj = {}'.format(nobj))
+                                     predicted = validate_output( nobj , rpi , "" )
+                                     if b == "0": b = ""
+                                     retv = callback.test_python_RE_genquery_iterators(a,b,c)
+                                     a,b,c = retv['arguments']
+                                     callback.writeLine('stdout', 'actual:    [{}][{}][{}]'.format(a,b,c))
+                                     callback.writeLine('stdout', 'predicted: [{}]{}'.format( nobj,predicted))
+                                 def validate_output(N, y, result):
+                                     n = int(N); x = 0
+                                     if y != '0': x=int(y)
+                                     mfinal = 0 ; nlists = 0
+                                     if x > 0: nlists = (n + x - 1) // x
+                                     if nlists > 0: mfinal = x + n - nlists * x
+                                     return "[{}][{}]".format(nlists,mfinal)
+                                 input *rpi=$,*nobj=$
+                                 output ruleExecOut
+                         ''' % (self.test_admin_coll_path,))
+                print(rule_string, file = f, end = '')
+
+            IrodsController().start()
+
+            irods_rule_language_option = ""  #default to python
+            pattern=re.compile(r'^(\S+):\s*(\[.*\]$)',re.M)
+
+            for rowsPerIter in ( "0", "7", "8", "9"): # if "0" then row_iterator; else paged_iterator
+                cmd2run = '''irule {} -F {} \*rpi='"{}"' \*nobj="'{}'" '''.format(
+                             irods_rule_language_option, rule_file, rowsPerIter, N )
+                out, _, _  = self.admin.run_icommand( cmd2run )
+                out_tuple = pattern.findall(out)
+                self.assertNotEqual( out_tuple[0][0], out_tuple[1][0] ) # keys not a match ("actual" != "predicted")
+                self.assertEqual   ( out_tuple[0][1], out_tuple[1][1] ) # but values should match
+
+            IrodsController().stop()
+
+    def modify_rulebase_and_tst (self,N):
+
+        irods_config = IrodsConfig()
+        orig = irods_config.server_config['plugin_configuration']['rule_engines']
+
+        irods_config.server_config['plugin_configuration']['rule_engines'] = orig + [{
+                'instance_name': 'irods_rule_engine_plugin-irods_rule_language-instance',
+                'plugin_name': 'irods_rule_engine_plugin-irods_rule_language',
+                'plugin_specific_configuration': {
+                    "re_data_variable_mapping_set": [
+                        "core"
+                    ],
+                    "re_function_name_mapping_set": [
+                        "core"
+                    ],
+                    "re_rulebase_set": [
+                        "core"
+                    ],
+                    "regexes_for_supported_peps": [
+                        "ac[^ ]*",
+                        "msi[^ ]*",
+                        "[^ ]*pep_[^ ]*_(pre|post)"
+                    ]
+                },
+                "shared_memory_instance": "irods_rule_language_rule_engine"
+            }]
+
+        irods_config.commit(irods_config.server_config, irods_config.server_config_path, make_backup=True)
+
+        with temporary_core_file() as core:
+
+            core.prepend_to_imports( 'from genquery import test_python_RE_genquery_iterators' )
+
+            rule_file = ""
+
+            with generateRuleFile( names_list = self.to_unlink, **{'prefix':"test_core_py_mods_"} ) as f:
+
+                rule_file = f.name
+
+                rule_string = D_('''\
+                         irodsRule() {
+                             *a = "%s/%%" # collection  plus Sql match pattern
+                             *b = "*rpi"  # rows_per_iter
+                             *c = ""      # empty string (no verbose log dump)
+                             *predicted = ""
+                             validate_output(*nobj,*rpi,*predicted)
+                             #-- should assert that *a == *nobj
+                             if ("*b" == "0") { *b = "" } # bc irule chokes on '\*rpi=""'
+                             test_python_RE_genquery_iterators(*a,*b,*c)
+                             writeLine("stdout", "actual:    [*a]:[*b][*c]")
+                             writeLine("stdout", "predicted: [*nobj]:*predicted")
+                         }
+                         validate_output(*N , *y, *result) {
+                             *n = int(*N) ; *x = 0
+                             if ("*y" != "") { *x = int(*y) }
+                             *mfinal = 0 ; *nlists = 0
+                             if (*x > 0) { *nlists = int (( double(*n) + *x - 0.99) / *x) }
+                             if (*nlists > 0) { *mfinal = *x + *n - (*nlists) * (*x)  }
+                             *result = "[*nlists][*mfinal]"
+                         }
+                         input *rpi=$,*nobj=$
+                         output ruleExecOut
+                         ''' % (self.test_admin_coll_path,))
+                print(rule_string, file = f, end = '')
+
+            IrodsController().start()
+
+            irods_rule_language_option = "-r irods_rule_engine_plugin-irods_rule_language-instance"
+            pattern=re.compile(r'^(\S+):\s*(\[.*\]$)',re.M)
+
+            for rowsPerIter in ( "0", "7", "8", "9"): # if "0" then row_iterator; else paged_iterator
+                cmd2run = 'irule {} -F {} \*rpi="{}" \*nobj="{}"'.format(irods_rule_language_option, rule_file, rowsPerIter, N)
+                out, _, _ = self.user0.run_icommand( cmd2run )
+                out_tuple = pattern.findall(out)
+                self.assertNotEqual( out_tuple[0][0], out_tuple[1][0]) # keys not a match ("actual" != "predicted")
+                self.assertEqual(    out_tuple[0][1], out_tuple[1][1]) # but values should match
+
+            IrodsController().stop()
+
+    def tearDown(self):
+
+        if self.full_test:
+
+            # - clean up in admin home collection
+            self.admin.assert_icommand('icd')
+            self.admin.assert_icommand('irm -f {}'.format(self.bundled_coll))
+            self.admin.assert_icommand('irm -rf {}'.format(self.dir_for_coll))
+
+            # - clean up in local filesystem
+            lib.execute_command('rm -fr {}/'.format(self.test_dir_path))
+            lib.execute_command('rm -f {}'.format(self.test_tar_path))
+
+            for f in self.to_unlink:
+                os.unlink(f)
+
+        super(Test_Genquery_Iterator, self).tearDown()
+

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -186,7 +186,7 @@ if __name__ == '__main__':
     if options.include_auth_tests:
         test_identifiers.append('test_auth')
     if options.run_python_suite:
-        test_identifiers.extend(['test_ssl', 'test_iadmin', 'test_resource_types', 'test_catalog',
+        test_identifiers.extend(['test_prep_genquery_iterator', 'test_ssl', 'test_iadmin', 'test_resource_types', 'test_catalog',
                                  'test_rulebase', 'test_symlink_operations', 'test_resource_tree', 'test_load_balanced_suite',
                                  'test_icommands_file_operations', 'test_imeta_set', 'test_all_rules', 'test_iscan', 'test_ipasswd',
                                  'test_ichmod', 'test_iput_options', 'test_ireg', 'test_irsync', 'test_iticket', 'test_irodsctl',


### PR DESCRIPTION
Created new tests  (test_prep_genquery_iterator.py) for the Python RE
plugin's upcoming [genquery iterator](https://github.com/irods/irods_rule_engine_plugin_python) capability.

In addition a change was made to a test of recursive iput from "./" in
test_iput_options.py that related to irods/irods [#2010].  This was in order
to stabilize an erratic behavior which (in addition to being problem in
itself) interacted badly in CI with the tests outlined here.

The tests are dependent on the existence of /etc/irods/genquery.py which,
as alluded to, will be present in versions >= 4.2.5  of the python rule plugin.

If the module is not seen at the path /etc/irods/genquery.py (such as if the
python rule plugin is not installed, or outdated), all tests of it will be
skipped.

Two iteration methods are offered by the module, namely result-at-a-time
and paged.

The tests currently-in-force are:

   1. test_multiples_256

      - tests that we can query from 512 total results, yielding exactly
        that many rows. We augment the python rulebase in core.py with a
        function that directly executes the query, then generate and run
        a ".r" rule file in Python to call that function as the admin user.

   2. test_with_modified_rulebase_on_boundary

      - queries 512 objects, from the user0 account, using different
        page sizes; then checks the results (number of iterations and
        remainder , related to the quotient and modulo results of dividing
        512 by the page size) against expected/computed results.
        The test does this via a native RE ".r" file which calls a
        unit test function embedded in the genquery.py module.
        Page sizes are "0" (i.e. use row iterator), "7", "8" and "9" (for
        these last three values, the paged iterator is used with the
        corresponding integer #rows per page).

   3. test_with_modified_rulebase_off_boundary

      - Same as above but query off of a 256*N boundary, this time against
        (512 + 7 * 8 * 9) total results.

The next two nested-iteration tests currently are skipped because
of uncertain msiCloseGenQuery semantics. There are times when iRODS
appears to internally free the objects (during the rsGenQuery call)
that hold the state of the query.  Of particular interest in applications
using the GenQuery is the part of that state that tracks the progress of
pagination (SQL_MAX_ROWS = 256 at a time) through the yielded results.

A caller typically monitors the value of continueInx returned by
msiGetMoreRows() to determine whether or not the call just made to that
microservice should be the last one. Ideally, msiCloseGenquery is also
called after the last call to msiGetMoreRows.

But there is also strong evidence that when msiGetMoreRows returns an error
code of CAT_NO_ROWS_FOUND, the appropriate assumption to be made by the calling
application is that iRODS has already terminated the pagination of results
and freed the memory and objects associated with the query.  This happens
in particular on the last page of query results returned when the total number
of matching results for the query is (N * SQL_MAX_ROWS) with N a positive
integer.

In genquery.py, we currently choose a conservative resource management policy
in this regard: i.e., in the Python code, we do not close the query ourselves.
This is not a problem for a short-running iRODS agent, but may lead to the
consumption of large amounts of memory if there are many queries made within
the lifetime of said iRODS agent. For this reason, we offer a choice:

   * A user can alter the iterator module policy can be altered from its default
   to that of ensuring msiCloseGenQuery is called at the proper times, based on
   the above heuristic.  This is configurable by assigning a boolean True value
   to a flag declared in the module (`genquery.AUTO_FREE_QUERIES`)

   * For the present time, however, `AUTO_FREE_QUERIES` is false by default, and
   thus we disable the especially query-heavy tests mentioned below. However,
   once the microservice API is boxed in and documented a bit better, we fully
   expect to be able to switch them back on.

These are the resource-heavy tests which are now disabled by default:

   4. test_nested_paged_iterators

      - nests paged+row+paged iterators of non-overlapping sets, on three
        hierarchical levels, to produce 300*2*300 results total

   5. test_multiples_256_nested

      - the ambitious version of test # 1 above, wherein  2*256*512 results
        are queried in mixed row/row/paged iterator loops three-deep.
