### PR TITLE
[4197] moved stop operation into the cleanup

### DIFF
--- a/server/core/src/initServer.cpp
+++ b/server/core/src/initServer.cpp
@@ -549,6 +549,7 @@ cleanup() {
         /* close any opened server to server connection */
         disconnectAllSvrToSvrConn();
     }
+    irods::re_plugin_globals->global_re_mgr.call_stop_operations();
 }
 
 void

--- a/server/core/src/rodsAgent.cpp
+++ b/server/core/src/rodsAgent.cpp
@@ -436,7 +436,6 @@ runIrodsAgent( sockaddr_un agent_addr ) {
         cleanupAndExit( status );
     }
 
-    irods::re_serialization::serialization_map_t m = irods::re_serialization::get_serialization_map();
     irods::re_plugin_globals.reset(new irods::global_re_plugin_mgr);
     irods::re_plugin_globals->global_re_mgr.call_start_operations();
 
@@ -565,7 +564,6 @@ runIrodsAgent( sockaddr_un agent_addr ) {
 
     new_net_obj->to_server( &rsComm );
     cleanup();
-    irods::re_plugin_globals->global_re_mgr.call_stop_operations();
     free( rsComm.thread_ctx );
     free( rsComm.auth_scheme );
 


### PR DESCRIPTION
This addresses the resource cleanup problem with rule engines, and in particular fixes a problem expressed by the python rule engine plugin where it would not import a new core file for new agents.