### PR TITLE
[#3776] Prevent double free in agent spawner (master)

### DIFF
--- a/server/core/include/rodsServer.hpp
+++ b/server/core/include/rodsServer.hpp
@@ -69,9 +69,6 @@ spawnAgent( agentProc_t *connReq, agentProc_t **agentProcHead );
 int
 execAgent( int newSock, startupPack_t *startupPack );
 int
-queConnectedAgentProc( int childPid, agentProc_t *connReq,
-                       agentProc_t **agentProcHead );
-int
 getAgentProcCnt();
 int
 chkAgentProcCnt();

--- a/server/core/src/rodsAgent.cpp
+++ b/server/core/src/rodsAgent.cpp
@@ -90,7 +90,7 @@ int receiveDataFromServer( int conn_tmp_socket ) {
     memset( in_buf, 0, 1024 );
     bool data_complete = false;
 
-    char ack_buffer[256];
+    char ack_buffer[256]{};
     snprintf( ack_buffer, 256, "OK" );
 
     while (!data_complete) {
@@ -194,8 +194,8 @@ irodsAgentSignalExit( int ) {
 }
 
 int
-runIrodsAgent( sockaddr_un agent_addr ) {
-    int status;
+runIrodsAgentFactory( sockaddr_un agent_addr ) {
+    int status{};
     rsComm_t rsComm;
 
     using log = irods::experimental::log;
@@ -305,10 +305,9 @@ runIrodsAgent( sockaddr_un agent_addr ) {
             // select returned, attempt to receive data
             // If 0 bytes are received, socket has been closed
             // If a socket address is on the line, create it and fork a child process
-            char in_buf[1024];
-            memset( in_buf, 0, sizeof(in_buf));
+            char in_buf[1024]{};
+            int tmp_socket{};
             const ssize_t bytes_received = recv( conn_socket, &in_buf, sizeof(in_buf), 0 );
-            int tmp_socket;
             if ( bytes_received == -1 ) {
                 rodsLog(LOG_ERROR, "Error receiving data from rodsServer, errno = [%d]: %s", errno, strerror( errno ) );
                 return SYS_SOCK_READ_ERR;
@@ -319,8 +318,7 @@ runIrodsAgent( sockaddr_un agent_addr ) {
             } else {
                 // Assume that we have received valid data over the socket connection
                 // Set up the temporary (per-agent) sockets
-                sockaddr_un tmp_socket_addr;
-                memset( &tmp_socket_addr, 0, sizeof(tmp_socket_addr) );
+                sockaddr_un tmp_socket_addr{};
                 tmp_socket_addr.sun_family = AF_UNIX;
                 strncpy( tmp_socket_addr.sun_path, in_buf, sizeof(tmp_socket_addr.sun_path) );
                 unsigned int len = sizeof(tmp_socket_addr);
@@ -343,9 +341,25 @@ runIrodsAgent( sockaddr_un agent_addr ) {
                 }
 
                 // Send acknowledgement that socket has been created
-                char ack_buffer[256];
+                char ack_buffer[256]{};
                 len = snprintf( ack_buffer, sizeof(ack_buffer), "OK" );
-                send ( conn_socket, ack_buffer, len, 0 );
+                const auto bytes_sent{send(conn_socket, ack_buffer, len, 0)};
+                if (bytes_sent < 0) {
+                    rodsLog(LOG_ERROR, "[%s] - Error sending acknowledgment to rodsServer, errno = [%d][%s]", __FUNCTION__, errno, strerror(errno));
+                    return SYS_SOCK_READ_ERR;
+                }
+
+                // Wait for connection message from main server
+                memset(in_buf, 0, sizeof(in_buf));
+                recv(conn_socket, in_buf, sizeof(in_buf), 0);
+                if (0 != std::string(in_buf).compare("connection_successful")) {
+                    rodsLog(LOG_ERROR, "[%s:%d] - received failure message in connecting to socket from server", __FUNCTION__, __LINE__);
+                    status = close( tmp_socket );
+                    if (status < 0) {
+                        rodsLog(LOG_ERROR, "close(tmp_socket) failed with errno = [%d]: %s", errno, strerror(errno));
+                    }
+                    continue;
+                }
 
                 conn_tmp_socket = accept( tmp_socket, (struct sockaddr*) &tmp_socket_addr, &len);
                 if (-1 == conn_tmp_socket) {

--- a/server/core/src/rodsServer.cpp
+++ b/server/core/src/rodsServer.cpp
@@ -44,13 +44,14 @@ using namespace boost::filesystem;
 
 #include "irods_random.hpp"
 
-struct sockaddr_un local_addr;
-int agent_conn_socket;
-bool connected_to_agent = false;
+struct sockaddr_un local_addr{};
+int agent_conn_socket{};
+bool connected_to_agent{};
 
-pid_t agent_spawning_pid;
-char agent_factory_socket_file[128];
-char agent_factory_socket_dir[128];
+pid_t agent_spawning_pid{};
+const char socket_dir_template[]{"/tmp/irods_sockets_XXXXXX"};
+char agent_factory_socket_dir[sizeof(socket_dir_template)]{};
+char agent_factory_socket_file[sizeof(local_addr.sun_path)]{};
 
 uint ServerBootTime;
 int SvrSock;
@@ -77,7 +78,12 @@ boost::condition_variable SpawnReqCond;
 
 std::vector<std::string> setExecArg( const char *commandArgv );
 
-int runIrodsAgent( sockaddr_un agent_addr );
+int runIrodsAgentFactory(sockaddr_un agent_addr);
+
+int queueConnectedAgentProc(
+    int childPid,
+    agentProc_t *connReq,
+    agentProc_t **agentProcHead);
 
 namespace {
 // We incorporate the cache salt into the rule engine's named_mutex and shared memory object.
@@ -256,29 +262,28 @@ main( int argc, char **argv )
     char random_suffix[65];
     get64RandomBytes( random_suffix );
 
-    char mkdtemp_template[] = "/tmp/irods_sockets_XXXXXX";
-    char* mkdtemp_result = mkdtemp(mkdtemp_template); 
-    if ( mkdtemp_result == NULL ) {
-        rodsLog( LOG_ERROR, "Error creating tmp directory for iRODS sockets, mkdtemp errno [%d]: [%s]", errno, strerror(errno) );
-        free( logDir );
+    char mkdtemp_template[sizeof(socket_dir_template)]{};
+    snprintf(mkdtemp_template, sizeof(mkdtemp_template), "%s", socket_dir_template);
+
+    const char* mkdtemp_result = mkdtemp(mkdtemp_template);
+    if (!mkdtemp_result) {
+        rodsLog(LOG_ERROR, "Error creating tmp directory for iRODS sockets, mkdtemp errno [%d]: [%s]", errno, strerror(errno));
+        free(logDir);
         return SYS_INTERNAL_ERR;
     }
-    strcpy( agent_factory_socket_dir, mkdtemp_result );
-
-    strcpy( agent_factory_socket_file, agent_factory_socket_dir );
-    strcat( agent_factory_socket_file, "/irods_factory_" );
-    strcat( agent_factory_socket_file, random_suffix );
-    strcpy( local_addr.sun_path, agent_factory_socket_file );
+    snprintf(agent_factory_socket_dir, sizeof(agent_factory_socket_dir), "%s", mkdtemp_result);
+    snprintf(agent_factory_socket_file, sizeof(agent_factory_socket_file), "%s/irods_factory_%s", agent_factory_socket_dir, random_suffix);
+    snprintf(local_addr.sun_path, sizeof(local_addr.sun_path), "%s", agent_factory_socket_file);
 
     agent_spawning_pid = fork();
 
     if ( agent_spawning_pid == 0 ) {
-        // Child process
+        // Agent factory process (parent)
         ProcessType = AGENT_PT;
         free( logDir );
-        return runIrodsAgent( local_addr );
+        return runIrodsAgentFactory( local_addr );
     } else if ( agent_spawning_pid > 0 ) {
-        // Parent process
+        // Main iRODS server (grandparent)
         rodsLog( LOG_NOTICE, "Agent factory process pid = [%d]", agent_spawning_pid );
         agent_conn_socket = socket( AF_UNIX, SOCK_STREAM, 0 );
 
@@ -461,7 +466,11 @@ serverMain( char *logDir ) {
         irods::server_control_plane ctrl_plane(
             irods::CFG_SERVER_CONTROL_PLANE_PORT );
 
-        startProcConnReqThreads();
+        status = startProcConnReqThreads();
+        if(status < 0) {
+            rodsLog(LOG_ERROR, "[%s] - Error in startProcConnReqThreads()", __FUNCTION__);
+            return status;
+        }
         if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             try {
                 PurgeLockFileThread = new boost::thread( purgeLockFileWorkerTask );
@@ -732,7 +741,9 @@ spawnAgent( agentProc_t *connReq, agentProc_t **agentProcHead ) {
     startupPack = &connReq->startupPack;
 
     childPid = execAgent( newSock, startupPack );
-    queConnectedAgentProc( childPid, connReq, agentProcHead );
+    if (childPid > 0) {
+        queueConnectedAgentProc(childPid, connReq, agentProcHead);
+    }
 
     return childPid;
 }
@@ -796,53 +807,67 @@ ssize_t sendSocketOverSocket( int writeFd, int socket ) {
 
 int
 execAgent( int newSock, startupPack_t *startupPack ) {
-    ssize_t status;
-    unsigned int len = sizeof(local_addr);
-    char in_buf[1024];
-    memset( in_buf, 0, sizeof(in_buf) );
-
     // Create unique socket for each call to exec agent
-    sockaddr_un tmp_socket_addr;
-    char tmp_socket_file[128];
-    char random_suffix[65];
-    int tmp_socket;
-    memset( &tmp_socket_addr, 0, sizeof(tmp_socket_addr) );
-    tmp_socket_addr.sun_family = AF_UNIX;
-    get64RandomBytes( random_suffix );
+    char random_suffix[65]{};
+    get64RandomBytes(random_suffix);
 
-    strcpy( tmp_socket_file, agent_factory_socket_dir );
-    strcat( tmp_socket_file, "/irods_agent_" );
-    strcat( tmp_socket_file, random_suffix );
+    sockaddr_un tmp_socket_addr{};
+    char tmp_socket_file[sizeof(tmp_socket_addr.sun_path)]{};
+    snprintf(tmp_socket_file, sizeof(tmp_socket_file), "%s/irods_agent_%s", agent_factory_socket_dir, random_suffix);
 
-    status = send( agent_conn_socket, tmp_socket_file, strlen(tmp_socket_file), 0 );
+    ssize_t status{send(agent_conn_socket, tmp_socket_file, strlen(tmp_socket_file), 0)};
     if ( status < 0 ) {
         rodsLog( LOG_ERROR, "Error sending socket to agent factory process, errno = [%d]: %s", errno, strerror( errno ) );
     } else if ( static_cast<size_t>(status) < strlen( tmp_socket_file ) ) {
-
         rodsLog( LOG_DEBUG, "Failed to send entire message - msg [%s] is [%d] bytes long, sent [%d] bytes", tmp_socket_file, strlen( tmp_socket_file ), status );
     }
 
-    strcpy( tmp_socket_addr.sun_path, tmp_socket_file );
+    tmp_socket_addr.sun_family = AF_UNIX;
+    strncpy(tmp_socket_addr.sun_path, tmp_socket_file, sizeof(tmp_socket_addr.sun_path));
 
-    tmp_socket = socket( AF_UNIX, SOCK_STREAM, 0 );
+    int tmp_socket{socket(AF_UNIX, SOCK_STREAM, 0)};
     if ( tmp_socket < 0 ) {
         rodsLog( LOG_ERROR, "Unable to create socket in execAgent, errno = [%d]: %s", errno, strerror( errno ) );
     }
 
+    const auto cleanup_sockets{[&]() {
+        if (close(tmp_socket) < 0) {
+            rodsLog(LOG_ERROR, "close(tmp_socket) failed with errno = [%d]: %s", errno, strerror(errno));
+        }
+        if (unlink(tmp_socket_file) < 0) {
+            rodsLog(LOG_ERROR, "unlink(tmp_socket_file) failed with errno = [%d]: %s", errno, strerror(errno));
+        }
+    }};
+
     // Wait until receiving acknowledgement that socket has been created
-    status = recv( agent_conn_socket, &in_buf, 1024, 0 );
-    if ( status < 0 ) {
-        rodsLog( LOG_ERROR, "Error in recv acknowledgement from agent factory process, errno = [%d]: %s", errno, strerror( errno ) );
-        return SYS_SOCK_READ_ERR;
-    } else if ( strcmp(in_buf, "OK") != 0 ) {
-        rodsLog( LOG_ERROR, "Bad acknowledgement from agent factory process, message = [%s]", in_buf );
-        return status;
+    char in_buf[1024]{};
+    status = recv( agent_conn_socket, &in_buf, sizeof(in_buf), 0 );
+    if (status < 0) {
+        rodsLog(LOG_ERROR, "Error in recv acknowledgement from agent factory process, errno = [%d]: %s", errno, strerror(errno));
+        status = SYS_SOCK_READ_ERR;
+    } else if (0 != strcmp(in_buf, "OK")) {
+        rodsLog(LOG_ERROR, "Bad acknowledgement from agent factory process, message = [%s]", in_buf);
+        status = SYS_SOCK_READ_ERR;
+    }
+    else {
+        status = connect(tmp_socket, (const struct sockaddr*) &tmp_socket_addr, sizeof(local_addr));
+        if (status < 0) {
+            rodsLog(LOG_ERROR, "Unable to connect to socket in agent factory process, errno = [%d]: %s", errno, strerror(errno));
+            status = SYS_SOCK_CONNECT_ERR;
+        }
     }
 
-    status = connect( tmp_socket, (const struct sockaddr*) &tmp_socket_addr, len );
     if (status < 0) {
-        rodsLog( LOG_ERROR, "Unable to connect to socket in agent factory process, errno = [%d]: %s", errno, strerror( errno ) );
-        return SYS_SOCK_CONNECT_ERR;
+        // Agent factory expects a message about connection to the agent - send failure
+        const std::string failure_message{"spawn_failure"};
+        send(agent_conn_socket, failure_message.c_str(), failure_message.length() + 1, 0);
+        cleanup_sockets();
+        return status;
+    }
+    else {
+        // Notify agent factory of success and send data to agent process
+        const std::string connection_successful{"connection_successful"};
+        send(agent_conn_socket, connection_successful.c_str(), connection_successful.length() + 1, 0);
     }
 
     status = sendEnvironmentVarStrToSocket( SP_RE_CACHE_SALT,irods::get_server_property<const std::string>( irods::CFG_RE_CACHE_SALT_KW).c_str(),  tmp_socket );
@@ -924,40 +949,30 @@ execAgent( int newSock, startupPack_t *startupPack ) {
         rodsLog( LOG_ERROR, "Failed to send \"end_of_vars;\" to agent" );
     }
 
-    status = recv( tmp_socket, &in_buf, 1024, 0 );
+    status = recv( tmp_socket, &in_buf, sizeof(in_buf), 0 );
     if ( status < 0 ) {
         rodsLog( LOG_ERROR, "Error in recv acknowledgement from agent factory process, errno = [%d]: %s", errno, strerror( errno ) );
+        cleanup_sockets();
         return SYS_SOCK_READ_ERR;
     } else if ( strcmp(in_buf, "OK") != 0 ) {
         rodsLog( LOG_ERROR, "Bad acknowledgement from agent factory process, message = [%s]", in_buf );
-        return status;
+        cleanup_sockets();
+        return SYS_SOCK_READ_ERR;
     }
-
     sendSocketOverSocket( tmp_socket, newSock );
-
-    status = recv( tmp_socket, &in_buf, 1024, 0 );
+    status = recv( tmp_socket, &in_buf, sizeof(in_buf), 0 );
     if ( status < 0 ) {
         rodsLog( LOG_ERROR, "Error in recv child_pid from agent factory process, errno = [%d]: %s", errno, strerror( errno ) );
+        cleanup_sockets();
         return SYS_SOCK_READ_ERR;
     }
 
-    int childPid = atoi(in_buf);
-
-    status = close( tmp_socket );
-    if ( status < 0 ) {
-        rodsLog( LOG_ERROR, "close(tmp_socket) failed with errno = [%d]: %s", errno, strerror( errno ) );
-    }
-
-    status = unlink( tmp_socket_file );
-    if ( status < 0 ) {
-        rodsLog( LOG_ERROR, "unlink(tmp_socket_file) failed with errno = [%d]: %s", errno, strerror( errno ) );
-    }
-
-    return childPid;
+    cleanup_sockets();
+    return std::atoi(in_buf);
 }
 
 int
-queConnectedAgentProc( int childPid, agentProc_t *connReq,
+queueConnectedAgentProc( int childPid, agentProc_t *connReq,
                        agentProc_t **agentProcHead ) {
     if ( connReq == NULL ) {
         return USER__NULL_INPUT_ERR;


### PR DESCRIPTION
The main server agent spawner which handles connection requests can
fail when communicating with the agent factory. On failure, the
connection request is freed by the spawning thread and continues.
Later, procChildren comes to clean up the connection request queue
and also frees the connection request, which results in a double free.

This change puts a new message exchange between the main server and
the agent factory when establishing the connection. After the connection
is made, an acknowledgement is sent from the main server to the agent
factory. If anything other than the expected value (a success message)
is received, the agent factory will not fork an agent process.

The server process now consistently cleans up the open sockets and
associated socket files before returning from execAgent.

---
[CI tests running](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1743/)