### PR TITLE
[#3776] Prevent double free in agent spawner (4-2-stable)

### DIFF
--- a/server/core/include/rodsServer.hpp
+++ b/server/core/include/rodsServer.hpp
@@ -69,9 +69,6 @@ spawnAgent( agentProc_t *connReq, agentProc_t **agentProcHead );
 int
 execAgent( int newSock, startupPack_t *startupPack );
 int
-queConnectedAgentProc( int childPid, agentProc_t *connReq,
-                       agentProc_t **agentProcHead );
-int
 getAgentProcCnt();
 int
 chkAgentProcCnt();


### PR DESCRIPTION
The main server agent spawner which handles connection requests can
fail when communicating with the agent factory. On failure, the
connection request is freed by the spawning thread and continues.
Later, procChildren comes to clean up the connection request queue
and also frees the connection request, which results in a double free.

This change puts a new message exchange between the main server and
the agent factory when establishing the connection. After the connection
is made, an acknowledgement is sent from the main server to the agent
factory. If anything other than the expected value (a success message)
is received, the agent factory will not fork an agent process.

The server process now consistently cleans up the open sockets and
associated socket files before returning from execAgent.

(cherry-picked from SHA: 7fdb4c6ae3eee29aca262eafb1468b1dd978974f)

---
[CI tests passed](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1745/)