### PR TITLE
[#4194][#4240] Integrate new query iterator with iuserinfo (master)

### DIFF
--- a/lib/core/include/irods_query.hpp
+++ b/lib/core/include/irods_query.hpp
@@ -9,7 +9,7 @@
 #include "genQuery.h"
 #include "specificQuery.h"
 #endif
-
+#include "irods_log.hpp"
 #include "rcMisc.h"
 
 #include <algorithm>
@@ -106,16 +106,17 @@ namespace irods {
                 return query_string_;
             }
 
+            bool query_limit_exceeded(const uint32_t _count) {
+                return query_limit_ && _count >= query_limit_;
+            }
+
             bool page_in_flight(const int row_idx_) {
                 return (row_idx_ < row_cnt());
             }
 
             bool query_complete() {
                 // finished page, and out of pages
-                if(cont_idx() <= 0) {
-                    return true;
-                }
-                return false;
+                return cont_idx() <= 0;
             }
 
             value_type capture_results(int _row_idx) {
@@ -144,32 +145,37 @@ namespace irods {
 
             query_impl_base(
                 query_helper::comm_type* _comm,
+                const uint32_t           _query_limit,
                 const std::string&       _q) :
                 comm_{_comm},
+                query_limit_{_query_limit},
                 query_string_{_q},
                 gen_output_{} {
             };
             protected:
             query_helper::comm_type* comm_;
-            const std::string& query_string_;
+            const uint32_t query_limit_;
+            const std::string query_string_;
             genQueryOut_t* gen_output_;
         }; // class query_impl_base
 
         class gen_query_impl : public query_impl_base {
             public:
             virtual ~gen_query_impl() {
-                // Close statements for this query
-                gen_input_.continueInx = gen_output_->continueInx;
-                freeGenQueryOut(&gen_output_);
-                gen_input_.maxRows = 0;
-                auto err = query_helper::gen_query_fcn(
-                               comm_,
-                               &gen_input_,
-                               &gen_output_);
-                if (CAT_NO_ROWS_FOUND != err && err < 0) {
-                    irods::log(ERROR(err, (boost::format(
-                                "[%s] - Failed to close statement with continueInx [%d]") %
-                                __FUNCTION__ % gen_input_.continueInx).str()));
+                if(gen_output_->continueInx) {
+                    // Close statements for this query
+                    gen_input_.continueInx = gen_output_->continueInx;
+                    freeGenQueryOut(&gen_output_);
+                    gen_input_.maxRows = 0;
+                    auto err = query_helper::gen_query_fcn(
+                                   comm_,
+                                   &gen_input_,
+                                   &gen_output_);
+                    if (CAT_NO_ROWS_FOUND != err && err < 0) {
+                        irods::log(ERROR(err, (boost::format(
+                                    "[%s] - Failed to close statement with continueInx [%d]") %
+                                    __FUNCTION__ % gen_input_.continueInx).str()));
+                    }
                 }
             }
 
@@ -189,12 +195,12 @@ namespace irods {
 
             gen_query_impl(
                 query_helper::comm_type* _comm,
-                int                      _max_rows,
+                int                      _query_limit,
                 const std::string&       _query_string) :
-                query_impl_base(_comm, _query_string) {
+                query_impl_base(_comm, _query_limit, _query_string) {
 
                 memset(&gen_input_, 0, sizeof(gen_input_));
-                gen_input_.maxRows = _max_rows;
+                gen_input_.maxRows = MAX_SQL_ROWS;
                 const int fill_err = fillGenQueryInpFromStrCond(
                                          const_cast<char*>(_query_string.c_str()),
                                          &gen_input_);
@@ -213,19 +219,21 @@ namespace irods {
         class spec_query_impl : public query_impl_base {
             public:
             virtual ~spec_query_impl() {
-                // Close statement for this query
-                spec_input_.continueInx = gen_output_->continueInx;
-                freeGenQueryOut(&gen_output_);
-                spec_input_.maxRows = 0;
-                auto err = query_helper::spec_query_fcn(
-                               comm_,
-                               &spec_input_,
-                               &gen_output_);
-                if (CAT_NO_ROWS_FOUND != err && err < 0) {
-                    irods::log(ERROR(
-                                err, (boost::format(
-                                "[%s] - Failed to close statement with continueInx [%d]") %
-                                __FUNCTION__ % spec_input_.continueInx).str()));
+                if(gen_output_->continueInx) {
+                    // Close statement for this query
+                    spec_input_.continueInx = gen_output_->continueInx;
+                    freeGenQueryOut(&gen_output_);
+                    spec_input_.maxRows = 0;
+                    auto err = query_helper::spec_query_fcn(
+                                   comm_,
+                                   &spec_input_,
+                                   &gen_output_);
+                    if (CAT_NO_ROWS_FOUND != err && err < 0) {
+                        irods::log(ERROR(
+                                    err, (boost::format(
+                                    "[%s] - Failed to close statement with continueInx [%d]") %
+                                    __FUNCTION__ % spec_input_.continueInx).str()));
+                    }
                 }
             }
 
@@ -245,12 +253,12 @@ namespace irods {
 
             spec_query_impl(
                 query_helper::comm_type* _comm,
-                int                      _max_rows,
+                int                      _query_limit,
                 const std::string&       _query_string) :
-                query_impl_base(_comm, _query_string) {
+                query_impl_base(_comm, _query_limit, _query_string) {
 
                 memset(&spec_input_, 0, sizeof(spec_input_));
-                spec_input_.maxRows = _max_rows;
+                spec_input_.maxRows = MAX_SQL_ROWS;
                 spec_input_.sql = const_cast<char*>(_query_string.c_str());
 
                 int spec_err = query_helper::spec_query_fcn(
@@ -270,12 +278,10 @@ namespace irods {
         }; // class spec_query_impl
 
         class iterator {
-            query_helper::comm_type* comm_;
             const std::string query_string_;
-            uintmax_t max_rows_;
             uint32_t row_idx_;
+            uint32_t total_rows_processed_;
             genQueryInp_t* gen_input_; 
-            genQueryOut_t* gen_output_; 
             bool end_iteration_state_;
 
             std::shared_ptr<query_impl_base> query_impl_;
@@ -288,39 +294,30 @@ namespace irods {
             using iterator_category = std::forward_iterator_tag;
 
             explicit iterator() :
-                comm_{},
                 query_string_{},
-                max_rows_{},
                 row_idx_{},
+                total_rows_processed_{},
                 gen_input_{},
-                gen_output_{},
                 end_iteration_state_{true},
                 query_impl_{} {
             }
 
             explicit iterator(std::shared_ptr<query_impl_base> _qimp) :
-                comm_{},
                 query_string_{},
-                max_rows_{},
                 row_idx_{},
+                total_rows_processed_{},
                 gen_input_{},
-                gen_output_{},
                 end_iteration_state_{false},
                 query_impl_(_qimp) {
             }
 
             explicit iterator(
-                query_helper::comm_type* _comm,
                 const std::string&       _query_string,
-                const uintmax_t&         _max_rows,
-                genQueryInp_t*           _gen_input,
-                genQueryOut_t*           _gen_output) :
-                comm_{_comm},
+                genQueryInp_t*           _gen_input) :
                 query_string_{_query_string},
-                max_rows_{_max_rows},
                 row_idx_{},
+                total_rows_processed_{},
                 gen_input_{_gen_input},
-                gen_output_{_gen_output},
                 end_iteration_state_{false},
                 query_impl_{} {
             } // ctor
@@ -359,6 +356,12 @@ namespace irods {
             }
 
             void advance_query() {
+                total_rows_processed_++;
+                if(query_impl_->query_limit_exceeded(total_rows_processed_)) {
+                    end_iteration_state_ = true;
+                    return;
+                }
+
                 row_idx_++;
                 if(query_impl_->page_in_flight(row_idx_)) {
                     return;
@@ -394,18 +397,18 @@ namespace irods {
         explicit query(
             query_helper::comm_type* _comm,
             const std::string&       _query_string,
-            uintmax_t                _max_rows   = MAX_SQL_ROWS,
+            uintmax_t                _query_limit = 0,
             query_type               _query_type = GENERAL) {
                 if(_query_type == GENERAL) {
                     query_impl_ = std::make_shared<gen_query_impl>(
                                       _comm,
-                                      _max_rows,
+                                      _query_limit,
                                       _query_string);
                 }
                 else if(_query_type == SPECIFIC) {
                     query_impl_ = std::make_shared<spec_query_impl>(
                                       _comm,
-                                      _max_rows,
+                                      _query_limit,
                                       _query_string);
                 }
 

--- a/scripts/irods/test/test_iuserinfo.py
+++ b/scripts/irods/test/test_iuserinfo.py
@@ -1,0 +1,77 @@
+import sys
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    import unittest2 as unittest
+
+from . import session
+from . import resource_suite
+
+#class Test_IUserinfo(SessionsMixin, unittest.TestCase):
+class Test_IUserinfo(resource_suite.ResourceBase, unittest.TestCase):
+    def setUp(self):
+        super(Test_IUserinfo, self).setUp()
+
+        # create a remote user with the same name as a local one
+        self.admin_session = session.make_session_for_existing_admin()
+        test_session = self.admin_session
+        self.local_user = test_session.username
+        self.local_zone = test_session.zone_name
+        self.remote_user = test_session.username
+        self.remote_zone = 'remoteZone'
+
+        self.admin_session.assert_icommand(['iadmin', 'mkzone', self.remote_zone, 'remote'])
+        self.admin_session.assert_icommand(['iadmin', 'mkuser', '{self.remote_user}#{self.remote_zone}'.format(**locals()), 'rodsadmin'])
+
+    def tearDown(self):
+        self.admin_session.assert_icommand(['iadmin', 'rmuser', '{self.remote_user}#{self.remote_zone}'.format(**locals())])
+        self.admin_session.assert_icommand(['iadmin', 'rmzone', self.remote_zone])
+        super(Test_IUserinfo, self).tearDown()
+
+    def test_iuserinfo_with_zone(self):
+        test_session = self.admin_session
+
+        # STDOUT_MULTILINE requires ordered output which is not guaranteed,
+        # so capture output in a string and compare against expected output
+        expected_groups = ['member of group: rods', 'member of group: public', 'member of group: rodsadmin']
+        _,out,_ = test_session.assert_icommand(['iuserinfo', '{self.local_user}#{self.local_zone}'.format(**locals())], 'STDOUT', ['zone: ' + self.local_zone])
+        self.assertTrue(self.local_zone in out)
+        self.assertTrue(self.remote_zone not in out)
+        for group in expected_groups:
+            self.assertTrue(group in out)
+
+        _,out,_ = test_session.assert_icommand(['iuserinfo', '{self.remote_user}#{self.remote_zone}'.format(**locals())], 'STDOUT', ['zone: ' + self.remote_zone])
+        self.assertTrue(expected_groups[-1] not in out)
+        self.assertTrue(self.local_zone not in out)
+        self.assertTrue(self.remote_zone in out)
+        for group in expected_groups[:-1]:
+            self.assertTrue(group in out)
+
+    def test_iuserinfo_no_zone(self):
+        test_session = self.admin_session
+        user = test_session.username
+        zone = test_session.zone_name
+        _,out,_ = test_session.assert_icommand(['iuserinfo', user], 'STDOUT', 'name: ' +user)
+        self.assertTrue(zone in out)
+        self.assertTrue(self.remote_zone not in out)
+
+    def test_iuserinfo_no_input(self):
+        test_session = self.admin_session
+        user = test_session.username
+        zone = test_session.zone_name
+        _,out,_ = test_session.assert_icommand(['iuserinfo'], 'STDOUT', 'name: ' + user)
+        self.assertTrue(zone in out)
+        self.assertTrue(self.remote_zone not in out)
+
+    def test_iuserinfo_invalid_user_and_zone(self):
+        test_session = self.admin_session
+        test_session.assert_icommand(['iuserinfo', 'invalidUser#{self.local_zone}'.format(**locals())], 'STDOUT',
+                                     'User invalidUser#{self.local_zone} does not exist.'.format(**locals()))
+        test_session.assert_icommand(['iuserinfo', '{self.local_user}#invalidZone'.format(**locals())], 'STDOUT',
+                                     'User {self.local_user}#invalidZone does not exist.'.format(**locals()))
+
+    def test_iuserinfo_bad_input(self):
+        self.admin_session.assert_icommand(['iuserinfo', 'this#should#fail'], 'STDOUT', 'Failed parsing input')
+
+    def test_iuserinfo_group(self):
+        self.admin_session.assert_icommand(['iuserinfo', 'public'], 'STDOUT', 'Not a member of any group')

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -192,8 +192,7 @@ if __name__ == '__main__':
                                  'test_ichmod', 'test_iput_options', 'test_ireg', 'test_irsync', 'test_iticket', 'test_irodsctl',
                                  'test_resource_configuration', 'test_control_plane', 'test_native_rule_engine_plugin', 'test_quotas',
                                  'test_ils', 'test_irmdir', 'test_ichksum', 'test_iquest', 'test_imeta_help', 'test_irepl', 'test_itrim',
-                                 'test_irm', 'test_rule_engine_plugin_passthrough','test_irule'])
-
+                                 'test_irm', 'test_rule_engine_plugin_passthrough', 'test_irule', 'test_iuserinfo'])
     if options.run_plugin_tests:
         test_identifiers.extend(get_plugin_tests())
 


### PR DESCRIPTION
max_rows has changed to query_limit conceptually within the query
iterator. Now the user of query objects passes a limit for the
number of results that the iterator will traverse before stopping.
The default value of 0 means that there is no limit and the iterator
will continue until there are no more results. The iterator tracks
how many rows it has processed and when this value exceeds the limit
value, the iterator enters the end iteration state.

The query string is now copied into the query base implementation
object instead of just holding a reference in case the user has passed
a temporary when constructing the query object.

Also...

Adds tests with varying types of inputs for iuserinfo to make sure
zone names are interpreted appropriately by the client.

---
[CI tests running](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1752/)