### PR TITLE
[#3998] Prevent reading of msParam with no type (master)

### DIFF
--- a/lib/core/src/msParam.cpp
+++ b/lib/core/src/msParam.cpp
@@ -62,6 +62,10 @@ addMsParamToArray( msParamArray_t *msParamArray, const char *label,
             continue;
         }
         if ( strcmp( msParamArray->msParam[i]->label, label ) == 0 ) {
+            if (!type || !msParamArray->msParam[i]->type) {
+                rodsLog(LOG_ERROR, "[%s] - type is null for [%s]", __FUNCTION__, label);
+                continue;
+            }
             /***  Jan 28 2010 to make it not given an error ***/
             if ( !strcmp( msParamArray->msParam[i]->type, STR_MS_T ) &&
                     !strcmp( type, STR_MS_T ) &&

--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/functions.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/functions.cpp
@@ -1924,15 +1924,21 @@ Res *smsi_remoteExec( Node** paramsr, int, Node* node, ruleExecInfo_t* rei, int,
         return newErrorRes( r, ret );
     }
 
-    // Add ruleExecOut to input param and execute rule
+    // Add ruleExecOut to input param and execute rule if the type is set
+    // Use add here because ruleExecOut is specifically not stored in rei, not env
     msParam_t* rule_exec_out{getMsParamByLabel(rei->msParamArray, "ruleExecOut")};
-    addMsParam(execMyRuleInp.inpParamArray, rule_exec_out->label, rule_exec_out->type, rule_exec_out->inOutStruct, rule_exec_out->inpOutBuf);
+    if (rule_exec_out && rule_exec_out->type) {
+        addMsParamToArray(execMyRuleInp.inpParamArray, rule_exec_out->label, rule_exec_out->type, rule_exec_out->inOutStruct, rule_exec_out->inpOutBuf, 0);
+    }
     i = rsExecMyRule( rei->rsComm, &execMyRuleInp,  &outParamArray );
 
     if (outParamArray) {
-        // Put ruleExecOut into rei->msParamArray
+        // Put ruleExecOut into rei->msParamArray if the type is set
+        // Use fill rather than add because the label already exists in rei->msParamArray
         replMsParam(getMsParamByLabel(outParamArray, "ruleExecOut"), rule_exec_out);
-        addMsParam(rei->msParamArray, rule_exec_out->label, rule_exec_out->type, rule_exec_out->inOutStruct, rule_exec_out->inpOutBuf);
+        if (rule_exec_out && rule_exec_out->type) {
+            fillMsParam(getMsParamByLabel(rei->msParamArray, "ruleExecOut"), rule_exec_out->label, rule_exec_out->type, rule_exec_out->inOutStruct, rule_exec_out->inpOutBuf);
+        }
 
         // Remove ruleExecOut before storing param array to env
         rmMsParamByLabel(outParamArray, "ruleExecOut", 1);

--- a/scripts/irods/test/rule_texts_for_tests.py
+++ b/scripts/irods/test/rule_texts_for_tests.py
@@ -371,6 +371,64 @@ INPUT *arg1="abc", *arg2="def", *arg3="ghi"
 OUTPUT ruleExecOut
 '''
 
+#===== Test_Remote_Exec =====
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Remote_Exec'] = {}
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Remote_Exec']['test_remote_no_writeline'] = '''
+test_remote_no_writeLine {{
+    remote("{host}", "<ZONE>{zone}</ZONE>") {{
+        *a = "remote";
+    }}
+    writeLine("stdout", "a=*a");
+}}
+INPUT *a="input"
+OUTPUT ruleExecOut
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Remote_Exec']['test_remote_writeline'] = '''
+test_remote_writeLine {{
+    remote("{host}", "<ZONE>{zone}</ZONE>") {{
+        writeLine("stdout", "Remote writeLine");
+    }}
+}}
+INPUT null
+OUTPUT ruleExecOut
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Remote_Exec']['test_remote_in_remote_writeline'] = '''
+test_remote_writeLine {{
+    remote("{host}", "<ZONE>{zone}</ZONE>") {{
+        remote("{host}", "<ZONE>{zone}</ZONE>") {{
+            writeLine("stdout", "Remote in remote writeLine");
+        }}
+        writeLine("stdout", "Remote writeLine");
+    }}
+}}
+INPUT null
+OUTPUT ruleExecOut
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Remote_Exec']['test_remote_in_delay_writeline'] = '''
+test_remote_writeLine {{
+    delay("<PLUSET>1s</PLUSET>") {{
+        remote("{host}", "<ZONE>{zone}</ZONE>") {{
+            writeLine("serverLog", "Remote in delay writeLine");
+        }}
+        writeLine("serverLog", "Delay writeLine");
+    }}
+}}
+INPUT null
+OUTPUT ruleExecOut
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Remote_Exec']['test_delay_in_remote_writeline'] = '''
+test_remote_writeLine {{
+    remote("{host}", "<ZONE>{zone}</ZONE>") {{
+        delay("<PLUSET>1s</PLUSET>") {{
+            writeLine("serverLog", "Delay in remote writeLine");
+        }}
+        writeLine("stdout", "Remote writeLine");
+    }}
+}}
+INPUT null
+OUTPUT ruleExecOut
+'''
+
 #==============================================================
 #========================== Python ============================
 #==============================================================


### PR DESCRIPTION
In remote execution blocks, ruleExecOut is not always assigned a type.
This causes a strcmp on a null pointer to char in addMsParamToArray. This
change adds a check in smsi_remoteExec before copying around the ruleExecOut
param to ensure that its type is not null. A check is also done in
addMsParamToArray to ensure type is not null before attempting the strcmp.

---

[CI tests passed](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1778/)