### PR TITLE
[#4269][#4271] Add thread pool and connection pool (4-2-stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,7 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/core/src/bunUtil.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/chksumUtil.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/clientLogin.cpp
+  ${CMAKE_SOURCE_DIR}/lib/core/src/connection_pool.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/cpUtil.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/fsckUtil.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/getUtil.cpp

--- a/cmake/development_library.cmake
+++ b/cmake/development_library.cmake
@@ -22,6 +22,7 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/core/include/base64.h
   ${CMAKE_SOURCE_DIR}/lib/core/include/bunUtil.h
   ${CMAKE_SOURCE_DIR}/lib/core/include/chksumUtil.h
+  ${CMAKE_SOURCE_DIR}/lib/core/include/connection_pool.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/cpUtil.h
   ${CMAKE_SOURCE_DIR}/lib/core/include/fsckUtil.h
   ${CMAKE_SOURCE_DIR}/lib/core/include/getRodsEnv.h

--- a/cmake/development_library.cmake
+++ b/cmake/development_library.cmake
@@ -136,6 +136,7 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/core/include/sslSockComm.h
   ${CMAKE_SOURCE_DIR}/lib/core/include/stringOpr.h
   ${CMAKE_SOURCE_DIR}/lib/core/include/termiosUtil.hpp
+  ${CMAKE_SOURCE_DIR}/lib/core/include/thread_pool.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/trimUtil.h
   )
 

--- a/lib/core/include/connection_pool.hpp
+++ b/lib/core/include/connection_pool.hpp
@@ -1,0 +1,84 @@
+#ifndef IRODS_CONNECTION_POOL_HPP
+#define IRODS_CONNECTION_POOL_HPP
+
+#include "rcConnect.h"
+
+#include <memory>
+#include <vector>
+#include <mutex>
+#include <atomic>
+#include <string>
+
+namespace irods
+{
+    class connection_pool
+    {
+    public:
+        // A wrapper around a connection in the pool.
+        // On destruction, the underlying connection is immediately returned
+        // to the pool.
+        class connection_proxy
+        {
+        public:
+            friend class connection_pool;
+
+            connection_proxy(connection_proxy&&);
+            connection_proxy& operator=(connection_proxy&&);
+
+            ~connection_proxy();
+
+            operator rcComm_t&() const noexcept;
+
+        private:
+            connection_proxy(connection_pool& _pool, rcComm_t& _conn, int _index) noexcept;
+
+            static constexpr int uninitialized_index{-1};
+
+            connection_pool* pool_;
+            rcComm_t* conn_;
+            int index_;
+        };
+
+        connection_pool(int _size,
+                        const std::string& _host,
+                        const int _port,
+                        const std::string& _username,
+                        const std::string& _zone);
+
+        connection_pool(const connection_pool&) = delete;
+        connection_pool& operator=(const connection_pool&) = delete;
+
+        connection_proxy get_connection();
+
+    private:
+        using connection_pointer = std::unique_ptr<rcComm_t, int(*)(rcComm_t*)>;
+
+        struct connection_context
+        {
+            std::mutex mutex{};
+            std::atomic<bool> in_use{};
+            connection_pointer conn{nullptr, rcDisconnect};
+            rErrMsg_t error{};
+        };
+
+        void return_connection(int _index);
+
+        void create_connection(
+            int _index,
+            std::function<void()> _on_conn_err,
+            std::function<void()> _on_login_err);
+
+        bool verify_connection(int _index);
+
+        rcComm_t* refresh_connection(int _index);
+
+        const std::string host_;
+        const int port_;
+        const std::string username_;
+        const std::string zone_;
+        std::vector<connection_context> conn_ctxs_;
+    };
+} // namespace irods
+
+#endif // IRODS_CONNECTION_POOL_HPP
+

--- a/lib/core/include/thread_pool.hpp
+++ b/lib/core/include/thread_pool.hpp
@@ -1,0 +1,66 @@
+#ifndef IRODS_THREAD_POOL_HPP
+#define IRODS_THREAD_POOL_HPP
+
+#include <boost/asio.hpp>
+#include <boost/thread.hpp>
+
+#include <memory>
+
+namespace irods {
+    class thread_pool {
+        public:
+            explicit thread_pool(int _size)
+                : io_service_{std::make_shared<boost::asio::io_service>()}
+                , work_{std::make_shared<boost::asio::io_service::work>(*io_service_)}
+            {
+                for (decltype(_size) i{}; i < _size; i++) {
+                    thread_group_.create_thread([this] {
+                        io_service_->run();
+                    });
+                }
+            }
+
+            ~thread_pool() {
+                stop();
+                join();
+            }
+
+            template <typename Function>
+            static inline void dispatch(thread_pool& _pool, Function&& _func) {
+                _pool.dispatch(std::forward<Function>(_func));
+            }
+
+            template <typename Function>
+            static inline void post(thread_pool& _pool, Function&& _func) {
+                _pool.post(std::forward<Function>(_func));
+            }
+
+            void join() {
+                thread_group_.join_all();
+            }
+
+            void stop() {
+                if (io_service_) {
+                    io_service_->stop();
+                }
+            }
+
+        private:
+            boost::thread_group thread_group_;
+            std::shared_ptr<boost::asio::io_service> io_service_;
+            std::shared_ptr<boost::asio::io_service::work> work_;
+
+            template <typename Function>
+            void dispatch(Function&& _func) {
+                io_service_->dispatch(std::forward<Function>(_func));
+            }
+
+            template <typename Function>
+            void post(Function&& _func) {
+                io_service_->post(std::forward<Function>(_func));
+            }
+    };
+} // namespace irods
+
+#endif // IRODS_THREAD_POOL_HPP
+

--- a/lib/core/src/connection_pool.cpp
+++ b/lib/core/src/connection_pool.cpp
@@ -1,0 +1,151 @@
+#include "connection_pool.hpp"
+
+#include "irods_query.hpp"
+#include "thread_pool.hpp"
+
+#include <stdexcept>
+#include <thread>
+
+namespace irods {
+
+connection_pool::connection_proxy::~connection_proxy()
+{
+    if(pool_ && conn_ && uninitialized_index != index_) {
+        pool_->return_connection(index_);
+    }
+}
+
+connection_pool::connection_proxy::connection_proxy(
+    connection_proxy&& _rhs)
+    : pool_{_rhs.pool_}
+    , conn_{_rhs.conn_}
+    , index_{_rhs.index_}
+{
+    _rhs.pool_ = nullptr;
+    _rhs.conn_ = nullptr;
+    _rhs.index_ = uninitialized_index;
+}
+
+connection_pool::connection_proxy& connection_pool::connection_proxy::operator=(
+    connection_proxy&& _rhs) {
+    pool_ = _rhs.pool_;
+    conn_ = _rhs.conn_;
+    index_ = _rhs.index_;
+    _rhs.pool_ = nullptr;
+    _rhs.conn_ = nullptr;
+    _rhs.index_ = uninitialized_index;
+    return *this;
+}
+
+connection_pool::connection_proxy::operator rcComm_t&() const noexcept
+{
+    return *conn_;
+}
+
+connection_pool::connection_proxy::connection_proxy(connection_pool& _pool,
+                                                    rcComm_t& _conn,
+                                                    int _index) noexcept
+    : pool_{&_pool}
+    , conn_{&_conn}
+    , index_{_index}
+{
+}
+
+connection_pool::connection_pool(int _size,
+                                 const std::string& _host,
+                                 const int _port,
+                                 const std::string& _username,
+                                 const std::string& _zone)
+    : host_{_host}
+    , port_{_port}
+    , username_{_username}
+    , zone_{_zone}
+    , conn_ctxs_(_size)
+{
+    if (_size < 1) {
+        throw std::runtime_error{"invalid connection pool size"};
+    }
+
+    // Always initialize the first connection to guarantee that the
+    // network plugin is loaded. This guarantees that asynchronous calls
+    // to rcConnect do not cause a segfault.
+    create_connection(0,
+            [] { throw std::runtime_error{"connect error"}; },
+            [] { throw std::runtime_error{"client login error"}; });
+
+    // If the size of the pool is one, then return immediately.
+    if (_size == 1) {
+        return;
+    }
+
+    for (int i = 1; i < _size; ++i) {
+        create_connection(i,
+                [] { throw std::runtime_error{"connect error"}; },
+                [] { throw std::runtime_error{"client login error"}; });
+    }
+}
+
+void connection_pool::create_connection(
+    int _index,
+    std::function<void()> _on_conn_err,
+    std::function<void()> _on_login_err)
+{
+    auto& context = conn_ctxs_[_index];
+    context.conn.reset(rcConnect(host_.c_str(), port_, username_.c_str(), zone_.c_str(), NO_RECONN, &context.error));
+
+    if (!context.conn) {
+        _on_conn_err();
+        return;
+    }
+
+    if (clientLogin(context.conn.get()) != 0) {
+        _on_login_err();
+    }
+}
+
+connection_pool::connection_proxy connection_pool::get_connection()
+{
+    for (int i = 0;; i = ++i % conn_ctxs_.size()) {
+        std::unique_lock<std::mutex> lock{conn_ctxs_[i].mutex, std::defer_lock};
+
+        if (lock.try_lock()) {
+            if (!conn_ctxs_[i].in_use.load()) {
+                conn_ctxs_[i].in_use.store(true);
+                return {*this, *refresh_connection(i), i};
+            }
+        }
+    }
+}
+
+void connection_pool::return_connection(int _index)
+{
+    conn_ctxs_[_index].in_use.store(false);
+}
+
+bool connection_pool::verify_connection(int _index) {
+    auto& context = conn_ctxs_[_index];
+    if(!context.conn) {
+        return false;
+    }
+    try {
+        irods::query qobj{context.conn.get(),
+            "SELECT ZONE_NAME WHERE ZONE_TYPE = 'local'"};
+    } catch(const irods::exception&) {
+        return false;
+    }
+    return true;
+}
+
+rcComm_t* connection_pool::refresh_connection(int _index) {
+    // Reset rError stack to clear from possible previous use
+    conn_ctxs_[_index].error = {};
+    if(!verify_connection(_index)) {
+        create_connection(_index,
+            [] { throw std::runtime_error{"connect error"}; },
+            [] { throw std::runtime_error{"login error"}; });
+    }
+    return conn_ctxs_[_index].conn.get();
+}
+
+} // namespace irods
+


### PR DESCRIPTION
Adds a light wrapper around a boost::asio::io_service and thread_group
to represent a thread_pool (boost::thread::thread_pool was introduced
in boost 1.66, which is newer than the version in use in 4-2-stable).
Each thread points to an io_service and a work object which can be
modified via free-standing functions irods::thread_pool::post and
irods::thread_pool::dispatch (again, modeled after boost::asio).

Adds a mechanism for pooling iRODS connections using irods::thread_pool.
When a connection taken from the pool is destructed, it is returned to the
pool.

These are part of the iRODS dev package.