### PR TITLE
[#4157] in msiGetMoreRows prevent CAT_NO_ROWS_FOUND on page boundary

### DIFF
--- a/scripts/irods/test/test_prep_genquery_iterator.py
+++ b/scripts/irods/test/test_prep_genquery_iterator.py
@@ -61,7 +61,7 @@ def genquery_module_available():
             try:
                 sys.path.insert(0,IRODS_CONFIG_DIR)
                 import genquery
-                if getattr(genquery,'AUTO_FREE_QUERIES',None) is True:
+                if getattr(genquery,'AUTO_CLOSE_QUERIES',None) is True:
                     Allow_Intensive_Memory_Use = True
                 idx =  sys.path.index(IRODS_CONFIG_DIR)
             except ImportError: # not fatal, past versions were only importable via PREP

--- a/server/re/src/genQueryMS.cpp
+++ b/server/re/src/genQueryMS.cpp
@@ -353,6 +353,7 @@ msiGetMoreRows( msParam_t *genQueryInp_msp, msParam_t *genQueryOut_msp, msParam_
         /* return continuation index separately in case it is needed in conditional expressions */
         resetMsParam( continueInx );
         fillIntInMsParam( continueInx, genQueryOut->continueInx );
+        rei->status = 0;
     }
 
     return rei->status;


### PR DESCRIPTION

This change also restores continueInx flag (in the genQueryOut structure) as the sole
and proper indication of when msiGetMoreRows has reached its last serviceable
iteration within an ICAT query spanning more than 1 page of results. (nonzero rei->status
codes prevent the propagation of return values in arithmetics.cpp)