### PR TITLE
[#3995] Moved usage of namespace boost::filesystem into functions (4-2-stable)

### DIFF
--- a/lib/core/src/rcMisc.cpp
+++ b/lib/core/src/rcMisc.cpp
@@ -47,14 +47,6 @@
 #include <boost/format.hpp>
 #include <boost/generator_iterator.hpp>
 
-// TODO:THIS NEEDS TO BE GONE (Issue 3995)
-//
-// Replace this with:
-// namespace fs = boost::filesystem;
-// within the scope of functions and
-// objects that need it.
-using namespace boost::filesystem;
-
 /* check with the input path is a valid path -
  * 1 - valid
  * 0 - not valid
@@ -62,7 +54,9 @@ using namespace boost::filesystem;
 
 int
 isPath( char *myPath ) {
-    path p( myPath );
+    namespace fs = boost::filesystem;
+
+    fs::path p( myPath );
 
     if ( exists( p ) ) {
         return 1;
@@ -74,7 +68,9 @@ isPath( char *myPath ) {
 
 rodsLong_t
 getFileSize( char *myPath ) {
-    path p( myPath );
+    namespace fs = boost::filesystem;
+
+    fs::path p( myPath );
 
     if ( exists( p ) && is_regular_file( p ) ) {
         return file_size( p );
@@ -2550,7 +2546,9 @@ isHomeColl( char * myPath ) {
 
 int
 openRestartFile( char * restartFile, rodsRestart_t * rodsRestart ) {
-    path p( restartFile );
+    namespace fs = boost::filesystem;
+
+    fs::path p( restartFile );
     char buf[MAX_NAME_LEN * 3];
     char *inptr;
     char tmpStr[MAX_NAME_LEN];


### PR DESCRIPTION
Replaced using namespace directives with namespace alias.