### PR TITLE
[#4319] Convert source l3descInx for remote copies (4-2-stable)

### DIFF
--- a/server/api/src/rsDataCopy.cpp
+++ b/server/api/src/rsDataCopy.cpp
@@ -82,6 +82,8 @@ remoteDataCopy( rsComm_t *rsComm, dataCopyInp_t *dataCopyInp,
         return status;
     }
 
+    dataCopyInp->dataOprInp.srcL3descInx =
+        convL3descInx( dataCopyInp->dataOprInp.srcL3descInx );
     dataCopyInp->dataOprInp.destL3descInx =
         convL3descInx( dataCopyInp->dataOprInp.destL3descInx );
 


### PR DESCRIPTION
When performing a remote data copy, the destination l3descInx in the
dataOprInp structure passed to rcDataCopy is converted to match a valid
value on the remote machine. This also needs to be done for the source
l3descInx or else the remote copy may fail if it is not valid on the
other machine. This has been demonstrated on locally executed replications
being driven by a remote call.