### PR TITLE
[4326] Update so that the plugins must set the physical path (master)

### DIFF
--- a/plugins/resources/univmss/libunivmss.cpp
+++ b/plugins/resources/univmss/libunivmss.cpp
@@ -484,6 +484,9 @@ irods::error univ_mss_file_rename(
 
     }
 
+    // issue 4326 - plugins must set the physical path to the new path
+    fco->physical_path(_new_file_name);
+
     return CODE( status );
 
 } // univ_mss_file_rename

--- a/plugins/resources/unixfilesystem/libunixfilesystem.cpp
+++ b/plugins/resources/unixfilesystem/libunixfilesystem.cpp
@@ -1210,6 +1210,9 @@ irods::error unix_file_rename(
             // make the call to rename
             int status = rename( fco->physical_path().c_str(), new_full_path.c_str() );
 
+            // issue 4326 - plugins must set the physical path to the new path 
+            fco->physical_path(new_full_path);
+
             // =-=-=-=-=-=-=-
             // handle error cases
             int err_status = UNIX_FILE_RENAME_ERR - errno;

--- a/server/api/src/rsFileRename.cpp
+++ b/server/api/src/rsFileRename.cpp
@@ -116,12 +116,6 @@ int _rsFileRename(
         irods::error err = PASSMSG( msg.str(), rename_err );
         irods::log( err );
     }
-    // =-=-=-=-=-=-=-
-    // compare fco phy path and old file name
-    // if they differ then repave for next call
-    if ( file_obj->physical_path() == _rename_inp->oldFileName ) {
-        file_obj->physical_path( _rename_inp->newFileName );
-    }
 
     // =-=-=-=-=-=-=-
     // percolate possible change in phy path up

--- a/server/core/include/irods_resource_constants.hpp
+++ b/server/core/include/irods_resource_constants.hpp
@@ -101,7 +101,6 @@ namespace irods {
     const std::string RESOURCE_CREATE_PATH( "resource_property_create_path" );
     const std::string RESOURCE_QUOTA_OVERRUN( "resource_property_quota_overrun" );
 
-
 }; // namespace irods
 
 #endif // __IRODS_RESOURCE_CONSTANTS_HPP__


### PR DESCRIPTION
[4326] Do not set the physical path in rsFileRename.cpp.  Set it in libunixfilesystem.cpp and libunivmss.cpp.