### PR TITLE
[#4351] Make delay server more resilient (4-2-stable)

### DIFF
--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/functions.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/functions.cpp
@@ -2559,8 +2559,13 @@ char *wildCardToRegex( char *buf ) {
     return buf2;
 }
 
-Res *smsi_segfault( Node**, int, Node*, ruleExecInfo_t*, int, Env*, rError_t*, Region* ) {
-
+Res *smsi_segfault(Node**, int, Node* node, ruleExecInfo_t* rei, int, Env*, rError_t* errmsg, Region* r) {
+    if (rei->uoic->authInfo.authFlag < LOCAL_PRIV_USER_AUTH) {
+        char buf[ERR_MSG_LEN];
+        snprintf(buf, ERR_MSG_LEN, "[%s]: permission denied", __FUNCTION__);
+        generateAndAddErrMsg(buf, node, CAT_INSUFFICIENT_PRIVILEGE_LEVEL, errmsg);
+        return newErrorRes(r, CAT_INSUFFICIENT_PRIVILEGE_LEVEL);
+    }
     raise( SIGSEGV );
     return NULL;
 }

--- a/scripts/irods/test/rule_texts_for_tests.py
+++ b/scripts/irods/test/rule_texts_for_tests.py
@@ -140,6 +140,14 @@ acSetNumThreads() {
     writeLine("serverLog", "test_rule_engine_2309: get: acSetNumThreads oprType [$oprType]");
 }
 '''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Native_Rule_Engine_Plugin']['test_msiSegFault'] = '''
+test_msiSegFault {{
+    writeLine("stdout", "We are about to segfault...");
+    msiSegFault();
+    writeLine("stdout", "You should never see this line.");
+}}
+OUTPUT ruleExecOut
+'''
 
 #===== Test_Quotas =====
 
@@ -495,7 +503,34 @@ test_delay_with_output_param {{
     }}
     writeLine("stdout", "rule queued");
 }}
-OUTPUT ruleExecOut 
+OUTPUT ruleExecOut
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Delay_Queue']['test_sigpipe_in_delay_server'] = '''
+test_sigpipe_in_delay_server {{
+    delay("<PLUSET>0.1s</PLUSET>") {{
+        writeLine("serverLog", "We are about to segfault...");
+        msiSegFault();
+        writeLine("serverLog", "You should never see this line.");
+    }}
+    delay("<PLUSET>{longer_delay_time}s</PLUSET>") {{
+        writeLine("serverLog", "Follow-up rule executed later!");
+    }}
+    writeLine("stdout", "rule queued");
+}}
+OUTPUT ruleExecOut
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Delay_Queue']['test_exception_in_delay_server'] = '''
+test_exception_in_delay_server {{
+    delay("<PLUSET>0.1s</PLUSET>") {{
+        writeLine("serverLog", "Sleeping now...");
+        msiSleep("{sleep_time}", "0");
+        msiSegFault();
+    }}
+    delay("<PLUSET>{longer_delay_time}s</PLUSET>") {{
+        writeLine("serverLog", "Follow-up rule executed later!");
+    }}
+}}
+OUTPUT ruleExecOut
 '''
 
 #===== Test_Execution_Frequency =====

--- a/scripts/irods/test/test_delay_queue.py
+++ b/scripts/irods/test/test_delay_queue.py
@@ -308,6 +308,132 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
             os.remove(rule_file)
             irodsctl.restart()
 
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Delete this line on resolution of #4094')
+    def test_sigpipe_in_delay_server(self):
+        irodsctl = IrodsController()
+
+        re_server_sleep_time = 2
+        longer_delay_time = re_server_sleep_time * 2
+        parameters = {}
+        parameters['longer_delay_time'] = str(longer_delay_time)
+        rule_text_key = 'test_sigpipe_in_delay_server'
+        rule_text = rule_texts[self.plugin_name][self.class_name][rule_text_key].format(**parameters)
+        rule_file = rule_text_key + '.r'
+        with open(rule_file, 'w') as f:
+            f.write(rule_text)
+
+        try:
+            # load server_config.json to inject new settings
+            server_config_filename = paths.server_config_path()
+            with open(server_config_filename) as f:
+                svr_cfg = json.load(f)
+            svr_cfg['advanced_settings']['rule_engine_server_sleep_time_in_seconds'] = re_server_sleep_time
+
+            # dump to a string to repave the existing server_config.json
+            new_server_config = json.dumps(svr_cfg, sort_keys=True, indent=4, separators=(',', ': '))
+            with lib.file_backed_up(server_config_filename):
+                # repave the existing server_config.json
+                with open(server_config_filename, 'w') as f:
+                    f.write(new_server_config)
+
+                # Bounce server to apply setting
+                irodsctl.restart()
+
+                # Fire off rule and wait for message to get written out to serverLog
+                initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
+                self.admin.assert_icommand(['irule', '-F', rule_file], 'STDOUT_SINGLELINE', "rule queued")
+                time.sleep(re_server_sleep_time + 2)
+                actual_count = lib.count_occurrences_of_string_in_log(
+                    paths.server_log_path(),
+                    'We are about to segfault...',
+                    start_index=initial_size_of_server_log)
+                expected_count = 1
+                self.assertTrue(expected_count == actual_count, msg='expected {expected_count} occurrences in serverLog, found {actual_count}'.format(**locals()))
+
+                # See if the later rule is executed (i.e. delay server is still alive)
+                time.sleep(longer_delay_time * 2)
+                actual_count = lib.count_occurrences_of_string_in_log(
+                    paths.server_log_path(),
+                    'Follow-up rule executed later!',
+                    start_index=initial_size_of_server_log)
+                expected_count = 1
+                self.assertTrue(expected_count == actual_count, msg='expected {expected_count} occurrences in serverLog, found {actual_count}'.format(**locals()))
+
+        finally:
+            os.remove(rule_file)
+            self.admin.assert_icommand(['iqdel', '-a'])
+            irodsctl.restart()
+
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Delete this line on resolution of #4094')
+    def test_exception_in_delay_server(self):
+        config = IrodsConfig()
+        irodsctl = IrodsController()
+        server_config_filename = paths.server_config_path()
+
+        delay_job_sleep_time = 5
+        parameters = {}
+        parameters['sleep_time'] = str(delay_job_sleep_time)
+        parameters['longer_delay_time'] = str(delay_job_sleep_time)
+        rule_text_key = 'test_exception_in_delay_server'
+        rule_text = rule_texts[self.plugin_name][self.class_name][rule_text_key].format(**parameters)
+        rule_file = rule_text_key + '.r'
+        with open(rule_file, 'w') as f:
+            f.write(rule_text)
+
+        odbc_ini_file = os.path.join(test.settings.FEDERATION.IRODS_DIR, '.odbc.ini')
+        try:
+            # load server_config.json to inject new settings
+            server_config_filename = paths.server_config_path()
+            with open(server_config_filename) as f:
+                svr_cfg = json.load(f)
+            svr_cfg['advanced_settings']['rule_engine_server_sleep_time_in_seconds'] = 1
+
+            # dump to a string to repave the existing server_config.json
+            new_server_config = json.dumps(svr_cfg, sort_keys=True, indent=4, separators=(',', ': '))
+            with lib.file_backed_up(server_config_filename):
+                with lib.file_backed_up(config.client_environment_path):
+                    # repave the existing server_config.json
+                    with open(server_config_filename, 'w') as f:
+                        f.write(new_server_config)
+
+                    lib.update_json_file_from_dict(
+                        config.client_environment_path,
+                        {'irods_connection_pool_refresh_time_in_seconds' : 2})
+
+                    # Bounce server to apply setting
+                    irodsctl.restart()
+                    initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
+                    initial_size_of_re_log = lib.get_file_size_by_path(paths.re_log_path())
+                    with lib.file_backed_up(odbc_ini_file):
+                        self.admin.assert_icommand(['irule', '-F', rule_file])
+                        time.sleep(2)
+                        os.unlink(odbc_ini_file)
+                        time.sleep(5)
+
+                    # Restore .odbc.ini and wait for delay server to execute rule properly
+                    time.sleep(delay_job_sleep_time * 2)
+
+                    # The delay server should have caught the exception from the connection error on trying to delete the rule the first time
+                    unexpected_string = 'terminating with uncaught exception of type std::runtime_error: connect error'
+                    actual_count = lib.count_occurrences_of_string_in_log(
+                        paths.re_log_path(),
+                        unexpected_string,
+                        start_index=initial_size_of_re_log)
+                    expected_count = 0
+                    self.assertTrue(expected_count == actual_count, msg='expected {expected_count} occurrences in reLog, found {actual_count}'.format(**locals()))
+
+                    # The delay server should not have zombified, so the later rule should have executed
+                    actual_count = lib.count_occurrences_of_string_in_log(
+                        paths.server_log_path(),
+                        'Follow-up rule executed later!',
+                        start_index=initial_size_of_server_log)
+                    expected_count = 1
+                    self.assertTrue(expected_count == actual_count, msg='expected {expected_count} occurrences in serverLog, found {actual_count}'.format(**locals()))
+
+        finally:
+            os.remove(rule_file)
+            irodsctl.restart()
+
 
 @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'Skip for topology testing from resource server: reads server log')
 class Test_Execution_Frequency(resource_suite.ResourceBase, unittest.TestCase):

--- a/scripts/irods/test/test_native_rule_engine_plugin.py
+++ b/scripts/irods/test/test_native_rule_engine_plugin.py
@@ -369,3 +369,16 @@ OUTPUT ruleExecOut
         os.remove(rule_file)
         os.remove(rule_file_2)
 
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'rule language only')
+    def test_msiSegFault(self):
+        rule_text = rule_texts[self.plugin_name][self.class_name]['test_msiSegFault']
+        rule_file = 'test_msiSegFault.r'
+        with open(rule_file, 'w') as f:
+            f.write(rule_text)
+        try:
+            # Should get SYS_INTERNAL_ERR because it's a segmentation fault
+            self.admin.assert_icommand(['irule', '-F', rule_file],'STDERR','SYS_INTERNAL_ERR')
+            # Should get CAT_INSUFFICIENT_PRIVILEGE_LEVEL because this is for admin users only
+            self.user0.assert_icommand(['irule', '-F', rule_file],'STDERR','CAT_INSUFFICIENT_PRIVILEGE_LEVEL')
+        finally:
+            os.unlink(rule_file)


### PR DESCRIPTION
[CI tests passed](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1936/)

test_sigpipe_in_delay_server and test_exception_in_delay_server are nearly identical, but they are testing two different scenarios. In a way, test_exception_in_delay_server covers test_sigpipe_in_delay_server, but I wanted to keep them distinct. I am fine with removing test_sigpipe_in_delay_server if we feel it is not needed.