### PR TITLE
[#4356] Make "pending SQL at cllDisconnect" true (master)

### DIFF
--- a/scripts/irods/test/test_icommands_file_operations.py
+++ b/scripts/irods/test/test_icommands_file_operations.py
@@ -31,6 +31,8 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
     class_name = 'Test_ICommands_File_Operations'
 
     def setUp(self):
+        # TODO: Remove this sleep when #4359 is resolved
+        time.sleep(30)
         super(Test_ICommands_File_Operations, self).setUp()
         self.testing_tmp_dir = '/tmp/irods-test-icommands-recursive'
         shutil.rmtree(self.testing_tmp_dir, ignore_errors=True)


### PR DESCRIPTION
A warning message is appearing in the logs stating that there is pending
SQL at cllDisconnect when in fact the number of pending statements is 0.
This change ensures that there are pending statements before attempting
to process or log them.

---
[CI tests running](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1944/)

For reference, the comparison used to be:
https://github.com/irods/irods/blob/e521a02daa8af971fddc9beb62ad02dd57242632/plugins/database/src/low_level_odbc.cpp#L284