### PR TITLE
[#1376] Fix memory leaks detected in delay server (4-2-stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -719,6 +719,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/re/src/reDataObjOpr.cpp
   ${CMAKE_SOURCE_DIR}/server/re/src/reIn2p3SysRule.cpp
   ${CMAKE_SOURCE_DIR}/server/re/src/reNaraMetaData.cpp
+  ${CMAKE_SOURCE_DIR}/server/re/src/reStruct.cpp
   ${CMAKE_SOURCE_DIR}/server/re/src/reSysDataObjOpr.cpp
   ${CMAKE_SOURCE_DIR}/server/re/src/sharedmemory.cpp
   ${CMAKE_SOURCE_DIR}/server/re/src/testMS.cpp

--- a/lib/core/include/irods_query.hpp
+++ b/lib/core/include/irods_query.hpp
@@ -151,6 +151,8 @@ namespace irods {
                                     __FUNCTION__ % gen_input_.continueInx).str()));
                     }
                 }
+                freeGenQueryOut(&this->gen_output_);
+                clearGenQueryInp(&gen_input_);
             }
 
             void reset_for_page_boundary() override {
@@ -223,6 +225,7 @@ namespace irods {
                                     __FUNCTION__ % spec_input_.continueInx).str()));
                     }
                 }
+                freeGenQueryOut(&this->gen_output_);
             }
 
             void reset_for_page_boundary() override {

--- a/lib/core/src/packStruct.cpp
+++ b/lib/core/src/packStruct.cpp
@@ -2821,6 +2821,7 @@ addPointerToPackedOut( packedOutput_t &packedOutput, int len, void *pointer ) {
     }
     else if ( len > 0 ) {
         *tmpPtr = malloc( len );
+        memset(*tmpPtr, 0, len);
     }
     else {
         /* add a NULL pointer */

--- a/plugins/rule_engines/CMakeLists.txt
+++ b/plugins/rule_engines/CMakeLists.txt
@@ -12,7 +12,6 @@ set(
   ${CMAKE_SOURCE_DIR}/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/nre.reHelpers2.cpp
   ${CMAKE_SOURCE_DIR}/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/nre.reLib1.cpp
   ${CMAKE_SOURCE_DIR}/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/parser.cpp
-  ${CMAKE_SOURCE_DIR}/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/reStruct.cpp
   ${CMAKE_SOURCE_DIR}/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/reVariableMap.cpp
   ${CMAKE_SOURCE_DIR}/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/reVariableMap.gen.cpp
   ${CMAKE_SOURCE_DIR}/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/restructs.cpp

--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/include/reFuncDefs.hpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/include/reFuncDefs.hpp
@@ -4,9 +4,6 @@
 #ifndef RE_FUNCDEFS_HPP
 #define RE_FUNCDEFS_HPP
 
-/* definition for freeSpeialStructFlag in freeRuleExecInfoStruct and
- * freeRuleExecInfoInternals
- */
 #include "restructs.hpp"
 #include "reGlobalsExtern.hpp"
 #include "irods_re_structs.hpp"
@@ -98,24 +95,6 @@ int replaceLongValue( char *start, int size, rodsLong_t inval, int paramLen );
 
 int replaceULongValue( char *start, int size, rodsULong_t inval, int paramLen );
 
-void *mallocAndZero( int s );
-
-int copyRuleExecInfo( ruleExecInfo_t *from, ruleExecInfo_t *to );
-
-int freeRuleExecInfoStruct( ruleExecInfo_t *rs, int freeSpeialStructFlag );
-
-int freeRuleExecInfoInternals( ruleExecInfo_t *rs, int freeSpeialStructFlag );
-
-int copyDataObjInfo( dataObjInfo_t *from, dataObjInfo_t *to );
-
-int copyCollInfo( collInfo_t *from, collInfo_t *to );
-
-int freeCollInfo( collInfo_t *rs );
-
-int copyUserInfo( userInfo_t *from, userInfo_t *to );
-
-int freeUserInfo( userInfo_t *rs );
-
 
 #if 0	// #1472
 int copyRescInfo( rescInfo_t *from, rescInfo_t *to );
@@ -124,9 +103,6 @@ int copyRescGrpInfo( rescGrpInfo_t *from, rescGrpInfo_t *to );
 int freeRescGrpInfo( rescGrpInfo_t *rs );
 #endif
 
-int copyKeyValPairStruct( keyValPair_t *from, keyValPair_t *to );
-
-int freeKeyValPairStruct( keyValPair_t *rs );
 /*
 int reREMatch(char *pat, char *str);
 */

--- a/server/core/src/irodsReServer.cpp
+++ b/server/core/src/irodsReServer.cpp
@@ -1,4 +1,5 @@
 #include "initServer.hpp"
+#include "irods_at_scope_exit.hpp"
 #include "irods_delay_queue.hpp"
 #include "irods_log.hpp"
 #include "irods_query.hpp"
@@ -58,10 +59,9 @@ namespace {
     ruleExecSubmitInp_t fill_rule_exec_submit_inp(
         const std::vector<std::string>& exec_info) {
         namespace bfs = boost::filesystem;
+
         ruleExecSubmitInp_t rule_exec_submit_inp{};
         rule_exec_submit_inp.packedReiAndArgBBuf = (bytesBuf_t*)malloc(sizeof(bytesBuf_t));
-        rule_exec_submit_inp.packedReiAndArgBBuf->buf = malloc(REI_BUF_LEN);
-        rule_exec_submit_inp.packedReiAndArgBBuf->len = REI_BUF_LEN;
 
         const auto& rule_exec_id = exec_info[0].c_str();
         const auto& rei_file_path = exec_info[2].c_str();
@@ -73,7 +73,7 @@ namespace {
         }
 
         rule_exec_submit_inp.packedReiAndArgBBuf->len = static_cast<int>(bfs::file_size(p));
-        rule_exec_submit_inp.packedReiAndArgBBuf->buf = malloc(rule_exec_submit_inp.packedReiAndArgBBuf->len);
+        rule_exec_submit_inp.packedReiAndArgBBuf->buf = malloc(rule_exec_submit_inp.packedReiAndArgBBuf->len + 1);
 
         int fd = open(rei_file_path, O_RDONLY, 0);
         if (fd < 0) {
@@ -83,7 +83,7 @@ namespace {
         }
 
         memset(rule_exec_submit_inp.packedReiAndArgBBuf->buf, 0,
-               rule_exec_submit_inp.packedReiAndArgBBuf->len);
+               rule_exec_submit_inp.packedReiAndArgBBuf->len + 1);
         ssize_t status{read(fd, rule_exec_submit_inp.packedReiAndArgBBuf->buf,
                         rule_exec_submit_inp.packedReiAndArgBBuf->len)};
         close(fd);
@@ -223,6 +223,16 @@ namespace {
 
         exec_rule_expression_t exec_rule = pack_exec_rule_expression(_inp);
         exec_rule.params_ = rei_and_arg->rei->msParamArray;
+        irods::at_scope_exit<std::function<void()>> at_scope_exit{[&exec_rule, &rei_and_arg] {
+            clearBBuf(&exec_rule.rule_text_);
+            if(rei_and_arg->rei) {
+                if(rei_and_arg->rei->rsComm) {
+                    free(rei_and_arg->rei->rsComm);
+                }
+                freeRuleExecInfoStruct(rei_and_arg->rei, (FREE_MS_PARAM | FREE_DOINP));
+            }
+            free(rei_and_arg);
+        }};
 
         status = rcExecRuleExpression(&_comm, &exec_rule);
         if (strlen(_inp.exeFrequency) > 0) {
@@ -281,6 +291,11 @@ namespace {
         }
         // Prepare input for rule execution API call
         ruleExecSubmitInp_t rule_exec_submit_inp{};
+
+        irods::at_scope_exit<std::function<void()>> at_scope_exit{[&rule_exec_submit_inp] {
+            freeBBuf(rule_exec_submit_inp.packedReiAndArgBBuf);
+        }};
+
         try{
             rule_exec_submit_inp = fill_rule_exec_submit_inp(_rule_info);
         } catch(const irods::exception& e) {
@@ -312,7 +327,6 @@ int main() {
     signal(SIGINT, signal_exit_handler);
     signal(SIGHUP, signal_exit_handler);
     signal(SIGTERM, signal_exit_handler);
-    signal(SIGKILL, signal_exit_handler);
     signal(SIGUSR1, signal_exit_handler);
 
     auto log_fd = init_log();

--- a/server/re/include/irods_re_structs.hpp
+++ b/server/re/include/irods_re_structs.hpp
@@ -86,4 +86,27 @@ packReiAndArg( ruleExecInfo_t *rei, char *myArgv[],
 int
 unpackReiAndArg( rsComm_t *rsComm, ruleExecInfoAndArg_t **reiAndArg,
                  bytesBuf_t *packedReiAndArgBBuf );
+
+int copyRuleExecInfo( ruleExecInfo_t *from, ruleExecInfo_t *to );
+
+int freeRuleExecInfoStruct( ruleExecInfo_t *rs, int freeSpecialStructFlag );
+
+int freeRuleExecInfoInternals( ruleExecInfo_t *rs, int freeSpecialStructFlag );
+
+int copyDataObjInfo( dataObjInfo_t *from, dataObjInfo_t *to );
+
+int copyCollInfo( collInfo_t *from, collInfo_t *to );
+
+int freeCollInfo( collInfo_t *rs );
+
+int copyUserInfo( userInfo_t *from, userInfo_t *to );
+
+int freeUserInfo( userInfo_t *rs );
+
+int copyKeyValPairStruct( keyValPair_t *from, keyValPair_t *to );
+
+int freeKeyValPairStruct( keyValPair_t *rs );
+
+void *mallocAndZero( int s );
+
 #endif // IRODS_RE_STRUCTS_HPP

--- a/server/re/src/reStruct.cpp
+++ b/server/re/src/reStruct.cpp
@@ -1,8 +1,7 @@
 /*** Copyright (c), The Regents of the University of California            ***
  *** For more information please refer to files in the COPYRIGHT directory ***/
 
-#include "reGlobalsExtern.hpp"
-#include "reFuncDefs.hpp"
+#include "irods_re_structs.hpp"
 #include "rcMisc.h"
 #include "objMetaOpr.hpp"
 #include "resource.hpp"
@@ -98,19 +97,19 @@ copyRuleExecInfo( ruleExecInfo_t *from, ruleExecInfo_t *to ) {
 }
 
 int
-freeRuleExecInfoStruct( ruleExecInfo_t *rs, int freeSpeialStructFlag ) {
-    freeRuleExecInfoInternals( rs, freeSpeialStructFlag );
+freeRuleExecInfoStruct( ruleExecInfo_t *rs, int freeSpecialStructFlag ) {
+    freeRuleExecInfoInternals( rs, freeSpecialStructFlag );
     free( rs );
     return 0;
 }
 int
-freeRuleExecInfoInternals( ruleExecInfo_t *rs, int freeSpeialStructFlag ) {
-    if ( rs->msParamArray != NULL && ( freeSpeialStructFlag & FREE_MS_PARAM ) > 0 ) {
+freeRuleExecInfoInternals( ruleExecInfo_t *rs, int freeSpecialStructFlag ) {
+    if ( rs->msParamArray != NULL && ( freeSpecialStructFlag & FREE_MS_PARAM ) > 0 ) {
         clearMsParamArray( rs->msParamArray, 1 );
         free( rs->msParamArray );
     }
 
-    if ( rs->doinp != NULL && ( freeSpeialStructFlag & FREE_DOINP ) > 0 ) {
+    if ( rs->doinp != NULL && ( freeSpecialStructFlag & FREE_DOINP ) > 0 ) {
         clearDataObjInp( rs->doinp );
         free( rs->doinp );
     }
@@ -134,7 +133,7 @@ freeRuleExecInfoInternals( ruleExecInfo_t *rs, int freeSpeialStructFlag ) {
         freeKeyValPairStruct( rs->condInputData );
     }
     if ( rs->next != NULL ) {
-        freeRuleExecInfoStruct( rs->next, freeSpeialStructFlag );
+        freeRuleExecInfoStruct( rs->next, freeSpecialStructFlag );
     }
     return 0;
 }


### PR DESCRIPTION
Query iterator and several places in the delay server itself had leaks
detected in Valgrind.

[CI tests running](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1963/)