### PR TITLE
[#4344] Use syslog utility in delay server (master)

### DIFF
--- a/scripts/irods/configuration.py
+++ b/scripts/irods/configuration.py
@@ -388,10 +388,6 @@ class IrodsConfig(object):
         return paths.server_log_path()
 
     @property
-    def re_log_path(self):
-        return paths.re_log_path()
-
-    @property
     def server_bin_directory(self):
         return paths.server_bin_directory()
 

--- a/scripts/irods/paths.py
+++ b/scripts/irods/paths.py
@@ -104,9 +104,6 @@ def server_parent_log_path():
 def server_log_path():
     return '/var/log/irods/irods.log'
 
-def re_log_path():
-    return '/var/log/irods/irods.log'
-
 def server_bin_directory():
     return os.path.join(
         root_directory(),


### PR DESCRIPTION
As of this change, irodsReServer will no longer write to the reLog.

Adjusts tests to check inside server log for delay server messages.

---
[CI tests passed](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/)

Not sure why the irods::experimental::log::init() call is necessary (not needed for agent spawner process, which is what I based this change upon), but it seems that the irodsReServer process becomes a zombie if not. Am I holding it wrong, @korydraughn?