### PR TITLE
Re-exposes dataObjInp_t to Native Rule Language - (master)

### DIFF
--- a/lib/core/include/irods_query.hpp
+++ b/lib/core/include/irods_query.hpp
@@ -1,14 +1,15 @@
 #ifndef IRODS_QUERY_HPP
 #define IRODS_QUERY_HPP
 
-#if defined(RODS_SERVER) || defined(RODS_CLERVER)
-#include "rsGenQuery.hpp"
-#include "specificQuery.h"
-#include "rsSpecificQuery.hpp"
+#ifdef RODS_SERVER
+    #include "rsGenQuery.hpp"
+    #include "specificQuery.h"
+    #include "rsSpecificQuery.hpp"
 #else
-#include "genQuery.h"
-#include "specificQuery.h"
+    #include "genQuery.h"
+    #include "specificQuery.h"
 #endif
+
 #include "irods_log.hpp"
 #include "rcMisc.h"
 
@@ -191,19 +192,19 @@ namespace irods {
 
             private:
             genQueryInp_t gen_input_; 
-            #if defined(RODS_SERVER) || defined(RODS_CLERVER)
-                const std::function<
-                    int(connection_type*,
-                        genQueryInp_t*,
-                        genQueryOut_t**)>
-                            gen_query_fcn{rsGenQuery};
-            #else
-                const std::function<
-                    int(connection_type*,
-                        genQueryInp_t*,
-                        genQueryOut_t**)>
-                            gen_query_fcn{rcGenQuery};
-            #endif
+#ifdef RODS_SERVER
+            const std::function<
+                int(connection_type*,
+                    genQueryInp_t*,
+                    genQueryOut_t**)>
+                        gen_query_fcn{rsGenQuery};
+#else
+            const std::function<
+                int(connection_type*,
+                    genQueryInp_t*,
+                    genQueryOut_t**)>
+                        gen_query_fcn{rcGenQuery};
+#endif
 
         }; // class gen_query_impl
 
@@ -267,19 +268,19 @@ namespace irods {
 
             private:
             specificQueryInp_t spec_input_; 
-            #if defined(RODS_SERVER) || defined(RODS_CLERVER)
-                const std::function<
-                    int(connection_type*,
-                        specificQueryInp_t*,
-                        genQueryOut_t**)>
-                            spec_query_fcn{rsSpecificQuery};
-            #else
-                const std::function<
-                    int(connection_type*,
-                        specificQueryInp_t*,
-                        genQueryOut_t**)>
-                            spec_query_fcn{rcSpecificQuery};
-            #endif
+#ifdef RODS_SERVER
+            const std::function<
+                int(connection_type*,
+                    specificQueryInp_t*,
+                    genQueryOut_t**)>
+                        spec_query_fcn{rsSpecificQuery};
+#else
+            const std::function<
+                int(connection_type*,
+                    specificQueryInp_t*,
+                    genQueryOut_t**)>
+                        spec_query_fcn{rcSpecificQuery};
+#endif
         }; // class spec_query_impl
 
         class iterator {

--- a/lib/core/src/connection_pool.cpp
+++ b/lib/core/src/connection_pool.cpp
@@ -1,13 +1,7 @@
 #include "connection_pool.hpp"
 
-#include "thread_pool.hpp"
-
-// The connection pool only supports "rcComm_t" so, undefine the
-// following macros in case they have been defined. Doing this guarantees
-// that the query iterator implementation uses "rcComm_t" instead of "rsComm_t".
-#undef RODS_SERVER
-#undef RODS_CLERVER
 #include "irods_query.hpp"
+#include "thread_pool.hpp"
 
 #include <stdexcept>
 #include <thread>

--- a/scripts/irods/test/test_dynamic_peps.py
+++ b/scripts/irods/test/test_dynamic_peps.py
@@ -1,0 +1,41 @@
+from __future__ import print_function
+import os
+import sys
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from . import session
+from .. import test
+from .. import lib
+from .. import paths
+from ..configuration import IrodsConfig
+
+class Test_Dynamic_PEPs(session.make_sessions_mixin([('otherrods', 'rods')], []), unittest.TestCase):
+
+    def setUp(self):
+        super(Test_Dynamic_PEPs, self).setUp()
+        self.admin = self.admin_sessions[0]
+
+    def tearDown(self):
+        super(Test_Dynamic_PEPs, self).tearDown()
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing")
+    def test_if_collInp_t_is_exposed__issue_4370(self):
+        config = IrodsConfig()
+
+        with lib.file_backed_up(config.server_config_path):
+            core_re_path = os.path.join(config.core_re_directory, 'core.re')
+
+            with lib.file_backed_up(core_re_path):
+                prefix = "i4370_PATH => "
+
+                with open(core_re_path, 'a') as core_re:
+                    core_re.write('pep_api_coll_create_pre(*a, *b, *coll_input) { writeLine("serverLog", "' + prefix + '" ++ *coll_input.coll_name); }\n')
+
+                coll_path = os.path.join(self.admin.session_collection, "i4370_test_collection")
+                self.admin.assert_icommand(['imkdir', coll_path])
+                self.assertTrue(lib.count_occurrences_of_string_in_log(paths.server_log_path(), prefix + coll_path) == 1)
+

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -192,7 +192,8 @@ if __name__ == '__main__':
                                  'test_ichmod', 'test_iput_options', 'test_ireg', 'test_irsync', 'test_iticket', 'test_irodsctl',
                                  'test_resource_configuration', 'test_control_plane', 'test_native_rule_engine_plugin', 'test_quotas',
                                  'test_ils', 'test_irmdir', 'test_ichksum', 'test_iquest', 'test_imeta_help', 'test_irepl', 'test_itrim',
-                                 'test_irm', 'test_rule_engine_plugin_passthrough', 'test_irule', 'test_iuserinfo', 'test_delay_queue', 'test_imv'])
+                                 'test_irm', 'test_rule_engine_plugin_passthrough', 'test_irule', 'test_iuserinfo', 'test_delay_queue', 'test_imv',
+                                 'test_dynamic_peps'])
     if options.run_plugin_tests:
         test_identifiers.extend(get_plugin_tests())
 

--- a/server/re/src/irods_re_serialization.cpp
+++ b/server/re/src/irods_re_serialization.cpp
@@ -551,6 +551,32 @@ namespace irods {
             return SUCCESS();
         } // serialize_collInfo_ptr
 
+        static error serialize_collInp_ptr(
+                boost::any              _p,
+                serialized_parameter_t& _out) { 
+            try {
+                collInp_t* l = boost::any_cast<collInp_t*>(_p);
+
+                if (l) {
+                    _out["coll_name"] = l->collName;
+                    _out["flags"] = l->flags;
+                    _out["opr_type"] = l->oprType;
+
+                    serialize_keyValPair(l->condInput, _out);
+
+                } else {
+                    _out["collInp_ptr"] = "nullptr";
+                }
+            }
+            catch ( std::exception& ) {
+                return ERROR(
+                         INVALID_ANY_CAST,
+                         "failed to cast collInp ptr" );
+            }
+
+            return SUCCESS();
+        } // serialize_collInp_ptr
+
         static error serialize_modAVUMetaInp_ptr(
                 boost::any               _p,
                 serialized_parameter_t& _out) { 
@@ -935,6 +961,7 @@ namespace irods {
                 { std::type_index(typeid(keyValPair_t*)), serialize_keyValPair_ptr },
                 { std::type_index(typeid(userInfo_t*)), serialize_userInfo_ptr },
                 { std::type_index(typeid(collInfo_t*)), serialize_collInfo_ptr },
+                { std::type_index(typeid(collInp_t*)), serialize_collInp_ptr },
                 { std::type_index(typeid(modAVUMetadataInp_t*)), serialize_modAVUMetaInp_ptr },
                 { std::type_index(typeid(modAccessControlInp_t*)), serialize_modAccessControlInp_ptr },
                 { std::type_index(typeid(modDataObjMeta_t*)), serialize_modDataObjMeta_ptr },

--- a/server/re/src/irods_re_serialization.cpp
+++ b/server/re/src/irods_re_serialization.cpp
@@ -339,7 +339,7 @@ namespace irods {
                 boost::any               _p,
                 serialized_parameter_t& _out) { 
             try {
-                dataObjInp_t* l = &boost::any_cast<dataObjInp_t&>(_p);
+                dataObjInp_t* l = boost::any_cast<dataObjInp_t*>(_p);
 
                 if (l) {
                     _out["obj_path"]    = l->objPath;
@@ -683,7 +683,7 @@ namespace irods {
                 if (l) {
                     serialized_parameter_t src;
                     error ret = serialize_dataObjInp_ptr(
-                            l->srcDataObjInp,
+                            &l->srcDataObjInp,
                             src );
                     if(!ret.ok()) {
                         irods::log(PASS(ret));
@@ -697,7 +697,7 @@ namespace irods {
 
                     serialized_parameter_t dst;
                     ret = serialize_dataObjInp_ptr(
-                            l->destDataObjInp,
+                            &l->destDataObjInp,
                             dst );
                     if(!ret.ok()) {
                         irods::log(PASS(ret));


### PR DESCRIPTION
Tested in Docker.

All tests passed in Docker except the following (which I believe are docker related issues):
- test_resource_types
- test_resource_tree