### PR TITLE
[#3398] Properly handle "&&" in collection names when removing (master)

### DIFF
--- a/plugins/database/src/general_query.cpp
+++ b/plugins/database/src/general_query.cpp
@@ -28,8 +28,11 @@
 #include "mid_level.hpp"
 #include "low_level.hpp"
 #include "irods_virtual_path.hpp"
+
 #include <boost/algorithm/string.hpp>
+
 #include <string>
+#include <algorithm>
 
 extern int logSQLGenQuery;
 
@@ -96,6 +99,38 @@ char tableAbbrevs;
 
 int debug = 0;
 int debug2 = 0;
+
+namespace
+{
+    int mask_query_argument(std::string& _condition, std::string::size_type _offset)
+    {
+        if (_condition.empty() || _offset >= _condition.size()) {
+            return -1;
+        }
+
+        const auto bpos = _condition.find_first_of("'", _offset);
+
+        if (bpos == std::string::npos) {
+            return -1;
+        }
+
+        const auto epos = _condition.find_first_of("'", bpos + 1);
+
+        if (epos == std::string::npos) {
+            return -1;
+        }
+
+        std::fill(&_condition[bpos + 1], &_condition[epos], ' ');
+
+        return epos + 1;
+    }
+
+    void mask_query_arguments(std::string& _condition)
+    {
+        int offset = 0;
+        while ((offset = mask_query_argument(_condition, offset)) > -1);
+    }
+} // anonymous namespace
 
 /*
  Used by fklink (below) to find an existing name and return the
@@ -919,7 +954,6 @@ compoundConditionSpecified( char *condition ) {
     return 1;
 }
 
-
 /* When there's a compound condition, need to put () around it, use the
    tablename.column for each part, and put OR or AND between.
    Uses and updates whereSQL in addition to the arguments.
@@ -963,9 +997,28 @@ handleCompoundCondition( char *condition, int prevWhereLen ) {
             return USER_STRLEN_TOOLONG;
         }
 
-        char* orptr = strstr( condPart1, "||" );
-        char* andptr = strstr( condPart1, "&&" );
-        char *cptr = NULL;
+        char* orptr{};
+        char* andptr{};
+
+        {
+            std::string tmp = condPart1;
+
+            // Masking the query arguments (characters surrounded by quotes) is
+            // required in case the arguments contain character sequences that
+            // can trip up the parser (e.g. "&&" and "||"). This allows the parser
+            // to find the correct location of the "and" and "or" operators.
+            mask_query_arguments(tmp);
+
+            if (const auto pos = tmp.find("||"); pos != std::string::npos) {
+                orptr = condPart1 + pos;
+            }
+
+            if (const auto pos = tmp.find("&&"); pos != std::string::npos) {
+                andptr = condPart1 + pos;
+            }
+        }
+
+        char *cptr{};
         int type = 0;
         if ( orptr != NULL && ( andptr == NULL || orptr < andptr ) ) {
             cptr = orptr;

--- a/scripts/irods/test/test_irm.py
+++ b/scripts/irods/test/test_irm.py
@@ -36,3 +36,10 @@ class Test_Irm(session.make_sessions_mixin([('otherrods', 'rods')], []), unittes
         self.admin.assert_icommand('iput {0}'.format(filename_path))
         self.admin.assert_icommand('irm -rn0 {0}'.format(filename), 'STDERR', 'USER_INCOMPATIBLE_PARAMS')
 
+    def test_irm_delete_collection_with_ampersand_in_name_causes_error__issue_3398(self):
+        collection = 'testDeleteACollectionWithAmpInTheNameBug170 && hail hail rock & roll  &'
+        self.admin.assert_icommand("imkdir '{0}'".format(collection))
+        self.admin.assert_icommand("ils -l '{0}'".format(self.admin.session_collection), 'STDOUT', collection)
+        self.admin.assert_icommand("irm -r '{0}'".format(collection))
+        self.admin.assert_icommand("ils -l '{0}'".format(self.admin.session_collection_trash), 'STDOUT', collection)
+


### PR DESCRIPTION
All tests passed in Docker (except the ones that usually fail).