### PR TITLE
[#4382] Stacktraces now appear in the log file (master)

### DIFF
--- a/scripts/irods/test/test_stacktrace.py
+++ b/scripts/irods/test/test_stacktrace.py
@@ -1,0 +1,31 @@
+import sys
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from . import session
+from .. import test
+from .. import paths
+from .. import lib
+from ..configuration import IrodsConfig
+
+class Test_Stacktrace(session.make_sessions_mixin([('otherrods', 'rods')], []), unittest.TestCase):
+
+    plugin_name = IrodsConfig().default_rule_engine_plugin
+
+    def setUp(self):
+        super(Test_Stacktrace, self).setUp()
+        self.admin = self.admin_sessions[0]
+
+    def tearDown(self):
+        super(Test_Stacktrace, self).tearDown()
+
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python' or test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing")
+    def test_stacktraces_appear_in_log__issue_4382(self):
+        self.admin.assert_icommand_fail("irule 'msiSegFault()' null ruleExecOut")
+        self.assertTrue(lib.count_occurrences_of_string_in_log(paths.server_log_path(), 'Dumping stacktrace and exiting') > 0)
+        self.assertTrue(lib.count_occurrences_of_string_in_log(paths.server_log_path(), '"stacktrace":') > 0)
+        self.assertTrue(lib.count_occurrences_of_string_in_log(paths.server_log_path(), '<0>\\tOffset:') > 0)
+

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -193,7 +193,7 @@ if __name__ == '__main__':
                                  'test_resource_configuration', 'test_control_plane', 'test_native_rule_engine_plugin', 'test_quotas',
                                  'test_ils', 'test_irmdir', 'test_ichksum', 'test_iquest', 'test_imeta_help', 'test_irepl', 'test_itrim',
                                  'test_irm', 'test_rule_engine_plugin_passthrough', 'test_irule', 'test_iuserinfo', 'test_delay_queue', 'test_imv',
-                                 'test_dynamic_peps', 'test_ifsck'])
+                                 'test_dynamic_peps', 'test_ifsck', 'test_stacktrace'])
     if options.run_plugin_tests:
         test_identifiers.extend(get_plugin_tests())
 

--- a/server/core/src/irods_signal.cpp
+++ b/server/core/src/irods_signal.cpp
@@ -1,30 +1,38 @@
 #include "irods_signal.hpp"
 #include "irods_stacktrace.hpp"
+#include "irods_logger.hpp"
 
 #include <string.h>
 #include <signal.h>
-#include <cstdlib>
 
-#include <iostream>
+#include <cstdlib>
+#include <sstream>
 
 // Define signal handlers for irods
 
-extern "C" {
-
+extern "C"
+{
     /// @brief Signal handler for seg faults
-    static void segv_handler(
-        int signal ) {
-        std::cerr << "Caught signal [" << signal << "]. Dumping stacktrace and exiting" << std::endl;
-        std::cerr << irods::stacktrace().dump();
-        exit(signal);
+    static void segv_handler(int _signal)
+    {
+        using log = irods::experimental::log;
+
+        std::stringstream ss;
+        ss << "Caught signal [" << _signal << "]. Dumping stacktrace and exiting ...\n";
+
+        log::server::error({{"log_message", ss.str()},
+                            {"stacktrace", irods::stacktrace().dump()}});
+
+        exit(_signal);
     }
 
-    void register_handlers( void ) {
+    void register_handlers()
+    {
         struct sigaction action;
         memset(&action, 0, sizeof(action));
         action.sa_handler = segv_handler;
-        sigaction( SIGSEGV, &action, 0 );
-        sigaction( SIGABRT, &action, 0 );
-        sigaction( SIGINT, &action, 0 );
+        sigaction(SIGSEGV, &action, 0);
+        sigaction(SIGABRT, &action, 0);
+        sigaction(SIGINT, &action, 0);
     }
 }


### PR DESCRIPTION
Docker - Passed
[CI](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/2086/) - Passed (with a false positive)

FYI: Boost has a stacktrace library and notes about handling stacktraces with signals.
- [Boost.Stacktrace](https://www.boost.org/doc/libs/1_67_0/doc/html/stacktrace/getting_started.html#stacktrace.getting_started.handle_terminates_aborts_and_seg)

The man pages for [signal safety](http://man7.org/linux/man-pages//man7/signal-safety.7.html) lists the functions that are safe to use in signals too.
