### PR TITLE
[#4060] Paths now escape '\f' character (4-2-stable)

### DIFF
--- a/lib/core/include/rodsPath.h
+++ b/lib/core/include/rodsPath.h
@@ -62,6 +62,13 @@ int
 getFileType( rodsPath_t *rodsPath );
 void
 clearRodsPath( rodsPath_t *rodsPath );
+
+// Returns a new path with the following special characters escaped:
+//   - '\f'
+//
+// The character array returned is dynamically allocated. The caller is expected
+// to deallocate this memory using "free".
+char* escape_path(const char* _path);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/core/src/lsUtil.cpp
+++ b/lib/core/src/lsUtil.cpp
@@ -5,6 +5,8 @@
 #include "miscUtil.h"
 #include "rcGlobalExtern.h"
 
+#include "filesystem.hpp"
+
 char zoneHint[MAX_NAME_LEN];
 
 int
@@ -17,60 +19,52 @@ lsUtil( rcComm_t *conn, rodsEnv *myRodsEnv, rodsArguments_t *myRodsArgs,
 
     if ( myRodsArgs->ticket == True ) {
         if ( myRodsArgs->ticketString == NULL ) {
-            rodsLog( LOG_ERROR,
-                     "initCondForPut: NULL ticketString error" );
+            rodsLog( LOG_ERROR, "initCondForPut: NULL ticketString error" );
             return USER__NULL_INPUT_ERR;
         }
-        else {
-            setSessionTicket( conn, myRodsArgs->ticketString );
-        }
+
+        setSessionTicket( conn, myRodsArgs->ticketString );
     }
 
     genQueryInp_t genQueryInp;
     initCondForLs( &genQueryInp );
 
     int savedStatus = 0;
+
     for ( int i = 0; i < rodsPathInp->numSrc; i++ ) {
         int status = 0;
         rstrcpy( zoneHint, rodsPathInp->srcPath[i].outPath, MAX_NAME_LEN );
-        if ( rodsPathInp->srcPath[i].objType == UNKNOWN_OBJ_T ||
-                rodsPathInp->srcPath[i].objState == UNKNOWN_ST ) {
-            status = getRodsObjType( conn, &rodsPathInp->srcPath[i] );
-            if ( rodsPathInp->srcPath[i].objState == NOT_EXIST_ST ) {
-                if ( status == NOT_EXIST_ST ) {
-                    rodsLog( LOG_ERROR,
-                             "lsUtil: srcPath %s does not exist or user lacks access permission",
-                             rodsPathInp->srcPath[i].outPath );
-                }
-                savedStatus = USER_INPUT_PATH_ERR;
-                continue;
-            }
+
+        namespace fs = irods::experimental::filesystem;
+
+        auto* src_path = rodsPathInp->srcPath[i].outPath;
+        const auto object_status = fs::client::status(*conn, src_path);
+
+        if (!fs::client::exists(object_status)) {
+            rodsLog(LOG_ERROR, "lsUtil: srcPath %s does not exist or user lacks access permission", src_path);
+            savedStatus = USER_INPUT_PATH_ERR;
+            continue;
         }
 
-        if ( rodsPathInp->srcPath[i].objType == DATA_OBJ_T ) {
-            status = lsDataObjUtil( conn, &rodsPathInp->srcPath[i],
-                                    myRodsArgs, &genQueryInp );
+        if (fs::client::is_data_object(object_status)) {
+            status = lsDataObjUtil( conn, &rodsPathInp->srcPath[i], myRodsArgs, &genQueryInp );
         }
-        else if ( rodsPathInp->srcPath[i].objType ==  COLL_OBJ_T ) {
-            status = lsCollUtil( conn, &rodsPathInp->srcPath[i],
-                                 myRodsEnv, myRodsArgs );
+        else if (fs::client::is_collection(object_status)) {
+            status = lsCollUtil( conn, &rodsPathInp->srcPath[i], myRodsEnv, myRodsArgs );
         }
         else {
             /* should not be here */
-            rodsLog( LOG_ERROR,
-                     "lsUtil: invalid ls objType %d for %s",
-                     rodsPathInp->srcPath[i].objType, rodsPathInp->srcPath[i].outPath );
+            rodsLog(LOG_ERROR, "lsUtil: invalid ls objType %d for %s", rodsPathInp->srcPath[i].objType, src_path);
             return USER_INPUT_PATH_ERR;
         }
+
         /* XXXX may need to return a global status */
-        if ( status < 0 && status != CAT_NO_ROWS_FOUND &&
-                status != SYS_SPEC_COLL_OBJ_NOT_EXIST ) {
-            rodsLogError( LOG_ERROR, status,
-                          "lsUtil: ls error for %s, status = %d",
-                          rodsPathInp->srcPath[i].outPath, status );
+        if ( status < 0 && status != CAT_NO_ROWS_FOUND && status != SYS_SPEC_COLL_OBJ_NOT_EXIST ) {
+            rodsLogError(LOG_ERROR, status, "lsUtil: ls error for %s, status = %d", src_path, status);
             savedStatus = status;
         }
     }
+
     return savedStatus;
 }
 

--- a/scripts/core_tests_list.json
+++ b/scripts/core_tests_list.json
@@ -38,5 +38,6 @@
     "test_all_rules",
     "test_symlink_operations",
     "test_icommands_file_operations",
-    "test_iadmin"
+    "test_iadmin",
+    "test_ipwd"
 ]

--- a/scripts/irods/test/test_ipwd.py
+++ b/scripts/irods/test/test_ipwd.py
@@ -1,0 +1,28 @@
+import sys
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from . import session
+from .. import test
+
+class Test_Ipwd(session.make_sessions_mixin([('otherrods', 'rods')], []), unittest.TestCase):
+
+    def setUp(self):
+        super(Test_Ipwd, self).setUp()
+        self.admin = self.admin_sessions[0]
+
+    def tearDown(self):
+        super(Test_Ipwd, self).tearDown()
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing")
+    def test_collection_with_backslash_in_name_does_not_cause_problems__issue_4060(self):
+        col = 'issue_4060_test\\folder'
+        self.admin.assert_icommand(['imkdir', col])
+        self.admin.assert_icommand('ils', 'STDOUT', col)
+        self.admin.assert_icommand(['icd', col])
+        self.admin.assert_icommand('ipwd', 'STDOUT', col)
+        self.admin.assert_icommand('ils', 'STDOUT', col)
+


### PR DESCRIPTION
Passed in new CI (core tests and federation only)