### PR TITLE
[#4495] Chunk libarchive reads for extractions (master)

### DIFF
--- a/scripts/core_tests_list.json
+++ b/scripts/core_tests_list.json
@@ -5,6 +5,7 @@
     "test_delay_queue",
     "test_dynamic_peps",
     "test_iadmin",
+    "test_ibun",
     "test_ichksum",
     "test_ichmod",
     "test_icommands_file_operations",

--- a/scripts/irods/test/test_ibun.py
+++ b/scripts/irods/test/test_ibun.py
@@ -1,0 +1,57 @@
+from __future__ import print_function
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+import os
+import shutil
+
+from . import resource_suite
+from .. import lib
+
+class Test_Ibun(resource_suite.ResourceBase, unittest.TestCase):
+
+    def setUp(self):
+        super(Test_Ibun, self).setUp()
+
+    def tearDown(self):
+        super(Test_Ibun, self).tearDown()
+
+    def test_ibun_extraction_of_big_zip_file__issue_4495(self):
+        try:
+            root_name = 'test_ibun_extraction_of_big_zip_file__issue_4495_dir'
+            unzip_collection_name = 'my_exploded_coll'
+            unzip_directory_name = 'my_exploded_dir'
+            known_file = 'known_file'
+            zip_file_name = 'bigzip.zip'
+
+            source_dir = '/var/lib/irods/scripts'
+            for i in range(0, 10):
+                dest_dir = os.path.join(root_name, str(i))
+                shutil.copytree(source_dir, dest_dir)
+
+            filesize = 3900000000
+            lib.make_file(os.path.join(root_name, known_file), filesize, 'random')
+
+            out,_ = lib.execute_command(['du', '-h', root_name])
+            print(out)
+
+            lib.execute_command(['zip', '-r', zip_file_name, root_name])
+            out,_ = lib.execute_command(['ls', '-l', zip_file_name])
+            print(out)
+
+            self.admin.assert_icommand(['iput', zip_file_name])
+
+            self.admin.assert_icommand(['ibun', '-x', zip_file_name, unzip_collection_name])
+            self.admin.assert_icommand(['ils', '-lr', unzip_collection_name], 'STDOUT', known_file)
+
+            self.admin.assert_icommand(['iget', '-r', unzip_collection_name, unzip_directory_name])
+            lib.execute_command(['diff', '-r', root_name, os.path.join(unzip_directory_name, root_name)])
+        finally:
+            self.admin.run_icommand(['irm', '-f', zip_file_name])
+            self.admin.run_icommand(['irm', '-rf', unzip_collection_name])
+            shutil.rmtree(root_name, ignore_errors=True)
+            shutil.rmtree(unzip_directory_name, ignore_errors=True)
+            os.unlink(zip_file_name)


### PR DESCRIPTION
The extract operation in structfile resource plugin reads in entire files into a memory buffer without regard for size. If the file in question overflows an int when its size in bytes is calculated, libarchive will fail to read the file and extraction will do nothing. This change iterates over the file using a block size and the buffer pointer in use today. The block_size has been hard-coded to 1MB as performance gains above this are negligible, and block sizes below this only become increasingly worse as the value decreases.

The `make_file` utility in lib.py grew an option to pass a block size as well. This allows for much larger files than was possible before as `dd` will not always be able to generate a file large enough to meet the requested size in the current implementation. Now the count and bs parameters are used to generate files properly with an append of any leftover bytes in the event of an uneven division.