### PR TITLE
[#4118] Add test for extracting large tar file (4-2-stable)

### DIFF
--- a/scripts/irods/lib.py
+++ b/scripts/irods/lib.py
@@ -300,13 +300,14 @@ def make_file(f_name, f_size, contents='zero', block_size_in_bytes=1000):
               'random': '/dev/urandom'}[contents]
 
     count = f_size / block_size_in_bytes
-    leftover_size = f_size % block_size_in_bytes
     if count > 0:
         execute_command(['dd', 'if='+source, 'of='+f_name, 'count='+str(count), 'bs='+str(block_size_in_bytes)])
+        leftover_size = f_size % block_size_in_bytes
         if leftover_size > 0:
             execute_command(['dd', 'if='+source, 'of='+f_name, 'count=1', 'bs='+str(leftover_size), 'oflag=append', 'conv=notrunc'])
     else:
-        execute_command(['dd', 'if='+source, 'of='+f_name, 'count=1', 'bs='+str(leftover_size)])
+        execute_command(['dd', 'if='+source, 'of='+f_name, 'count=1', 'bs='+str(f_size)])
+
 
 def make_dir_p(directory):
     try:

--- a/scripts/irods/test/rule_texts_for_tests.py
+++ b/scripts/irods/test/rule_texts_for_tests.py
@@ -28,6 +28,18 @@ acAclPolicy {
 }
 '''
 
+#===== Test_AllRules =====
+
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_AllRules'] = {}
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_AllRules']['test_msiTarFileExtract_big_file__issue_4118'] = '''
+myTestRule {{
+    msiTarFileExtract(*File,*Coll,*Resc,*Status);
+    writeLine("stdout","Extract files from a tar file *File into collection *Coll on resource *Resc");
+}}
+INPUT *File="{logical_path_to_tar_file}", *Coll="{logical_path_to_untar_coll}", *Resc="demoResc"
+OUTPUT ruleExecOut
+'''
+
 #===== Test_ICommands_File_Operations =====
 
 rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_ICommands_File_Operations'] = {}

--- a/scripts/irods/test/test_ibun.py
+++ b/scripts/irods/test/test_ibun.py
@@ -15,6 +15,7 @@ class Test_Ibun(resource_suite.ResourceBase, unittest.TestCase):
 
     def setUp(self):
         super(Test_Ibun, self).setUp()
+        self.known_file_name = 'known_file'
 
     def tearDown(self):
         super(Test_Ibun, self).tearDown()
@@ -24,7 +25,6 @@ class Test_Ibun(resource_suite.ResourceBase, unittest.TestCase):
             root_name = 'test_ibun_extraction_of_big_zip_file__issue_4495_dir'
             unzip_collection_name = 'my_exploded_coll'
             unzip_directory_name = 'my_exploded_dir'
-            known_file = 'known_file'
             zip_file_name = 'bigzip.zip'
 
             source_dir = '/var/lib/irods/scripts'
@@ -33,7 +33,7 @@ class Test_Ibun(resource_suite.ResourceBase, unittest.TestCase):
                 shutil.copytree(source_dir, dest_dir)
 
             filesize = 3900000000
-            lib.make_file(os.path.join(root_name, known_file), filesize, 'random')
+            lib.make_file(os.path.join(root_name, self.known_file_name), filesize, 'random')
 
             out,_ = lib.execute_command(['du', '-h', root_name])
             print(out)
@@ -45,7 +45,7 @@ class Test_Ibun(resource_suite.ResourceBase, unittest.TestCase):
             self.admin.assert_icommand(['iput', zip_file_name])
 
             self.admin.assert_icommand(['ibun', '-x', zip_file_name, unzip_collection_name])
-            self.admin.assert_icommand(['ils', '-lr', unzip_collection_name], 'STDOUT', known_file)
+            self.admin.assert_icommand(['ils', '-lr', unzip_collection_name], 'STDOUT', self.known_file_name)
 
             self.admin.assert_icommand(['iget', '-r', unzip_collection_name, unzip_directory_name])
             lib.execute_command(['diff', '-r', root_name, os.path.join(unzip_directory_name, root_name)])
@@ -54,4 +54,48 @@ class Test_Ibun(resource_suite.ResourceBase, unittest.TestCase):
             self.admin.run_icommand(['irm', '-rf', unzip_collection_name])
             shutil.rmtree(root_name, ignore_errors=True)
             shutil.rmtree(unzip_directory_name, ignore_errors=True)
-            os.unlink(zip_file_name)
+            if os.path.exists(zip_file_name):
+                os.unlink(zip_file_name)
+
+    def test_ibun_extraction_of_big_tar_file__issue_4118(self):
+        try:
+            root_name = 'test_ibun_extraction_of_big_tar_file__issue_4118_dir'
+            untar_collection_name = 'my_exploded_coll'
+            untar_directory_name = 'my_exploded_dir'
+            tar_file_name = 'bigtar.tar'
+
+            # Generate a junk file
+            filesize = 524288000 # 500MB
+            lib.make_file(self.known_file_name, filesize, 'random')
+            out,_ = lib.execute_command(['ls', '-l', self.known_file_name])
+            print(out)
+
+            # Copy junk file until a sufficiently large tar file size is reached
+            os.mkdir(root_name)
+            for i in range(0, 13):
+                lib.execute_command(['cp', self.known_file_name, os.path.join(root_name, self.known_file_name + str(i))])
+
+            os.unlink(self.known_file_name)
+
+            out,_ = lib.execute_command(['ls', '-l', root_name])
+            print(out)
+
+            lib.execute_command(['tar', '-cf', tar_file_name, root_name])
+            out,_ = lib.execute_command(['ls', '-l', tar_file_name])
+            print(out)
+
+            self.admin.assert_icommand(['iput', tar_file_name])
+
+            self.admin.assert_icommand(['ibun', '-x', tar_file_name, untar_collection_name])
+            self.admin.assert_icommand(['ils', '-lr', untar_collection_name], 'STDOUT', self.known_file_name)
+
+            self.admin.assert_icommand(['iget', '-r', untar_collection_name, untar_directory_name])
+            lib.execute_command(['diff', '-r', root_name, os.path.join(untar_directory_name, root_name)])
+        finally:
+            self.admin.run_icommand(['irm', '-f', tar_file_name])
+            self.admin.run_icommand(['irm', '-rf', untar_collection_name])
+            shutil.rmtree(root_name, ignore_errors=True)
+            shutil.rmtree(untar_directory_name, ignore_errors=True)
+            if os.path.exists(tar_file_name):
+                os.unlink(tar_file_name)
+


### PR DESCRIPTION
ibun -x of sufficiently large tar files needs a test to match the
test for extraction of sufficiently large zip files.

Also, fixed bug with "leftover" size for creating files in lib.make_file.