### PR TITLE
[#4487] Extend hierarchy parser for ease of use (master)

### DIFF
--- a/lib/core/include/irods_hierarchy_parser.hpp
+++ b/lib/core/include/irods_hierarchy_parser.hpp
@@ -19,6 +19,9 @@ namespace irods {
             /// @brief ctor doesn't do much, until it has a string
             hierarchy_parser( void );
 
+            /// @brief ctor - calls set_string using passed value
+            explicit hierarchy_parser( const std::string& _hier );
+
             /// @brief copy constructor
             hierarchy_parser( const hierarchy_parser& parser );
 
@@ -34,7 +37,13 @@ namespace irods {
              * This method returns a properly formatted hierarchy string, terminating
              * the string at the _term_resc resource if non-empty.
              */
-            error str( std::string& _ret_string, const std::string& _term_resc = std::string( "" ) ) const;
+            error str( std::string& _ret_string, const std::string& _term_resc = "" ) const;
+
+            /** @brief Returns the resource hierarchy string.
+             * This method returns a properly formatted hierarchy string, terminating
+             * the string at the _term_resc resource if non-empty.
+             */
+            std::string str(const std::string& _term_resc = "") const;
 
             /// @brief Adds another level of hierarchy by adding the specified child resource
             error add_child( const std::string& _resc );
@@ -42,14 +51,26 @@ namespace irods {
             /// @brief Returns the first resource
             error first_resc( std::string& _ret_resc ) const;
 
+            /// @brief Returns the first resource
+            std::string first_resc() const;
+
             /// @brief Returns the last resource in the hierarchy
             error last_resc( std::string& _ret_resc ) const;
+
+            /// @brief Returns the last resource in the hierarchy
+            std::string last_resc() const;
 
             /// @brief Returns the next resource in the hierarchy after the specified resource
             error next( const std::string& _current, std::string& _ret_resc ) const;
 
+            /// @brief Returns the next resource in the hierarchy after the specified resource
+            std::string next(const std::string& _current) const;
+
             /// @brief Returns the number of levels in the resource hierarchy
             error num_levels( int& levels ) const;
+
+            /// @brief Returns the number of levels in the resource hierarchy
+            int num_levels() const;
 
             /// @brief Returns an iterator to the beginning of the list
             const_iterator begin( void ) const;

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 # Each file in the ./cmake/test_config directory defines variables for a specific test.
 # New tests should be added to this list.
 set(TEST_INCLUDE_LIST test_config/irods_linked_list_iterator
+                      test_config/irods_hierarchy_parser
                       test_config/irods_filesystem
                       test_config/irods_dstream)
 

--- a/unit_tests/cmake/test_config/irods_hierarchy_parser.cmake
+++ b/unit_tests/cmake/test_config/irods_hierarchy_parser.cmake
@@ -1,0 +1,12 @@
+set(IRODS_TEST_TARGET irods_hierarchy_parser)
+
+set(IRODS_TEST_SOURCE_FILES main.cpp
+                            test_irods_hierarchy_parser.cpp)
+
+set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
+                            ${CMAKE_SOURCE_DIR}/lib/core/include
+                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
+                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include)
+ 
+set(IRODS_TEST_LINK_LIBRARIES irods_common
+                              c++abi)

--- a/unit_tests/irods_error_enum_matcher.hpp
+++ b/unit_tests/irods_error_enum_matcher.hpp
@@ -1,0 +1,30 @@
+#include "rodsErrorTable.h"
+#include <boost/format.hpp>
+#include <iostream>
+
+// The matcher class
+template<typename T = IRODS_ERROR_ENUM>
+class error_enum : public Catch::MatcherBase<T> {
+    T rhs_;
+public:
+    explicit error_enum(const T _rhs) : rhs_{_rhs} {}
+
+    // Performs the test for this matcher
+    bool match(T const& _lhs) const override {
+        return _lhs == rhs_;
+    }
+
+    // Produces a string describing what this matcher does. It should
+    // include any provided data (the begin/ end in this case) and
+    // be written as if it were stating a fact (in the output it will be
+    // preceded by the value under test).
+    virtual std::string describe() const override {
+        return (boost::format("is equal to %lld") % rhs_).str();
+    }
+};
+
+// The builder function
+inline error_enum<long long> equals_irods_error(const long long _rhs) {
+    return error_enum(_rhs);
+}
+

--- a/unit_tests/test_irods_hierarchy_parser.cpp
+++ b/unit_tests/test_irods_hierarchy_parser.cpp
@@ -1,0 +1,110 @@
+#include "catch.hpp"
+
+#include "irods_error_enum_matcher.hpp"
+#include "irods_exception.hpp"
+#include "irods_hierarchy_parser.hpp"
+
+using parser = irods::hierarchy_parser;
+
+TEST_CASE("test_hierarchy_parser_delimiter", "[delim]") {
+    REQUIRE(";" == parser::delimiter());
+}
+
+TEST_CASE("test_hierarchy_parser", "[hierarchy]") {
+    const std::string str = "a;b;c;d;e";
+    parser p{str};
+
+    REQUIRE(5 == p.num_levels());
+    REQUIRE("a" == p.first_resc());
+    REQUIRE("e" == p.last_resc());
+
+    SECTION("str") {
+        REQUIRE(str == p.str());
+        REQUIRE("a" == p.str("a"));
+        REQUIRE("a;b;c" == p.str("c"));
+        REQUIRE(str == p.str("e"));
+        REQUIRE(str == p.str("f"));
+    }
+    SECTION("resc_in_hier") {
+        REQUIRE(p.resc_in_hier("a"));
+        REQUIRE(p.resc_in_hier("e"));
+        REQUIRE(!p.resc_in_hier("b;c;d"));
+        REQUIRE(!p.resc_in_hier("f"));
+    }
+    SECTION("next") {
+        REQUIRE("b" == p.next("a"));
+        REQUIRE("e" == p.next("d"));
+        REQUIRE_THROWS_WITH(p.next("e"),
+                            Catch::Contains(std::to_string(NO_NEXT_RESC_FOUND)));
+        REQUIRE_THROWS_WITH(p.next("f"),
+                            Catch::Contains(std::to_string(CHILD_NOT_FOUND)));
+    }
+}
+
+TEST_CASE("test_hierarchy_parser_standalone_resource", "[standalone]") {
+    const std::string str = "a";
+    parser p{str};
+
+    REQUIRE(1 == p.num_levels());
+    REQUIRE(str == p.first_resc());
+    REQUIRE(str == p.last_resc());
+
+    SECTION("str") {
+        REQUIRE(str == p.str());
+        REQUIRE(str == p.str("a"));
+        REQUIRE(str == p.str("c"));
+    }
+    SECTION("resc_in_hier") {
+        REQUIRE(p.resc_in_hier("a"));
+        REQUIRE(!p.resc_in_hier("b"));
+    }
+    SECTION("next") {
+        REQUIRE_THROWS_WITH(p.next("a"),
+                            Catch::Contains(std::to_string(NO_NEXT_RESC_FOUND)));
+        REQUIRE_THROWS_WITH(p.next("f"),
+                            Catch::Contains(std::to_string(CHILD_NOT_FOUND)));
+    }
+}
+
+TEST_CASE("test_hierarchy_parser_delimiter_nonsense", "[hierarchy][delim][pathological]") {
+    SECTION("trailing delimiter") {
+        const std::string str = "a;b;c;d;e;";
+        const std::string corrected_str = "a;b;c;d;e";
+        parser p{str};
+
+        REQUIRE(5 == p.num_levels());
+        REQUIRE("a" == p.first_resc());
+        REQUIRE("e" == p.last_resc());
+        REQUIRE(corrected_str == p.str());
+    }
+    SECTION("leading delimiter") {
+        const std::string str = ";a;b;c;d;e";
+        const std::string corrected_str = "a;b;c;d;e";
+        parser p{str};
+
+        REQUIRE(5 == p.num_levels());
+        REQUIRE("a" == p.first_resc());
+        REQUIRE("e" == p.last_resc());
+        REQUIRE(corrected_str == p.str());
+    }
+}
+
+TEST_CASE("test_hierarchy_parser_set_string_empty", "[delim][empty][pathological]") {
+    SECTION("delimiter") {
+        parser p;
+        irods::error e = p.set_string(parser::delimiter());
+        REQUIRE_THAT(e.code(), equals_irods_error(SYS_INVALID_INPUT_PARAM));
+    }
+    SECTION("empty string") {
+        parser p;
+        irods::error e = p.set_string("");
+        REQUIRE_THAT(e.code(), equals_irods_error(SYS_INVALID_INPUT_PARAM));
+    }
+}
+
+TEST_CASE("test_hierarchy_parser_empty", "[delim][empty][pathological]") {
+    REQUIRE_THROWS_WITH(parser{parser::delimiter()},
+                        Catch::Contains(std::to_string(SYS_INVALID_INPUT_PARAM)));
+    REQUIRE_THROWS_WITH(parser{""},
+                        Catch::Contains(std::to_string(SYS_INVALID_INPUT_PARAM)));
+}


### PR DESCRIPTION
Overloads several functions in irods::hierarchy_parser to return
values directly rather than using output reference parameters.

Adds a new unit test for the hierarchy parser.