### PR TITLE
[#4534] irods::filesystem::path::lexically_normal now follows the standard (4-2-stable)

### DIFF
--- a/lib/core/src/rodsPath.cpp
+++ b/lib/core/src/rodsPath.cpp
@@ -452,7 +452,7 @@ getLastPathElement(char* _logical_path, char* _last_path_element)
 
     std::string path_string = _logical_path;
 
-    if (fs::path::separator == path_string.back()) {
+    if (fs::path::preferred_separator == path_string.back()) {
         path_string = path_string.substr(0, path_string.size() - 1);
         rstrcpy(_last_path_element, path_string.data(), MAX_NAME_LEN);
         return 0;
@@ -468,7 +468,7 @@ getLastPathElement(char* _logical_path, char* _last_path_element)
 
     path_string = object_name.string();
 
-    if (fs::path::separator == path_string.back()) {
+    if (fs::path::preferred_separator == path_string.back()) {
         path_string = path_string.substr(0, path_string.size() - 1);
     }
 

--- a/lib/filesystem/include/filesystem/detail.hpp
+++ b/lib/filesystem/include/filesystem/detail.hpp
@@ -22,7 +22,7 @@ namespace detail {
 
     inline auto is_separator(path::value_type _c) noexcept -> bool
     {
-        return path::separator == _c;
+        return path::preferred_separator == _c;
     }
 
 } // namespace detail

--- a/lib/filesystem/include/filesystem/path.hpp
+++ b/lib/filesystem/include/filesystem/path.hpp
@@ -26,7 +26,7 @@ namespace filesystem {
         using const_reverse_iterator    = reverse_iterator;
         // clang-format on
 
-        static constexpr value_type separator = '/';
+        static constexpr value_type preferred_separator = '/';
 
     private:
         // clang-format off
@@ -227,7 +227,7 @@ namespace filesystem {
         auto has_object_name() const -> bool     { return !object_name().empty(); }
         auto has_stem() const -> bool            { return !stem().empty(); }
         auto has_extension() const -> bool       { return !extension().empty(); }
-        auto is_absolute() const -> bool         { return !empty() && separator == value_.front(); }
+        auto is_absolute() const -> bool         { return !empty() && preferred_separator == value_.front(); }
         auto is_relative() const -> bool         { return !is_absolute(); }
         // clang-format on
 

--- a/unit_tests/src/filesystem/test_path.cpp
+++ b/unit_tests/src/filesystem/test_path.cpp
@@ -283,6 +283,54 @@ TEST_CASE("path lexical operations", "[lexical operations]")
 {
     SECTION("normal form of path")
     {
+        // This table holds the expected output of the C++17 Std. Filesystem's
+        // path::lexically_normal() function. The first value represents the string
+        // that lexically normal will be called on. The second value is the expected output.
+        const std::vector<std::pair<std::string, std::string>> paths{
+            {"/tempZone/home/rods/.", "/tempZone/home/rods/"},
+            {"/tempZone/home/rods/..", "/tempZone/home/"},
+            {"/tempZone/home/rods/foo", "/tempZone/home/rods/foo"},
+            {"/tempZone/home/rods/foo.", "/tempZone/home/rods/foo."},
+            {"/tempZone/home/rods/foo^", "/tempZone/home/rods/foo^"},
+            {"/tempZone/home/rods/foo~", "/tempZone/home/rods/foo~"},
+            {"/tempZone/home/rods/foo/", "/tempZone/home/rods/foo/"},
+            {"/tempZone/home/rods/foo/.", "/tempZone/home/rods/foo/"},
+            {"/tempZone/home/rods/foo/..", "/tempZone/home/rods/"},
+            {"tempZone/home/rods/.", "tempZone/home/rods/"},
+            {"tempZone/home/rods/..", "tempZone/home/"},
+            {"tempZone/home/rods/foo", "tempZone/home/rods/foo"},
+            {"tempZone/home/rods/foo.", "tempZone/home/rods/foo."},
+            {"tempZone/home/rods/foo^", "tempZone/home/rods/foo^"},
+            {"tempZone/home/rods/foo~", "tempZone/home/rods/foo~"},
+            {"tempZone/home/rods/foo/", "tempZone/home/rods/foo/"},
+            {"tempZone/home/rods/foo/.", "tempZone/home/rods/foo/"},
+            {"tempZone/home/rods/foo/..", "tempZone/home/rods/"},
+            {"/foo", "/foo"},
+            {"/foo/", "/foo/"},
+            {"foo/", "foo/"},
+            {"/", "/"},
+            {"/.", "/"},
+            {"/..", "/"},
+            {".", "."},
+            {"./", "."},
+            {"./.", "."},
+            {"././.", "."},
+            {"..", ".."},
+            {"../", ".."},
+            {"../..", "../.."},
+            {"../../..", "../../.."},
+            {"../file/../..", "../.."},
+            {"/../file/../..", "/"},
+            {"", ""}
+        };
+
+        for (auto&& p : paths) {
+            DYNAMIC_SECTION("normal form of path [" << p.first << "]")
+            {
+                REQUIRE(p.second == fs::path{p.first}.lexically_normal());
+            }
+        }
+
         REQUIRE("foo/" == fs::path{"foo/./bar/.."}.lexically_normal());
         REQUIRE("foo/" == fs::path{"foo/.///bar/../"}.lexically_normal());
     }


### PR DESCRIPTION
Core tests passed in CI.