### PR TITLE
[#4551] irods::filesystem::path::parent_path() is compliant with the standard (4-2-stable)

### DIFF
--- a/lib/filesystem/src/filesystem.cpp
+++ b/lib/filesystem/src/filesystem.cpp
@@ -308,16 +308,12 @@ namespace NAMESPACE_IMPL {
 
             if (is_collection(to_status)) {
                 copy_data_object(_comm, _from, _to / _from.object_name(), _options);
-
                 return;
             }
 
             copy_data_object(_comm, _from, _to, _options);
-
-            return;
         }
-
-        if (is_collection(from_status)) {
+        else if (is_collection(from_status)) {
             if (copy_options::recursive == (copy_options::recursive & _options) ||
                 copy_options::none == _options)
             {
@@ -926,7 +922,7 @@ namespace NAMESPACE_IMPL {
         }
         else if (is_collection(s)) {
             sql = "select META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE, META_COLL_ATTR_UNITS where COLL_NAME = '";
-            sql += _p.parent_path();
+            sql += _p;
             sql += "'";
         }
         else {

--- a/lib/filesystem/src/path.cpp
+++ b/lib/filesystem/src/path.cpp
@@ -215,9 +215,7 @@ namespace filesystem {
 
     auto path::parent_path() const -> path
     {
-        return (empty() || begin() == --end())
-            ? path{}
-            : join(begin(), --end());
+        return !has_relative_path() ? *this : join(begin(), --end());
     }
 
     auto path::object_name() const -> path

--- a/unit_tests/src/filesystem/test_path.cpp
+++ b/unit_tests/src/filesystem/test_path.cpp
@@ -378,6 +378,7 @@ TEST_CASE("path decomposition", "[decomposition]")
 {
     const fs::path p = "/a/b/c/d.txt";
 
+    REQUIRE(fs::path{"/"}.parent_path() == "/");
     REQUIRE(p.root_collection() == "/");
     REQUIRE(p.relative_path() == "a/b/c/d.txt");
     REQUIRE(p.parent_path() == "/a/b/c");


### PR DESCRIPTION
Passed core tests in CI.