### PR TITLE
[#4459] fix implicit cast bug when talking to oracle

### DIFF
--- a/scripts/irods/database_upgrade.py
+++ b/scripts/irods/database_upgrade.py
@@ -43,7 +43,7 @@ def run_update(irods_config, cursor):
         for row in rows:
             resc_id = row[0]
             resc_name = row[1]
-            database_connect.execute_sql_statement(cursor, "update R_DATA_MAIN set resc_id=? where resc_hier=? or resc_hier like ?", resc_id, resc_name, ''.join(['%;', resc_name]))
+            database_connect.execute_sql_statement(cursor, "update R_DATA_MAIN set resc_id=? where resc_hier=? or resc_hier like ?", int(resc_id), resc_name, ''.join(['%;', resc_name]))
         if irods_config.catalog_database_type == 'postgres':
             database_connect.execute_sql_statement(cursor, "update r_resc_main as rdm set resc_parent = am.resc_id from ( select resc_name, resc_id from r_resc_main ) as am where am.resc_name = rdm.resc_parent;")
         elif irods_config.catalog_database_type == 'cockroachdb':


### PR DESCRIPTION
When pypyodbc talks to oracle, the implicit cast from
string->int->numbers(38) was dropping the last character of the string.

It is not yet clear if this is a pypyodbc bug or Oracle ODBC bug.