### PR TITLE
[#4649] Use fillMsParam in convertToMsParam (4-2-stable)

### DIFF
--- a/server/re/src/irods_re_plugin.cpp
+++ b/server/re/src/irods_re_plugin.cpp
@@ -51,7 +51,10 @@ namespace irods{
             fillStrInMsParam( t, const_cast<char*>( (*(boost::any_cast<std::string *>(itr))).c_str() ));
         } else if(itr.type() == typeid(msParam_t*)) {
             memset(t, 0, sizeof(*t));
-            replMsParam(boost::any_cast<msParam_t*>(itr), t);
+            auto msp = boost::any_cast<msParam_t*>(itr);
+            fillMsParam(t, msp->label, msp->type, msp->inOutStruct, msp->inpOutBuf);
+            msp->inOutStruct = nullptr;
+            msp->inpOutBuf = nullptr;
         } else {
             return ERROR(-1, "cannot convert parameter");
         }


### PR DESCRIPTION
...instead of replMsParam. Fixes memory leak in conversions
made in rule engine plugins.

---

CI tests to be run. 