### PR TITLE
[#4650] User Administration Library (master)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,42 @@ set_target_properties(irods_filesystem_server PROPERTIES CXX_STANDARD ${IRODS_CX
 target_compile_options(irods_filesystem_server PRIVATE -fPIC -Wno-write-strings)
 target_compile_definitions(irods_filesystem_server PRIVATE ${IRODS_COMPILE_DEFINITIONS} IRODS_FILESYSTEM_ENABLE_SERVER_SIDE_API IRODS_TRANSPORT_ENABLE_SERVER_SIDE_API)
 
+add_library(
+  irods_user_administration_client
+  OBJECT
+  ${CMAKE_SOURCE_DIR}/lib/core/src/user_administration.cpp
+  )
+target_include_directories(
+  irods_user_administration_client
+  PRIVATE
+  ${CMAKE_BINARY_DIR}/lib/core/include
+  ${CMAKE_SOURCE_DIR}/lib/core/include
+  ${CMAKE_SOURCE_DIR}/lib/api/include
+  ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+  )
+set_target_properties(irods_user_administration_client PROPERTIES CXX_STANDARD ${IRODS_CXX_STANDARD})
+target_compile_options(irods_user_administration_client PRIVATE -fPIC -Wno-write-strings)
+target_compile_definitions(irods_user_administration_client PRIVATE ${IRODS_COMPILE_DEFINITIONS})
+
+add_library(
+  irods_user_administration_server
+  OBJECT
+  ${CMAKE_SOURCE_DIR}/lib/core/src/user_administration.cpp
+  )
+target_include_directories(
+  irods_user_administration_server
+  PRIVATE
+  ${CMAKE_BINARY_DIR}/lib/core/include
+  ${CMAKE_SOURCE_DIR}/lib/core/include
+  ${CMAKE_SOURCE_DIR}/lib/api/include
+  ${CMAKE_SOURCE_DIR}/server/core/include
+  ${CMAKE_SOURCE_DIR}/server/api/include
+  ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+  )
+set_target_properties(irods_user_administration_server PROPERTIES CXX_STANDARD ${IRODS_CXX_STANDARD})
+target_compile_options(irods_user_administration_server PRIVATE -fPIC -Wno-write-strings)
+target_compile_definitions(irods_user_administration_server PRIVATE ${IRODS_COMPILE_DEFINITIONS} IRODS_USER_ADMINISTRATION_ENABLE_SERVER_SIDE_API)
+
 set(
   IRODS_LIBIRODS_CLIENT_SOURCES
   ${CMAKE_SOURCE_DIR}/lib/api/src/rcAuthCheck.cpp
@@ -452,6 +488,7 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/core/src/cpUtil.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/fsckUtil.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/getUtil.cpp
+  ${CMAKE_SOURCE_DIR}/lib/core/src/group.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_c_api.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_client_api_table.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_client_negotiation.cpp
@@ -476,8 +513,10 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/core/src/sockComm.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/sslSockComm.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/trimUtil.cpp
+  ${CMAKE_SOURCE_DIR}/lib/core/src/user.cpp
   $<TARGET_OBJECTS:irods_filesystem_path>
   $<TARGET_OBJECTS:irods_filesystem_client>
+  $<TARGET_OBJECTS:irods_user_administration_client>
   )
 add_library(
   irods_client
@@ -726,6 +765,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/re/src/sharedmemory.cpp
   ${CMAKE_SOURCE_DIR}/server/re/src/testMS.cpp
   $<TARGET_OBJECTS:irods_filesystem_server>
+  $<TARGET_OBJECTS:irods_user_administration_server>
   )
 add_library(
   irods_server
@@ -1069,6 +1109,7 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/core/src/fsckUtil.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/getRodsEnv.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/getUtil.cpp
+  ${CMAKE_SOURCE_DIR}/lib/core/src/group.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/hashtable.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_auth_factory.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/irods_auth_manager.cpp
@@ -1143,6 +1184,7 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/core/src/sslSockComm.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/stringOpr.cpp
   ${CMAKE_SOURCE_DIR}/lib/core/src/trimUtil.cpp
+  ${CMAKE_SOURCE_DIR}/lib/core/src/user.cpp
   )
 
 set(
@@ -1182,6 +1224,8 @@ add_library(
   $<TARGET_OBJECTS:irods_filesystem_path>
   $<TARGET_OBJECTS:irods_filesystem_client>
   $<TARGET_OBJECTS:irods_filesystem_server>
+  $<TARGET_OBJECTS:irods_user_administration_client>
+  $<TARGET_OBJECTS:irods_user_administration_server>
   )
 target_link_libraries(
   RodsAPIs

--- a/cmake/development_library.cmake
+++ b/cmake/development_library.cmake
@@ -28,6 +28,7 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/core/include/fsckUtil.h
   ${CMAKE_SOURCE_DIR}/lib/core/include/getRodsEnv.h
   ${CMAKE_SOURCE_DIR}/lib/core/include/getUtil.h
+  ${CMAKE_SOURCE_DIR}/lib/core/include/group.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/guiProgressCallback.h
   ${CMAKE_SOURCE_DIR}/lib/core/include/irods_assert.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/irods_auth_constants.hpp
@@ -144,6 +145,8 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/core/include/termiosUtil.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/thread_pool.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/trimUtil.h
+  ${CMAKE_SOURCE_DIR}/lib/core/include/user.hpp
+  ${CMAKE_SOURCE_DIR}/lib/core/include/user_administration.hpp
   )
 
 set(

--- a/lib/core/include/group.hpp
+++ b/lib/core/include/group.hpp
@@ -1,0 +1,26 @@
+#ifndef IRODS_USER_ADMINISTRTION_GROUP_HPP
+#define IRODS_USER_ADMINISTRTION_GROUP_HPP
+
+#include <string>
+#include <ostream>
+
+namespace irods::experimental::administration
+{
+    inline namespace v1
+    {
+        struct group
+        {
+            explicit group(std::string name);
+
+            auto operator==(const group& other) const noexcept -> bool;
+            auto operator!=(const group& other) const noexcept -> bool;
+            auto operator< (const group& other) const noexcept -> bool;
+
+            std::string name;
+        }; // group
+
+        auto operator<<(std::ostream& out, const group& user) -> std::ostream&;
+    } // namespace v1
+} // namespace irods::experimental::administration
+
+#endif // IRODS_USER_ADMINISTRTION_GROUP_HPP

--- a/lib/core/include/user.hpp
+++ b/lib/core/include/user.hpp
@@ -1,0 +1,28 @@
+#ifndef IRODS_USER_ADMINISTRTION_USER_HPP
+#define IRODS_USER_ADMINISTRTION_USER_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+
+namespace irods::experimental::administration
+{
+    inline namespace v1
+    {
+        struct user
+        {
+            explicit user(std::string name, std::optional<std::string> zone = std::nullopt);
+
+            auto operator==(const user& other) const noexcept -> bool;
+            auto operator!=(const user& other) const noexcept -> bool;
+            auto operator< (const user& other) const noexcept -> bool;
+
+            std::string name;
+            std::string zone;
+        }; // user
+
+        auto operator<<(std::ostream& out, const user& user) -> std::ostream&;
+    } // namespace v1
+} // namespace irods::experimental::administration
+
+#endif // IRODS_USER_ADMINISTRTION_USER_HPP

--- a/lib/core/include/user_administration.hpp
+++ b/lib/core/include/user_administration.hpp
@@ -1,0 +1,113 @@
+#ifndef IRODS_USER_ADMINISTRATION_HPP
+#define IRODS_USER_ADMINISTRATION_HPP
+
+#undef NAMESPACE_IMPL
+#undef rxComm
+
+#ifdef IRODS_USER_ADMINISTRATION_ENABLE_SERVER_SIDE_API
+    #define NAMESPACE_IMPL      server
+    #define rxComm              rsComm_t
+#else 
+    #define NAMESPACE_IMPL      client
+    #define rxComm              rcComm_t
+#endif // IRODS_USER_ADMINISTRATION_ENABLE_SERVER_SIDE_API
+
+#include "rcConnect.h"
+#include "user.hpp"
+#include "group.hpp"
+
+#include <vector>
+#include <string>
+#include <optional>
+#include <ostream>
+#include <system_error>
+#include <stdexcept>
+
+namespace irods::experimental::administration
+{
+    inline namespace v1
+    {
+        // Types
+
+        enum class user_type
+        {
+            rodsuser,
+            groupadmin,
+            rodsadmin
+        }; // user_type
+
+        enum class zone_type
+        {
+            local,
+            remote
+        }; // zone_type
+
+        // Exceptions
+
+        class user_management_error
+            : std::runtime_error
+        {
+        public:
+            using std::runtime_error::runtime_error;
+        };
+    } // namespace v1
+} // irods::experimental::administration
+
+namespace irods::experimental::administration::NAMESPACE_IMPL
+{
+    inline namespace v1
+    {
+        // User Management
+
+        auto add_user(rxComm& conn,
+                      const user& user,
+                      user_type user_type = user_type::rodsuser,
+                      zone_type zone_type = zone_type::local) -> std::error_code;
+
+        auto remove_user(rxComm& conn, const user& user) -> std::error_code;
+
+        auto set_user_password(rxComm& conn, const user& user, std::string_view new_password) -> std::error_code;
+
+        auto set_user_type(rxComm& conn, const user& user, user_type new_user_type) -> std::error_code;
+
+        auto add_user_auth(rxComm& conn, const user& user, std::string_view auth) -> std::error_code;
+
+        auto remove_user_auth(rxComm& conn, const user& user, std::string_view auth) -> std::error_code;
+
+        // Group Management
+
+        auto add_group(rxComm& conn, const group& group) -> std::error_code;
+
+        auto remove_group(rxComm& conn, const group& group) -> std::error_code;
+
+        auto add_user_to_group(rxComm& conn, const group& group, const user& user) -> std::error_code;
+
+        auto remove_user_from_group(rxComm& conn, const group& group, const user& user) -> std::error_code;
+
+        // Query
+
+        auto users(rxComm& conn) -> std::vector<user>;
+        auto users(rxComm& conn, const group& group) -> std::vector<user>;
+
+        auto groups(rxComm& conn) -> std::vector<group>;
+        auto groups(rxComm& conn, const user& user) -> std::vector<group>;
+
+        auto exists(rxComm& conn, const user& user) -> bool;
+        auto exists(rxComm& conn, const group& group) -> bool;
+
+        auto id(rxComm& conn, const user& user) -> std::optional<std::string>;
+        auto id(rxComm& conn, const group& group) -> std::optional<std::string>;
+
+        auto type(rxComm& conn, const user& user) -> std::optional<user_type>;
+        auto auth_names(rxComm& conn, const user& user) -> std::vector<std::string>;
+
+        auto user_is_member_of_group(rxComm& conn, const group& group, const user& user) -> bool;
+
+        // Utility
+
+        auto local_unique_name(rxComm& conn, const user& user) -> std::string;
+    } // namespace v1
+} // namespace irods::experimental::administration::NAMESPACE_IMPL
+
+#endif // IRODS_USER_ADMINISTRATION_HPP
+

--- a/lib/core/src/group.cpp
+++ b/lib/core/src/group.cpp
@@ -1,0 +1,37 @@
+#include "group.hpp"
+
+#include "json.hpp"
+
+using json = nlohmann::json;
+
+namespace irods::experimental::administration
+{
+    inline namespace v1
+    {
+        group::group(std::string name)
+            : name{std::move(name)}
+        {
+        }
+
+        auto group::operator==(const group& other) const noexcept -> bool
+        {
+            return other.name == name;
+        }
+
+        auto group::operator!=(const group& other) const noexcept -> bool
+        {
+            return !(other == *this);
+        }
+
+        auto group::operator<(const group& other) const noexcept -> bool
+        {
+            return name < other.name;
+        }
+
+        auto operator<<(std::ostream& out, const group& group) -> std::ostream&
+        {
+            return out << json{{"name", group.name}}.dump();
+        }
+    } // namespace v1
+} // namespace irods::experimental::administration
+

--- a/lib/core/src/user.cpp
+++ b/lib/core/src/user.cpp
@@ -1,0 +1,38 @@
+#include "user.hpp"
+
+#include "json.hpp"
+
+using json = nlohmann::json;
+
+namespace irods::experimental::administration
+{
+    inline namespace v1
+    {
+        user::user(std::string name, std::optional<std::string> zone)
+            : name{std::move(name)}
+            , zone{zone ? *zone : ""}
+        {
+        }
+
+        auto user::operator==(const user& other) const noexcept -> bool
+        {
+            return other.name == name && other.zone == zone;
+        }
+
+        auto user::operator!=(const user& other) const noexcept -> bool
+        {
+            return !(*this == other);
+        }
+
+        auto user::operator<(const user& other) const noexcept -> bool
+        {
+            return name < other.name && zone < other.zone;
+        }
+
+        auto operator<<(std::ostream& out, const user& user) -> std::ostream&
+        {
+            return out << json{{"name", user.name}, {"zone", user.zone}}.dump();
+        }
+    } // namespace v1
+} // namespace irods::experimental::administration
+

--- a/lib/core/src/user_administration.cpp
+++ b/lib/core/src/user_administration.cpp
@@ -1,0 +1,488 @@
+#include "user_administration.hpp"
+
+#undef rxGeneralAdmin
+
+#ifdef IRODS_USER_ADMINISTRATION_ENABLE_SERVER_SIDE_API
+    #include "rsGeneralAdmin.hpp"
+    #define rxGeneralAdmin rsGeneralAdmin
+    #define RODS_SERVER 1 // For irods::query<rsComm_t>
+#else
+    #include "generalAdmin.h"
+    #define rxGeneralAdmin rcGeneralAdmin
+#endif // IRODS_USER_ADMINISTRATION_ENABLE_SERVER_SIDE_API
+
+#include "obf.h"
+#include "authenticate.h"
+#include "irods_query.hpp"
+#include "query_builder.hpp"
+
+#include <array>
+#include <iostream>
+
+namespace irods::experimental::administration::NAMESPACE_IMPL
+{
+    inline namespace v1
+    {
+        namespace
+        {
+            auto to_user_type(std::string_view user_type_string) -> user_type
+            {
+                // clang-format off
+                if      (user_type_string == "rodsuser")   { return user_type::rodsuser; }
+                else if (user_type_string == "groupadmin") { return user_type::groupadmin; }
+                else if (user_type_string == "rodsadmin")  { return user_type::rodsadmin; }
+                // clang-format on
+
+                throw user_management_error{"undefined user type"};
+            }
+
+            auto to_zone_type(std::string_view zone_type_string) -> zone_type
+            {
+                // clang-format off
+                if      (zone_type_string == "local")  { return zone_type::local; }
+                else if (zone_type_string == "remote") { return zone_type::remote; }
+                // clang-format on
+
+                throw user_management_error{"undefined zone type"};
+            }
+
+            auto to_c_str(user_type user_type) -> const char*
+            {
+                // clang-format off
+                switch (user_type) {
+                    case user_type::rodsuser:   return "rodsuser";
+                    case user_type::groupadmin: return "groupadmin";
+                    case user_type::rodsadmin:  return "rodsadmin";
+                    default:                    break;
+                }
+                // clang-format on
+
+                throw user_management_error{"cannot convert user_type to string"};
+            }
+
+            auto get_local_zone(rxComm& conn) -> std::string
+            {
+#ifdef IRODS_USER_ADMINISTRATION_ENABLE_SERVER_SIDE_API
+                return getLocalZoneName();
+#else
+                for (auto&& row : irods::query{&conn, "select ZONE_NAME where ZONE_TYPE = 'local'"}) {
+                    return row[0];
+                }
+
+                throw user_management_error{"cannot get local zone name"};
+#endif // IRODS_USER_ADMINISTRATION_ENABLE_SERVER_SIDE_API
+            }
+
+            auto obfuscate_password(std::string_view new_password) -> std::string
+            {
+                std::array<char, MAX_PASSWORD_LEN + 10> plain_text_password{};
+                std::strncpy(plain_text_password.data(), new_password.data(), MAX_PASSWORD_LEN);
+
+                if (const auto lcopy = MAX_PASSWORD_LEN - 10 - new_password.size(); lcopy > 15) {
+                    // The random string (second argument) is used for padding and must match 
+                    // what is defined on the server-side.
+                    std::strncat(plain_text_password.data(), "1gCBizHWbwIYyWLoysGzTe6SyzqFKMniZX05faZHWAwQKXf6Fs", lcopy);
+                }
+
+                std::array<char, MAX_PASSWORD_LEN + 10> key{};
+
+                // Decode (or prompt for current password) and store the obfuscated password in key.
+                // "obfGetPw" decodes the obfuscated password stored in .irods/.irodsA.
+                if (obfGetPw(key.data()) != 0) {
+                    throw user_management_error{"password obfuscation failed"};
+                }
+
+                std::array<char, MAX_PASSWORD_LEN + 100> obfuscate_password{};
+                obfEncodeByKey(plain_text_password.data(), key.data(), obfuscate_password.data());
+
+                return obfuscate_password.data();
+            }
+        } // anonymous namespace
+
+        auto add_user(rxComm& conn,
+                      const user& user,
+                      user_type user_type,
+                      zone_type zone_type) -> std::error_code
+        {
+            std::string name = local_unique_name(conn, user);
+            std::string zone;
+
+            if (zone_type::local == zone_type) {
+                zone = get_local_zone(conn);
+            }
+
+            generalAdminInp_t input{};
+            input.arg0 = "add";
+            input.arg1 = "user";
+            input.arg2 = name.data();
+            input.arg3 = to_c_str(user_type);
+            input.arg4 = zone.data();
+
+            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
+                return std::error_code{ec, std::generic_category()};
+            }
+
+            return {};
+        }
+
+        auto remove_user(rxComm& conn, const user& user) -> std::error_code
+        {
+            const auto name = local_unique_name(conn, user);
+
+            generalAdminInp_t input{};
+            input.arg0 = "rm";
+            input.arg1 = "user";
+            input.arg2 = name.data();
+            input.arg3 = user.zone.data();
+
+            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
+                return std::error_code{ec, std::generic_category()};
+            }
+
+            return {};
+        }
+
+        auto set_user_password(rxComm& conn, const user& user, std::string_view new_password) -> std::error_code
+        {
+            const auto obfuscated_password = obfuscate_password(new_password);
+
+            generalAdminInp_t input{};
+            input.arg0 = "modify";
+            input.arg1 = "user";
+            input.arg2 = user.name.data();
+            input.arg3 = "password";
+            input.arg4 = obfuscated_password.data();
+
+            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
+                return std::error_code{ec, std::generic_category()};
+            }
+
+            return {};
+        }
+
+        auto set_user_type(rxComm& conn, const user& user, user_type new_user_type) -> std::error_code
+        {
+            const auto name = local_unique_name(conn, user);
+
+            generalAdminInp_t input{};
+            input.arg0 = "modify";
+            input.arg1 = "user";
+            input.arg2 = name.data();
+            input.arg3 = "type";
+            input.arg4 = to_c_str(new_user_type);
+
+            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
+                return std::error_code{ec, std::generic_category()};
+            }
+
+            return {};
+        }
+
+        auto add_user_auth(rxComm& conn, const user& user, std::string_view auth) -> std::error_code
+        {
+            const auto name = local_unique_name(conn, user);
+
+            generalAdminInp_t input{};
+            input.arg0 = "modify";
+            input.arg1 = "user";
+            input.arg2 = name.data();
+            input.arg3 = "addAuth";
+            input.arg4 = auth.data();
+
+            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
+                return std::error_code{ec, std::generic_category()};
+            }
+
+            return {};
+        }
+
+        auto remove_user_auth(rxComm& conn, const user& user, std::string_view auth) -> std::error_code
+        {
+            const auto name = local_unique_name(conn, user);
+
+            generalAdminInp_t input{};
+            input.arg0 = "modify";
+            input.arg1 = "user";
+            input.arg2 = name.data();
+            input.arg3 = "rmAuth";
+            input.arg4 = auth.data();
+
+            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
+                return std::error_code{ec, std::generic_category()};
+            }
+
+            return {};
+        }
+
+        // Group Management
+
+        auto add_group(rxComm& conn, const group& group) -> std::error_code
+        {
+            const auto zone = get_local_zone(conn);
+
+            generalAdminInp_t input{};
+            input.arg0 = "add";
+            input.arg1 = "user";
+            input.arg2 = group.name.data();
+            input.arg3 = "rodsgroup";
+            input.arg4 = zone.data();
+
+            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
+                return std::error_code{ec, std::generic_category()};
+            }
+
+            return {};
+        }
+
+        auto remove_group(rxComm& conn, const group& group) -> std::error_code
+        {
+            const auto zone = get_local_zone(conn);
+
+            generalAdminInp_t input{};
+            input.arg0 = "rm";
+            input.arg1 = "user";
+            input.arg2 = group.name.data();
+            input.arg3 = zone.data();
+
+            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
+                return std::error_code{ec, std::generic_category()};
+            }
+
+            return {};
+        }
+
+        auto add_user_to_group(rxComm& conn, const group& group, const user& user) -> std::error_code
+        {
+            generalAdminInp_t input{};
+            input.arg0 = "modify";
+            input.arg1 = "group";
+            input.arg2 = group.name.data();
+            input.arg3 = "add";
+            input.arg4 = user.name.data();
+            input.arg5 = user.zone.data();
+
+            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
+                return std::error_code{ec, std::generic_category()};
+            }
+
+            return {};
+        }
+
+        auto remove_user_from_group(rxComm& conn, const group& group, const user& user) -> std::error_code
+        {
+            generalAdminInp_t input{};
+            input.arg0 = "modify";
+            input.arg1 = "group";
+            input.arg2 = group.name.data();
+            input.arg3 = "remove";
+            input.arg4 = user.name.data();
+            input.arg5 = user.zone.data();
+
+            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
+                return std::error_code{ec, std::generic_category()};
+            }
+
+            return {};
+        }
+
+        // Query
+
+        auto users(rxComm& conn) -> std::vector<user>
+        {
+            std::vector<user> users;
+
+            for (auto&& row : irods::query{&conn, "select USER_NAME, USER_ZONE where USER_TYPE != 'rodsgroup'"}) {
+                users.emplace_back(row[0], row[1]);
+            }
+
+            return users;
+        }
+
+        auto users(rxComm& conn, const group& group) -> std::vector<user>
+        {
+            std::vector<user> users;
+
+            std::string gql = "select USER_NAME, USER_ZONE "
+                              "where USER_TYPE != 'rodsgroup' and USER_GROUP_NAME = '";
+            gql += group.name;
+            gql += "'";
+
+            for (auto&& row : irods::query{&conn, gql}) {
+                users.emplace_back(row[0], row[1]);
+            }
+
+            return users;
+        }
+
+        auto groups(rxComm& conn) -> std::vector<group>
+        {
+            std::vector<group> groups;
+
+            for (auto&& row : irods::query{&conn, "select USER_GROUP_NAME where USER_TYPE = 'rodsgroup'"}) {
+                groups.emplace_back(row[0]);
+            }
+
+            return groups;
+        }
+
+        auto groups(rxComm& conn, const user& user) -> std::vector<group>
+        {
+            std::vector<std::string> args{local_unique_name(conn, user)};
+
+            query_builder qb;
+            
+            qb.type(query_type::specific)
+              .zone_hint(user.zone.empty() ? get_local_zone(conn) : user.zone)
+              .bind_arguments(args);
+
+            std::vector<group> groups;
+
+            try {
+                for (auto&& row : qb.build(conn, "listGroupsForUser")) {
+                    groups.emplace_back(row[1]);
+                }
+            }
+            catch (...) {
+                // GenQuery fallback.
+                groups.clear();
+
+                for (auto&& g : NAMESPACE_IMPL::groups(conn)) {
+                    if (user_is_member_of_group(conn, g, user)) {
+                        groups.push_back(std::move(g));
+                    }
+                }
+            }
+
+            return groups;
+        }
+
+        auto exists(rxComm& conn, const user& user) -> bool
+        {
+            std::string gql = "select USER_ID where USER_TYPE != 'rodsgroup' and USER_NAME = '";
+            gql += user.name;
+            gql += "' and USER_ZONE = '";
+            gql += (user.zone.empty() ? get_local_zone(conn) : user.zone);
+            gql += "'";
+
+            for (auto&& row : irods::query{&conn, gql}) {
+                static_cast<void>(row);
+                return true;
+            }
+
+            return false;
+        }
+
+        auto exists(rxComm& conn, const group& group) -> bool
+        {
+            std::string gql = "select USER_GROUP_ID where USER_TYPE = 'rodsgroup' and USER_GROUP_NAME = '";
+            gql += group.name;
+            gql += "'";
+
+            for (auto&& row : irods::query{&conn, gql}) {
+                static_cast<void>(row);
+                return true;
+            }
+
+            return false;
+        }
+
+        auto id(rxComm& conn, const user& user) -> std::optional<std::string>
+        {
+            std::string gql = "select USER_ID where USER_TYPE != 'rodsgroup' and USER_NAME = '";
+            gql += local_unique_name(conn, user);
+            gql += "' and USER_ZONE = '";
+            gql += (user.zone.empty() ? get_local_zone(conn) : user.zone);
+            gql += "'";
+
+            for (auto&& row : irods::query{&conn, gql}) {
+                return row[0];
+            }
+
+            return std::nullopt;
+        }
+
+        auto id(rxComm& conn, const group& group) -> std::optional<std::string>
+        {
+            std::string gql = "select USER_GROUP_ID where USER_TYPE = 'rodsgroup' and USER_GROUP_NAME = '";
+            gql += group.name;
+            gql += "'";
+
+            for (auto&& row : irods::query{&conn, gql}) {
+                return row[0];
+            }
+
+            return std::nullopt;
+        }
+
+        auto type(rxComm& conn, const user& user) -> std::optional<user_type>
+        {
+            std::string gql = "select USER_TYPE where USER_TYPE != 'rodsgroup' and USER_NAME = '";
+            gql += local_unique_name(conn, user);
+            gql += "' and USER_ZONE = '";
+            gql += (user.zone.empty() ? get_local_zone(conn) : user.zone);
+            gql += "'";
+
+            for (auto&& row : irods::query{&conn, gql}) {
+                return to_user_type(row[0]);
+            }
+
+            return std::nullopt;
+        }
+
+        auto auth_names(rxComm& conn, const user& user) -> std::vector<std::string>
+        {
+            std::vector<std::string> auth_names;
+
+            std::string gql = "select USER_DN where USER_TYPE != 'rodsgroup' and USER_NAME = '";
+            gql += local_unique_name(conn, user);
+            gql += "' and USER_ZONE = '";
+            gql += (user.zone.empty() ? get_local_zone(conn) : user.zone);
+            gql += "'";
+
+            for (auto&& row : irods::query{&conn, gql}) {
+                auth_names.push_back(row[0]);
+            }
+
+            return auth_names;
+        }
+
+        auto user_is_member_of_group(rxComm& conn, const group& group, const user& user) -> bool
+        {
+            std::string gql = "select USER_ID where USER_TYPE != 'rodsgroup' and USER_NAME = '";
+            gql += local_unique_name(conn, user);
+            gql += "' and USER_ZONE = '";
+            gql += (user.zone.empty() ? get_local_zone(conn) : user.zone);
+            gql += "' and USER_GROUP_NAME = '";
+            gql += group.name;
+            gql += "'";
+
+            for (auto&& row : irods::query{&conn, gql}) {
+                static_cast<void>(row);
+                return true;
+            }
+
+            return false;
+        }
+
+        // Utility
+
+        auto local_unique_name(rxComm& conn, const user& user) -> std::string
+        {
+            // Implies that the user belongs to the local zone and
+            // is not a remote user (i.e. federation).
+            if (user.zone.empty()) {
+                return user.name;
+            }
+
+            auto name = user.name;
+
+            if (user.zone != get_local_zone(conn)) {
+                name += '#';
+                name += user.zone;
+            }
+
+            return name;
+        }
+    } // namespace v1
+} // namespace irods::experimental::administration::NAMESPACE_IMPL
+

--- a/scripts/irods/database_upgrade.py
+++ b/scripts/irods/database_upgrade.py
@@ -79,6 +79,15 @@ def run_update(irods_config, cursor):
             group_id = row[0]
             database_connect.execute_sql_statement(cursor, "insert into R_USER_GROUP values (?,?,?,?);", group_id, group_id, timestamp, timestamp)
 
+        # Add specific query that allows listing all groups a user is a member of.
+        sql = ("insert into R_SPECIFIC_QUERY (alias, sqlStr, create_ts) "
+               "values ('listGroupsForUser', "
+                        "'select group_user_id, user_name from R_USER_GROUP ug"
+                        " inner join R_USER_MAIN u on ug.group_user_id = u.user_id"
+                        " where user_type_name = ''rodsgroup'' and ug.user_id = (select user_id from R_USER_MAIN where user_name = ? and user_type_name != ''rodsgroup'')', "
+                        "'1580297960');")
+        database_connect.execute_sql_statement(cursor, sql)
+
     else:
         raise IrodsError('Upgrade to schema version %d is unsupported.' % (new_schema_version))
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -39,7 +39,8 @@ set(TEST_INCLUDE_LIST test_config/irods_connection_pool
                       test_config/irods_linked_list_iterator
                       test_config/irods_logical_paths_and_special_characters
                       test_config/irods_query_builder
-                      test_config/irods_shared_memory_object)
+                      test_config/irods_shared_memory_object
+                      test_config/irods_user_administration)
 
 foreach(IRODS_TEST_CONFIG ${TEST_INCLUDE_LIST})
     unset_irods_test_variables()

--- a/unit_tests/cmake/test_config/irods_user_administration.cmake
+++ b/unit_tests/cmake/test_config/irods_user_administration.cmake
@@ -1,0 +1,16 @@
+set(IRODS_TEST_TARGET irods_user_administration)
+
+set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/src/test_user_administration.cpp)
+
+set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
+                            ${CMAKE_SOURCE_DIR}/lib/core/include
+                            ${CMAKE_SOURCE_DIR}/lib/api/include
+                            ${CMAKE_SOURCE_DIR}/server/core/include
+                            ${CMAKE_SOURCE_DIR}/server/icat/include
+                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
+                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include)
+ 
+set(IRODS_TEST_LINK_LIBRARIES irods_common
+                              irods_client
+                              c++abi)

--- a/unit_tests/src/test_user_administration.cpp
+++ b/unit_tests/src/test_user_administration.cpp
@@ -1,0 +1,157 @@
+#include "catch.hpp"
+
+#include "connection_pool.hpp"
+#include "user_administration.hpp"
+#include "irods_at_scope_exit.hpp"
+
+#include <algorithm>
+#include <iterator>
+
+TEST_CASE("user group administration")
+{
+    namespace adm = irods::experimental::administration;
+
+    auto conn_pool = irods::make_connection_pool();
+    auto conn = conn_pool->get_connection();
+
+    SECTION("local user operations")
+    {
+        adm::user test_user{"unit_test_test_user"};
+
+        irods::at_scope_exit remove_user{[&conn, &test_user] {
+            if (adm::client::exists(conn, test_user)) {
+                adm::client::remove_user(conn, test_user);
+            }
+        }};
+
+        REQUIRE(adm::client::add_user(conn, test_user).value() == 0);
+        REQUIRE(adm::client::exists(conn, test_user));
+        REQUIRE(adm::client::set_user_password(conn, test_user, "testpassword").value() == 0);
+        REQUIRE(adm::client::set_user_type(conn, test_user, adm::user_type::rodsadmin).value() == 0);
+
+        REQUIRE(adm::client::remove_user(conn, test_user).value() == 0);
+        REQUIRE_FALSE(adm::client::exists(conn, test_user));
+    }
+
+    SECTION("user types")
+    {
+        adm::user test_user{"unit_test_test_user"};
+
+        irods::at_scope_exit remove_user{[&conn, &test_user] {
+            if (adm::client::exists(conn, test_user)) {
+                adm::client::remove_user(conn, test_user);
+            }
+        }};
+
+        REQUIRE(adm::client::add_user(conn, test_user).value() == 0);
+        REQUIRE(adm::client::type(conn, test_user) == adm::user_type::rodsuser);
+
+        REQUIRE(adm::client::set_user_type(conn, test_user, adm::user_type::rodsadmin).value() == 0);
+        REQUIRE(adm::client::type(conn, test_user) == adm::user_type::rodsadmin);
+
+        REQUIRE(adm::client::set_user_type(conn, test_user, adm::user_type::groupadmin).value() == 0);
+        REQUIRE(adm::client::type(conn, test_user) == adm::user_type::groupadmin);
+
+        REQUIRE(adm::client::remove_user(conn, test_user).value() == 0);
+    }
+
+#ifdef IRODS_TEST_REMOTE_USER_ADMINISTRATION_OPERATIONS
+    SECTION("remote user operations")
+    {
+        adm::user test_user{"unit_test_test_user", "otherZone"};
+
+        irods::at_scope_exit remove_user{[&conn, &test_user] {
+            if (adm::client::exists(conn, test_user)) {
+                adm::client::remove_user(conn, test_user);
+            }
+        }};
+
+        REQUIRE(adm::client::add_user(conn, test_user, adm::user_type::rodsuser, adm::zone_type::remote).value() == 0);
+        REQUIRE(adm::client::exists(conn, test_user));
+
+        REQUIRE(adm::client::remove_user(conn, test_user).value() == 0);
+        REQUIRE_FALSE(adm::client::exists(conn, test_user));
+    }
+#endif // IRODS_TEST_REMOTE_USER_ADMINISTRATION_OPERATIONS
+
+    SECTION("group operations")
+    {
+        adm::group test_group{"unit_test_test_group"};
+
+        irods::at_scope_exit remove_group{[&conn, &test_group] {
+            if (adm::client::exists(conn, test_group)) {
+                adm::client::remove_group(conn, test_group);
+            }
+        }};
+
+        REQUIRE(adm::client::add_group(conn, test_group).value() == 0);
+        REQUIRE(adm::client::exists(conn, test_group));
+
+        adm::user test_user{"unit_test_test_user"};
+
+        irods::at_scope_exit remove_user{[&conn, &test_group, &test_user] {
+            if (adm::client::exists(conn, test_user)) {
+                adm::client::remove_user_from_group(conn, test_group, test_user);
+                adm::client::remove_user(conn, test_user);
+            }
+        }};
+
+        REQUIRE(adm::client::add_user(conn, test_user).value() == 0);
+        REQUIRE(adm::client::add_user_to_group(conn, test_group, test_user).value() == 0);
+        REQUIRE(adm::client::user_is_member_of_group(conn, test_group, test_user));
+
+        REQUIRE(adm::client::remove_user_from_group(conn, test_group, test_user).value() == 0);
+        REQUIRE(adm::client::remove_user(conn, test_user).value() == 0);
+        REQUIRE_FALSE(adm::client::user_is_member_of_group(conn, test_group, test_user));
+
+        REQUIRE(adm::client::remove_group(conn, test_group).value() == 0);
+        REQUIRE_FALSE(adm::client::exists(conn, test_group));
+    }
+
+    SECTION("list all groups containing a specific user")
+    {
+        const std::vector groups{
+            adm::group{"unit_test_test_group_a"},
+            adm::group{"unit_test_test_group_b"},
+            adm::group{"unit_test_test_group_c"}
+        };
+
+        irods::at_scope_exit remove_groups{[&conn, &groups] {
+            for (auto&& g : groups) {
+                if (adm::client::exists(conn, g)) {
+                    adm::client::remove_group(conn, g);
+                }
+            }
+        }};
+
+        for (auto&& g : groups) {
+            adm::client::add_group(conn, g);
+        }
+
+        adm::user test_user{"unit_test_test_user"};
+
+        irods::at_scope_exit remove_user{[&conn, &groups, &test_user] {
+            if (adm::client::exists(conn, test_user)) {
+                for (auto&& g : groups) {
+                    adm::client::remove_user_from_group(conn, g, test_user);
+                }
+
+                adm::client::remove_user(conn, test_user);
+            }
+        }};
+
+        REQUIRE(adm::client::add_user(conn, test_user).value() == 0);
+        REQUIRE(adm::client::add_user_to_group(conn, groups[0], test_user).value() == 0);
+        REQUIRE(adm::client::add_user_to_group(conn, groups[2], test_user).value() == 0);
+
+        auto groups_containing_user = adm::client::groups(conn, test_user);
+        std::sort(std::begin(groups_containing_user), std::end(groups_containing_user));
+
+        REQUIRE(groups_containing_user == std::vector{
+            adm::group{"public"},
+            adm::group{"unit_test_test_group_a"},
+            adm::group{"unit_test_test_group_c"}
+        });
+    }
+}
+

--- a/unit_tests/unit_tests_list.json
+++ b/unit_tests/unit_tests_list.json
@@ -8,5 +8,6 @@
     "irods_linked_list_iterator",
     "irods_logical_paths_and_special_characters",
     "irods_query_builder",
-    "irods_shared_memory_object"
+    "irods_shared_memory_object",
+    "irods_user_administration"
 ]


### PR DESCRIPTION
- Added new specific query for listing all groups a user is a member of.
- Unit-testing of remote operations is disabled by default. To enable,
  define the macro "IRODS_TEST_REMOTE_USER_ADMINISTRATION_OPERATIONS".