### PR TITLE
[#4672][#4632] Add missing entries to r_user_group table (4-2-stable)

### DIFF
--- a/VERSION.json.dist.in
+++ b/VERSION.json.dist.in
@@ -1,6 +1,6 @@
 {
     "irods_version": "@IRODS_VERSION@",
-    "catalog_schema_version": 6,
+    "catalog_schema_version": 7,
     "commit_id": "@IRODS_GIT_SHA1@",
     "configuration_schema_version": 3
 }

--- a/scripts/irods/database_connect.py
+++ b/scripts/irods/database_connect.py
@@ -418,6 +418,18 @@ def setup_database_values(irods_config, cursor=None, default_resource_directory=
             admin_user_id,
             timestamp,
             timestamp)
+    execute_sql_statement(cursor,
+            "insert into R_USER_GROUP values (?,?,?,?);",
+            admin_group_id,
+            admin_group_id,
+            timestamp,
+            timestamp)
+    execute_sql_statement(cursor,
+            "insert into R_USER_GROUP values (?,?,?,?);",
+            public_group_id,
+            public_group_id,
+            timestamp,
+            timestamp)
 
     #password
     scrambled_password = password_obfuscation.scramble(irods_config.admin_password,


### PR DESCRIPTION
- Allows "rodsadmin" and "public" groups to be found via USER_GROUP_NAME.
- Bumps catalog schema version.