### PR TITLE
[#4735] Use free function to create single-conn pool (master)

### DIFF
--- a/server/core/src/irodsReServer.cpp
+++ b/server/core/src/irodsReServer.cpp
@@ -244,15 +244,7 @@ namespace {
                 logger::delay_server::error((boost::format("rcRuleExecDel failed for %s, stat=%d") %
                     _inp.ruleExecId % status).str());
                 // Establish a new connection as the original may be invalid
-                rodsEnv env{};
-                _getRodsEnv(env);
-                auto tmp_pool = std::make_shared<irods::connection_pool>(
-                    1,
-                    env.rodsHost,
-                    env.rodsPort,
-                    env.rodsUserName,
-                    env.rodsZone,
-                    env.irodsConnectionPoolRefreshTime);
+                auto tmp_pool = irods::make_connection_pool();
                 status = rcRuleExecDel(&static_cast<rcComm_t&>(tmp_pool->get_connection()), &rule_exec_del_inp);
                 if (status < 0) {
                     logger::delay_server::error(


### PR DESCRIPTION
Passed CI tests as part of #4749 and removed due to being a separate issue.