### PR TITLE
Revert "[#4727] Skip Test_Resource_Replication_With_Retry" (4-2-stable)

### DIFF
--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -4489,7 +4489,6 @@ OUTPUT ruleExecOut
             self.admin.assert_icommand(['iadmin', 'modresc', 'unix3Resc', 'host', test.settings.HOSTNAME_3])
             self.admin.assert_icommand(['iadmin', 'rmresc', test_resc])
 
-@unittest.skip('FIXME: Remove this line on resolution of #4727')
 @unittest.skipIf(False == test.settings.USE_MUNGEFS, "These tests require mungefs")
 class Test_Resource_Replication_With_Retry(ChunkyDevTest, ResourceSuite, unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This reverts commit 6a68379b7e8218cb0420e6550db477b61bf5ef09.

Accompanied by irods/irods_testing_jenkins#67, the tests pass in CI.