### PR TITLE
[4848] Update resource suite to clean up registered file

### DIFF
--- a/scripts/irods/test/resource_suite.py
+++ b/scripts/irods/test/resource_suite.py
@@ -532,6 +532,8 @@ class ResourceSuite(ResourceBase):
         # local cleanup
         if os.path.exists(datafilename):
             os.unlink(datafilename)
+        if os.path.exists(fullpath):
+            os.unlink(fullpath)
 
     def test_admin_local_iput_relative_physicalpath_into_server_bin(self):
         # local setup


### PR DESCRIPTION
Files registered outside of vault are no longer deleted so they need to be cleaned up in test.