### PR TITLE
[#4916] Atomic API plugin detects database flavor and uses the correct SQL syntax (master)

### DIFF
--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -880,6 +880,8 @@ OUTPUT ruleExecOut
             self.admin.run_icommand(['iadmin', 'rmresc', destination_resource])
             self.admin.run_icommand(['iadmin', 'rmresc', leaf_resource])
 
+    @unittest.skip(("Fails against databases with transaction isolation level set to REPEATABLE-READ (e.g. MySQL). "
+                    "For more details, see https://github.com/irods/irods/issues/4917"))
     def test_msi_atomic_apply_metadata_operations__issue_4484(self):
         def do_test(entity_name, entity_type, operation, expected_output=None):
             json_input = json.dumps({

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(BUILD_UNIT_TESTS YES CACHE BOOL "Build unit tests")
 set(UNIT_TESTS_RUN_AFTER_BUILD NO CACHE BOOL "Run after building unit tests")
 set(UNIT_TESTS_REPORTING_STYLE "junit" CACHE STRING "The style of output used for unit test reporting [console, compact, junit, xml]")
 set(UNIT_TESTS_REPORT_FILENAME "report.xml" CACHE STRING "The filename of the unit test report")
+set(UNIT_TESTS_ENABLE_ALL NO CACHE BOOL "Enables all unit tests")
 
 if (NOT BUILD_UNIT_TESTS)
     return()
@@ -25,6 +26,10 @@ include(utils)
 if (UNIT_TESTS_RUN_AFTER_BUILD)
     set(TEST_RUNNER_ARGS -r ${UNIT_TESTS_REPORTING_STYLE}
                          -o ${UNIT_TESTS_REPORT_FILENAME})
+endif()
+
+if (UNIT_TESTS_ENABLE_ALL)
+    add_definitions(-DIRODS_ENABLE_ALL_UNIT_TESTS)
 endif()
 
 # List of cmake files defined under ./cmake/test_config.

--- a/unit_tests/src/filesystem/test_filesystem.cpp
+++ b/unit_tests/src/filesystem/test_filesystem.cpp
@@ -548,8 +548,17 @@ TEST_CASE("filesystem")
             REQUIRE_THROWS(fs::client::remove_metadata(conn, "invalid_path", metadata), "cannot apply metadata operations: unknown object type");
         }
 
+#ifdef IRODS_ENABLE_ALL_UNIT_TESTS
         SECTION("atomic operations")
         {
+            // IMPORTANT
+            // ~~~~~~~~~
+            // This test will fail against databases that have the transaction isolation
+            // level set to REPEATABLE-READ or higher (e.g. MySQL by default). This is because
+            // the database plugin cannot see changes committed by the nanodbc library.
+            //
+            // For more details, see: https://github.com/irods/irods/issues/4917
+
             std::array<fs::metadata, 3> metadata{{
                 {"n1", "v1", "u1"},
                 {"n2", "v2", "u2"},
@@ -571,6 +580,7 @@ TEST_CASE("filesystem")
             REQUIRE_NOTHROW(fs::client::remove_metadata(conn, sandbox, metadata));
             REQUIRE(fs::client::get_metadata(conn, sandbox).empty());
         }
+#endif // IRODS_ENABLE_ALL_UNIT_TESTS
     }
 }
 


### PR DESCRIPTION
Disables all tests that call the database plugin and nanodbc within the same process.