### PR TITLE
Include <cstring> if using std:mem functions

### DIFF
--- a/lib/core/include/dstream.hpp
+++ b/lib/core/include/dstream.hpp
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <algorithm>
 #include <utility>
+#include <cstring>
 
 namespace irods::experimental::io
 {

--- a/unit_tests/src/filesystem/test_path.cpp
+++ b/unit_tests/src/filesystem/test_path.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 #include <utility>
 #include <algorithm>
+#include <cstring>
 
 #ifdef __cpp_lib_filesystem
     #include <filesystem>


### PR DESCRIPTION
It is a little naughty to use std::memcpy and similar without directly including #include <cstring> and this behaviour is not guaranteed to work on all platforms or with future C++ library versions.