### PR TITLE
Remove some server log reading in tests (master)

### DIFF
--- a/plugins/microservices/CMakeLists.txt
+++ b/plugins/microservices/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(administration)
 add_subdirectory(msi_atomic_apply_acl_operations)
 add_subdirectory(msi_atomic_apply_metadata_operations)
+add_subdirectory(msi_get_agent_pid)
 add_subdirectory(msi_touch)

--- a/plugins/microservices/msi_get_agent_pid/CMakeLists.txt
+++ b/plugins/microservices/msi_get_agent_pid/CMakeLists.txt
@@ -1,0 +1,28 @@
+set(IRODS_PLUGIN_TARGET msi_get_agent_pid)
+
+add_library(${IRODS_PLUGIN_TARGET} MODULE libmsi_get_agent_pid.cpp)
+
+target_compile_definitions(${IRODS_PLUGIN_TARGET} PRIVATE ENABLE_RE
+                                                          ${IRODS_COMPILE_DEFINITIONS}
+                                                          IRODS_ENABLE_SYSLOG)
+
+set_property(TARGET ${IRODS_PLUGIN_TARGET} PROPERTY CXX_STANDARD ${IRODS_CXX_STANDARD})
+
+target_include_directories(${IRODS_PLUGIN_TARGET} PRIVATE ${CMAKE_BINARY_DIR}/lib/core/include
+                                                          ${CMAKE_SOURCE_DIR}/lib/core/include
+                                                          ${CMAKE_SOURCE_DIR}/lib/api/include
+                                                          ${CMAKE_SOURCE_DIR}/server/drivers/include
+                                                          ${CMAKE_SOURCE_DIR}/server/api/include
+                                                          ${CMAKE_SOURCE_DIR}/server/core/include
+                                                          ${CMAKE_SOURCE_DIR}/server/icat/include
+                                                          ${CMAKE_SOURCE_DIR}/server/re/include
+                                                          ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                                                          ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
+
+target_link_libraries(${IRODS_PLUGIN_TARGET} PRIVATE irods_server
+                                                     irods_common
+                                                     ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)
+
+install(TARGETS ${IRODS_PLUGIN_TARGET}
+        LIBRARY DESTINATION ${IRODS_PLUGINS_DIRECTORY}/microservices
+        COMPONENT ${IRODS_PACKAGE_COMPONENT_SERVER_NAME})

--- a/plugins/microservices/msi_get_agent_pid/libmsi_get_agent_pid.cpp
+++ b/plugins/microservices/msi_get_agent_pid/libmsi_get_agent_pid.cpp
@@ -1,0 +1,62 @@
+#include "irods_ms_plugin.hpp"
+#include "irods_re_structs.hpp"
+#include "msParam.h"
+#include "rodsErrorTable.h"
+#include "irods_error.hpp"
+#include "irods_logger.hpp"
+
+#include <exception>
+#include <functional>
+#include <string>
+
+namespace
+{
+    using log = irods::experimental::log;
+
+    auto msi_impl(msParam_t* _out_pid, ruleExecInfo_t* rei) -> int
+    {
+        try {
+            const auto pid_str = std::to_string(getpid());
+            fillStrInMsParam(_out_pid, pid_str.c_str());
+            return 0;
+        }
+        catch (const std::exception& e) {
+            log::microservice::error(e.what());
+            return SYS_INTERNAL_ERR;
+        }
+        catch (...) {
+            log::microservice::error("An unknown error occurred while processing the request.");
+            return SYS_UNKNOWN_ERROR;
+        }
+    } // msi_impl
+
+    template <typename... Args, typename Function>
+    auto make_msi(const std::string& name, Function func) -> irods::ms_table_entry*
+    {
+        auto* msi = new irods::ms_table_entry{sizeof...(Args)};
+        msi->add_operation<Args..., ruleExecInfo_t*>(name, std::function<int(Args..., ruleExecInfo_t*)>(func));
+        return msi;
+    } // make_msi
+} // anonymous namespace
+
+extern "C"
+auto plugin_factory() -> irods::ms_table_entry*
+{
+    return make_msi<msParam_t*>("msi_get_agent_pid", msi_impl);
+}
+
+#ifdef IRODS_FOR_DOXYGEN
+/// \brief Gets the pid of the agent which executes this microservice.
+///
+/// \since 4.2.9
+///
+/// \param[out]    _out_pid     A place to write down the agent pid
+/// \param[in,out] _rei         A ::RuleExecInfo object that is automatically handled by the
+///                             rule engine plugin framework. Users must ignore this parameter.
+///
+/// \return An integer.
+/// \retval 0 on success
+/// \retval Error code on failure
+auto msi_get_agent_pid(msParam_t* _out_pid, ruleExecInfo_t* rei) -> int;
+#endif // IRODS_FOR_DOXYGEN
+

--- a/plugins/resources/replication/irods_create_write_replicator.cpp
+++ b/plugins/resources/replication/irods_create_write_replicator.cpp
@@ -54,7 +54,7 @@ namespace irods {
                     addKeyVal( &dataObjInp.condInput, DEST_RESC_NAME_KW, root_resource_.c_str() );
                     addKeyVal( &dataObjInp.condInput, IN_PDMO_KW, sub_hier.c_str() );
 
-                    try { 
+                    try {
                         const auto status = data_obj_repl_with_retry( _ctx, dataObjInp );
                         char* sys_error = NULL;
                         auto rods_error = rodsErrorName( status, &sys_error );

--- a/scripts/irods/lib.py
+++ b/scripts/irods/lib.py
@@ -574,3 +574,10 @@ def log_message_occurrences_is_one_of_list_of_counts(msg, expected_value_list=No
     if server_log_path is None:
         server_log_path=paths.server_log_path()
     return count_occurrences_of_string_in_log(server_log_path, msg, start_index) in expected_value_list
+
+def metadata_attr_with_value_exists(session, attr, value):
+    print('looking for attr:[{0}] value:[{1}]'.format(attr, value))
+    out, _, _ = session.run_icommand(['iquest', '%s',
+        '"select META_DATA_ATTR_VALUE where META_DATA_ATTR_NAME = \'{}\'"'.format(attr)])
+    print(out)
+    return value in out

--- a/scripts/irods/test/rule_texts_for_tests.py
+++ b/scripts/irods/test/rule_texts_for_tests.py
@@ -204,6 +204,118 @@ test_msiSegFault {{
 }}
 OUTPUT ruleExecOut
 '''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Native_Rule_Engine_Plugin']['test_peps_for_parallel_mode_transfers__4404_get'] = '''
+pep_api_data_obj_get_pre (*INSTANCE_NAME, *COMM, *DATAOBJINP, *BUFFER, *PORTAL_OPR_OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_peps_for_parallel_mode_transfers__4404_get","data-obj-get-pre");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+pep_api_data_obj_get_post (*INSTANCE_NAME, *COMM, *DATAOBJINP, *BUFFER, *PORTAL_OPR_OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_peps_for_parallel_mode_transfers__4404_get","data-obj-get-post");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+pep_api_data_obj_get_except (*INSTANCE_NAME, *COMM, *DATAOBJINP, *BUFFER, *PORTAL_OPR_OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_peps_for_parallel_mode_transfers__4404_get","data-obj-get-except");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+pep_api_data_obj_get_finally (*INSTANCE_NAME, *COMM, *DATAOBJINP, *BUFFER, *PORTAL_OPR_OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_peps_for_parallel_mode_transfers__4404_get","data-obj-get-finally");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Native_Rule_Engine_Plugin']['test_peps_for_parallel_mode_transfers__4404_put'] = '''
+pep_api_data_obj_put_pre (*INSTANCE_NAME, *COMM, *DATAOBJINP, *BUFFER, *PORTAL_OPR_OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_peps_for_parallel_mode_transfers__4404_put","data-obj-put-pre");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+pep_api_data_obj_put_post (*INSTANCE_NAME, *COMM, *DATAOBJINP, *BUFFER, *PORTAL_OPR_OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_peps_for_parallel_mode_transfers__4404_put","data-obj-put-post");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+pep_api_data_obj_put_except (*INSTANCE_NAME, *COMM, *DATAOBJINP, *BUFFER, *PORTAL_OPR_OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_peps_for_parallel_mode_transfers__4404_put","data-obj-put-except");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+pep_api_data_obj_put_finally (*INSTANCE_NAME, *COMM, *DATAOBJINP, *BUFFER, *PORTAL_OPR_OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_peps_for_parallel_mode_transfers__4404_put","data-obj-put-finally");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Native_Rule_Engine_Plugin']['test_dynamic_policy_enforcement_point_exception_for_plugins__4128_pre_pep_fail'] = '''
+pep_resource_open_pre(*INST, *CTX, *OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_dynamic_policy_enforcement_point_exception_for_plugins__4128_pre_pep_fail","PRE PEP FAIL");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+    failmsg(-1, "POST PEP FAIL")
+}}
+pep_resource_open_except(*INST, *CTX, *OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_dynamic_policy_enforcement_point_exception_for_plugins__4128_pre_pep_fail","EXCEPT FOR PRE PEP FAIL");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+'''
+
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Native_Rule_Engine_Plugin']['test_dynamic_policy_enforcement_point_exception_for_plugins__4128_op_fail'] = '''
+pep_resource_open_except(*INST, *CTX, *OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_dynamic_policy_enforcement_point_exception_for_plugins__4128_op_fail","EXCEPT FOR OPERATION FAIL");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Native_Rule_Engine_Plugin']['test_dynamic_policy_enforcement_point_exception_for_plugins__4128_post_pep_fail'] = '''
+pep_resource_open_post(*INST, *CTX, *OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_dynamic_policy_enforcement_point_exception_for_plugins__4128_post_pep_fail","POST PEP FAIL");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+    failmsg(-1, "POST PEP FAIL")
+}}
+pep_resource_open_except(*INST, *CTX, *OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_dynamic_policy_enforcement_point_exception_for_plugins__4128_post_pep_fail","EXCEPT FOR POST PEP FAIL");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+'''
+
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Native_Rule_Engine_Plugin']['test_dynamic_policy_enforcement_point_exception_for_apis__4128_pre_pep_fail'] = '''
+pep_api_data_obj_get_pre(*INST, *COMM, *INP, *PORT, *BUF)
+{{
+    msiAddKeyVal(*key_val_pair,"test_dynamic_policy_enforcement_point_exception_for_apis__4128_pre_pep_fail","PRE PEP FAIL");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+    failmsg(-1, "PRE PEP FAIL")
+}}
+pep_api_data_obj_get_except(*INST, *COMM, *INP, *PORT, *BUF)
+{{
+    msiAddKeyVal(*key_val_pair,"test_dynamic_policy_enforcement_point_exception_for_apis__4128_pre_pep_fail","EXCEPT FOR PRE PEP FAIL");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Native_Rule_Engine_Plugin']['test_dynamic_policy_enforcement_point_exception_for_apis__4128_op_fail'] = '''
+pep_api_data_obj_get_except(*INST, *COMM, *INP, *PORT, *BUF)
+{{
+    msiAddKeyVal(*key_val_pair,"test_dynamic_policy_enforcement_point_exception_for_apis__4128_op_fail","EXCEPT FOR OPERATION FAIL");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Native_Rule_Engine_Plugin']['test_dynamic_policy_enforcement_point_exception_for_apis__4128_post_pep_fail'] = '''
+pep_resource_open_post(*INST, *CTX, *OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_dynamic_policy_enforcement_point_exception_for_apis__4128_post_pep_fail","POST PEP FAIL");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+    failmsg(-1, "POST PEP FAIL")
+}}
+pep_resource_open_except(*INST, *CTX, *OUT)
+{{
+    msiAddKeyVal(*key_val_pair,"test_dynamic_policy_enforcement_point_exception_for_apis__4128_post_pep_fail","EXCEPT FOR POST PEP FAIL");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{resource}","-R");
+}}
+'''
 
 rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Native_Rule_Engine_Plugin']['test_failing_on_code_5043'] = '''
 fail_on_code(*name) {

--- a/scripts/irods/test/rule_texts_for_tests.py
+++ b/scripts/irods/test/rule_texts_for_tests.py
@@ -513,7 +513,8 @@ rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Delay_Queue']['
 test_batch_delay_processing {{
     for(*i = 0; *i < {expected_count}; *i = *i + 1) {{
         delay("<PLUSET>0.1s</PLUSET>") {{
-            writeLine("serverLog", "delay *i");
+            msiAddKeyVal(*key_val_pair,"{metadata_attr}","{metadata_value}_*i");
+            msiAssociateKeyValuePairsToObj(*key_val_pair,"{logical_path}","-d");
         }}
     }}
 }}
@@ -522,7 +523,8 @@ OUTPUT ruleExecOut
 rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Delay_Queue']['test_delay_block_with_output_param__3906'] = '''
 test_delay_with_output_param {{
     delay("<PLUSET>0.1s</PLUSET>") {{
-        writeLine("serverLog", "delayed rule executed");
+        msiAddKeyVal(*key_val_pair,"{metadata_attr}","{metadata_value}");
+        msiAssociateKeyValuePairsToObj(*key_val_pair,"{logical_path}","-d");
     }}
     *status = "rule queued";
 }}
@@ -532,18 +534,22 @@ OUTPUT *status
 rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Delay_Queue']['test_delay_queue_with_long_job'] = '''
 test_delay_queue_with_long_job {{
     delay("<PLUSET>0.1s</PLUSET>") {{
-        writeLine("serverLog", "Sleeping...");
+        msiAddKeyVal(*sleep_kvp,"{metadata_attr}","Sleeping...");
+        msiAssociateKeyValuePairsToObj(*sleep_kvp,"{logical_path}","-d");
         msiSleep("{long_job_run_time}", "0");
-        writeLine("serverLog", "Waking!");
+        msiAddKeyVal(*wake_kvp,"{metadata_attr}","Waking!");
+        msiAssociateKeyValuePairsToObj(*wake_kvp,"{logical_path}","-d");
     }}
     for(*i = 0; *i < {delay_job_batch_size}; *i = *i + 1) {{
         delay("<PLUSET>{sooner_delay}s</PLUSET>") {{
-            writeLine("serverLog", "sooner: *i");
+            msiAddKeyVal(*sooner_kvp,"{metadata_attr}_sooner","sooner: *i");
+            msiAssociateKeyValuePairsToObj(*sooner_kvp,"{logical_path}","-d");
         }}
     }}
     for(*i = 0; *i < {delay_job_batch_size}; *i = *i + 1) {{
         delay("<PLUSET>{later_delay}s</PLUSET>") {{
-            writeLine("serverLog", "later: *i");
+            msiAddKeyVal(*later_kvp,"{metadata_attr}_later","later: *i");
+            msiAssociateKeyValuePairsToObj(*later_kvp,"{logical_path}","-d");
         }}
     }}
 }}
@@ -552,14 +558,22 @@ OUTPUT ruleExecOut
 rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Delay_Queue']['test_delay_queue_connection_refresh'] = '''
 test_delay_queue_connection_refresh {{
     delay("<PLUSET>0.1s</PLUSET>") {{
-        writeLine("serverLog", "sleep 1...");
+        msi_get_agent_pid(*first_pid)
+        msiAddKeyVal(*first_kvp,"{metadata_attr}::job_1","before::*first_pid");
+        msiAssociateKeyValuePairsToObj(*first_kvp,"{logical_path}","-d");
         msiSleep("{sleep_time}", "0");
-        writeLine("serverLog", "wakeup 1!");
+        msi_get_agent_pid(*second_pid)
+        msiAddKeyVal(*second_kvp,"{metadata_attr}::job_1","after::*second_pid");
+        msiAssociateKeyValuePairsToObj(*second_kvp,"{logical_path}","-d");
     }}
     delay("<PLUSET>0.1s</PLUSET>") {{
-        writeLine("serverLog", "sleep 2...");
+        msi_get_agent_pid(*first_pid)
+        msiAddKeyVal(*first_kvp,"{metadata_attr}::job_2","before::*first_pid");
+        msiAssociateKeyValuePairsToObj(*first_kvp,"{logical_path}","-d");
         msiSleep("{sleep_time}", "0");
-        writeLine("serverLog", "wakeup 2!");
+        msi_get_agent_pid(*second_pid)
+        msiAddKeyVal(*second_kvp,"{metadata_attr}::job_2","after::*second_pid");
+        msiAssociateKeyValuePairsToObj(*second_kvp,"{logical_path}","-d");
     }}
 }}
 OUTPUT ruleExecOut
@@ -567,9 +581,11 @@ OUTPUT ruleExecOut
 rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Delay_Queue']['test_failed_delay_job'] = '''
 test_delay_with_output_param {{
     delay("<PLUSET>0.1s</PLUSET><INST_NAME>irods_rule_engine_plugin-irods_rule_language-instance</INST_NAME>") {{
-        writeLine("serverLog", "We are about to fail...");
+        msiAddKeyVal(*kvp,"{metadata_attr}","We are about to fail...");
+        msiAssociateKeyValuePairsToObj(*kvp,"{logical_path}","-d");
         msiGoodFailure();
-        writeLine("serverLog", "You should never see this line.");
+        msiAddKeyVal(*fail_kvp,"{metadata_attr}","You should never see this line.");
+        msiAssociateKeyValuePairsToObj(*fail_kvp,"{logical_path}","-d");
     }}
     writeLine("stdout", "rule queued");
 }}
@@ -578,12 +594,15 @@ OUTPUT ruleExecOut
 rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Delay_Queue']['test_sigpipe_in_delay_server'] = '''
 test_sigpipe_in_delay_server {{
     delay("<PLUSET>0.1s</PLUSET><INST_NAME>irods_rule_engine_plugin-irods_rule_language-instance</INST_NAME>") {{
-        writeLine("serverLog", "We are about to segfault...");
+        msiAddKeyVal(*kvp,"{metadata_attr}","We are about to segfault...");
+        msiAssociateKeyValuePairsToObj(*kvp,"{logical_path}","-d");
         msiSegFault();
-        writeLine("serverLog", "You should never see this line.");
+        msiAddKeyVal(*fail_kvp,"{metadata_attr}","You should never see this line.");
+        msiAssociateKeyValuePairsToObj(*fail_kvp,"{logical_path}","-d");
     }}
     delay("<PLUSET>{longer_delay_time}s</PLUSET><INST_NAME>irods_rule_engine_plugin-irods_rule_language-instance</INST_NAME>") {{
-        writeLine("serverLog", "Follow-up rule executed later!");
+        msiAddKeyVal(*kvp,"{metadata_attr}","Follow-up rule executed later!");
+        msiAssociateKeyValuePairsToObj(*kvp,"{logical_path}","-d");
     }}
     writeLine("stdout", "rule queued");
 }}
@@ -592,12 +611,14 @@ OUTPUT ruleExecOut
 rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Delay_Queue']['test_exception_in_delay_server'] = '''
 test_exception_in_delay_server {{
     delay("<PLUSET>0.1s</PLUSET><INST_NAME>irods_rule_engine_plugin-irods_rule_language-instance</INST_NAME>") {{
-        writeLine("serverLog", "Sleeping now...");
-        msiSleep("{sleep_time}", "0");
+        msiAddKeyVal(*kvp,"{metadata_attr}","Sleeping now...");
+        msiAssociateKeyValuePairsToObj(*kvp,"{logical_path}","-d");
+        msiSleep("{sleep_time}", "0"); # sleep to simulate a "long" job
         msiSegFault();
     }}
     delay("<PLUSET>{longer_delay_time}s</PLUSET><INST_NAME>irods_rule_engine_plugin-irods_rule_language-instance</INST_NAME>") {{
-        writeLine("serverLog", "Follow-up rule executed later!");
+        msiAddKeyVal(*kvp,"{metadata_attr}","Follow-up rule executed later!");
+        msiAssociateKeyValuePairsToObj(*kvp,"{logical_path}","-d");
     }}
 }}
 OUTPUT ruleExecOut

--- a/scripts/irods/test/test_delay_queue.py
+++ b/scripts/irods/test/test_delay_queue.py
@@ -10,6 +10,7 @@ import os
 import time
 
 from . import resource_suite
+from . import session
 from .. import test
 from .. import paths
 from .. import lib
@@ -17,15 +18,29 @@ from ..configuration import IrodsConfig
 from ..controller import IrodsController
 from .rule_texts_for_tests import rule_texts
 
-@unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'Skip for topology testing from resource server: reads server log')
-class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
+class Test_Delay_Queue(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 'apass')]), unittest.TestCase):
     plugin_name = IrodsConfig().default_rule_engine_plugin
     class_name = 'Test_Delay_Queue'
 
     def setUp(self):
         super(Test_Delay_Queue, self).setUp()
 
+        self.admin = self.admin_sessions[0]
+
+        self.filename = 'test_delay_queue'
+        self.local_path = os.path.join(self.admin.local_session_dir, self.filename)
+        self.logical_path = os.path.join(self.admin.session_collection, self.filename)
+        if not os.path.exists(self.local_path):
+            lib.make_file(self.local_path, 1024)
+        self.admin.assert_icommand(['iput', self.local_path, self.logical_path])
+        out, err, rc = self.admin.run_icommand(['iquest', '%s', '"select DATA_ID where DATA_NAME = \'{}\'"'.format(self.filename)])
+        self.assertEqual(rc, 0, msg='error occurred getting data_id:[{}],stderr:[{}]'.format(rc, err))
+        self.data_id = out.strip()
+
     def tearDown(self):
+        self.admin.assert_icommand(['irm', '-f', self.logical_path])
+        self.admin.assert_icommand(['iadmin', 'rum'])
+
         super(Test_Delay_Queue, self).tearDown()
 
     def no_delayed_rules(self):
@@ -48,7 +63,10 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
 
         # Simple delay rule with a writeLine
         rule_text_key = 'test_failed_delay_job'
-        rule_text = rule_texts[self.plugin_name][self.class_name][rule_text_key]
+        parameters = {}
+        parameters['logical_path'] = self.logical_path
+        parameters['metadata_attr'] = rule_text_key
+        rule_text = rule_texts[self.plugin_name][self.class_name][rule_text_key].format(**parameters)
         rule_file = rule_text_key + '.r'
         with open(rule_file, 'w') as f:
             f.write(rule_text)
@@ -70,20 +88,18 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
                 # Bounce server to apply setting
                 irodsctl.restart(test_mode=True)
 
-                # Fire off rule and wait for message to get written out to serverLog
-                initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
                 self.admin.assert_icommand(['irule', '-F', rule_file], 'STDOUT_SINGLELINE', "rule queued")
 
-                # Expected count is 3 because...
-                # 1. writeLine writes the string
-                # 2. rsExecRuleExpression writes the rule text on failure
-                # 3. delayed execution server writes the failed rule text under delay_server category
-                expected_count = 3
                 lib.delayAssert(
-                    lambda: lib.log_message_occurrences_equals_count(
-                        msg='We are about to fail...',
-                        count=expected_count,
-                        start_index=initial_size_of_server_log))
+                    lambda: lib.metadata_attr_with_value_exists(
+                        self.admin,
+                        parameters['metadata_attr'],
+                        'We are about to fail...')
+                )
+                self.assertFalse(lib.metadata_attr_with_value_exists(
+                    self.admin,
+                    parameters['metadata_attr'],
+                    'You should never see this line.'))
 
         finally:
             os.remove(rule_file)
@@ -96,16 +112,19 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
 
         delay_job_batch_size = 5
         re_server_sleep_time = 3
-        sooner_delay = 1
-        later_delay = re_server_sleep_time * 2
+        sooner_delay = 0.1
+        later_delay = re_server_sleep_time * 5
         long_job_run_time = re_server_sleep_time * 10
 
+        rule_text_key = 'test_delay_queue_with_long_job'
         parameters = {}
         parameters['delay_job_batch_size'] = delay_job_batch_size
         parameters['sooner_delay'] = sooner_delay
         parameters['later_delay'] = later_delay
         parameters['long_job_run_time'] = long_job_run_time
-        rule_text_key = 'test_delay_queue_with_long_job'
+        parameters['logical_path'] = self.logical_path
+        parameters['metadata_attr'] = rule_text_key
+        parameters['metadata_value'] = rule_text_key
         rule_text = rule_texts[self.plugin_name][self.class_name][rule_text_key].format(**parameters)
         rule_file = rule_text_key + '.r'
         with open(rule_file, 'w') as f:
@@ -129,41 +148,48 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
                 irodsctl.restart(test_mode=True)
 
                 # Fire off rule and ensure the delay queue is correctly populated
-                initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
                 self.admin.assert_icommand(['irule', '-F', rule_file])
-                actual_count = self.count_strings_in_queue('writeLine')
-                expected_count = delay_job_batch_size * 2 + 2
+                self.assertEqual(
+                    delay_job_batch_size * 2 + 2,
+                    self.count_strings_in_queue('msiAssociateKeyValuePairsToObj'))
 
                 # "Sooner" rules should execute
                 expected_count = delay_job_batch_size
-                lib.delayAssert(
-                    lambda: lib.log_message_occurrences_equals_count(
-                        msg='sooner:',
-                        count=expected_count,
-                        start_index=initial_size_of_server_log))
-                self.assertTrue(0 == self.count_strings_in_queue('sooner:'))
-                lib.delayAssert(
-                    lambda: lib.log_message_occurrences_equals_count(
-                        msg='later:',
-                        count=0,
-                        start_index=initial_size_of_server_log))
-                self.assertTrue(delay_job_batch_size == self.count_strings_in_queue('later:'))
-                self.assertTrue(1 == self.count_strings_in_queue('Sleeping...'))
+                for i in range(parameters['delay_job_batch_size']):
+                    lib.delayAssert(
+                        lambda: lib.metadata_attr_with_value_exists(
+                            self.admin,
+                            '_'.join([parameters['metadata_attr'], 'sooner']),
+                            'sooner: ' + str(i))
+                    )
+                self.assertEqual(0, self.count_strings_in_queue('sooner:'))
+                self.assertEqual(delay_job_batch_size, self.count_strings_in_queue('later:'))
+                self.assertEqual(1, self.count_strings_in_queue('Sleeping...'))
+
+                for i in range(parameters['delay_job_batch_size']):
+                    self.assertFalse(lib.metadata_attr_with_value_exists(
+                        self.admin,
+                        '_'.join([parameters['metadata_attr'], 'later']),
+                        'later: ' + str(i))
+                    )
 
                 # "Later" rules should execute... but long-running job should still be in queue
-                lib.delayAssert(
-                    lambda: lib.log_message_occurrences_equals_count(
-                        msg='later:',
-                        count=expected_count,
-                        start_index=initial_size_of_server_log))
-                self.assertTrue(0 == self.count_strings_in_queue('later:'))
-                self.assertTrue(1 == self.count_strings_in_queue('Sleeping...'))
+                for i in range(parameters['delay_job_batch_size']):
+                    lib.delayAssert(
+                        lambda: lib.metadata_attr_with_value_exists(
+                            self.admin,
+                            '_'.join([parameters['metadata_attr'], 'later']),
+                            'later: ' + str(i))
+                    )
+                self.assertEqual(0, self.count_strings_in_queue('later:'))
+                self.assertEqual(1, self.count_strings_in_queue('Sleeping...'))
 
                 # Wait for long-running job to finish and make sure it has
                 lib.delayAssert(
-                    lambda: lib.log_message_occurrences_equals_count(
-                        msg='Waking!',
-                        start_index=initial_size_of_server_log))
+                    lambda: lib.metadata_attr_with_value_exists(
+                        self.admin,
+                        parameters['metadata_attr'], 'Waking!')
+                )
                 lib.delayAssert(self.no_delayed_rules)
 
         finally:
@@ -176,9 +202,12 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
         server_config_filename = paths.server_config_path()
 
         expected_count = 10
+        rule_text_key = 'test_batch_delay_processing__3941'
         parameters = {}
         parameters['expected_count'] = expected_count
-        rule_text_key = 'test_batch_delay_processing__3941'
+        parameters['logical_path'] = self.logical_path
+        parameters['metadata_attr'] = rule_text_key
+        parameters['metadata_value'] = rule_text_key
         rule_text = rule_texts[self.plugin_name][self.class_name][rule_text_key].format(**parameters)
         rule_file = rule_text_key + '.r'
         with open(rule_file, 'w') as f:
@@ -202,16 +231,16 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
             irodsctl.restart(test_mode=True)
 
             # Fire off rule and ensure the delay queue is correctly populated
-            initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
             self.admin.assert_icommand(['irule', '-F', rule_file])
-            actual_count = self.count_strings_in_queue('writeLine')
 
             # Wait for messages to get written out and ensure that all the messages were written to serverLog
-            lib.delayAssert(
-                lambda: lib.log_message_occurrences_equals_count(
-                    msg='writeLine: inString = delay ',
-                    count=expected_count,
-                    start_index=initial_size_of_server_log))
+            for i in range(parameters['expected_count']):
+                lib.delayAssert(
+                    lambda: lib.metadata_attr_with_value_exists(
+                        self.admin,
+                        parameters['metadata_attr'],
+                        '_'.join([parameters['metadata_value'], str(i)]))
+                )
             lib.delayAssert(self.no_delayed_rules)
 
         os.remove(rule_file)
@@ -225,7 +254,11 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
         server_config_filename = paths.server_config_path()
 
         rule_text_key = 'test_delay_block_with_output_param__3906'
-        rule_text = rule_texts[self.plugin_name][self.class_name][rule_text_key]
+        parameters = {}
+        parameters['metadata_attr'] = rule_text_key
+        parameters['metadata_value'] = 'wedidit'
+        parameters['logical_path'] = self.logical_path
+        rule_text = rule_texts[self.plugin_name][self.class_name][rule_text_key].format(**parameters)
         rule_file = rule_text_key + '.r'
         with open(rule_file, 'w') as f:
             f.write(rule_text)
@@ -247,12 +280,12 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
             irodsctl.restart(test_mode=True)
 
             # Fire off rule and wait for message to get written out to serverLog
-            initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
             self.admin.assert_icommand(['irule', '-F', rule_file], 'STDOUT_SINGLELINE', "rule queued")
             lib.delayAssert(
-                lambda: lib.log_message_occurrences_equals_count(
-                    msg='writeLine: inString = delayed rule executed',
-                    start_index=initial_size_of_server_log))
+                lambda: lib.metadata_attr_with_value_exists(
+                    self.admin,
+                    parameters['metadata_attr'], parameters['metadata_value'])
+            )
 
         os.remove(rule_file)
 
@@ -265,9 +298,11 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
         config = IrodsConfig()
 
         rule_sleep_time = 4
+        rule_text_key = 'test_delay_queue_connection_refresh'
         parameters = {}
         parameters['sleep_time'] = rule_sleep_time
-        rule_text_key = 'test_delay_queue_connection_refresh'
+        parameters['metadata_attr'] = rule_text_key
+        parameters['logical_path'] = self.logical_path
         rule_text = rule_texts[self.plugin_name][self.class_name][rule_text_key].format(**parameters)
         rule_file = rule_text_key + '.r'
         with open(rule_file, 'w') as f:
@@ -297,31 +332,29 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
                     irodsctl.restart(test_mode=True)
 
                     # Fire off rule and ensure the delay queue is correctly populated
-                    initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
                     self.admin.assert_icommand(['irule', '-F', rule_file])
-                    time.sleep(rule_sleep_time * 2 + 2)
 
-                    sleeping_pids = []
-                    waking_pids = []
-                    with open(paths.server_log_path(), 'r') as f:
-                        f.seek(initial_size_of_server_log)
-                        for line in f:
-                            if 'sleep' in line:
-                                log_line_map = json.loads(line)
-                                sleeping_pids.append(log_line_map['server_pid'])
-                            if 'wakeup' in line:
-                                log_line_map = json.loads(line)
-                                waking_pids.append(log_line_map['server_pid'])
+                    iquest = '"select META_DATA_ATTR_VALUE where META_DATA_ATTR_NAME = \'{}\'"'
 
-                    expected_count = 2
-                    self.assertTrue(len(sleeping_pids) == expected_count)
-                    self.assertTrue(len(waking_pids) == expected_count)
-                    for i in range(expected_count):
-                        self.assertTrue(sleeping_pids[i] == waking_pids[i],
-                            msg='sleeping_pid:{0} != waking_pid:{1}'.format(sleeping_pids[i], waking_pids[i]))
-                        if i < expected_count - 1:
-                            self.assertTrue(sleeping_pids[i] != sleeping_pids[i + 1],
-                                msg='pids are equal:[{}]'.format(sleeping_pids[i]))
+                    job_names = ['job_1', 'job_2']
+                    pid_map = {}
+                    for job in job_names:
+                        attr = '::'.join([parameters['metadata_attr'], job])
+                        lib.delayAssert(lambda:
+                            2 == len(self.admin.run_icommand(['iquest', '%s', iquest.format(attr)])[0].splitlines()))
+                        pid_map[job] = {}
+                        out,_,rc = self.admin.run_icommand(['iquest', '%s', iquest.format(attr)])
+                        self.assertEqual(0, rc)
+                        for value in out.splitlines():
+                            s = value.split('::')
+                            job_id = str(s[0])
+                            pid = str(s[1])
+                            pid_map[job][job_id] = pid
+
+                    self.assertEqual(pid_map['job_1']['before'], pid_map['job_1']['after'])
+                    self.assertEqual(pid_map['job_2']['before'], pid_map['job_2']['after'])
+                    self.assertNotEqual(pid_map['job_1']['before'], pid_map['job_2']['before'])
+                    self.assertNotEqual(pid_map['job_1']['after'], pid_map['job_2']['after'])
 
         finally:
             os.remove(rule_file)
@@ -333,9 +366,11 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
 
         re_server_sleep_time = 2
         longer_delay_time = re_server_sleep_time * 2
+        rule_text_key = 'test_sigpipe_in_delay_server'
         parameters = {}
         parameters['longer_delay_time'] = str(longer_delay_time)
-        rule_text_key = 'test_sigpipe_in_delay_server'
+        parameters['logical_path'] = self.logical_path
+        parameters['metadata_attr'] = rule_text_key
         rule_text = rule_texts[self.plugin_name][self.class_name][rule_text_key].format(**parameters)
         rule_file = rule_text_key + '.r'
         with open(rule_file, 'w') as f:
@@ -359,23 +394,24 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
                 irodsctl.restart(test_mode=True)
 
                 # Fire off rule and wait for message to get written out to serverLog
-                initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
                 self.admin.assert_icommand(['irule', '-F', rule_file], 'STDOUT_SINGLELINE', "rule queued")
 
-                # Delayed rule writes to log and delay server writes rule that failed (agent should have died, so no rsExecRuleExpression)
-                expected_count = 2
                 lib.delayAssert(
-                    lambda: lib.log_message_occurrences_equals_count(
-                        msg='We are about to segfault...',
-                        count=expected_count,
-                        start_index=initial_size_of_server_log))
-
-                # See if the later rule is executed (i.e. delay server is still alive)
+                    lambda: lib.metadata_attr_with_value_exists(
+                        self.admin,
+                        parameters['metadata_attr'],
+                        'We are about to segfault...')
+                )
                 lib.delayAssert(
-                    lambda: lib.log_message_occurrences_equals_count(
-                        msg='Follow-up rule executed later!',
-                        start_index=initial_size_of_server_log))
-
+                    lambda: lib.metadata_attr_with_value_exists(
+                        self.admin,
+                        parameters['metadata_attr'],
+                        'Follow-up rule executed later!')
+                )
+                self.assertFalse(lib.metadata_attr_with_value_exists(
+                    self.admin,
+                    parameters['metadata_attr'],
+                    'You should never see this line.'))
 
         finally:
             os.remove(rule_file)
@@ -389,10 +425,12 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
         server_config_filename = paths.server_config_path()
 
         delay_job_sleep_time = 5
+        rule_text_key = 'test_exception_in_delay_server'
         parameters = {}
         parameters['sleep_time'] = str(delay_job_sleep_time)
         parameters['longer_delay_time'] = str(delay_job_sleep_time)
-        rule_text_key = 'test_exception_in_delay_server'
+        parameters['logical_path'] = self.logical_path
+        parameters['metadata_attr'] = rule_text_key
         rule_text = rule_texts[self.plugin_name][self.class_name][rule_text_key].format(**parameters)
         rule_file = rule_text_key + '.r'
         with open(rule_file, 'w') as f:
@@ -420,27 +458,21 @@ class Test_Delay_Queue(resource_suite.ResourceBase, unittest.TestCase):
 
                     # Bounce server to apply setting
                     irodsctl.restart(test_mode=True)
-                    initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
                     with lib.file_backed_up(odbc_ini_file):
                         self.admin.assert_icommand(['irule', '-F', rule_file])
                         time.sleep(2)
+                        # remove connection to database while rule is executing (should be sleeping)
                         os.unlink(odbc_ini_file)
                         time.sleep(delay_job_sleep_time * 2)
 
                     # Restore .odbc.ini and wait for delay server to execute rule properly
                     # The delay server should not have zombified, so the later rule should have executed
                     lib.delayAssert(
-                        lambda: lib.log_message_occurrences_equals_count(
-                            msg='Follow-up rule executed later!',
-                            start_index=initial_size_of_server_log))
-
-                    # The delay server should have caught the exception from the connection error on trying to delete the rule the first time
-                    unexpected_string = 'terminating with uncaught exception of type std::runtime_error: connect error'
-                    lib.delayAssert(
-                        lambda: lib.log_message_occurrences_equals_count(
-                            msg=unexpected_string,
-                            count=0,
-                            start_index=initial_size_of_server_log))
+                        lambda: lib.metadata_attr_with_value_exists(
+                            self.admin,
+                            parameters['metadata_attr'],
+                            'Follow-up rule executed later!')
+                    )
 
         finally:
             os.remove(rule_file)

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -459,7 +459,7 @@ OUTPUT ruleExecOut
             rc, _, stderr = self.admin.assert_icommand_fail(['irule', '-r', 'irods_rule_engine_plugin-irods_rule_language-instance', '-F', rule_file_path])
 
             self.admin.assert_icommand(['ilsresc', '-l', 'demoResc'], 'STDOUT_SINGLELINE', ['free space', free_space])
-            self.assertTrue(0 != rc)
+            self.assertNotEqual(0, rc)
             self.assertTrue('status = -32000 SYS_INVALID_RESC_INPUT' in stderr)
 
             lib.delayAssert(

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -3986,8 +3986,10 @@ class Test_Resource_Replication_With_Retry(ChunkyDevTest, ResourceSuite, unittes
         irods_config = IrodsConfig()
 
         with session.make_session_for_existing_admin() as admin_session:
-            self.munge_mount=tempfile.mkdtemp(prefix='munge_mount_')
-            self.munge_target=tempfile.mkdtemp(prefix='munge_target_')
+            self.munge_mount = os.path.abspath('munge_mount')
+            self.munge_target = os.path.abspath('munge_target')
+            lib.make_dir_p(self.munge_mount)
+            lib.make_dir_p(self.munge_target)
             assert_command('mungefs ' + self.munge_mount + ' -omodules=subdir,subdir=' + self.munge_target)
 
             self.munge_resc = 'ufs1munge'
@@ -4425,7 +4427,7 @@ class Test_Resource_Replication_With_Retry(ChunkyDevTest, ResourceSuite, unittes
         self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 3 ", " & " + filename])
         self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 4 ", " & " + filename])
 
-        self.admin.assert_icommand("irepl -a " + filename)
+        self.admin.assert_icommand(['irepl', '-R', 'fourthresc', filename])
 
         # should have dirty copies
         self.admin.assert_icommand_fail("ils -L " + filename, 'STDOUT_SINGLELINE', [" 0 ", " & " + filename])

--- a/server/api/src/rsDataObjClose.cpp
+++ b/server/api/src/rsDataObjClose.cpp
@@ -215,59 +215,58 @@ int procChksumForClose(
     int status = 0;
     dataObjInfo_t *dataObjInfo = L1desc[l1descInx].dataObjInfo;
     int oprType = L1desc[l1descInx].oprType;
-    int srcL1descInx = 0;
-    dataObjInfo_t *srcDataObjInfo;
 
-    *chksumStr = NULL;
+    *chksumStr = nullptr;
     if ( oprType == REPLICATE_DEST || oprType == PHYMV_DEST ) {
-        srcL1descInx = L1desc[l1descInx].srcL1descInx;
+        const int srcL1descInx = L1desc[l1descInx].srcL1descInx;
         if ( srcL1descInx <= 2 ) {
-            rodsLog( LOG_NOTICE,
-                     "procChksumForClose: srcL1descInx %d out of range",
-                     srcL1descInx );
+            irods::log(LOG_NOTICE, fmt::format(
+                "{}: srcL1descInx {} out of range",
+                __FUNCTION__, srcL1descInx));
             return SYS_FILE_DESC_OUT_OF_RANGE;
         }
 
-        srcDataObjInfo = L1desc[srcL1descInx].dataObjInfo;
-        if ( strlen( srcDataObjInfo->chksum ) > 0 ) {
-            addKeyVal( &dataObjInfo->condInput, ORIG_CHKSUM_KW, srcDataObjInfo->chksum );
-        }
+        dataObjInfo_t *srcDataObjInfo = L1desc[srcL1descInx].dataObjInfo;
+        std::string_view source_checksum = srcDataObjInfo->chksum;
+        if (source_checksum.length() > 0) {
+            addKeyVal(&dataObjInfo->condInput, ORIG_CHKSUM_KW, source_checksum.data());
 
-        if ( strlen( srcDataObjInfo->chksum ) > 0 &&
-                srcDataObjInfo->replStatus > 0 ) {
-            /* the source has chksum. Must verify chksum */
-            status = _dataObjChksum( rsComm, dataObjInfo, chksumStr );
-            if ( status < 0 ) {
-                dataObjInfo->chksum[0] = '\0';
-                if ( status == DIRECT_ARCHIVE_ACCESS ) {
-                    *chksumStr = strdup( srcDataObjInfo->chksum );
-                    rstrcpy( dataObjInfo->chksum, *chksumStr, NAME_LEN );
-                    return 0;
+            if (STALE_REPLICA != srcDataObjInfo->replStatus) {
+                irods::log(LOG_DEBUG, fmt::format(
+                        "[{}:{}] - verifying checksum for [{}],source:[{}]",
+                        __FUNCTION__, __LINE__, dataObjInfo->objPath, source_checksum));
+
+                if (const int ec = _dataObjChksum( rsComm, dataObjInfo, chksumStr ); ec < 0) {
+                    dataObjInfo->chksum[0] = '\0';
+                    if (DIRECT_ARCHIVE_ACCESS == ec) {
+                        *chksumStr = strdup(source_checksum.data());
+                        rstrcpy( dataObjInfo->chksum, *chksumStr, NAME_LEN );
+                        return 0;
+                    }
+
+                    irods::log(LOG_NOTICE, fmt::format(
+                             "{}: _dataObjChksum error for {}, status = {}",
+                             __FUNCTION__, dataObjInfo->objPath, ec));
+
+                    return ec;
                 }
-                else {
-                    rodsLog( LOG_NOTICE,
-                             "procChksumForClose: _dataObjChksum error for %s, status = %d",
-                             dataObjInfo->objPath, status );
-                    return status;
+
+                if (!*chksumStr) {
+                    rodsLog(LOG_ERROR, "chksumStr is NULL");
+                    return SYS_INTERNAL_NULL_INPUT_ERR;
                 }
-            }
-            else if ( *chksumStr == NULL ) {
-                rodsLog( LOG_ERROR, "chksumStr is NULL" );
-                return SYS_INTERNAL_NULL_INPUT_ERR;
-            }
-            else {
+
                 rstrcpy( dataObjInfo->chksum, *chksumStr, NAME_LEN );
-                if ( strcmp( srcDataObjInfo->chksum, *chksumStr ) != 0 ) {
-                    rodsLog( LOG_NOTICE,
-                             "procChksumForClose: chksum mismatch for %s src [%s] new [%s]",
-                             dataObjInfo->objPath, srcDataObjInfo->chksum, *chksumStr );
-                    free( *chksumStr );
-                    *chksumStr = NULL;
+                if (source_checksum != *chksumStr) {
+                    irods::log(LOG_NOTICE, fmt::format(
+                         "{}: chksum mismatch for {} src [{}] new [{}]",
+                         __FUNCTION__, dataObjInfo->objPath, source_checksum, *chksumStr));
+                    free(*chksumStr);
+                    *chksumStr = nullptr;
                     return USER_CHKSUM_MISMATCH;
                 }
-                else {
-                    return 0;
-                }
+
+                return 0;
             }
         }
     }
@@ -345,7 +344,7 @@ int procChksumForClose(
         }
         else if ( oprType == COPY_DEST ) {
             /* created through copy */
-            srcL1descInx = L1desc[l1descInx].srcL1descInx;
+            const int srcL1descInx = L1desc[l1descInx].srcL1descInx;
             if ( srcL1descInx <= 2 ) {
                 /* not a valid srcL1descInx */
                 rodsLog( LOG_DEBUG,
@@ -354,7 +353,7 @@ int procChksumForClose(
                 /* just register it for now */
                 return 0;
             }
-            srcDataObjInfo = L1desc[srcL1descInx].dataObjInfo;
+            dataObjInfo_t *srcDataObjInfo = L1desc[srcL1descInx].dataObjInfo;
             if ( strlen( srcDataObjInfo->chksum ) > 0 ) {
                 addKeyVal( &dataObjInfo->condInput, ORIG_CHKSUM_KW, srcDataObjInfo->chksum );
 
@@ -405,7 +404,7 @@ int procChksumForClose(
         }
         else if ( oprType == COPY_DEST ) {
             /* created through copy */
-            srcL1descInx = L1desc[l1descInx].srcL1descInx;
+            const int srcL1descInx = L1desc[l1descInx].srcL1descInx;
             if ( srcL1descInx <= 2 ) {
                 /* not a valid srcL1descInx */
                 rodsLog( LOG_DEBUG,
@@ -413,7 +412,7 @@ int procChksumForClose(
                          srcL1descInx );
                 return 0;
             }
-            srcDataObjInfo = L1desc[srcL1descInx].dataObjInfo;
+            dataObjInfo_t* srcDataObjInfo = L1desc[srcL1descInx].dataObjInfo;
             if ( strlen( srcDataObjInfo->chksum ) == 0 ) {
                 free( *chksumStr );
                 *chksumStr = NULL;
@@ -700,7 +699,7 @@ void close_physical_file(rsComm_t* comm, const int l1descInx)
 } // close_physical_file
 
 void update_checksum_if_needed(
-    rsComm_t* comm,
+    rsComm_t* _comm,
     const int l1descInx,
     ix::key_value_proxy<keyValPair_t>& p)
 {
@@ -715,7 +714,29 @@ void update_checksum_if_needed(
 
     if (update_checksum) {
         char *chksumStr{};
-        if (const int status = procChksumForClose(comm, l1descInx, &chksumStr); status < 0) {
+        if (const int status = procChksumForClose(_comm, l1descInx, &chksumStr); status < 0) {
+            free(chksumStr);
+
+            l1desc.dataObjInfo->replStatus = STALE_REPLICA;
+
+            keyValPair_t regParam{};
+            auto kvp = irods::experimental::make_key_value_proxy(regParam);
+            kvp[IN_PDMO_KW] = l1desc.dataObjInfo->rescHier;
+            kvp[REPL_STATUS_KW] = std::to_string(l1desc.dataObjInfo->replStatus);
+            if (getValByKey(&L1desc[l1descInx].dataObjInp->condInput, ADMIN_KW)) {
+                kvp[ADMIN_KW] = "";
+            }
+
+            modDataObjMeta_t inp{};
+            inp.dataObjInfo = l1desc.dataObjInfo;
+            inp.regParam = kvp.get();
+
+            if (const int ec = rsModDataObjMeta(_comm, &inp); ec < 0) {
+                irods::log(LOG_ERROR, fmt::format(
+                    "{} - rsModDataObjMeta failed [{}]",
+                    __FUNCTION__, ec));
+            }
+
             THROW(status, "procChksumForClose returned an error");
         }
         if (chksumStr) {
@@ -831,7 +852,7 @@ int rsDataObjClose(
     rsComm_t *rsComm,
     openedDataObjInp_t *dataObjCloseInp)
 {
-    const auto l1descInx = dataObjCloseInp->l1descInx; 
+    const auto l1descInx = dataObjCloseInp->l1descInx;
     if (l1descInx < 3 || l1descInx >= NUM_L1_DESC) {
         rodsLog(LOG_NOTICE,
             "rsDataObjClose: l1descInx %d out of range", l1descInx);

--- a/server/api/src/rsDataObjRepl.cpp
+++ b/server/api/src/rsDataObjRepl.cpp
@@ -1,62 +1,65 @@
-#include "dataObjRepl.h"
-#include "dataObjOpr.hpp"
-#include "dataObjCreate.h"
-#include "dataObjOpen.h"
+#include "apiNumber.h"
 #include "dataObjClose.h"
-#include "dataObjPut.h"
+#include "dataObjCreate.h"
 #include "dataObjGet.h"
-#include "rodsLog.h"
-#include "objMetaOpr.hpp"
-#include "physPath.hpp"
-#include "specColl.hpp"
-#include "resource.hpp"
-#include "icatDefines.h"
+#include "dataObjLock.h"
+#include "dataObjOpen.h"
+#include "dataObjOpr.hpp"
+#include "dataObjPut.h"
+#include "dataObjRepl.h"
+#include "dataObjTrim.h"
+#include "fileStageToCache.h"
+#include "fileSyncToArch.h"
 #include "getRemoteZoneResc.h"
+#include "icatDefines.h"
 #include "l3FileGetSingleBuf.h"
 #include "l3FilePutSingleBuf.h"
-#include "fileSyncToArch.h"
-#include "fileStageToCache.h"
-#include "unbunAndRegPhyBunfile.h"
-#include "dataObjTrim.h"
-#include "dataObjLock.h"
 #include "miscServerFunct.hpp"
-#include "rsDataObjRepl.hpp"
-#include "apiNumber.h"
+#include "objMetaOpr.hpp"
+#include "physPath.hpp"
+#include "resource.hpp"
+#include "rodsLog.h"
 #include "rsDataCopy.hpp"
-#include "rsDataObjCreate.hpp"
-#include "rsDataObjOpen.hpp"
-#include "rsDataObjRead.hpp"
-#include "rsDataObjWrite.hpp"
 #include "rsDataObjClose.hpp"
-#include "rsDataObjUnlink.hpp"
-#include "rsUnregDataObj.hpp"
-#include "rsL3FileGetSingleBuf.hpp"
+#include "rsDataObjCreate.hpp"
 #include "rsDataObjGet.hpp"
+#include "rsDataObjOpen.hpp"
 #include "rsDataObjPut.hpp"
-#include "rsL3FilePutSingleBuf.hpp"
+#include "rsDataObjRead.hpp"
+#include "rsDataObjRepl.hpp"
+#include "rsDataObjUnlink.hpp"
+#include "rsDataObjWrite.hpp"
 #include "rsFileStageToCache.hpp"
 #include "rsFileSyncToArch.hpp"
+#include "rsL3FileGetSingleBuf.hpp"
+#include "rsL3FilePutSingleBuf.hpp"
 #include "rsUnbunAndRegPhyBunfile.hpp"
+#include "rsUnregDataObj.hpp"
+#include "specColl.hpp"
+#include "unbunAndRegPhyBunfile.h"
 
 #include "irods_at_scope_exit.hpp"
-#include "irods_resource_backport.hpp"
-#include "irods_resource_redirect.hpp"
 #include "irods_log.hpp"
 #include "irods_logger.hpp"
-#include "irods_stacktrace.hpp"
-#include "irods_server_properties.hpp"
-#include "irods_server_api_call.hpp"
 #include "irods_random.hpp"
+#include "irods_resource_backport.hpp"
+#include "irods_resource_redirect.hpp"
+#include "irods_server_api_call.hpp"
+#include "irods_server_properties.hpp"
+#include "irods_stacktrace.hpp"
 #include "irods_string_tokenize.hpp"
 #include "key_value_proxy.hpp"
-#include "voting.hpp"
 #include "key_value_proxy.hpp"
+#include "replica_access_table.hpp"
+#include "voting.hpp"
 
 #include <string_view>
 #include <vector>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/format.hpp>
+
+#include "fmt/format.h"
 
 namespace ix = irods::experimental;
 
@@ -225,26 +228,44 @@ int replicate_data(
     L1desc[destination_l1descInx].srcL1descInx = source_l1descInx;
 
     // Copy data from source to destination
-    const int status = dataObjCopy(rsComm, destination_l1descInx);
+    int status = dataObjCopy(rsComm, destination_l1descInx);
     if (status < 0) {
         rodsLog(LOG_ERROR, "[%s] - dataObjCopy failed for [%s]", __FUNCTION__, destination_inp.objPath);
     }
     L1desc[destination_l1descInx].bytesWritten = L1desc[destination_l1descInx].dataObjInfo->dataSize;
 
+    // Save the token for the replica access table so that it can be removed
+    // in the event of a failure in close. On failure, the entry is restored,
+    // but this will prevent retries of the operation as the token information
+    // is lost by the time we have returned to the caller.
+    const auto token = L1desc[destination_l1descInx].replica_token;
+
     // Close destination replica
     int close_status = close_replica(rsComm, destination_l1descInx, status);
     if (close_status < 0) {
-        rodsLog(LOG_ERROR,
-                "[%s] - closing destination replica [%s] failed with [%d]",
-                __FUNCTION__, destination_inp.objPath, close_status);
+        irods::log(LOG_ERROR, fmt::format(
+            "[{}] - closing destination replica [{}] failed with [{}]",
+            __FUNCTION__, destination_inp.objPath, close_status));
+
+        if (status >= 0) {
+            status = close_status;
+        }
+
+        auto& rat = irods::experimental::replica_access_table::instance();
+        rat.erase_pid(token, getpid());
     }
     // Close source replica
-    close_status = close_replica(rsComm, source_l1descInx, status);
+    close_status = close_replica(rsComm, source_l1descInx, 0);
     if (close_status < 0) {
-        rodsLog(LOG_ERROR,
-                "[%s] - closing source replica [%s] failed with [%d]",
-                __FUNCTION__, source_inp.objPath, close_status);
+        irods::log(LOG_ERROR, fmt::format(
+            "[{}] - closing source replica [{}] failed with [{}]",
+            __FUNCTION__, source_inp.objPath, close_status));
+
+        if (status >= 0) {
+            status = close_status;
+        }
     }
+
     return status;
 } // replicate_data
 
@@ -290,8 +311,15 @@ int repl_data_obj(
         const char* dest_hier = getValByKey(&destination_inp.condInput, RESC_HIER_STR_KW);
         for (const auto& r : file_obj->replicas()) {
             // TODO: #4010 - This short-circuits resource logic for handling good replicas
-            if (r.resc_hier() == dest_hier && (r.replica_status() & 0x0F) == GOOD_REPLICA) {
-                return 0;
+            if (r.resc_hier() == dest_hier) {
+                if (GOOD_REPLICA == r.replica_status()) {
+                    const char* source_hier = getValByKey(&source_inp.condInput, RESC_HIER_STR_KW);
+                    irods::log(LOG_DEBUG, fmt::format(
+                        "[{}:{}] - hierarchy contains good replica already, source:[{}],dest:[{}]",
+                        __FUNCTION__, __LINE__, dest_hier, source_hier));
+                    return 0;
+                }
+                break;
             }
         }
         status = replicate_data(rsComm, source_inp, destination_inp);


### PR DESCRIPTION
In order to increase coverage in distributed testing and prevent timing issues with respect to flushing to logs, this change uses `msiAssociateKeyValuePairsToObj` instead of `writeLine` in several rules in the delay queue tests and the NREP tests. Also adds a new microservice to get the PID of the agent executing it.

Tests are being run now.