### PR TITLE
Add const struct support in key_value_proxy and change interface a little (master)

### DIFF
--- a/lib/core/include/key_value_proxy.hpp
+++ b/lib/core/include/key_value_proxy.hpp
@@ -5,16 +5,17 @@
 #include "rcMisc.h"
 
 #include "lifetime_manager.hpp"
+
 #include <algorithm>
 #include <limits>
 #include <string>
 #include <string_view>
 
-// TODO: take a pass over std::string allocations
-
 namespace irods::experimental {
-    /// \class key_value_proxy
-    ///
+    /// \brief Tag which indicates that a missing key will be inserted with an empty value.
+    /// \since 4.2.9
+    static struct insert_key {} insert_key;
+
     /// \brief Presents a std::map-like interface to a keyValuePair_t legacy iRODS struct.
     ///
     /// Holds a pointer to a keyValPair_t whose lifetime is managed outside of the proxy object.
@@ -24,156 +25,189 @@ namespace irods::experimental {
     /// the lifetime of the object may need to extend past the lifetime of the key_value_proxy.
     ///
     /// \see https://en.cppreference.com/w/cpp/container/map
-    ///
     /// \since 4.2.8
+    template<
+        typename K,
+        typename = std::enable_if_t<
+            std::is_same_v<keyValPair_t, typename std::remove_const_t<K>>
+        >
+    >
     class key_value_proxy
     {
     public:
         // Aliases for various types used in key_value_proxy
         using key_type = std::string_view;
-        using value_type = std::string;
-        using kvp = keyValPair_t;
+        using value_type = std::string_view;
+        using kvp_type = K;
+        using kvp_pointer_type = kvp_type*;
         using size_type = int;
         using pair_type = std::pair<key_type, value_type>;
 
-        /// \class handle
-        ///
-        /// \brief Class representing a handle for an entry with a particular key.
-        ///
-        /// Allows the key_value_proxy object to present access and assignment of the value
-        /// for a particular key in the kvps.
-        ///
-        /// \since 4.2.8
-        class handle {
+        /// \brief Base class representing a handle for an entry with a particular key.
+        /// \since 4.2.9
+        class handle
+        {
             friend class key_value_proxy;
+
+        public:
+            // Accessors
+            /// \brief Accessor method for key
+            /// \throws std::out_of_range - If index_ is invalid
+            /// \retval Key for the index held by this handle
+            /// \since 4.2.8
+            auto key() const -> key_type { return key_; }
+
+            /// \brief Accessor method for value
+            /// \throws std::out_of_range - If index_ is invalid
+            /// \retval Value held by this handle
+            /// \since 4.2.9
+            auto value() const -> value_type
+            {
+                throw_if_index_is_invalid();
+                return kvp_->value[index_];
+            }
+
+            /// \returns bool
+            /// \retval true if value of the handle is equal to the value for this handle; otherwise, false.
+            /// \since 4.2.9
+            auto operator==(const handle& h) const -> bool { return value() == h.value(); }
+
+            /// \returns bool
+            /// \retval true if specified string is equal to the value for this handle; otherwise, false.
+            /// \since 4.2.9
+            auto operator==(value_type s) const -> bool { return s == value(); }
+
+            /// \returns bool
+            /// \retval true if value of the handle is not equal to the value for this handle; otherwise, false.
+            /// \since 4.2.9
+            auto operator!=(const handle& h) const -> bool { return !(this == h); }
+
+            /// \returns bool
+            /// \retval true if specified string is equal to the value for the specified handle; otherwise, false.
+            /// \since 4.2.9
+            friend auto operator==(value_type s, const handle& h) -> bool { return s == h.value(); }
+
+            /// \brief Returns the value for the handle's key in the kvp_type map
+            /// \returns const std::string&
+            /// \since 4.2.8
+            operator const std::string&() const { return value(); }
+
+            // Modifiers
+            /// \brief Sets value for this handle's key using passed value
+            /// \param[in] v - value to insert
+            /// \since 4.2.9
+            auto operator=(value_type v) -> handle&
+            {
+                index_ = addKeyVal(kvp_, key().data(), v.data());
+                throw_if_index_is_invalid();
+                key_ = kvp_->keyWord[index_];
+                return *this;
+            }
+
+            /// \brief Sets value for this handle's key using passed handle's value
+            /// \param[in] h - handle providing value to insert
+            /// \throws std::out_of_range - If index_ is invalid after attempting insert
+            /// \since 4.2.9
+            auto operator=(const handle& h) -> handle&
+            {
+                index_ = addKeyVal(kvp_, key().data(), h.value().data());
+                throw_if_index_is_invalid();
+                key_ = kvp_->keyWord[index_];
+                return *this;
+            }
+
         private:
-            /// \fn handle(key_type _key, kvp& _kvp)
+            /// \brief Pointer to C-style iRODS struct around which this interface is meant to wrap.
+            /// \since 4.2.9
+            const kvp_pointer_type kvp_;
+
+            /// \brief The index of the key-value pair in the kvp_type array
+            /// \since 4.2.9
+            size_type index_;
+
+            /// \brief The key for the key-value pair managed by this handle
+            /// \since 4.2.9
+            key_type key_;
+
+            /// \brief Constructs handle for specified key in the specified kvp
             ///
+            /// Sets the index of the specified key in the map. If no such key exists and
+            /// the underlying struct is const, a std::out_of_range exception is thrown.
+            ///
+            /// If the handle does not contain the specified key, attempting to access the
+            /// key or value before an assignment is made will result in a std::out_of_range
+            /// being thrown for many member methods.
+            ///
+            /// \param[in] _key - Key for which the handle is being created
+            /// \param[in] _kvp - Reference to kvp into which the handle will reach
+            ///
+            /// \throws std::out_of_range - If underlying struct is const and no such key is found
+            ///
+            /// \since 4.2.8
+            handle(key_type key, kvp_type& kvp)
+                : kvp_{&kvp}
+                , index_{index_of(key, kvp)}
+                , key_{key}
+            {
+                if constexpr (std::is_const_v<kvp_type>) {
+                    throw_if_index_is_invalid();
+                }
+            }
+
             /// \brief Constructs handle for specified key in the specified kvp
             ///
             /// Sets the index of the specified key in the map. If no such key exists, it
-            /// is inserted and the index is set to the end of the array of kvps.
+            /// is inserted and the index is set to the end of the array of kvps, unless
+            /// the underlying struct is const. In this case, out_of_range is thrown.
             ///
+            /// If the handle does not contain the specified key, attempting to access the
+            /// key or value before an assignment is made will result in a std::out_of_range
+            /// being thrown for many member methods.
+            ///
+            /// \param[in] insert_key - Tag struct which indicates that missing keys should be inserted
             /// \param[in] _key - Key for which the handle is being created
-            /// \param[in] _kvp - Reference to kvp into which the handle will reach 
+            /// \param[in] _kvp - Reference to kvp into which the handle will reach
             ///
-            /// \since 4.2.8
-            handle(key_type _key, kvp& _kvp)
-                : kvp_{&_kvp}
-                , index_{index_of(_key, _kvp)}
-                , val_{}
+            /// \throws std::out_of_range - If underlying struct is const and no such key is found
+            ///
+            /// \since 4.2.9
+            handle(struct insert_key, key_type key, kvp_type& kvp)
+                : kvp_{&kvp}
+                , index_{index_of(key, kvp)}
+                , key_{key}
             {
                 if (index_ < 0) {
-                    addKeyVal(kvp_, _key.data(), "");
-                    index_ = kvp_->len - 1;
-                }
-                else {
-                    val_ = kvp_->value[index_];
+                    index_ = addKeyVal(kvp_, key.data(), "");
                 }
             }
 
-        public:
-            /// \fn key_type key() const
-            ///
-            /// \brief Accessor method for key
-            ///
-            /// \return key_type
-            ///
-            /// \since 4.2.8
-            auto key() const -> key_type
-            {
-                return kvp_->keyWord[index_];
-            }
-
-            /// \fn void operator=(const value_type& _v)
-            ///
-            /// \brief Sets value for handle's key in the kvp map
-            ///
-            /// \since 4.2.8
-            auto operator=(const value_type& _v) -> void
-            {
-                addKeyVal(kvp_, kvp_->keyWord[index_], _v.data());
-                val_ = _v;
-            }
-
-            /// \fn operator const std::string&() const
-            ///
-            /// \brief Returns the value for the handle's key in the kvp map
-            ///
-            /// \returns const std::string&
-            ///
-            /// \since 4.2.8
-            operator const std::string&() const { return val_; }
-
-            /// \fn bool operator==(const std::string& _s, const handle& _h) const
-            ///
-            /// \returns bool
-            /// \retval true if specified string is equal to the value for this handle; otherwise, false.
-            ///
-            /// \since 4.2.8
-            friend auto operator==(const std::string& _s, const handle& _h) -> bool
-            {
-                return _s == _h.val_;
-            }
-
-            /// \fn bool operator==(const handle& _h, const std::string& _s) const
-            ///
-            /// \returns bool
-            /// \retval true if the value for this handle is equal to the specified string; otherwise, false.
-            ///
-            /// \since 4.2.8
-            friend auto operator==(const handle& _h, const std::string& _s) -> bool
-            {
-                return _s == _h.val_;
-            }
-
-        private:
-            /// \var kvp* kvp_;
-            ///
-            /// \brief Pointer to C-style iRODS struct around which this interface is meant to wrap.
-            ///
-            /// \since 4.2.8
-            kvp* kvp_;
-
-            /// \var size_type index_
-            ///
-            /// \brief The index of the key-value pair in the kvp array
-            ///
-            /// \since 4.2.8
-            size_type index_;
-
-            /// \var value_type val_
-            ///
-            /// \brief The value for the key-value pair managed by this handle
-            ///
-            /// \since 4.2.8
-            value_type val_;
-
-            /// \fn static size_type index_of(key_type _k, kvp& _kvp)
-            ///
-            /// \brief Returns index of the specified key in the kvp array.
-            ///
+            /// \brief Returns index of the specified key in the kvp_type array.
             /// \returns size_type
-            /// \retval index of the specified key in the kvp if found; otherwise, -1.
-            ///
-            /// \since 4.2.8
-            static auto index_of(key_type _k, kvp& _kvp) -> size_type
+            /// \retval index of the specified key in the kvp_type if found; otherwise, -1.
+            /// \since 4.2.9
+            static auto index_of(key_type k, kvp_type& kvp) -> size_type
             {
-                for (size_type i = 0; i < _kvp.len; i++) {
-                    if (_k == _kvp.keyWord[i]) {
+                for (size_type i = 0; i < kvp.len; i++) {
+                    if (k == kvp.keyWord[i]) {
                         return i;
                     }
                 }
                 return -1;
             }
-        };
 
-        /// \class iterator
-        ///
+            /// \brief Throws std::out_of_range if index_ is invalid
+            /// \throws std::out_of_range - If index_ is invalid
+            /// \since 4.2.9
+            auto throw_if_index_is_invalid() const -> void
+            {
+                if (index_ < 0) {
+                    throw std::out_of_range{"key not found"};
+                }
+            }
+        }; // class handle
+
         /// \brief Iterator for array of kvps managed by a key_value_proxy
-        ///
         /// \see https://en.cppreference.com/w/cpp/iterator/iterator
-        ///
         /// \since 4.2.8
         class iterator {
         public:
@@ -184,12 +218,8 @@ namespace irods::experimental {
             using difference_type   = size_type;
             using iterator_category = std::forward_iterator_tag;
 
-            /// \fn iterator(kvp& _kvp)
-            ///
             /// \brief Default constructor for iterator
-            ///
-            /// Initializes to invalid index and nullptr for kvp
-            ///
+            /// Initializes to invalid index and nullptr for kvp_type
             /// \since 4.2.8
             iterator()
                 : index_{-1}
@@ -197,25 +227,17 @@ namespace irods::experimental {
             {
             }
 
-            /// \fn iterator(kvp& _kvp)
-            ///
             /// \brief Constructs iterator for array of kvps starting at index 0
-            ///
             /// \see https://en.cppreference.com/w/cpp/iterator/iterator
-            ///
             /// \since 4.2.8
-            explicit iterator(kvp& _kvp)
+            explicit iterator(kvp_type& _kvp)
                 : index_{0}
                 , kvp_{&_kvp}
             {
             }
 
-            /// \fn iterator operator++()
-            ///
             /// \see https://en.cppreference.com/w/cpp/iterator/iterator
-            ///
             /// \returns iterator
-            ///
             /// \since 4.2.8
             auto operator++() -> iterator
             {
@@ -225,12 +247,8 @@ namespace irods::experimental {
                 return *this;
             }
 
-            /// \fn iterator operator++(int)
-            ///
             /// \see https://en.cppreference.com/w/cpp/iterator/iterator
-            ///
             /// \returns iterator
-            ///
             /// \since 4.2.8
             auto operator++(int) -> iterator
             {
@@ -239,50 +257,34 @@ namespace irods::experimental {
                 return ret;
             }
 
-            /// \fn bool operator==(const iterator& _rhs) const
-            ///
             /// \see https://en.cppreference.com/w/cpp/iterator/iterator
-            ///
             /// \returns bool
             /// \retval true if indices match; otherwise, false.
-            ///
             /// \since 4.2.8
             auto operator==(const iterator& _rhs) const -> bool
             {
                 return index_ == _rhs.index_;
             }
 
-            /// \fn bool operator!=(const iterator& _rhs) const
-            ///
             /// \see https://en.cppreference.com/w/cpp/iterator/iterator
-            ///
             /// \returns bool
             /// \retval Inverse of operator==
-            ///
             /// \since 4.2.8
             auto operator!=(const iterator& _rhs) const -> bool
             {
                 return !(*this == _rhs);
             }
 
-            /// \fn handle operator*()
-            ///
             /// \see https://en.cppreference.com/w/cpp/iterator/iterator
-            ///
             /// \returns handle - See handle class for details
-            ///
             /// \since 4.2.8
             auto operator*() -> handle
             {
                 return {kvp_->keyWord[index_], *kvp_};
             }
 
-            /// \fn const handle operator*() const
-            ///
             /// \see https://en.cppreference.com/w/cpp/iterator/iterator
-            ///
             /// \returns handle - See handle class for details
-            ///
             /// \since 4.2.8
             auto operator*() const -> const handle
             {
@@ -290,42 +292,48 @@ namespace irods::experimental {
             }
 
         private:
-            /// \var size_type index_
-            ///
-            /// \brief Index into the array of kvp
-            ///
+            /// \brief Index into the array of kvp_type
             /// \since 4.2.8
             size_type index_;
 
-            /// \var kvp* kvp_
-            ///
-            /// \brief Pointer to proxy object's underlying kvp
-            ///
+            /// \brief Pointer to proxy object's underlying kvp_type
             /// \since 4.2.8
-            kvp* kvp_;
-        };
+            kvp_type* kvp_;
+        }; // class iterator
 
-        /// \fn key_value_proxy(kvp& _kvp)
-        ///
-        /// \brief Constructs proxy using an existing kvp
-        ///
+        /// \brief Constructs proxy using an existing kvp_type
         /// \since 4.2.8
-        explicit key_value_proxy(kvp& _kvp)
+        explicit key_value_proxy(kvp_type& _kvp)
             : kvp_{&_kvp}
         {
         }
 
+        /// \brief Move constructor
+        /// \since 4.2.9
+        key_value_proxy(key_value_proxy&& other)
+            : kvp_{other.kvp_}
+        {
+            other.kvp_ = nullptr;
+        }
+
+        /// \brief Move assignment operator
+        /// \since 4.2.9
+        key_value_proxy& operator=(key_value_proxy&& other)
+        {
+            kvp_ = other.kvp_;
+            other.kvp_ = nullptr;
+            return *this;
+        }
+
         // Element access
-        /// \fn handle at(key_type _k)
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/at
-        ///
-        /// \param[in] _k - key for which to search in the kvp map
-        ///
+        /// \param[in] _k - key for which to search in the kvp_type map
         /// \returns handle - See handle class for details.
         /// \throws std::out_of_range
-        ///
         /// \since 4.2.8
+        template<
+            typename P = kvp_type,
+            typename = std::enable_if_t<!std::is_const_v<P>>>
         auto at(key_type _k) -> handle
         {
             if (contains(_k)) {
@@ -334,63 +342,78 @@ namespace irods::experimental {
             throw std::out_of_range{"key not found"};
         }
 
-        /// \fn handle operator[](key_type _k)
-        ///
+        /// \see https://en.cppreference.com/w/cpp/container/map/at
+        /// \param[in] _k - key for which to search in the kvp_type map
+        /// \returns const handle - See handle class for details.
+        /// \throws std::out_of_range
+        /// \since 4.2.9
+        auto at(key_type _k) const -> const handle
+        {
+            if (contains(_k)) {
+                return {_k, *kvp_};
+            }
+            throw std::out_of_range{"key not found"};
+        }
+
         /// \see https://en.cppreference.com/w/cpp/container/map/operator_at
-        ///
-        /// \param[in] _k - key for which to search in the kvp map
-        ///
+        /// \param[in] _k - key for which to search in the kvp_type map
         /// \returns handle - See handle class for details.
-        ///
         /// \since 4.2.8
-        auto operator[](key_type _k) -> handle { return {_k, *kvp_}; }
+        template<
+            typename P = kvp_type,
+            typename = std::enable_if_t<!std::is_const_v<P>>>
+        auto operator[](key_type _k) -> handle { return {insert_key, _k, *kvp_}; }
+
+        /// \brief Access handle into struct for this key - does not insert if missing.
+        /// \see https://en.cppreference.com/w/cpp/container/map/operator_at
+        /// \param[in] _k - key for which to search in the kvp_type map
+        /// \returns handle - See handle class for details.
+        /// \since 4.2.8
+        auto operator[](key_type k) const -> const handle { return {k, *kvp_}; }
 
         // Iterators
-        /// \fn iterator begin()
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/begin
-        ///
         /// \since 4.2.8
+        template<
+            typename P = kvp_type,
+            typename = std::enable_if_t<!std::is_const_v<P>>>
         auto begin() -> iterator { return iterator{*kvp_}; }
 
-        /// \fn const iterator cbegin() const
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/begin
-        ///
+        /// \since 4.2.9
+        auto begin() const -> const iterator { return iterator{*kvp_}; }
+
+        /// \see https://en.cppreference.com/w/cpp/container/map/begin
         /// \since 4.2.8
         auto cbegin() const -> const iterator { return iterator{*kvp_}; }
 
-        /// \fn iterator end()
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/end
-        ///
         /// \since 4.2.8
+        template<
+            typename P = kvp_type,
+            typename = std::enable_if_t<!std::is_const_v<P>>>
         auto end() -> iterator { return {}; }
 
-        /// \fn const iterator cend() const
-        ///
+        /// \see https://en.cppreference.com/w/cpp/container/map/end
+        /// \since 4.2.9
+        auto end() const -> const iterator { return {}; }
+
         /// \see https://en.cppreference.com/w/cpp/container/map/end
         ///
         /// \since 4.2.8
         auto cend() const -> const iterator { return {}; }
 
         // capacity
-        /// \fn bool empty() const noexcept
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/empty
         ///
         /// \since 4.2.8
         auto empty() const noexcept -> bool { return 0 == size(); }
 
-        /// \fn size_type size() const noexcept
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/size
         ///
         /// \since 4.2.8
         auto size() const noexcept -> size_type { return kvp_->len; }
 
-        /// \fn size_type max_size() const noexcept
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/max_size
         ///
         /// \since 4.2.8
@@ -400,56 +423,60 @@ namespace irods::experimental {
         }
 
         // Modifiers
-        /// \fn void clear()
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/clear
         ///
         /// \since 4.2.8
+        template<
+            typename P = kvp_type,
+            typename = std::enable_if_t<!std::is_const_v<P>>>
         auto clear() -> void { clearKeyVal(kvp_); }
 
-        /// \fn std::pair<iterator, bool> insert(pair_type&& _p)
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/insert
         ///
         /// \since 4.2.8
+        template<
+            typename P = kvp_type,
+            typename = std::enable_if_t<!std::is_const_v<P>>>
         auto insert(pair_type&& _p) -> std::pair<iterator, bool>
         {
-            const auto k = std::get<key_type>(_p);
+            const auto k = std::get<0>(_p);
             if (const auto& elem = find(k); end() != elem) {
                 return {elem, false};
             }
-            const auto& v = std::get<value_type>(_p);
+            const auto v = std::get<1>(_p);
             addKeyVal(kvp_, k.data(), v.data());
             return {find(k), true};
         }
 
-        /// \fn std::pair<iterator, bool> insert_or_assign(pair_type&& _p)
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/insert_or_assign
         ///
         /// \since 4.2.8
+        template<
+            typename P = kvp_type,
+            typename = std::enable_if_t<!std::is_const_v<P>>>
         auto insert_or_assign(pair_type&& _p) -> std::pair<iterator, bool>
         {
-            const auto k = std::get<key_type>(_p);
-            const auto& v = std::get<value_type>(_p);
+            const auto k = std::get<0>(_p);
+            const auto v = std::get<1>(_p);
             const bool insertion = !contains(k);
             addKeyVal(kvp_, k.data(), v.data());
             return {find(k), insertion};
         }
 
-        /// \fn void erase(key_type _k) const
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/erase
         ///
         /// \since 4.2.8
+        template<
+            typename P = kvp_type,
+            typename = std::enable_if_t<!std::is_const_v<P>>>
         auto erase(key_type _k) -> void { rmKeyVal(kvp_, _k.data()); }
 
         // Lookup
-        /// \fn iterator find(key_type _k)
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/find
-        ///
         /// \since 4.2.8
+        template<
+            typename P = kvp_type,
+            typename = std::enable_if_t<!std::is_const_v<P>>>
         auto find(key_type _k) -> iterator
         {
             if (empty()) {
@@ -462,10 +489,7 @@ namespace irods::experimental {
                                 });
         }
 
-        /// \fn iterator find(key_type _k) const
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/find
-        ///
         /// \since 4.2.8
         auto find(key_type _k) const -> iterator
         {
@@ -479,39 +503,42 @@ namespace irods::experimental {
                                 });
         }
 
-        /// \fn bool contains(key_type _k) const
-        ///
         /// \see https://en.cppreference.com/w/cpp/container/map/contains
-        ///
         /// \since 4.2.8
         auto contains(key_type _k) const -> bool { return find(_k) != cend(); }
 
-        /// \fn T& get()
+        /// \brief Returns pointer to stored struct
         ///
-        /// \brief Returns reference to stored kvp
+        /// \usage auto my_kvp_ptr = my_key_value_proxy.get();
         ///
-        /// \usage kvp& my_kvp = my_key_value_proxy.get();
+        /// \return kvp_pointer_type
         ///
-        /// \return T&
-        /// \retval Reference to stored kvp
+        /// \since 4.2.9
+        auto get() -> kvp_pointer_type { return kvp_; }
+
+        /// \brief Returns const pointer to stored struct
         ///
-        /// \since 4.2.8
-        auto get() -> kvp& { return *kvp_; }
+        /// \usage auto my_kvp_ptr = my_key_value_proxy.get();
+        ///
+        /// \return const kvp_pointer_type
+        ///
+        /// \since 4.2.9
+        auto get() const -> const kvp_pointer_type { return kvp_; }
 
     private:
-        /// \var kvp* kvp_
-        ///
-        /// \brief Pointer to underlying kvp (assumed to be an array)
-        ///
+        /// \brief Pointer to underlying kvp_type
         /// \since 4.2.8
-        kvp* kvp_;
+        kvp_pointer_type kvp_;
+
+        friend handle::handle(key_type _key, kvp_type& _kvp);
+        friend handle::handle(struct insert_key, key_type _key, kvp_type& _kvp);
     }; // class key_value_proxy
 
     using key_value_pair = std::pair<std::string, std::string>;
-    using proxy_struct_pair = std::pair<key_value_proxy, lifetime_manager<keyValPair_t>>;
 
-    /// \fn proxy_struct_pair make_key_value_proxy(std::initializer_list<key_value_pair> _kvps = {})
-    /// 
+    template<typename kvp_type>
+    using proxy_struct_pair = std::pair<key_value_proxy<kvp_type>, lifetime_manager<kvp_type>>;
+
     /// \brief Creates an empty keyValPair_t and wraps it with a proxy and lifetime_manager
     ///
     /// If no arguments are passed in, the keyValPair_t is initialized to empty.
@@ -525,7 +552,7 @@ namespace irods::experimental {
     /// \return std::pair<key_value_proxy, lifetime_manager<keyValPair_t>>
     ///
     /// \since 4.2.8
-    static auto make_key_value_proxy(std::initializer_list<key_value_pair> _kvps = {}) -> proxy_struct_pair
+    static auto make_key_value_proxy(std::initializer_list<key_value_pair> _kvps = {}) -> proxy_struct_pair<keyValPair_t>
     {
         keyValPair_t* cond_input = (keyValPair_t*)malloc(sizeof(keyValPair_t));
         std::memset(cond_input, 0, sizeof(keyValPair_t));
@@ -535,8 +562,15 @@ namespace irods::experimental {
             const auto& val = std::get<1>(kvp);
             proxy[key] = val;
         }
-        return {proxy, lifetime_manager(*cond_input)};
+        return {std::move(proxy), lifetime_manager{*cond_input}};
     }
+
+    template<typename kvp_type>
+    static auto make_key_value_proxy(kvp_type& kvp) -> key_value_proxy<kvp_type>
+    {
+        return std::move(key_value_proxy{kvp});
+    }
+
 } // namespace irods::experimental
 
 #endif // #ifndef IRODS_KEY_VALUE_PROXY_HPP

--- a/lib/core/src/rcMisc.cpp
+++ b/lib/core/src/rcMisc.cpp
@@ -789,6 +789,7 @@ addKeyVal( keyValPair_t *condInput, const char *keyWord, const char *value ) {
     if ( condInput == NULL ) {
         return SYS_INTERNAL_NULL_INPUT_ERR;
     }
+
     if ( condInput->keyWord == NULL || condInput->value == NULL ) {
         condInput->len = 0;
     }
@@ -800,12 +801,12 @@ addKeyVal( keyValPair_t *condInput, const char *keyWord, const char *value ) {
             free( condInput->value[i] );
             condInput->keyWord[i] = strdup( keyWord );
             condInput->value[i] = value ? strdup( value ) : NULL;
-            return 0;
+            return i;
         }
         else if ( strcmp( keyWord, condInput->keyWord[i] ) == 0 ) {
             free( condInput->value[i] );
             condInput->value[i] = value ? strdup( value ) : NULL;
-            return 0;
+            return i;
         }
     }
 
@@ -822,7 +823,7 @@ addKeyVal( keyValPair_t *condInput, const char *keyWord, const char *value ) {
     condInput->value[condInput->len] = value ? strdup( value ) : NULL;
     condInput->len++;
 
-    return 0;
+    return condInput->len - 1;
 }
 
 

--- a/server/api/src/rsDataObjOpen.cpp
+++ b/server/api/src/rsDataObjOpen.cpp
@@ -516,7 +516,7 @@ int change_replica_status_to_intermediate(
 
     modDataObjMeta_t inp{};
     inp.dataObjInfo = dataObjInfo;
-    inp.regParam = &proxy.get();
+    inp.regParam = proxy.get();
     const int status = rsModDataObjMeta(rsComm, &inp);
     if (status < 0) {
         rodsLog(LOG_ERROR,

--- a/unit_tests/src/test_irods_key_value_proxy.cpp
+++ b/unit_tests/src/test_irods_key_value_proxy.cpp
@@ -5,6 +5,9 @@
 #include "objInfo.h"
 #include "rcMisc.h"
 
+#include <algorithm>
+#include <iostream>
+
 const std::string KEY1 = "key1";
 const std::string KEY2 = "key2";
 const std::string KEY3 = "key3";
@@ -59,7 +62,213 @@ TEST_CASE("test_c_struct", "[keyValPair_t]")
     }
 
     clearKeyVal(&kvp);
-}
+} // test_c_struct
+
+TEST_CASE("test_proxy_with_existing_const_keyValPair_t", "[keyValPair_t][proxy][adapter][const]")
+{
+    keyValPair_t kvp{};
+    addKeyVal(&kvp, KEY1.c_str(), VAL1.c_str());
+    addKeyVal(&kvp, KEY2.c_str(), VAL2.c_str());
+
+    const keyValPair_t* kvpp{&kvp};
+
+    irods::experimental::key_value_proxy p{*kvpp};
+
+    SECTION("proxy_access")
+    {
+        REQUIRE(p.contains(KEY1));
+        REQUIRE(VAL1 == p.at(KEY1));
+        REQUIRE(VAL1 == p[KEY1]);
+
+        REQUIRE(p.contains(KEY2));
+        REQUIRE(VAL2 == p.at(KEY2));
+        REQUIRE(VAL2 == p[KEY2]);
+
+        REQUIRE_THROWS(p.at(KEY3));
+        REQUIRE_THROWS(p[KEY3]);
+        REQUIRE(!p.contains(KEY3));
+    }
+
+    SECTION("test_iterator")
+    {
+        auto [tmp, lm] = irods::experimental::make_key_value_proxy();
+        for (auto&& pair : p) {
+            tmp[pair.key()] = pair.value();
+        }
+
+        REQUIRE(std::all_of(
+            std::begin(p),
+            std::end(p),
+            [&tmp = tmp](const auto& pair) {
+                return pair.value() == tmp[pair.key()];
+            }
+        ));
+
+        REQUIRE(std::all_of(
+            std::cbegin(p),
+            std::cend(p),
+            [&tmp = tmp](const auto& pair) {
+                return pair.value() == tmp[pair.key()];
+            }
+        ));
+    }
+
+    SECTION("get")
+    {
+        using struct_type = decltype(p)::kvp_type;
+        using pointer_type = decltype(p)::kvp_pointer_type;
+        using const_struct_type = std::remove_reference_t<decltype(*kvpp)>;
+
+        static_assert(std::is_const_v<const_struct_type>);
+        static_assert(std::is_same_v<struct_type, const_struct_type>);
+        static_assert(std::is_same_v<pointer_type, const struct_type*>);
+
+        auto [tmp, lm] = irods::experimental::make_key_value_proxy({{KEY4, VAL4}});
+
+        // auto -> const keyValPair_t*
+        {
+        auto k = p.get();
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(*k)>>);
+        static_assert(std::is_same_v<decltype(k), pointer_type>);
+
+        k = tmp.get();
+        REQUIRE(getValByKey(k, KEY4.c_str()));
+        REQUIRE(!p.contains(KEY4));
+        }
+
+        // auto -> const keyValPair_t* const
+        {
+        const auto k = p.get();
+        static_assert(std::is_const_v<decltype(k)>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(*k)>>);
+        static_assert(std::is_same_v<decltype(k), const pointer_type>);
+
+        //k = tmp.get(); // should not compile - cannot change const pointer
+        }
+
+        // auto -> const keyValPair_t* const&
+        {
+        const auto& k = p.get();
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(k)>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(*k)>>);
+        static_assert(std::is_same_v<decltype(k), const pointer_type&>);
+
+        //k = tmp.get(); // should not compile - cannot change const pointer
+        }
+    }
+
+    clearKeyVal(&kvp);
+} // test_proxy_with_existing_const_keyValPair_t
+
+TEST_CASE("test_const_proxy_with_existing_keyValPair_t", "[keyValPair_t][proxy][adapter][const]")
+{
+    keyValPair_t kvp{};
+    addKeyVal(&kvp, KEY1.c_str(), VAL1.c_str());
+    addKeyVal(&kvp, KEY2.c_str(), VAL2.c_str());
+
+    const irods::experimental::key_value_proxy p{kvp};
+
+    SECTION("proxy_access")
+    {
+        REQUIRE(p.contains(KEY1));
+        REQUIRE(VAL1 == p.at(KEY1));
+        REQUIRE(VAL1 == p[KEY1]);
+
+        REQUIRE(p.contains(KEY2));
+        REQUIRE(VAL2 == p.at(KEY2));
+        REQUIRE(VAL2 == p[KEY2]);
+
+        REQUIRE_THROWS(p.at(KEY3));
+        REQUIRE_THROWS(p[KEY3].value());
+        REQUIRE(!p.contains(KEY3));
+    }
+
+    // demonstrate modifications to struct outside of proxy are accessible via the the const proxy
+    SECTION("test_iterator")
+    {
+        auto [tmp, lm] = irods::experimental::make_key_value_proxy();
+        for (auto&& h : p) {
+            tmp[h.key()] = h;
+        }
+
+        REQUIRE(std::all_of(
+            std::begin(p),
+            std::end(p),
+            [&tmp = tmp](const auto& h) {
+                return h.value() == tmp[h.key()];
+            }
+        ));
+
+        REQUIRE(std::all_of(
+            std::cbegin(p),
+            std::cend(p),
+            [&tmp = tmp](const auto& h) {
+                return h.value() == tmp[h.key()];
+            }
+        ));
+    }
+
+    // demonstrate modifications to struct outside of proxy are accessible via the the const proxy
+    SECTION("get")
+    {
+        using struct_type = decltype(p)::kvp_type;
+        using pointer_type = decltype(p)::kvp_pointer_type;
+
+        static_assert(!std::is_const_v<decltype(kvp)>);
+        static_assert(std::is_same_v<struct_type, decltype(kvp)>);
+        static_assert(!std::is_const_v<decltype(kvp)>);
+
+        auto [tmp, lm] = irods::experimental::make_key_value_proxy({{KEY4, VAL4}});
+
+        // auto -> keyValPair_t*
+        {
+        auto k = p.get();
+        static_assert(!std::is_const_v<decltype(k)>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(*k)>>);
+        static_assert(std::is_same_v<decltype(k), pointer_type>);
+        addKeyVal(k, KEY3.c_str(), VAL3.c_str());
+        REQUIRE(getValByKey(k, KEY3.c_str()));
+        REQUIRE(getValByKey(&kvp, KEY3.c_str()));
+        REQUIRE(p.contains(KEY3));
+
+        k = tmp.get();
+        REQUIRE(getValByKey(k, KEY4.c_str()));
+        REQUIRE(!p.contains(KEY4));
+        }
+
+        // const auto -> keyValPair_t* const
+        {
+        const auto k = p.get();
+        static_assert(std::is_const_v<decltype(k)>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(*k)>>);
+        static_assert(std::is_same_v<decltype(k), const pointer_type>);
+
+        addKeyVal(k, KEY3.c_str(), VAL3.c_str());
+        REQUIRE(getValByKey(k, KEY3.c_str()));
+        REQUIRE(getValByKey(&kvp, KEY3.c_str()));
+        REQUIRE(p.contains(KEY3));
+
+        //k = tmp.get(); // should not compile - cannot change const pointer
+        }
+
+        // const auto& -> keyValPair_t* const&
+        {
+        const auto& k = p.get();
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(k)>>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(*k)>>);
+        static_assert(std::is_same_v<decltype(k), const pointer_type&>);
+
+        addKeyVal(k, KEY3.c_str(), VAL3.c_str());
+        REQUIRE(getValByKey(k, KEY3.c_str()));
+        REQUIRE(getValByKey(&kvp, KEY3.c_str()));
+        REQUIRE(p.contains(KEY3));
+
+        //k = tmp.get(); // should not compile - cannot change const pointer
+        }
+    }
+
+    clearKeyVal(&kvp);
+} // test_const_proxy_with_existing_keyValPair_t
 
 TEST_CASE("test_proxy_with_existing_keyValPair_t", "[keyValPair_t][proxy][adapter]")
 {
@@ -71,16 +280,22 @@ TEST_CASE("test_proxy_with_existing_keyValPair_t", "[keyValPair_t][proxy][adapte
 
     SECTION("proxy_access")
     {
+        REQUIRE(p.contains(KEY1));
         REQUIRE(VAL1 == p[KEY1]);
         REQUIRE(VAL1 == p.at(KEY1));
-        REQUIRE(p.contains(KEY1));
 
+        REQUIRE(p.contains(KEY2));
         REQUIRE(VAL2 == p[KEY2]);
         REQUIRE(VAL2 == p.at(KEY2));
-        REQUIRE(p.contains(KEY2));
 
+        // at() does not insert missing keys...
         REQUIRE_THROWS(p.at(KEY3));
         REQUIRE(!p.contains(KEY3));
+
+        // ...but operator[] does
+        REQUIRE(std::string{} == p[KEY3]);
+        REQUIRE(p.contains(KEY3));
+        REQUIRE(std::string{} == p.at(KEY3));
     }
 
     SECTION("proxy_erase")
@@ -121,8 +336,17 @@ TEST_CASE("test_proxy_with_existing_keyValPair_t", "[keyValPair_t][proxy][adapte
         }
     }
 
+    SECTION("handle_assignment")
+    {
+        REQUIRE(p.contains(KEY1));
+        p[KEY3] = p[KEY1];
+        REQUIRE(p.contains(KEY3));
+        REQUIRE(p[KEY3] == p[KEY1]);
+        REQUIRE(VAL1 == p[KEY1]);
+    }
+
     clearKeyVal(&kvp);
-}
+} // test_proxy_with_existing_keyValPair_t
 
 TEST_CASE("test_factory_no_list", "[keyValPair_t][proxy][fresh]")
 {
@@ -181,7 +405,7 @@ TEST_CASE("test_factory_no_list", "[keyValPair_t][proxy][fresh]")
         REQUIRE(VAL2 == p.at(KEY2));
         }
     }
-}
+} // test_factory_no_list
 
 TEST_CASE("test_factory_with_initializer_list", "[keyValPair_t][proxy][init]")
 {
@@ -253,14 +477,37 @@ TEST_CASE("test_factory_with_initializer_list", "[keyValPair_t][proxy][init]")
         REQUIRE(VAL3 == p.at(KEY2));
         }
     }
-}
+} // test_factory_with_initializer_list
+
+TEST_CASE("test_factory_with_existing_kvp", "[keyValPair_t][proxy][init][factory]")
+{
+    keyValPair_t str{};
+    addKeyVal(&str, KEY1.c_str(), VAL1.c_str());
+
+    SECTION("keyValPair_t")
+    {
+        auto p = irods::experimental::make_key_value_proxy(str);
+        REQUIRE(p.contains(KEY1));
+        REQUIRE(VAL1 == p[KEY1]);
+    }
+
+    SECTION("const keyValPair_t")
+    {
+        const keyValPair_t* kvpp{&str};
+        auto p = irods::experimental::make_key_value_proxy(*kvpp);
+        REQUIRE(p.contains(KEY1));
+        REQUIRE(VAL1 == p[KEY1]);
+    }
+
+    clearKeyVal(&str);
+} // test_factory_with_existing_kvp
 
 TEST_CASE("test_proxy_lifetime_manager_getters", "[lifetime_manager]")
 {
     SECTION("lifetime_manager")
     {
         auto [p, m] = irods::experimental::make_key_value_proxy();
-        auto& kvp = m.get(); 
+        auto kvp = m.get(); 
         REQUIRE(0 == kvp.len);
         REQUIRE(nullptr == getValByKey(&kvp, KEY1.c_str()));
         addKeyVal(&kvp, KEY1.c_str(), VAL1.c_str());
@@ -270,10 +517,29 @@ TEST_CASE("test_proxy_lifetime_manager_getters", "[lifetime_manager]")
     SECTION("proxy")
     {
         auto [p, m] = irods::experimental::make_key_value_proxy();
-        auto& kvp = p.get();
-        REQUIRE(0 == kvp.len);
-        REQUIRE(nullptr == getValByKey(&kvp, KEY2.c_str()));
-        addKeyVal(&kvp, KEY2.c_str(), VAL2.c_str());
-        REQUIRE(VAL2 == getValByKey(&kvp, KEY2.c_str()));
+        auto kvp = p.get();
+        REQUIRE(0 == kvp->len);
+        REQUIRE(nullptr == getValByKey(kvp, KEY2.c_str()));
+        addKeyVal(kvp, KEY2.c_str(), VAL2.c_str());
+        REQUIRE(VAL2 == getValByKey(kvp, KEY2.c_str()));
     }
-}
+
+    SECTION("const struct")
+    {
+        keyValPair_t str{};
+        addKeyVal(&str, KEY1.c_str(), VAL1.c_str());
+
+        const keyValPair_t* kvpp{&str};
+
+        irods::experimental::key_value_proxy p{*kvpp};
+        auto kvp = p.get();
+        REQUIRE(1 == kvp->len);
+        REQUIRE(nullptr == getValByKey(kvp, KEY2.c_str()));
+
+        // should fail to build
+        //addKeyVal(&kvp, KEY2.c_str(), VAL2.c_str());
+
+        clearKeyVal(&str);
+    }
+} // test_proxy_lifetime_manager_getters
+


### PR DESCRIPTION
Adds template class for key_value_proxy to support const keyValPair_t
as well as enforcing the fact that the proxy only manages keyValPair_t's.

Several missing pieces were added to the iterator and handle classes to
flesh out the interface a little more.

`get()` was changed to return a pointer instead of a reference to the
underlying object in order to maintain const-ness of underlying struct.
Without this, a const keyValPair_t could be given to a proxy object and
returned as non-const.