### PR TITLE
[#4964] Deprecate rxSetRoundRobinContext (4-2-stable)

### DIFF
--- a/lib/api/src/rcSetRoundRobinContext.cpp
+++ b/lib/api/src/rcSetRoundRobinContext.cpp
@@ -3,6 +3,7 @@
 #include "procApiRequest.h"
 #include "apiNumber.h"
 
+[[deprecated("rcSetRoundRobinContext is no longer supported. Round-Robin resource has been deprecated.")]]
 int rcSetRoundRobinContext(
     rcComm_t*                  _comm,
     setRoundRobinContextInp_t* _inp) {

--- a/server/api/src/rsSetRoundRobinContext.cpp
+++ b/server/api/src/rsSetRoundRobinContext.cpp
@@ -13,9 +13,13 @@ extern irods::resource_manager resc_mgr;
 
 // =-=-=-=-=-=-=-
 // actual implementation of the API plugin
+[[deprecated("rsSetRoundRobinContext is no longer supported. Round-Robin resource has been deprecated.")]]
 int rsSetRoundRobinContext(
     rsComm_t*                  _comm,
     setRoundRobinContextInp_t* _inp ) {
+
+    rodsLog(LOG_WARNING, "Using deprecated API [%s]", __FUNCTION__);
+
     rodsLog( LOG_DEBUG, "rsSetRoundRobinContex" );
     // =-=-=-=-=-=-=-
     // error check - incoming parameters


### PR DESCRIPTION
Simply adds `[[deprecated]]` and logs a warning whenever the server-side API call is used.