### PR TITLE
Increase max password size

### DIFF
--- a/lib/api/include/authenticate.h
+++ b/lib/api/include/authenticate.h
@@ -6,7 +6,8 @@
 #define AUTH_SUBOP_REQ_AUTH "request challenge"
 #define AUTH_SUBOP_RESP "challenge response"
 
-#define MAX_PASSWORD_LEN 50
+// Increased password max size for OpenID token 
+#define MAX_PASSWORD_LEN 65536
 #define CHALLENGE_LEN 64    // 64 bytes of data and terminating null
 #define RESPONSE_LEN 16     // 16 bytes of data and terminating null
 

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -7410,8 +7410,8 @@ irods::error db_update_pam_password_op(
     char myTime[50];
     char rBuf[200];
     size_t i, j;
-    char randomPw[50];
-    char randomPwEncoded[50];
+    char randomPw[MAX_PASSWORD_LEN];
+    char randomPwEncoded[MAX_PASSWORD_LEN];
     int status;
     char passwordInIcat[MAX_PASSWORD_LEN + 2];
     char passwordModifyTime[50];
@@ -7533,7 +7533,7 @@ irods::error db_update_pam_password_op(
     while ( !pw_good ) {
         j = 0;
         get64RandomBytes( rBuf );
-        for ( i = 0; i < 50 && j < irods_pam_password_len - 1; i++ ) {
+        for ( i = 0; i < MAX_PASSWORD_LEN && j < irods_pam_password_len - 1; i++ ) {
             char c;
             c = rBuf[i] & 0x7f;
             if ( c < '0' ) {


### PR DESCRIPTION
In order to use openid tokens for authentication we needed to increase the maximum password length.

modified: lib/api/include/authenticate.h
modified: plugins/database/src/db_plugin.cpp

