### PR TITLE
[#5043] error() msvc - look up error code from name (4-2-stable)

### DIFF
--- a/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/functions.cpp
+++ b/plugins/rule_engines/irods_rule_engine_plugin-irods_rule_language/functions.cpp
@@ -1,5 +1,8 @@
 /* For copyright information please refer to files in the COPYRIGHT directory
  */
+
+#define MAKE_IRODS_ERROR_MAP
+#include "rodsErrorTable.h"
 #include "index.hpp"
 #include "functions.hpp"
 #include "arithmetics.hpp"
@@ -2048,6 +2051,19 @@ Res *smsi_substr( Node** paramsr, int, Node* node, ruleExecInfo_t*, int, Env*, r
     return retres;
 }
 
+Res *smsi_error( Node** paramsr, int, Node* node, ruleExecInfo_t*, int, Env*, rError_t* errmsg, Region* r ) {
+	Res * errName = paramsr[0];
+	const auto& name_map = irods_error_map_construction::irods_error_name_map;
+	int i {};
+	try { i = name_map.at( errName->text ); } catch(...) { }
+	if ( i == int{} )
+	{
+            generateAndAddErrMsg( "invalid error name", node, RE_RUNTIME_ERROR, errmsg );
+	    return newErrorRes(r, RE_RUNTIME_ERROR);
+	}
+	return newIntRes(r, -abs(i));
+}
+
 Res *smsi_split( Node** paramsr, int, Node*, ruleExecInfo_t*, int, Env*, rError_t*, Region* r ) {
     Res *strres = ( Res * )paramsr[0];
     Res *delimres = ( Res * )paramsr[1];
@@ -2672,6 +2688,7 @@ void getSystemFunctions( Hashtable *ft, Region* r ) {
     insertIntoHashTable( ft, "strlen", newFunctionFD( "string->integer", smsi_strlen, r ) );
     insertIntoHashTable( ft, "substr", newFunctionFD( "string * integer * integer->string", smsi_substr, r ) );
     insertIntoHashTable( ft, "split", newFunctionFD( "string * string -> list string", smsi_split, r ) );
+    insertIntoHashTable( ft, "error", newFunctionFD( "string -> integer", smsi_error, r ) );
     insertIntoHashTable( ft, "execCmdArg", newFunctionFD( "f string->string", smsi_execCmdArg, r ) );
     insertIntoHashTable( ft, "query", newFunctionFD( "expression ? -> `GenQueryInp_PI` * `GenQueryOut_PI`", smsi_query, r ) );
     insertIntoHashTable( ft, "unspeced", newFunctionFD( "-> ?", smsi_undefined, r ) );


### PR DESCRIPTION
Adds `error( "ERROR_NAME" ) -> [negative integer]`  to the system microservice table.

Tests not yet written.
