### PR TITLE
Use LD_LIBRARY_PATH so that avrogencpp finds the correct boost libs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ endif()
 
 add_custom_command(
   OUTPUT ${CMAKE_BINARY_DIR}/lib/core/include/server_control_plane_command.hpp
-  COMMAND ${IRODS_EXTERNALS_FULLPATH_AVRO}/bin/avrogencpp -n irods -o ${CMAKE_BINARY_DIR}/lib/core/include/server_control_plane_command.hpp -i ${CMAKE_SOURCE_DIR}/irods_schema_messaging/v1/server_control_plane_command.json
+  COMMAND LD_LIBRARY_PATH=${IRODS_EXTERNALS_FULLPATH_BOOST}/lib ${IRODS_EXTERNALS_FULLPATH_AVRO}/bin/avrogencpp -n irods -o ${CMAKE_BINARY_DIR}/lib/core/include/server_control_plane_command.hpp -i ${CMAKE_SOURCE_DIR}/irods_schema_messaging/v1/server_control_plane_command.json
   MAIN_DEPENDENCY ${CMAKE_SOURCE_DIR}/irods_schema_messaging/v1/server_control_plane_command.json
   )
 


### PR DESCRIPTION
Hi,

during the build, avrogencpp from externals was failing because it wasn't finding (the correct) boost libraries that also are in externals. 
```
[ 80%] Generating lib/core/include/server_control_plane_command.hpp
/home/hastings/work/irods/irods-externals/avro1.9.0-0/bin/avrogencpp -n irods -o /home/hastings/work/irods/irods/build3/lib/core/include/server_control_plane_command.hpp -i /home/hastings/work/irods/irods/irods_schema_messaging/v1/server_control_plane_command.json
/home/hastings/work/irods/irods-externals/avro1.9.0-0/bin/avrogencpp: symbol lookup error: /home/hastings/work/irods/irods-externals/avro1.9.0-0/bin/avrogencpp: undefined symbol: _ZNK5boost15program_options29value_semantic_codecvt_helperIcE5parseERNS_3anyERKNSt3__16vectorINS5_12basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEENSA_ISC_EEEEb
make[2]: *** [CMakeFiles/irodsServer.dir/build.make:62: lib/core/include/server_control_plane_command.hpp] Error 127
make[2]: Leaving directory '/home/hastings/work/irods/irods/build3'
make[1]: *** [CMakeFiles/Makefile2:716: CMakeFiles/irodsServer.dir/all] Error 2
make[1]: Leaving directory '/home/hastings/work/irods/irods/build3'
make: *** [Makefile:152: all] Error 2
```
Checking with ldd:
```% ldd /home/hastings/work/irods/irods-externals/avro1.9.0-0/bin/avrogencpp | grep boost
	libboost_filesystem.so.1.67.0 => /lib/x86_64-linux-gnu/libboost_filesystem.so.1.67.0 (0x00007f790ff60000)
	libboost_iostreams.so.1.67.0 => /lib/x86_64-linux-gnu/libboost_iostreams.so.1.67.0 (0x00007f790ff42000)
	libboost_program_options.so.1.67.0 => /lib/x86_64-linux-gnu/libboost_program_options.so.1.67.0 (0x00007f790febb000)
	libboost_regex.so.1.67.0 => /lib/x86_64-linux-gnu/libboost_regex.so.1.67.0 (0x00007f790fda6000)
	libboost_system.so.1.67.0 => /lib/x86_64-linux-gnu/libboost_system.so.1.67.0 (0x00007f790fd9d000)
```
Check again with LD_LIBRARY_PATH set:
```
 % LD_LIBRARY_PATH=$HOME/work/irods/irods-externals/boost1.67.0-0/lib ldd /home/hastings/work/irods/irods-externals/avro1.9.0-0/bin/avrogencpp | grep boost
	libboost_filesystem.so.1.67.0 => /home/hastings/work/irods/irods-externals/boost1.67.0-0/lib/libboost_filesystem.so.1.67.0 (0x00007ff270873000)
	libboost_iostreams.so.1.67.0 => /home/hastings/work/irods/irods-externals/boost1.67.0-0/lib/libboost_iostreams.so.1.67.0 (0x00007ff270853000)
	libboost_program_options.so.1.67.0 => /home/hastings/work/irods/irods-externals/boost1.67.0-0/lib/libboost_program_options.so.1.67.0 (0x00007ff2707e5000)
	libboost_regex.so.1.67.0 => /home/hastings/work/irods/irods-externals/boost1.67.0-0/lib/libboost_regex.so.1.67.0 (0x00007ff2706b9000)
	libboost_system.so.1.67.0 => /home/hastings/work/irods/irods-externals/boost1.67.0-0/lib/libboost_system.so.1.67.0 (0x00007ff2706b0000)
```
Looks good. 
So for this fix I set LD_LIBRARY_PATH when calling acrrogenccp in the add_custom_command. 
Finally, check by rerunning cmake and make:
```
[ 80%] Generating lib/core/include/server_control_plane_command.hpp
LD_LIBRARY_PATH=/home/hastings/work/irods/irods-externals/boost1.67.0-0/lib /home/hastings/work/irods/irods-externals/avro1.9.0-0/bin/avrogencpp -n irods -o /home/hastings/work/irods/irods/build3/lib/core/include/server_control_plane_command.hpp -i /home/hastings/work/irods/irods/irods_schema_messaging/v1/server_control_plan
cd /home/hastings/work/irods/irods/build3 && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /home/hastings/work/irods/irods /home/hastings/work/irods/irods /home/hastings/work/irods/irods/build3 /home/hastings/work/irods/irods/build3 /home/hastings/work/irods/irods/build3/CMakeFiles/irodsServer.dir/DependInfo.cmake --color=
Dependee "/home/hastings/work/irods/irods/build3/CMakeFiles/irodsServer.dir/DependInfo.cmake" is newer than depender "/home/hastings/work/irods/irods/build3/CMakeFiles/irodsServer.dir/depend.internal".
Dependee "/home/hastings/work/irods/irods/build3/CMakeFiles/CMakeDirectoryInformation.cmake" is newer than depender "/home/hastings/work/irods/irods/build3/CMakeFiles/irodsServer.dir/depend.internal".
Scanning dependencies of target irodsServer
```
And the build continued on without issue.

This problem likely goes unnoticed many systems since most of the time it would have been finding the system boost libraries that may be compatible.

Cheers,

Nick.
