### PR TITLE
[#4943] Don't close() fds before calling dup2() on them (4-2-stable)

### DIFF
--- a/server/core/src/rsLog.cpp
+++ b/server/core/src/rsLog.cpp
@@ -120,9 +120,6 @@ chkLogfileName( const char *logDir, const char *logFileName ) {
 
     CurLogfileName = logFile;
 
-    close( 0 );
-    close( 1 );
-    close( 2 );
     ( void ) dup2( i, 0 );
     ( void ) dup2( i, 1 );
     ( void ) dup2( i, 2 );


### PR DESCRIPTION
It is unnecessary to close() a fd before calling dup2() on it - dup2
will close the fd if necessary. Importantly, dup2 will do so
atomically, whereas the code here is racy - some other thread could
open() something inbetween the close() and dup2(), in which case that
other thread's FD will be overwritten.

This is a partial fix for #4943
Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>