### PR TITLE
Fix rsPhyPathReg for create + lifetime_manager tweaks + suppress some non-error log messages (master)

### DIFF
--- a/lib/core/include/lifetime_manager.hpp
+++ b/lib/core/include/lifetime_manager.hpp
@@ -13,7 +13,7 @@ namespace irods::experimental {
     } array_delete;
 
     /// \class lifetime_manager
-    /// 
+    ///
     /// \brief Manages the lifetime of a legacy iRODS structure.
     ///
     /// This class serves to wrap existing legacy iRODS C-style structures which
@@ -146,16 +146,25 @@ namespace irods::experimental {
             }
         }
 
-        /// \fn T& get()
+        /// \returns Pointer to managed structure
         ///
-        /// \brief Get reference to managed structure
+        /// \since 4.2.9
+        auto get() -> T* { return obj_; }
+
+        /// \brief Release the pointer from the lifetime manager
         ///
-        /// \usage T& t = my_lifetime_manager.get();
+        /// \return Pointer to the managed structure
         ///
-        /// \return T&
-        ///
-        /// \since 4.2.8
-        auto get() -> T& { return *obj_; }
+        /// \since 4.2.9
+        auto release() -> T* {
+            if (!obj_) {
+                return nullptr;
+            }
+
+            T* ret = obj_;
+            obj_ = nullptr;
+            return ret;
+        } // release
 
     private:
         /// \var T* obj_

--- a/lib/core/include/replica_proxy.hpp
+++ b/lib/core/include/replica_proxy.hpp
@@ -320,7 +320,7 @@ namespace irods::experimental::replica
 
     namespace detail
     {
-        auto populate_struct_from_results(
+        static auto populate_struct_from_results(
             dataObjInfo_t& _doi,
             const std::vector<std::string>& _info) -> void
         {

--- a/server/api/include/rsPhyBundleColl.hpp
+++ b/server/api/include/rsPhyBundleColl.hpp
@@ -12,7 +12,6 @@ int _rsPhyBundleColl( rsComm_t *rsComm, structFileExtAndRegInp_t *phyBundleCollI
 int createPhyBundleDataObj( rsComm_t *rsComm, char *collection, const std::string& _resc_name, const char* rescHier, dataObjInp_t *dataObjInp, char *dataType );
 int createPhyBundleDir( rsComm_t *rsComm, char *bunFilePath, char *outPhyBundleDir, char* hier );
 int rsMkBundlePath( rsComm_t *rsComm, char *collection, char *outPath, int myRanNum );
-int replDataObjForBundle( rsComm_t *rsComm, char *collName, char *dataName, const char *rescName, char* rescHier, char* destRescHier, int adminFlag, irods::physical_object& _obj);
 int isDataObjBundled( collEnt_t *collEnt );
 int setSubPhyPath( char *phyBunDir, rodsLong_t dataId, char *subBunPhyPath );
 int addSubFileToDir( curSubFileCond_t *curSubFileCond, bunReplCacheHeader_t *bunReplCacheHeader );

--- a/server/api/src/rsDataObjClose.cpp
+++ b/server/api/src/rsDataObjClose.cpp
@@ -685,13 +685,12 @@ rodsLong_t get_size_in_vault(
     return size_in_vault;
 } // get_size_in_vault
 
-void close_physical_file(
-    rsComm_t* comm,
-    const int l1descInx)
+void close_physical_file(rsComm_t* comm, const int l1descInx)
 {
     const int l3descInx = L1desc[l1descInx].l3descInx;
     if (l3descInx < 3) {
-        ix::log::api::info("invalid l3 descriptor index [{}]", l3descInx);
+        // This message will appear a lot for single buffer gets -- it is not necessarily an error
+        ix::log::api::debug("invalid l3 descriptor index [{}]", l3descInx);
         return;
     }
 

--- a/server/api/src/rsDataObjOpen.cpp
+++ b/server/api/src/rsDataObjOpen.cpp
@@ -729,7 +729,7 @@ int rsDataObjOpen_impl(
         else {
             irods::file_object_ptr obj(new irods::file_object());
             irods::error fac_err = irods::file_object_factory(rsComm, dataObjInp, obj, &dataObjInfoHead);
-            if (!fac_err.ok()) {
+            if (!fac_err.ok() && CAT_NO_ROWS_FOUND != fac_err.code()) {
                 irods::log(fac_err);
             }
             file_obj.swap(obj);

--- a/server/api/src/rsDataObjOpen.cpp
+++ b/server/api/src/rsDataObjOpen.cpp
@@ -157,69 +157,20 @@ void enable_creation_of_additional_replicas(rsComm_t& _comm)
     ix::key_value_proxy{_comm.session_props}[REG_REPL_KW] = "";
 } // enable_creation_of_additional_replicas
 
-auto register_intermediate_replica_for_new_data_object(
-    rsComm_t& _comm,
-    const int _dest_l1_desc_inx) -> int
-{
-    auto dest_replica = ix::replica::make_replica_proxy(*L1desc[_dest_l1_desc_inx].dataObjInfo);
+    auto register_intermediate_replica(
+        rsComm_t& _comm,
+        dataObjInp_t& _inp,
+        std::string_view _physical_path,
+        const int _dest_l1_desc_inx) -> int
+    {
+        auto cond_input = irods::experimental::make_key_value_proxy(_inp.condInput);
 
-    dest_replica.replica_status(INTERMEDIATE_REPLICA);
+        cond_input[REGISTER_AS_INTERMEDIATE_KW] = "";
+        cond_input[FILE_PATH_KW] = _physical_path;
+        cond_input[DATA_SIZE_KW] = std::to_string(0);
 
-    dataObjInfo_t* out{};
-
-    log::server::debug("[{}:{}]: registering new data object [{}]", __FUNCTION__, __LINE__, dest_replica.logical_path());
-
-    return rsRegDataObj(&_comm, dest_replica.get(), &out);
-} // register_intermediate_replica_for_new_data_object
-
-auto register_intermediate_replica_for_existing_data_object(
-    rsComm_t& _comm,
-    const int _dest_l1_desc_inx,
-    const ix::key_value_proxy<keyValPair_t>& _cond_input) -> int
-{
-    // get and validate source replica information
-    if (!_cond_input.contains(SOURCE_L1_DESC_KW)) {
-        log::api::error("[{}] - missing source l1 descriptor for replication", __FUNCTION__);
-        return SYS_INTERNAL_NULL_INPUT_ERR;
-    }
-
-    const int source_l1_desc_inx = std::atoi(_cond_input.at(SOURCE_L1_DESC_KW).value().data());
-    if (source_l1_desc_inx < 3 || source_l1_desc_inx >= NUM_L1_DESC) {
-        log::api::error("[{}] - source l1 descriptor is invalid", __FUNCTION__);
-        return SYS_FILE_DESC_OUT_OF_RANGE;
-    }
-
-    if (!L1desc[source_l1_desc_inx].dataObjInfo) {
-        log::api::error("[{}] - source l1 descriptor has null dataObjInfo", __FUNCTION__);
-        return SYS_INTERNAL_NULL_INPUT_ERR;
-    }
-
-    auto source_replica = ix::replica::make_replica_proxy(*L1desc[source_l1_desc_inx].dataObjInfo);
-    auto dest_replica   = ix::replica::make_replica_proxy(*L1desc[_dest_l1_desc_inx].dataObjInfo);
-
-    dest_replica.replica_status(INTERMEDIATE_REPLICA);
-    resc_mgr.hier_to_leaf_id(dest_replica.hierarchy().data(), dest_replica.get()->rescId);
-
-    log::server::debug("[{}:{}]: registering new replica for existing data object [{}]", __FUNCTION__, __LINE__, source_replica.logical_path());
-
-    // prepare input for replica registration
-    regReplica_t in{};
-    ix::key_value_proxy in_kvp{in.condInput};
-
-    in_kvp[REGISTER_AS_INTERMEDIATE_KW] = "";
-    if (_cond_input.contains(SU_CLIENT_USER_KW)) {
-        in_kvp[SU_CLIENT_USER_KW] = "";
-        in_kvp[ADMIN_KW] = "";
-    }
-    else if (_cond_input.contains(ADMIN_KW)) {
-        in_kvp[ADMIN_KW] = "";
-    }
-
-    in.srcDataObjInfo = source_replica.get();
-    in.destDataObjInfo = dest_replica.get();
-
-    return rsRegReplica(&_comm, &in);
-} // register_intermediate_replica_for_existing_data_object
+        return rsPhyPathReg(&_comm, &_inp);
+    } // register_intermediate_replica
 
 int l3CreateByObjInfo(
     rsComm_t* rsComm,
@@ -414,22 +365,14 @@ auto create_new_replica(
         return status;
     }
 
-    // register replica in the intermediate state
-    if (_obj->replicas().empty()) {
-        status = register_intermediate_replica_for_new_data_object(_comm, l1descInx);
-        if (status < 0) {
-            freeL1desc(l1descInx);
-            return status;
-        }
+    status = register_intermediate_replica(_comm, *L1desc[l1descInx].dataObjInp, dataObjInfo->filePath, l1descInx);
+    if (status < 0) {
+        freeL1desc(l1descInx);
+        return status;
     }
-    else {
-        status = register_intermediate_replica_for_existing_data_object(_comm, l1descInx, cond_input);
-        if (status < 0) {
-            freeL1desc(l1descInx);
-            return status;
-        }
 
-        L1desc[l1descInx].dataObjInfo->replNum = status;
+    if (cond_input.contains(KEY_VALUE_PASSTHROUGH_KW)) {
+        addKeyVal(&L1desc[l1descInx].dataObjInfo->condInput, KEY_VALUE_PASSTHROUGH_KW, cond_input.at(KEY_VALUE_PASSTHROUGH_KW).value().data());
     }
 
     if (cond_input.contains(NO_OPEN_FLAG_KW)) {

--- a/server/api/src/rsDataObjPut.cpp
+++ b/server/api/src/rsDataObjPut.cpp
@@ -337,7 +337,7 @@ int rsDataObjPut_impl(
             addKeyVal(&dataObjInp->condInput, RESC_HIER_STR_KW, hier.c_str());
         }
         else {
-            if (!fac_err.ok()) {
+            if (!fac_err.ok() && CAT_NO_ROWS_FOUND != fac_err.code()) {
                 irods::log(fac_err);
             }
             hier = h;

--- a/server/api/src/rsPhyBundleColl.cpp
+++ b/server/api/src/rsPhyBundleColl.cpp
@@ -1,48 +1,45 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-/* rsPhyBundleColl.c. See phyBundleColl.h for a description of
- * this API call.*/
-
-#include "phyBundleColl.h"
-#include "objMetaOpr.hpp"
-#include "resource.hpp"
-#include "collection.hpp"
-#include "specColl.hpp"
-#include "physPath.hpp"
-#include "dataObjOpr.hpp"
-#include "miscServerFunct.hpp"
-#include "openCollection.h"
-#include "readCollection.h"
 #include "closeCollection.h"
+#include "collection.hpp"
+#include "dataObjClose.h"
+#include "dataObjCreate.h"
+#include "dataObjOpr.hpp"
 #include "dataObjRepl.h"
 #include "dataObjUnlink.h"
-#include "dataObjCreate.h"
-#include "dataObjClose.h"
-#include "syncMountedColl.h"
-#include "regReplica.h"
-#include "unbunAndRegPhyBunfile.h"
 #include "fileChksum.h"
-#include "modDataObjMeta.h"
 #include "irods_stacktrace.hpp"
-#include "rsPhyBundleColl.hpp"
-#include "rsOpenCollection.hpp"
+#include "miscServerFunct.hpp"
+#include "modDataObjMeta.h"
+#include "objMetaOpr.hpp"
+#include "openCollection.h"
+#include "phyBundleColl.h"
+#include "physPath.hpp"
+#include "readCollection.h"
+#include "regReplica.h"
+#include "resource.hpp"
 #include "rsCloseCollection.hpp"
 #include "rsDataObjClose.hpp"
-#include "rsDataObjUnlink.hpp"
-#include "rsReadCollection.hpp"
-#include "rsUnbunAndRegPhyBunfile.hpp"
-#include "rsRegReplica.hpp"
-#include "rsModDataObjMeta.hpp"
-#include "rsStructFileSync.hpp"
-#include "rsDataObjRepl.hpp"
 #include "rsDataObjCreate.hpp"
+#include "rsDataObjRepl.hpp"
+#include "rsDataObjUnlink.hpp"
 #include "rsFileChksum.hpp"
+#include "rsModDataObjMeta.hpp"
+#include "rsOpenCollection.hpp"
+#include "rsPhyBundleColl.hpp"
+#include "rsReadCollection.hpp"
+#include "rsRegReplica.hpp"
+#include "rsStructFileSync.hpp"
+#include "rsUnbunAndRegPhyBunfile.hpp"
+#include "specColl.hpp"
+#include "syncMountedColl.h"
+#include "unbunAndRegPhyBunfile.h"
 
 // =-=-=-=-=-=-=-
+#include "irods_at_scope_exit.hpp"
+#include "irods_random.hpp"
 #include "irods_resource_backport.hpp"
 #include "irods_resource_redirect.hpp"
 #include "irods_stacktrace.hpp"
-#include "irods_random.hpp"
+#include "key_value_proxy.hpp"
 
 static rodsLong_t OneGig = ( 1024 * 1024 * 1024 );
 
@@ -344,21 +341,42 @@ replAndAddSubFileToDir( rsComm_t *rsComm, curSubFileCond_t *curSubFileCond,
 
     /* next dataObj. See if we need to replicate */
     if ( curSubFileCond->subPhyPath[0] == '\0' ) {
-        /* don't have a good cache copy yet. make one */
-        irods::physical_object obj;
-        int status = replDataObjForBundle( rsComm, curSubFileCond->collName,
-                                       curSubFileCond->dataName, myRescName,
-                                       0, 0, 1, obj);
-        if ( status >= 0 ) {
-            setSubPhyPath( phyBunDir, curSubFileCond->dataId,
-                           curSubFileCond->subPhyPath );
-            rstrcpy( curSubFileCond->cachePhyPath, obj.path().c_str(),
-                     MAX_NAME_LEN );
-            curSubFileCond->cacheReplNum = obj.repl_num();
-            curSubFileCond->subFileSize = obj.size();
+        try {
+            /* don't have a good cache copy yet. make one */
+            dataObjInp_t data_obj_inp{};
+            auto cond_input = irods::experimental::make_key_value_proxy(data_obj_inp.condInput);
+            irods::at_scope_exit free_kvp{ [&data_obj_inp] { clearKeyVal(&data_obj_inp.condInput); } };
+
+            cond_input[BACKUP_RESC_NAME_KW] = myRescName;
+            cond_input[ADMIN_KW] = "";
+
+            std::snprintf(data_obj_inp.objPath, MAX_NAME_LEN, "%s/%s", curSubFileCond->collName, curSubFileCond->dataName);
+
+            transferStat_t* trans_stat{};
+            if (const int ec = rsDataObjRepl(rsComm, &data_obj_inp, &trans_stat); ec < 0) {
+                THROW(ec, fmt::format("failed to replicate data object [{}], status:[{}]", data_obj_inp.objPath, ec));
+            }
+
+            // Find the replica and copy information into the phybun struct
+            const auto result = irods::resolve_resource_hierarchy(irods::OPEN_OPERATION, rsComm, data_obj_inp);
+            const auto& out_hier = std::get<std::string>(result);
+            const auto& file_obj = std::get<irods::file_object_ptr>(result);
+            for (const auto& r : file_obj->replicas()) {
+                if (out_hier == r.resc_hier()) {
+                    setSubPhyPath( phyBunDir, curSubFileCond->dataId, curSubFileCond->subPhyPath );
+                    rstrcpy(curSubFileCond->cachePhyPath, r.path().c_str(), MAX_NAME_LEN);
+                    curSubFileCond->cacheReplNum = r.repl_num();
+                    curSubFileCond->subFileSize = r.size();
+                    break;
+                }
+            }
+        }
+        catch (const irods::exception& e) {
+            irods::log(LOG_ERROR, e.what());
         }
     }
-    int status = addSubFileToDir( curSubFileCond, bunReplCacheHeader );
+
+    const int status = addSubFileToDir( curSubFileCond, bunReplCacheHeader );
     if ( status < 0 ) {
         rodsLog( LOG_ERROR,
                  "%s:addSubFileToDir error for %s,stst=%d",
@@ -626,57 +644,6 @@ isDataObjBundled( collEnt_t *collEnt ) {
     else {
         return 0;
     }
-}
-
-int
-replDataObjForBundle(
-    rsComm_t *rsComm,
-    char *collName,
-    char *dataName,
-    const char *rescName,
-    char* rescHier,
-    char* dstRescHier,
-    int adminFlag,
-    irods::physical_object& _obj) {
-    transferStat_t* transStat{};
-    dataObjInp_t dataObjInp{};
-
-    snprintf( dataObjInp.objPath, MAX_NAME_LEN, "%s/%s", collName, dataName );
-    addKeyVal( &dataObjInp.condInput, BACKUP_RESC_NAME_KW,   rescName );
-    if ( rescHier ) {
-        addKeyVal( &dataObjInp.condInput, RESC_HIER_STR_KW, rescHier );
-    }
-    if ( dstRescHier ) {
-        addKeyVal( &dataObjInp.condInput, DEST_RESC_HIER_STR_KW, dstRescHier );
-    }
-    if ( adminFlag > 0 ) {
-        addKeyVal( &dataObjInp.condInput, ADMIN_KW, "" );
-    }
-
-    int status = rsDataObjRepl(rsComm, &dataObjInp, &transStat);
-    if (status < 0) {
-        clearKeyVal( &dataObjInp.condInput );
-        return status;
-    }
-
-    try {
-        auto result = irods::resolve_resource_hierarchy(irods::OPEN_OPERATION, rsComm, dataObjInp);
-        auto out_hier = std::get<std::string>(result);
-        auto file_obj = std::get<irods::file_object_ptr>(result);
-        for (const auto& r : file_obj->replicas()) {
-            if (out_hier == r.resc_hier()) {
-                _obj = std::move(r);
-                break;
-            }
-        }
-    }
-    catch (const irods::exception& e) {
-        irods::log(LOG_ERROR, e.what());
-        status = e.code();
-    }
-
-    clearKeyVal( &dataObjInp.condInput );
-    return status;
 }
 
 int

--- a/server/core/include/irods_get_l1desc.hpp
+++ b/server/core/include/irods_get_l1desc.hpp
@@ -1,13 +1,34 @@
 #ifndef __IRODS_GET_L1DESC_HPP__
 #define __IRODS_GET_L1DESC_HPP__
 
+#define IRODS_FILESYSTEM_ENABLE_SERVER_SIDE_API
+#include "filesystem.hpp"
+
 #include "objDesc.hpp"
 
-namespace irods {
+#include <optional>
 
-    l1desc_t& get_l1desc( int );
+namespace irods
+{
+    using l1_index_type = int;
 
-}; // namespace irds
+    /// \returns Opened L1 descriptor specified opened L1 descriptor index
+    auto get_l1desc(const l1_index_type _index) -> l1desc_t&;
+
+    /// \brief Search for opened L1 descriptor based on logical path and hierarchy
+    ///
+    /// \param[in] _logical_path
+    /// \param[in] _resource_hierarchy
+    ///
+    /// \return Pointer to l1desc_t
+    /// \retval l1desc_t* If opened L1 descriptor with matching logical path and resource hierarchy is found
+    /// \retval nulltpr If no matching opened L1 descriptor was found
+    ///
+    /// \since 4.2.9
+    auto find_l1desc(
+       const irods::experimental::filesystem::path& _logical_path,
+       std::string_view _resource_hierarchy) -> l1desc_t*;
+}; // namespace irods
 
 #endif // __IRODS_GET_L1DESC_HPP__
 

--- a/server/core/src/irods_get_l1desc.cpp
+++ b/server/core/src/irods_get_l1desc.cpp
@@ -1,11 +1,37 @@
 #include "irods_get_l1desc.hpp"
+#include "key_value_proxy.hpp"
 #include "rsGlobalExtern.hpp"
 
-namespace irods {
+#define IRODS_REPLICA_ENABLE_SERVER_SIDE_API
+#include "replica_proxy.hpp"
 
-    l1desc_t& get_l1desc( int _idx ) {
-        return L1desc[ _idx ];
-    }
+namespace irods
+{
+    auto get_l1desc(const l1_index_type _index) -> l1desc_t&
+    {
+        return L1desc[_index];
+    } // get_l1desc
 
+    auto find_l1desc(
+       const irods::experimental::filesystem::path& _logical_path,
+       std::string_view _resource_hierarchy) -> l1desc_t*
+    {
+        const auto index_is_open = [](const l1_index_type _index)
+        {
+            return FD_INUSE == L1desc[_index].inuseFlag;
+        };
+
+        for (l1_index_type index = 3; index < NUM_L1_DESC && index_is_open(index); ++index) {
+            auto& fd = L1desc[index];
+            const auto repl = irods::experimental::replica::make_replica_proxy(*fd.dataObjInfo);
+
+            if (repl.logical_path() == _logical_path.c_str() &&
+                repl.hierarchy() == _resource_hierarchy) {
+                return &fd;
+            }
+        }
+
+        return {};
+    } // find_l1desc
 }; // namespace irods
 

--- a/unit_tests/src/test_irods_key_value_proxy.cpp
+++ b/unit_tests/src/test_irods_key_value_proxy.cpp
@@ -507,7 +507,7 @@ TEST_CASE("test_proxy_lifetime_manager_getters", "[lifetime_manager]")
     SECTION("lifetime_manager")
     {
         auto [p, m] = irods::experimental::make_key_value_proxy();
-        auto kvp = m.get(); 
+        auto kvp = *m.get();
         REQUIRE(0 == kvp.len);
         REQUIRE(nullptr == getValByKey(&kvp, KEY1.c_str()));
         addKeyVal(&kvp, KEY1.c_str(), VAL1.c_str());

--- a/unit_tests/src/test_irods_lifetime_manager.cpp
+++ b/unit_tests/src/test_irods_lifetime_manager.cpp
@@ -62,7 +62,7 @@ TEST_CASE("test_dataObjInfo_t", "[lib]")
 
 TEST_CASE("test_keyValPair_t", "[lib]")
 {
-    keyValPair_t* kvp = get_pointer_to_struct<keyValPair_t>(); 
+    keyValPair_t* kvp = get_pointer_to_struct<keyValPair_t>();
     const std::string k = "key1";
     const std::string v = "val1";
     irods::experimental::lifetime_manager lm{*kvp};
@@ -80,7 +80,7 @@ TEST_CASE("test_genQueryInp_genQueryOut", "[lib]")
 
 TEST_CASE("test_rodsObjStat_t", "[lib]")
 {
-    rodsObjStat_t* stat = get_pointer_to_struct<rodsObjStat_t>(); 
+    rodsObjStat_t* stat = get_pointer_to_struct<rodsObjStat_t>();
     const std::string hier = "pt;ufs0";
     irods::experimental::lifetime_manager lm{*stat};
     std::strncpy(stat->rescHier, hier.c_str(), hier.size());
@@ -124,6 +124,17 @@ TEST_CASE("test_delete", "[lib]")
     irods::experimental::lifetime_manager lm{*t};
     t->str(str.c_str());
     REQUIRE(str == t->str());
+}
+
+TEST_CASE("test_release", "[lib]")
+{
+    test_class* t = new test_class;
+    auto lm = irods::experimental::lifetime_manager{*t};
+    REQUIRE(lm.get());
+    REQUIRE(t == lm.release());
+    REQUIRE(!lm.get());
+    REQUIRE(!lm.release());
+    delete t;
 }
 
 TEST_CASE("test_array_delete", "[lib]")


### PR DESCRIPTION
CI tests are running - previously failing tests passed at the bench.

Some notes here...

1. rsPhyPathReg must now return the dataObjInfo_t of the replica that was just registered in the catalog. As such, some of the free's have been removed. This is not leaking these structs, but rather transfers ownership to the global L1 descriptor table, which is cleaned up on agent exit. Otherwise, the lifetime_manager provided by the replica_proxy factory method cleans up the dataObjInfo_t.

2. The shift to returning pointers in the get() and release() methods of the lifetime_manager is consistent with the proxy objects' get() methods. This was needed in order to prevent freeing the dataObjInfo_t generated in rsPhyPathReg.