### PR TITLE
[#5170] Add id to resource json serialization (master)

### DIFF
--- a/scripts/core_tests_list.json
+++ b/scripts/core_tests_list.json
@@ -37,6 +37,7 @@
     "test_itrim",
     "test_iunreg",
     "test_iuserinfo",
+    "test_izonereport",
     "test_load_balanced_suite",
     "test_misc",
     "test_native_rule_engine_plugin",

--- a/scripts/irods/test/test_catalog.py
+++ b/scripts/irods/test/test_catalog.py
@@ -34,65 +34,6 @@ class Test_Catalog(ResourceBase, unittest.TestCase):
     def test_no_distinct(self):
         self.admin.assert_icommand(['iquest', 'no-distinct', 'select RESC_ID'], 'STDOUT_SINGLELINE', 'RESC_ID = ');
 
-
-
-    ###################
-    # izonereport
-    ###################
-    def test_izonereport_with_coordinating_resources__ticket_3303(self):
-        try:
-            assert_command('iadmin mkresc repl_resc replication', 'STDOUT_SINGLELINE', 'repl_resc')
-            assert_command('iadmin mkresc comp_resc compound', 'STDOUT_SINGLELINE', 'comp_resc')
-            assert_command('iadmin modresc comp_resc context comp_resc_context')
-            assert_command('iadmin modresc repl_resc context repl_resc_context')
-
-            _, stdout, _ = assert_command('izonereport', 'STDOUT_SINGLELINE', 'comp_resc')
-
-            expected_names = [
-                'repl_resc',
-                'comp_resc'
-            ]
-
-            icat_server_object = json.loads(stdout)['zones'][0]['icat_server']
-            if "coordinating_resources" in icat_server_object.keys():
-                coord_array = icat_server_object['coordinating_resources']
-
-                for d in coord_array:
-                    assert d['name'] in expected_names
-            else:
-                assert false
-
-        finally:
-            assert_command('iadmin rmresc repl_resc')
-            assert_command('iadmin rmresc comp_resc')
-
-    @unittest.skip('FIXME: Remove this line once we figure out why the test fails in ci')
-    def test_izonereport_and_validate(self):
-        jsonschema_installed = True
-        if lib.get_os_distribution() == 'Ubuntu' and lib.get_os_distribution_version_major() == '12':
-            jsonschema_installed = False
-
-        validate_json_path = os.path.join(IrodsConfig().scripts_directory, 'validate_json.py')
-        zone_report = os.path.join(self.admin.local_session_dir, 'out.txt')
-        # bad URL
-        self.admin.assert_icommand("izonereport > %s" % (zone_report), use_unsafe_shell=True)
-        if jsonschema_installed:
-            assert_command('python %s %s https://irods.org/badurl' % (validate_json_path, zone_report), 'STDERR_MULTILINE',
-                               ['WARNING: Validation Failed'], desired_rc=2)
-        else:
-            assert_command('python %s %s https://irods.org/badurl' % (validate_json_path, zone_report),
-                               'STDERR_SINGLELINE', 'jsonschema not installed', desired_rc=2)
-
-        # good URL
-        self.admin.assert_icommand("izonereport > out.txt", use_unsafe_shell=True)
-        irods_config = IrodsConfig()
-        command = [sys.executable, validate_json_path, zone_report, '{0}/{1}/zone_bundle.json'.format(irods_config.server_config['schema_validation_base_uri'], irods_config.server_config['schema_version'])]
-        if jsonschema_installed:
-            assert_command(command, 'STDOUT_MULTILINE', ['Validating', '... Success'], desired_rc=0)
-        else:
-            assert_command(command, 'STDERR_SINGLELINE', 'jsonschema not installed', desired_rc=2)
-
-
     ###################
     # icd
     ###################

--- a/scripts/irods/test/test_iadmin.py
+++ b/scripts/irods/test/test_iadmin.py
@@ -1273,10 +1273,6 @@ class Test_Iadmin(resource_suite.ResourceBase, unittest.TestCase):
     def test_rodscurators_role(self):
         self.admin.assert_icommand("iadmin mkuser nopes rodscurators", 'STDERR_SINGLELINE', "CAT_INVALID_USER_TYPE")
 
-    def test_izonereport_key_sanitization(self):
-        self.admin.assert_icommand("izonereport | grep key | grep -v XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-                                   'STDOUT_SINGLELINE', '"irods_encryption_key_size": 32,', use_unsafe_shell=True)
-
     def test_impostor_resource_debug_logging(self):
         irods_config = IrodsConfig()
         server_config_filename = irods_config.server_config_path

--- a/scripts/irods/test/test_izonereport.py
+++ b/scripts/irods/test/test_izonereport.py
@@ -1,0 +1,79 @@
+from __future__ import print_function
+import sys
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    import unittest2 as unittest
+import os
+import json
+from .. import lib
+from . import session
+from ..test.command import assert_command
+from ..configuration import IrodsConfig
+
+class Test_Izonereport(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.admin = session.mkuser_and_return_session('rodsadmin', 'otherrods', 'rods', lib.get_hostname())
+        cls.admin.assert_icommand(['iadmin', 'mkresc', 'rand_resc', 'random'], 'STDOUT_SINGLELINE', 'rand_resc')
+        cls.admin.assert_icommand(['iadmin', 'mkresc', 'repl_resc', 'replication'], 'STDOUT_SINGLELINE', 'repl_resc')
+        cls.admin.assert_icommand(['iadmin', 'mkresc', 'comp_resc', 'compound'], 'STDOUT_SINGLELINE', 'comp_resc')
+        cls.admin.assert_icommand(['iadmin', 'modresc', 'comp_resc', 'context', 'comp_resc_context'])
+        cls.admin.assert_icommand(['iadmin', 'modresc', 'repl_resc', 'context', 'repl_resc_context'])
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.admin.assert_icommand(['iadmin', 'rmresc', 'rand_resc'])
+        cls.admin.assert_icommand(['iadmin', 'rmresc', 'repl_resc'])
+        cls.admin.assert_icommand(['iadmin', 'rmresc', 'comp_resc'])
+        with session.make_session_for_existing_admin() as admin_session:
+            cls.admin.__exit__()
+            admin_session.assert_icommand(['iadmin', 'rmuser', cls.admin.username])
+
+    def test_izonereport_key_sanitization(self):
+        self.admin.assert_icommand("izonereport | grep key | grep -v XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                                   'STDOUT_SINGLELINE', '"irods_encryption_key_size": 32,', use_unsafe_shell=True)
+
+    def test_izonereport_with_coordinating_resources__ticket_3303(self):
+        _, stdout, _ = self.admin.assert_icommand('izonereport', 'STDOUT_SINGLELINE', 'comp_resc')
+
+        expected_names = [
+            'rand_resc',
+            'repl_resc',
+            'comp_resc'
+        ]
+
+        icat_server_object = json.loads(stdout)['zones'][0]['icat_server']
+        self.assertIn('coordinating_resources', icat_server_object.keys())
+        coord_array = icat_server_object['coordinating_resources']
+        coord_names = map(lambda r : r['name'], coord_array)
+
+        for n in expected_names:
+            self.assertIn(n, coord_names)
+
+    @unittest.skip('FIXME: Remove this line once we figure out why the test fails in ci')
+    def test_izonereport_and_validate(self):
+        jsonschema_installed = True
+        if lib.get_os_distribution() == 'Ubuntu' and lib.get_os_distribution_version_major() == '12':
+            jsonschema_installed = False
+
+        validate_json_path = os.path.join(IrodsConfig().scripts_directory, 'validate_json.py')
+        zone_report = os.path.join(self.admin.local_session_dir, 'out.txt')
+        # bad URL
+        self.admin.assert_icommand("izonereport > %s" % (zone_report), use_unsafe_shell=True)
+        if jsonschema_installed:
+            assert_command('python %s %s https://irods.org/badurl' % (validate_json_path, zone_report), 'STDERR_MULTILINE',
+                               ['WARNING: Validation Failed'], desired_rc=2)
+        else:
+            assert_command('python %s %s https://irods.org/badurl' % (validate_json_path, zone_report),
+                               'STDERR_SINGLELINE', 'jsonschema not installed', desired_rc=2)
+
+        # good URL
+        self.admin.assert_icommand("izonereport > out.txt", use_unsafe_shell=True)
+        irods_config = IrodsConfig()
+        command = [sys.executable, validate_json_path, zone_report, '{0}/{1}/zone_bundle.json'.format(irods_config.server_config['schema_validation_base_uri'], irods_config.server_config['schema_version'])]
+        if jsonschema_installed:
+            assert_command(command, 'STDOUT_MULTILINE', ['Validating', '... Success'], desired_rc=0)
+        else:
+            assert_command(command, 'STDERR_SINGLELINE', 'jsonschema not installed', desired_rc=2)

--- a/server/core/src/irods_report_plugins_in_json.cpp
+++ b/server/core/src/irods_report_plugins_in_json.cpp
@@ -97,6 +97,12 @@ namespace irods {
             return PASS(ret);
         }
 
+        rodsLong_t id;
+        ret = _resc->get_property< rodsLong_t >( irods::RESOURCE_ID, id );
+        if ( !ret.ok() ) {
+            return PASS(ret);
+        }
+
         std::string name;
         ret = _resc->get_property< std::string >( irods::RESOURCE_NAME, name );
         if ( !ret.ok() ) {
@@ -146,6 +152,7 @@ namespace irods {
         }
 
         _entry["name"] = name;
+        _entry["id"] =  std::to_string( id );
         _entry["type"] = type;
         _entry["host"] = host_name;
         _entry["vault_path"] = vault;

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -61,7 +61,8 @@ set(TEST_INCLUDE_LIST test_config/irods_atomic_apply_acl_operations
                       test_config/irods_scoped_privileged_client
                       test_config/irods_shared_memory_object
                       test_config/irods_user_administration
-                      test_config/irods_with_durability)
+                      test_config/irods_with_durability
+                      test_config/irods_zone_report)
 
 foreach(IRODS_TEST_CONFIG ${TEST_INCLUDE_LIST})
     unset_irods_test_variables()

--- a/unit_tests/cmake/test_config/irods_zone_report.cmake
+++ b/unit_tests/cmake/test_config/irods_zone_report.cmake
@@ -1,0 +1,16 @@
+set(IRODS_TEST_TARGET irods_zone_report)
+
+set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/src/test_zone_report.cpp)
+
+set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
+                            ${CMAKE_SOURCE_DIR}/lib/core/include
+                            ${CMAKE_SOURCE_DIR}/lib/api/include
+                            ${CMAKE_SOURCE_DIR}/server/core/include
+                            ${CMAKE_SOURCE_DIR}/server/icat/include
+                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
+                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include)
+ 
+set(IRODS_TEST_LINK_LIBRARIES irods_common
+                              irods_client
+                              c++abi)

--- a/unit_tests/src/test_zone_report.cpp
+++ b/unit_tests/src/test_zone_report.cpp
@@ -1,0 +1,62 @@
+#include "catch.hpp"
+
+#include "connection_pool.hpp"
+#include "resource_administration.hpp"
+#include "irods_at_scope_exit.hpp"
+#include "server_report.h"
+
+#include <unistd.h>
+
+#include <tuple>
+
+#include "json.hpp"
+
+TEST_CASE("json zone report")
+{
+    namespace adm = irods::experimental::administration;
+
+    char host_name[64] {};
+    REQUIRE(gethostname(host_name, sizeof(host_name)) == 0);
+
+    adm::resource_registration_info ufs_info;
+    ufs_info.resource_name = "unit_test_ufs0";
+    ufs_info.resource_type = adm::resource_type::unixfilesystem.data();
+    ufs_info.host_name = host_name;
+    ufs_info.vault_path = "/tmp";
+
+    auto conn_pool = irods::make_connection_pool();
+    auto conn = conn_pool->get_connection();
+
+    irods::at_scope_exit remove_resources{[&conn, &ufs_info] {
+        adm::client::remove_resource(conn, ufs_info.resource_name);
+    }};
+
+    REQUIRE(adm::client::add_resource(conn, ufs_info).value() == 0);
+
+    // see issue #5170
+    SECTION("verify resource id from json serialization")
+    {
+        // we need a fresh connection because the cache is probably out of date
+        auto conn_pool = irods::make_connection_pool();
+        auto conn = conn_pool->get_connection();
+
+        auto [ec, info] = adm::client::resource_info(conn, ufs_info.resource_name);
+        REQUIRE(ec.value() == 0);
+        REQUIRE(info->type() == ufs_info.resource_type);
+
+        bytesBuf_t *jbuf{};
+        REQUIRE(rcServerReport(static_cast<rcComm_t*>(conn), &jbuf) == 0);
+        std::string report_str(static_cast<char*>(jbuf->buf), jbuf->len);
+
+        const nlohmann::json report = nlohmann::json::parse(report_str);
+        REQUIRE(report["resources"].size() >= 1);
+        std::string id_str;
+        for (const nlohmann::json &resource : report["resources"]) {
+            const std::string name = resource["name"].get<std::string>();
+            if (name == ufs_info.resource_name) {
+                id_str = resource["id"].get<std::string>();
+            }
+        }
+        REQUIRE(info->id() == id_str);
+    }
+}

--- a/unit_tests/unit_tests_list.json
+++ b/unit_tests/unit_tests_list.json
@@ -25,5 +25,6 @@
     "irods_scoped_privileged_client",
     "irods_shared_memory_object",
     "irods_user_administration",
-    "irods_with_durability"
+    "irods_with_durability",
+    "irods_zone_report"
 ]


### PR DESCRIPTION
This is meant to address #5170. I'll make another pull request for the `4-2-stable` branch once this one has passed review.

If a test case is required, I may need some direction. I've tried adding one to `test_resource_administration.cpp`, but the resources added with `adm::client` do not show up in the output from `rcServerReport`.