### PR TITLE
[#4949] Link libboost_system in msi_get_agent_pid (4-2-stable)

### DIFF
--- a/plugins/microservices/msi_get_agent_pid/CMakeLists.txt
+++ b/plugins/microservices/msi_get_agent_pid/CMakeLists.txt
@@ -21,6 +21,8 @@ target_include_directories(${IRODS_PLUGIN_TARGET} PRIVATE ${CMAKE_BINARY_DIR}/li
 
 target_link_libraries(${IRODS_PLUGIN_TARGET} PRIVATE irods_server
                                                      irods_common
+                                                     ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so
+                                                     ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
                                                      ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)
 
 install(TARGETS ${IRODS_PLUGIN_TARGET}


### PR DESCRIPTION
Cherry-picked from #5196 . Made to match other microservice plugins.