### PR TITLE
[#5213] Make Clang 10 happy (4-2-stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,16 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -Wl,--expor
 set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -stdlib=libc++ -Wl,-z,defs -pthread")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++ -Wl,-z,defs -pthread")
 add_compile_options(-nostdinc++ -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-parameter)
+
+# Stop clang 6 from whining about unrecognized warning flags
+add_compile_options(-Wno-unknown-warning-option)
+# Do not error on definition of implicit copy constructor for classes with a user-declared copy assignment operator.
+# This is needed because the boost headers throw this warning.
+add_compile_options(-Wno-error=deprecated-copy)
+# Do not error when overlapping comparisons always evaluate to false.
+# This is needed because the boost headers throw this warning.
+add_compile_options(-Wno-error=tautological-overlap-compare)
+
 link_libraries(c++abi)
 include_directories(${IRODS_EXTERNALS_FULLPATH_CLANG}/include/c++/v1
                     ${IRODS_EXTERNALS_FULLPATH_JSON}/include)

--- a/lib/core/include/dstream.hpp
+++ b/lib/core/include/dstream.hpp
@@ -433,13 +433,13 @@ namespace io {
     constexpr std::ios_base::openmode default_openmode{};
 
     template <typename T>
-    constexpr auto default_openmode<std::basic_istream<T>> = std::ios_base::in;
+    constexpr std::ios_base::openmode default_openmode<std::basic_istream<T>> = std::ios_base::in;
 
     template <typename T>
-    constexpr auto default_openmode<std::basic_ostream<T>> = std::ios_base::out;
+    constexpr std::ios_base::openmode default_openmode<std::basic_ostream<T>> = std::ios_base::out;
 
     template <typename T>
-    constexpr auto default_openmode<std::basic_iostream<T>> = std::ios_base::in | std::ios_base::out;
+    constexpr std::ios_base::openmode default_openmode<std::basic_iostream<T>> = std::ios_base::in | std::ios_base::out;
 
     // A concrete stream class template that wraps a basic_data_object_buf object.
     // The general stream used to instantiate this type must use "char" for the underlying
@@ -454,10 +454,10 @@ namespace io {
         static constexpr std::ios_base::openmode mandatory_openmode{};
 
         template <typename T>
-        static constexpr auto mandatory_openmode<std::basic_istream<T>> = std::ios_base::in;
+        static constexpr std::ios_base::openmode mandatory_openmode<std::basic_istream<T>> = std::ios_base::in;
 
         template <typename T>
-        static constexpr auto mandatory_openmode<std::basic_ostream<T>> = std::ios_base::out;
+        static constexpr std::ios_base::openmode mandatory_openmode<std::basic_ostream<T>> = std::ios_base::out;
 
     public:
         // clang-format off

--- a/lib/core/include/dstream.hpp
+++ b/lib/core/include/dstream.hpp
@@ -430,16 +430,16 @@ namespace io {
     // stream types defined by the C++ standard (i.e. basic_istream, basic_ostream,
     // or basic_iostream).
     template <typename>
-    constexpr std::ios_base::openmode default_openmode{};
+    inline static constexpr std::ios_base::openmode default_openmode{};
 
     template <typename T>
-    constexpr std::ios_base::openmode default_openmode<std::basic_istream<T>> = std::ios_base::in;
+    inline static constexpr std::ios_base::openmode default_openmode<std::basic_istream<T>> = std::ios_base::in;
 
     template <typename T>
-    constexpr std::ios_base::openmode default_openmode<std::basic_ostream<T>> = std::ios_base::out;
+    inline static constexpr std::ios_base::openmode default_openmode<std::basic_ostream<T>> = std::ios_base::out;
 
     template <typename T>
-    constexpr std::ios_base::openmode default_openmode<std::basic_iostream<T>> = std::ios_base::in | std::ios_base::out;
+    inline static constexpr std::ios_base::openmode default_openmode<std::basic_iostream<T>> = std::ios_base::in | std::ios_base::out;
 
     // A concrete stream class template that wraps a basic_data_object_buf object.
     // The general stream used to instantiate this type must use "char" for the underlying

--- a/lib/core/src/packStruct.cpp
+++ b/lib/core/src/packStruct.cpp
@@ -347,8 +347,8 @@ packedOutput_t
 initPackedOutput( const int len ) {
     return {
         .bBuf={
-            .buf=malloc(len),
-            .len=0
+            .len=0,
+            .buf=malloc(len)
         },
         .bufSize=len,
         .nopackBufArray={}
@@ -359,8 +359,8 @@ packedOutput_t
 initPackedOutputWithBuf( void *buf, const int len ) {
     return {
         .bBuf={
-            .buf=buf,
-            .len=0
+            .len=0,
+            .buf=buf
         },
         .bufSize=len,
         .nopackBufArray={}

--- a/lib/core/src/rcMisc.cpp
+++ b/lib/core/src/rcMisc.cpp
@@ -4505,7 +4505,7 @@ auto resolve_hostname_from_hosts_config(const std::string& name_to_resolve) -> s
             hosts_config = json::parse(std::ifstream{cfg_file});
         }
 
-        for(const auto entry : hosts_config.at("host_entries")) {
+        for(const auto& entry : hosts_config.at("host_entries")) {
             const auto addresses = entry.at("addresses");
             const std::string target_name{addresses.at(0).at("address")};
 

--- a/lib/filesystem/include/filesystem/path_traits.hpp
+++ b/lib/filesystem/include/filesystem/path_traits.hpp
@@ -12,15 +12,15 @@ namespace irods::experimental::filesystem
     namespace path_traits
     {
         template <typename>
-        constexpr bool is_pathable = false;
+        inline static constexpr bool is_pathable = false;
 
         // clang-format off
-        template <> constexpr bool is_pathable<char*>             = true;
-        template <> constexpr bool is_pathable<const char*>       = true;
-        template <> constexpr bool is_pathable<std::string>       = true;
-        template <> constexpr bool is_pathable<std::vector<char>> = true;
-        template <> constexpr bool is_pathable<std::list<char>>   = true;
-        template <> constexpr bool is_pathable<collection_entry>  = true;
+        template <> inline static constexpr bool is_pathable<char*>             = true;
+        template <> inline static constexpr bool is_pathable<const char*>       = true;
+        template <> inline static constexpr bool is_pathable<std::string>       = true;
+        template <> inline static constexpr bool is_pathable<std::vector<char>> = true;
+        template <> inline static constexpr bool is_pathable<std::list<char>>   = true;
+        template <> inline static constexpr bool is_pathable<collection_entry>  = true;
         // clang-format on
     } // namespace path_traits
 } // namespace irods::experimental::filesystem

--- a/unit_tests/src/test_irods_lifetime_manager.cpp
+++ b/unit_tests/src/test_irods_lifetime_manager.cpp
@@ -110,7 +110,7 @@ TEST_CASE("test_rError_t", "[lib]")
     for (const auto& err_ : errs) {
         addRErrorMsg(err, std::get<int>(err_), std::get<std::string>(err_).c_str());
     }
-    REQUIRE(errs.size() == err->len);
+    REQUIRE(static_cast<int>(errs.size()) == err->len);
     for (int i = 0; i < err->len; i++) {
         REQUIRE(std::get<int>(errs[i]) == err->errMsg[i]->status);
         REQUIRE(std::get<std::string>(errs[i]) == err->errMsg[i]->msg);

--- a/unit_tests/src/test_irods_linked_list_iterator.cpp
+++ b/unit_tests/src/test_irods_linked_list_iterator.cpp
@@ -50,7 +50,7 @@ TEST_CASE("irods_linked_list_iterator", "[iterator]")
     {
         int count = 0;
 
-        for (const auto _ : list.get())
+        for (const auto& _ : list.get())
         {
             (void) _;
             ++count;


### PR DESCRIPTION
Cherry-pick of #5209

Polished up the changes I've made to my local clone so that I can build with the version of clang I have installed.
I've verified that clang 6 is still happy, too.

See the individual commit messages for more information.

Addresses #5213

Cherry-pick wasn't clean, so I'm going to push it through jenkins again. Will update when that's done.