### PR TITLE
[#5300] irodsctl no longer kills containerized iRODS processes (4-2-stable)

### DIFF
--- a/scripts/irods/controller.py
+++ b/scripts/irods/controller.py
@@ -96,7 +96,7 @@ class IrodsController(object):
                 env=self.config.execution_environment)
 
             root_pid = lib.get_server_root_pid_with_retry()
-            if root_pid == -1:
+            if root_pid == 0:
                 raise IrodsError('Could not retrieve server root PID.')
 
             try_count = 1
@@ -217,13 +217,10 @@ class IrodsController(object):
                 self.config.xmsg_server_executable]
 
         d = {}
-        root_pid = lib.get_server_root_pid()
-
-        if root_pid != -1:
-            for b in binaries:
-                pids = lib.get_pids_executing_binary_file(b, root_pid)
-                if pids:
-                    d[b] = pids
+        for b in binaries:
+            pids = lib.get_pids_executing_binary_file(b, lib.get_server_root_pid())
+            if pids:
+                d[b] = pids
 
         return d
 


### PR DESCRIPTION
The changes have shown to be reliable in the simplest case. However, we need to consider the stop implementation in controller.py.

When stop is executed and the server takes longer than expected to shutdown, controller.py will begin killing processes. This is potentially bad because these changes rely on the root PID out living all descendants. This is just theory at the moment, but it needs to be investigated before merging this PR.