### PR TITLE
Implement/Use replica state table + replica status restoration + finalize utilities (master)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -807,6 +807,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/core/src/dataObjOpr.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/replica_access_table.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/fileOpr.cpp
+  ${CMAKE_SOURCE_DIR}/server/core/src/finalize_utilities.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/initServer.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_api_calling_functions.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/irods_api_number_validator.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -806,6 +806,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/core/src/collection.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/dataObjOpr.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/replica_access_table.cpp
+  ${CMAKE_SOURCE_DIR}/server/core/src/replica_state_table.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/fileOpr.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/finalize_utilities.cpp
   ${CMAKE_SOURCE_DIR}/server/core/src/initServer.cpp

--- a/cmake/development_library.cmake
+++ b/cmake/development_library.cmake
@@ -483,6 +483,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/core/include/dataObjOpr.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/replica_access_table.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/fileOpr.hpp
+  ${CMAKE_SOURCE_DIR}/server/core/include/finalize_utilities.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/initServer.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irodsReServer.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/irods_api_calling_functions.hpp

--- a/cmake/development_library.cmake
+++ b/cmake/development_library.cmake
@@ -482,6 +482,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/core/include/collection.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/dataObjOpr.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/replica_access_table.hpp
+  ${CMAKE_SOURCE_DIR}/server/core/include/replica_state_table.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/fileOpr.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/finalize_utilities.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/initServer.hpp

--- a/lib/core/include/data_object_proxy.hpp
+++ b/lib/core/include/data_object_proxy.hpp
@@ -182,6 +182,8 @@ namespace irods::experimental::data_object
             replica_list_.push_back(replica::replica_proxy{_repl});
         } // add_replica
 
+        operator bool() const noexcept { return static_cast<bool>(data_obj_info_); }
+
     private:
         /// \brief Pointer to underlying doi_type
         /// \since 4.2.9
@@ -351,6 +353,10 @@ namespace irods::experimental::data_object
     static auto duplicate_data_object(const data_object_proxy<DataObjInfo>& _obj)
         -> std::pair<data_object_proxy<DataObjInfo>, lifetime_manager<DataObjInfo>>
     {
+        if (!_obj) {
+            THROW(USER__NULL_INPUT_ERR, "object information is null");
+        }
+
         return duplicate_data_object(*_obj.get());
     } //duplicate_data_object
 

--- a/lib/core/include/replica_proxy.hpp
+++ b/lib/core/include/replica_proxy.hpp
@@ -73,7 +73,7 @@ namespace irods::experimental::replica
 
         /// \returns key_value_proxy
         ///
-        /// \retval condInput for the DataObjInfo node as a key_value_proxy
+        /// \returns condInput for the DataObjInfo node as a key_value_proxy
         ///
         /// \since 4.2.9
         auto cond_input()       const -> key_value_proxy<const KeyValPair>
@@ -83,7 +83,7 @@ namespace irods::experimental::replica
 
         /// \returns const SpecColl*
         ///
-        /// \retval specColl pointer for the DataObjInfo node
+        /// \returns specColl pointer for the DataObjInfo node
         ///
         /// \since 4.2.9
         auto special_collection_info() const noexcept -> const SpecColl*
@@ -93,7 +93,7 @@ namespace irods::experimental::replica
 
         /// \returns const doi_pointer_type
         ///
-        /// \retval Pointer to the underlying struct
+        /// \returns Pointer to the underlying struct
         ///
         /// \since 4.2.9
         auto get() const noexcept -> const doi_pointer_type { return doi_; }
@@ -265,7 +265,7 @@ namespace irods::experimental::replica
 
         /// \returns key_value_proxy
         ///
-        /// \retval condInput for the DataObjInfo node as a key_value_proxy
+        /// \returns condInput for the DataObjInfo node as a key_value_proxy
         ///
         /// \since 4.2.9
         template<
@@ -278,7 +278,7 @@ namespace irods::experimental::replica
 
         /// \returns SpecColl*
         ///
-        /// \retval specColl pointer for the DataObjInfo node
+        /// \returns specColl pointer for the DataObjInfo node
         ///
         /// \since 4.2.9
         template<
@@ -289,8 +289,8 @@ namespace irods::experimental::replica
             return doi_->specColl;
         }
 
-        /// \returns doi_pointer_type
-        /// \retval Pointer to the underlying struct
+        /// \returns Pointer to the underlying struct
+        ///
         /// \since 4.2.9
         template<
             typename P = doi_type,
@@ -382,8 +382,7 @@ namespace irods::experimental::replica
     ///
     /// Allocates a new DataObjInfo and wraps the struct in a proxy and lifetime_manager
     ///
-    /// \return std::pair<replica_proxy<DataObjInfo>, lifetime_manager<DataObjInfo>>
-    /// \retval replica_proxy and lifetime_manager for managing a new DataObjInfo
+    /// \returns replica_proxy and lifetime_manager for managing a new DataObjInfo
     ///
     /// \since 4.2.9
     static auto make_replica_proxy() -> std::pair<replica_proxy<DataObjInfo>, lifetime_manager<DataObjInfo>>
@@ -401,8 +400,7 @@ namespace irods::experimental::replica
     /// \param[in] _logical_path
     /// \param[in] _replica_number
     ///
-    /// \return std::pair<replica_proxy<DataObjInfo>, lifetime_manager<DataObjInfo>>
-    /// \retval replica_proxy and lifetime_manager for managing a new DataObjInfo
+    /// \returns replica_proxy and lifetime_manager for managing a new DataObjInfo
     ///
     /// \since 4.2.9
     template<typename rxComm>
@@ -430,8 +428,7 @@ namespace irods::experimental::replica
     /// \param[in] _logical_path
     /// \param[in] _leaf_resource_name
     ///
-    /// \return std::pair<replica_proxy<DataObjInfo>, lifetime_manager<DataObjInfo>>
-    /// \retval replica_proxy and lifetime_manager for managing a new DataObjInfo
+    /// \returns replica_proxy and lifetime_manager for managing a new DataObjInfo
     ///
     /// \since 4.2.9
     template<typename rxComm>
@@ -497,6 +494,102 @@ namespace irods::experimental::replica
         return duplicate_replica(*_replica.get());
     } // duplicate_replica
 
+    /// \brief Takes a structured JSON input and creates a replica proxy
+    ///
+    /// \param[in] _logical_path The DataObjInfo holds an objPath, but the catalog only holds the data name and collection ID
+    /// \param[in] _input \parblock
+    /// Structured JSON of the following format (order is unimportant, but all fields must be included):
+    /// \code{.js}
+    ///     {
+    ///         "data_id": <string>,
+    ///         "coll_id": <string>,
+    ///         "data_repl_num": <string>,
+    ///         "data_version": <string>,
+    ///         "data_type_name": <string>,
+    ///         "data_size": <string>,
+    ///         "data_path": <string>,
+    ///         "data_owner_name": <string>,
+    ///         "data_owner_zone": <string>,
+    ///         "data_is_dirty": <string>,
+    ///         "data_status": <string>,
+    ///         "data_checksum": <string>,
+    ///         "data_expiry_ts": <string>,
+    ///         "data_map_id": <string>,
+    ///         "data_mode": <string>,
+    ///         "r_comment": <string>,
+    ///         "create_ts": <string>,
+    ///         "modify_ts": <string>,
+    ///         "resc_id": <string>
+    ///     }
+    /// \endcode
+    /// \endparblock
+    ///
+    /// \returns data_object_proxy and lifetime_manager for underlying struct
+    ///
+    /// \since 4.2.9
+    static auto make_replica_proxy(std::string_view _logical_path, const nlohmann::json& _input)
+        -> std::pair<replica_proxy<DataObjInfo>, lifetime_manager<DataObjInfo>>
+    {
+        auto proxy_lm_pair = make_replica_proxy();
+        auto& proxy = proxy_lm_pair.first;
+
+        proxy.data_id(std::stoul(_input.at("data_id").get<std::string>()));
+        proxy.collection_id(std::stoul(_input.at("coll_id").get<std::string>()));
+        proxy.replica_number(std::stoi(_input.at("data_repl_num").get<std::string>()));
+        proxy.version(_input.at("data_version").get<std::string>());
+        proxy.type(_input.at("data_type_name").get<std::string>());
+        proxy.size(std::stoul(_input.at("data_size").get<std::string>()));
+        proxy.physical_path(_input.at("data_path").get<std::string>());
+        proxy.owner_user_name(_input.at("data_owner_name").get<std::string>());
+        proxy.owner_zone_name(_input.at("data_owner_zone").get<std::string>());
+        proxy.replica_status(std::stoi(_input.at("data_is_dirty").get<std::string>()));
+        proxy.status(_input.at("data_status").get<std::string>());
+        proxy.checksum(_input.at("data_checksum").get<std::string>());
+        proxy.data_expiry(_input.at("data_expiry_ts").get<std::string>());
+        proxy.map_id(std::stoi(_input.at("data_map_id").get<std::string>()));
+        proxy.mode(_input.at("data_mode").get<std::string>());
+        proxy.comments(_input.at("r_comment").get<std::string>());
+        proxy.ctime(_input.at("create_ts").get<std::string>());
+        proxy.mtime(_input.at("modify_ts").get<std::string>());
+        proxy.resource_id(std::stoul(_input.at("resc_id").get<std::string>()));
+
+        // TODO: not part of r_data_main, only tracks data_name and coll_id
+        proxy.logical_path(_logical_path);
+
+        return proxy_lm_pair;
+    } // make_replica_proxy
+
+    /// \brief Takes a replica proxy and generates a structured JSON object
+    ///
+    /// \param[in] _proxy replica_proxy containing data object information
+    ///
+    /// \returns Structured JSON of the following format: \parblock
+    /// \code{.js}
+    ///     {
+    ///         "data_id": <string>,
+    ///         "coll_id": <string>,
+    ///         "data_repl_num": <string>,
+    ///         "data_version": <string>,
+    ///         "data_type_name": <string>,
+    ///         "data_size": <string>,
+    ///         "data_path": <string>,
+    ///         "data_owner_name": <string>,
+    ///         "data_owner_zone": <string>,
+    ///         "data_is_dirty": <string>,
+    ///         "data_status": <string>,
+    ///         "data_checksum": <string>,
+    ///         "data_expiry_ts": <string>,
+    ///         "data_map_id": <string>,
+    ///         "data_mode": <string>,
+    ///         "r_comment": <string>,
+    ///         "create_ts": <string>,
+    ///         "modify_ts": <string>,
+    ///         "resc_id": <string>
+    ///     }
+    /// \endcode
+    /// \endparblock
+    ///
+    /// \since 4.2.9
     template<typename doi_type>
     static auto to_json(const replica_proxy<doi_type>& _proxy) -> nlohmann::json
     {

--- a/lib/core/include/rodsKeyWdDef.h
+++ b/lib/core/include/rodsKeyWdDef.h
@@ -306,6 +306,10 @@
 // to data_object_finalize, the mtime for that replica is set to the current time.
 #define SET_TIME_TO_NOW_KW                          "set time to now"
 
+// A keyword for the replication resource plugin which indicates the hierarchy selected
+// at the time of resolution. This information is lost if the l1 descriptor goes away.
+#define SELECTED_HIERARCHY_KW                       "selected_hierarchy"
+
 // clang-format on
 
 #endif  // RODS_KEYWD_DEF_H__

--- a/plugins/api/src/replica_close.cpp
+++ b/plugins/api/src/replica_close.cpp
@@ -89,16 +89,16 @@ namespace
 
     auto update_replica_size_and_status(rsComm_t& _comm,
                                         const l1desc_t& _l1desc,
-                                        bool _send_notifications) -> int;
+                                        const bool _send_notifications) -> int;
 
     auto update_replica_size(rsComm_t& _comm,
                              const l1desc_t& _l1desc,
-                             bool _send_notifications) -> int;
+                             const bool _send_notifications) -> int;
 
     auto update_replica_status(rsComm_t& _comm,
                                const l1desc_t& _l1desc,
                                std::string_view _new_status,
-                               bool _send_notifications) -> int;
+                               const bool _send_notifications) -> int;
 
     auto free_l1_descriptor(int _l1desc_index) -> int;
 
@@ -198,7 +198,7 @@ namespace
         return fmt::format("{:011}", now.time_since_epoch().count());
     }
 
-    auto update_replica_size_and_status(rsComm_t& _comm, const l1desc_t& _l1desc, bool _send_notifications) -> int
+    auto update_replica_size_and_status(rsComm_t& _comm, const l1desc_t& _l1desc, const bool _send_notifications) -> int
     {
         const auto size_on_disk = get_file_size(_comm, _l1desc);
 
@@ -236,7 +236,7 @@ namespace
         return rsModDataObjMeta(&_comm, &input);
     }
 
-    auto update_replica_size(rsComm_t& _comm, const l1desc_t& _l1desc, bool _send_notifications) -> int
+    auto update_replica_size(rsComm_t& _comm, const l1desc_t& _l1desc, const bool _send_notifications) -> int
     {
         const auto size_on_disk = get_file_size(_comm, _l1desc);
 
@@ -282,7 +282,7 @@ namespace
     auto update_replica_status(rsComm_t& _comm,
                                const l1desc_t& _l1desc,
                                std::string_view _new_status,
-                               bool _send_notifications) -> int
+                               const bool _send_notifications) -> int
     {
         dataObjInfo_t info{};
         std::strncpy(info.objPath, _l1desc.dataObjInfo->objPath, MAX_NAME_LEN);

--- a/plugins/api/src/replica_close.cpp
+++ b/plugins/api/src/replica_close.cpp
@@ -20,14 +20,15 @@
 #include "rsFileClose.hpp"
 #include "rsFileStat.hpp"
 #include "rsModDataObjMeta.hpp"
-#include "irods_server_api_call.hpp"
+#include "irods_configuration_keywords.hpp"
+#include "irods_exception.hpp"
+#include "irods_logger.hpp"
+#include "irods_query.hpp"
 #include "irods_re_serialization.hpp"
 #include "irods_resource_backport.hpp"
-#include "irods_configuration_keywords.hpp"
-#include "irods_query.hpp"
-#include "irods_exception.hpp"
+#include "irods_server_api_call.hpp"
 #include "replica_access_table.hpp"
-#include "irods_logger.hpp"
+#include "replica_state_table.hpp"
 
 #define IRODS_FILESYSTEM_ENABLE_SERVER_SIDE_API
 #include "filesystem.hpp"
@@ -212,15 +213,29 @@ namespace
         std::strncpy(info.rescHier, _l1desc.dataObjInfo->rescHier, MAX_NAME_LEN);
 
         keyValPair_t reg_params{};
-        addKeyVal(&reg_params, REPL_STATUS_KW, REPLICA_STATUS_GOOD);
 
+        if (CREATE_TYPE == _l1desc.openType) {
+            addKeyVal(&reg_params, DATA_SIZE_KW, std::to_string(size_on_disk).data());
+            addKeyVal(&reg_params, REPL_STATUS_KW, REPLICA_STATUS_GOOD);
+        }
         // If the size of the replica has changed since opening it, then update the size.
-        if (_l1desc.dataObjInfo->dataSize != size_on_disk) {
+        else if (_l1desc.dataObjInfo->dataSize != size_on_disk) {
             addKeyVal(&reg_params, DATA_SIZE_KW, std::to_string(size_on_disk).data());
             addKeyVal(&reg_params, DATA_MODIFY_KW, current_time_in_seconds().data());
+            addKeyVal(&reg_params, REPL_STATUS_KW, REPLICA_STATUS_GOOD);
         }
         // If the contents of the replica has changed, then update the last modified timestamp.
         else if (_l1desc.bytesWritten > 0) {
+            addKeyVal(&reg_params, DATA_MODIFY_KW, current_time_in_seconds().data());
+            addKeyVal(&reg_params, REPL_STATUS_KW, REPLICA_STATUS_GOOD);
+        }
+        // If nothing has been written, the status is restored from the replica state table
+        // so that the replica is not mistakenly marked as good when it is in fact stale.
+        else {
+            auto& rst = irods::replica_state_table::instance();
+            const auto previous_status = std::stoi(rst.get_property(_l1desc.dataObjInfo->objPath, _l1desc.dataObjInfo->replNum, "data_is_dirty"));
+
+            addKeyVal(&reg_params, REPL_STATUS_KW, std::to_string(previous_status).data());
             addKeyVal(&reg_params, DATA_MODIFY_KW, current_time_in_seconds().data());
         }
 
@@ -262,7 +277,7 @@ namespace
         }
         else {
             // Return immediately if nothing needs to be updated. Allowing the function
-            // to continue pass this point results in an SQL update error due to invalid
+            // to continue past this point results in an SQL update error due to invalid
             // SQL (i.e. no columns were specified for the update).
             return 0;
         }
@@ -342,6 +357,7 @@ namespace
             return BAD_INPUT_DESC_INDEX;
         }
 
+        auto& rst = irods::replica_state_table::instance();
         const auto& l1desc = L1desc[l1desc_index];
         const auto send_notifications = !json_input.contains("send_notifications") || json_input.at("send_notifications").get<bool>();
 
@@ -391,7 +407,24 @@ namespace
                     }
                 }
                 else if (update_status) {
-                    if (const auto ec = update_replica_status(*_comm, l1desc, REPLICA_STATUS_GOOD, send_notifications); ec != 0) {
+                    // Default to setting new status to good on the condition that things moved in an expected manner.
+                    int new_status = GOOD_REPLICA;
+
+                    const auto size_on_disk = get_file_size(*_comm, l1desc);
+
+                    if (size_on_disk < 0) {
+                        // Stale replica status on failure to verify size on disk.
+                        log::api::error("Failed to retrieve the replica's size on disk [error_code={}].", size_on_disk);
+                        new_status = STALE_REPLICA;
+                    }
+                    else if (size_on_disk == l1desc.dataObjInfo->dataSize &&
+                             l1desc.bytesWritten <= 0 &&
+                             CREATE_TYPE != l1desc.openType) {
+                        // If nothing changed, the replica status should be restored to the original status.
+                        new_status = std::stoi(rst.get_property(l1desc.dataObjInfo->objPath, l1desc.dataObjInfo->replNum, "data_is_dirty"));
+                    }
+
+                    if (const auto ec = update_replica_status(*_comm, l1desc, std::to_string(new_status), send_notifications); ec != 0) {
                         log::api::error("Failed to update the replica status in the catalog [error_code={}].", ec);
                         update_replica_status(*_comm, l1desc, REPLICA_STATUS_STALE, send_notifications);
                         return ec;
@@ -422,10 +455,16 @@ namespace
                 return ec;
             }
 
+            const std::string logical_path = l1desc.dataObjInfo->objPath;
+
             const auto ec = free_l1_descriptor(l1desc_index);
-            
+
             if (ec != 0) {
                 update_replica_status(*_comm, l1desc, REPLICA_STATUS_STALE, send_notifications);
+            }
+
+            if (rst.contains(logical_path)) {
+                rst.erase(logical_path);
             }
 
             return ec;

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -2654,6 +2654,7 @@ irods::error db_reg_data_obj_op(
         return ERROR( iVal, "" );
     }
     snprintf( collIdNum, MAX_NAME_LEN, "%lld", iVal );
+    _data_obj_info->collId = iVal;
 
     /* Make sure no collection already exists by this name */
     if ( logSQL != 0 ) {
@@ -2682,13 +2683,20 @@ irods::error db_reg_data_obj_op(
     snprintf( dataReplNum, MAX_NAME_LEN, "%d", _data_obj_info->replNum );
     snprintf( dataStatusNum, MAX_NAME_LEN, "%d", _data_obj_info->replStatus );
     snprintf( dataSizeNum, MAX_NAME_LEN, "%lld", _data_obj_info->dataSize );
-    getNowStr( myTime );
 
+    getNowStr( myTime );
     if (0 == strcmp(_data_obj_info->dataModify, "")) {
         strcpy(_data_obj_info->dataModify, myTime);
     }
+    if (0 == strcmp(_data_obj_info->dataCreate, "")) {
+        strcpy(_data_obj_info->dataCreate, myTime);
+    }
+
+    std::snprintf(_data_obj_info->dataOwnerName, sizeof(_data_obj_info->dataOwnerName), "%s", _ctx.comm()->clientUser.userName);
+    std::snprintf(_data_obj_info->dataOwnerZone, sizeof(_data_obj_info->dataOwnerZone), "%s", _ctx.comm()->clientUser.rodsZone);
 
     std::string resc_id_str = boost::lexical_cast<std::string>(_data_obj_info->rescId);
+
     cllBindVars[0] = dataIdNum;
     cllBindVars[1] = collIdNum;
     cllBindVars[2] = logicalFileName;
@@ -2698,12 +2706,12 @@ irods::error db_reg_data_obj_op(
     cllBindVars[6] = dataSizeNum;
     cllBindVars[7] = resc_id_str.c_str();
     cllBindVars[8] = _data_obj_info->filePath;
-    cllBindVars[9] = _ctx.comm()->clientUser.userName;
-    cllBindVars[10] = _ctx.comm()->clientUser.rodsZone;
+    cllBindVars[9] = _data_obj_info->dataOwnerName;
+    cllBindVars[10] = _data_obj_info->dataOwnerZone;
     cllBindVars[11] = dataStatusNum;
     cllBindVars[12] = _data_obj_info->chksum;
     cllBindVars[13] = _data_obj_info->dataMode;
-    cllBindVars[14] = myTime;
+    cllBindVars[14] = _data_obj_info->dataCreate;
     cllBindVars[15] = _data_obj_info->dataModify;
     cllBindVars[16] = data_expiry_ts;
     cllBindVars[17] = "EMPTY_RESC_NAME";

--- a/plugins/resources/replication/librepl.cpp
+++ b/plugins/resources/replication/librepl.cpp
@@ -30,6 +30,7 @@
 #include "irods_random.hpp"
 #include "irods_exception.hpp"
 #include "rsGenQuery.hpp"
+#include "key_value_proxy.hpp"
 
 // =-=-=-=-=-=-=-
 // stl includes
@@ -216,16 +217,34 @@ irods::error get_selected_hierarchy(
     irods::hierarchy_parser selected_parser{};
     bool resc_hier_in_keyword{};
     irods::file_object_ptr file_obj = boost::dynamic_pointer_cast<irods::file_object>(_ctx.fco());
-    if (file_obj->l1_desc_idx() > 0) {
-        const auto hier_str{getValByKey(&L1desc[file_obj->l1_desc_idx()].dataObjInp->condInput, RESC_HIER_STR_KW)};
-        if (!hier_str) {
-            return ERROR(SYS_INTERNAL_NULL_INPUT_ERR,
-                         (boost::format(
-                          "[%s] - No hierarchy string found in keywords for file object.") %
-                          __FUNCTION__).str().c_str());
+
+    if (!resc_hier_in_keyword) {
+        auto cond_input = irods::experimental::make_key_value_proxy((KeyValPair&)file_obj->cond_input());
+        if (cond_input.contains(SELECTED_HIERARCHY_KW)) {
+            const auto hier_str = cond_input.at(SELECTED_HIERARCHY_KW).value();
+            if (hier_str.empty()) {
+                return ERROR(SYS_INTERNAL_NULL_INPUT_ERR,
+                             (boost::format(
+                              "[%s] - No hierarchy string found in keywords for file object.") %
+                              __FUNCTION__).str().c_str());
+            }
+            selected_parser.set_string(hier_str.data());
+            resc_hier_in_keyword = selected_parser.resc_in_hier(name);
         }
-        selected_parser.set_string(hier_str);
-        resc_hier_in_keyword = selected_parser.resc_in_hier(name);
+    }
+
+    if (!resc_hier_in_keyword) {
+        if (file_obj->l1_desc_idx() > 0) {
+            const auto hier_str{getValByKey(&L1desc[file_obj->l1_desc_idx()].dataObjInp->condInput, RESC_HIER_STR_KW)};
+            if (!hier_str) {
+                return ERROR(SYS_INTERNAL_NULL_INPUT_ERR,
+                             (boost::format(
+                              "[%s] - No hierarchy string found in keywords for file object.") %
+                              __FUNCTION__).str().c_str());
+            }
+            selected_parser.set_string(hier_str);
+            resc_hier_in_keyword = selected_parser.resc_in_hier(name);
+        }
     }
 
     // Get resc hier from the file object directly if not in RESC_HIER_STR_KW

--- a/scripts/core_tests_list.json
+++ b/scripts/core_tests_list.json
@@ -20,6 +20,7 @@
     "test_imv",
     "test_ipasswd",
     "test_iphymv",
+    "test_iput",
     "test_iput_options",
     "test_ipwd",
     "test_iquest",

--- a/scripts/irods/test/test_iphymv.py
+++ b/scripts/irods/test/test_iphymv.py
@@ -83,16 +83,40 @@ class Test_iPhymv(ResourceBase, unittest.TestCase):
 
     @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'Skip for Topology Testing on Resource Server')
     def test_iphymv_unable_to_unlink__2820(self):
-        filepath = os.path.join(self.admin.local_session_dir, 'file')
-        lib.make_file(filepath, 1)
-        dest_path = self.admin.session_collection + '/file'
-        self.admin.assert_icommand('ireg '+filepath+' '+dest_path)
+        filename = 'test_iphymv_unable_to_unlink__2820'
+        localfile = os.path.join(self.admin.local_session_dir, filename)
+        lib.make_file(localfile, 1)
+        dest_path = os.path.join(self.admin.session_collection, filename)
 
-        os.chmod(filepath, 0444)
-        self.admin.assert_icommand('iphymv -S demoResc -R TestResc '+dest_path, 'STDERR_SINGLELINE', 'Permission denied')
+        try:
+            # put a data object so that a file appears in the vault
+            self.admin.assert_icommand(['iput', localfile, dest_path])
 
-        os.chmod(filepath, 0666)
-        self.admin.assert_icommand('iphymv -S demoResc -R TestResc '+dest_path)
+            # modify the permissions on the physical file in the vault to deny unlinking to the service account
+            filepath = os.path.join(self.admin.get_vault_session_path(), filename)
+            self.admin.assert_icommand(['ils', '-L', dest_path], 'STDOUT', filepath)
+            os.chmod(filepath, 0444)
+
+            # attempt and fail to phymv the replica (due to no permissions for unlink)
+            self.admin.assert_icommand(['iphymv', '-S', 'demoResc', '-R', 'TestResc', dest_path], 'STDERR_SINGLELINE', 'Permission denied')
+            self.admin.assert_icommand(['ils', '-L', dest_path], 'STDOUT', 'demoResc')
+
+            # ensure that physical file was not unlinked
+            self.assertTrue(os.path.exists(filepath))
+
+            # set the permissions on the physical file back to allow unlinking to the service account
+            os.chmod(filepath, 0666)
+
+            # attempt to phymv the replica (and succeed)
+            self.admin.assert_icommand(['iphymv', '-S', 'demoResc', '-R', 'TestResc', dest_path])
+
+            # ensure that file was unlinked
+            self.assertFalse(os.path.exists(filepath))
+            self.admin.assert_icommand(['ils', '-L', dest_path], 'STDOUT', 'TestResc')
+
+        finally:
+            os.unlink(localfile)
+            self.admin.assert_icommand(['irm', '-f', dest_path])
 
     def test_iphymv_to_self(self):
         filename = 'test_iphymv_to_self'

--- a/scripts/irods/test/test_iput.py
+++ b/scripts/irods/test/test_iput.py
@@ -1,0 +1,176 @@
+from __future__ import print_function
+import os
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from . import session
+from .. import test
+from .. import lib
+
+class test_iput_with_checksums(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 'apass')]), unittest.TestCase):
+    def setUp(self):
+        super(test_iput_with_checksums, self).setUp()
+        self.admin = self.admin_sessions[0]
+
+        self.resource = 'test_iput_with_checksums_resource'
+        self.vault_path = os.path.join(self.admin.local_session_dir, self.resource + '_storage_vault')
+        self.admin.assert_icommand(
+            ['iadmin', 'mkresc', self.resource, 'unixfilesystem', ':'.join([test.settings.HOSTNAME_2, self.vault_path])],
+            'STDOUT', test.settings.HOSTNAME_2)
+
+    def tearDown(self):
+        self.admin.run_icommand(['irm', '-f', self.object_name])
+        self.admin.assert_icommand(['iadmin', 'rmresc', self.resource])
+        super(test_iput_with_checksums, self).tearDown()
+
+    def test_zero_length_put(self):
+        self.object_name = 'test_zero_length_put'
+        self.run_tests(self.object_name, 0)
+
+    def test_small_put(self):
+        self.object_name = 'test_small_put'
+        self.run_tests(self.object_name, 512)
+
+    @unittest.skip('parallel transfer not yet working')
+    def test_large_put(self):
+        self.object_name = 'test_large_put'
+        self.run_tests(self.object_name, 5120000)
+
+    def get_checksum(self, object_name):
+        iquest_result,_,ec = self.admin.run_icommand(['iquest', '%s', '"select DATA_CHECKSUM where DATA_NAME = \'{}\'"'.format(object_name)])
+        self.assertEqual(0, ec)
+
+        print(iquest_result)
+        self.assertEqual(1, len(iquest_result.splitlines()))
+
+        return '' if u'\n' == iquest_result else iquest_result
+
+    def run_tests(self, filename, file_size):
+        lib.make_file(filename, file_size, 'arbitrary')
+        filename_tmp = filename + '_tmp'
+        self.admin.assert_icommand(['iput', '-K', filename, filename_tmp])
+        expected_checksum = self.get_checksum(filename_tmp)
+
+        try:
+            self.new_register(filename, expected_checksum)
+            self.new_verify(filename, expected_checksum)
+            self.overwrite_register_good_no_checksum(filename, expected_checksum)
+            self.overwrite_register_good_with_checksum(filename, expected_checksum)
+            self.overwrite_register_stale_no_checksum(filename, expected_checksum)
+            self.overwrite_register_stale_with_checksum(filename, expected_checksum)
+            self.overwrite_verify_good_no_checksum(filename, expected_checksum)
+            self.overwrite_verify_good_with_checksum(filename, expected_checksum)
+            self.overwrite_verify_stale_no_checksum(filename, expected_checksum)
+            self.overwrite_verify_stale_with_checksum(filename, expected_checksum)
+        finally:
+            os.unlink(filename)
+            self.admin.run_icommand(['irm', '-f', filename_tmp])
+
+    def new_register(self, filename, expected_checksum):
+        try:
+            self.admin.assert_icommand(['iput', '-R', self.resource, '-k', filename, self.object_name])
+            self.assertEqual(self.get_checksum(self.object_name), expected_checksum)
+        finally:
+            self.admin.assert_icommand(['irm', '-f', self.object_name])
+
+    def new_verify(self, filename, expected_checksum):
+        try:
+            self.admin.assert_icommand(['iput', '-R', self.resource, '-K', filename, self.object_name])
+            self.assertEqual(self.get_checksum(self.object_name), expected_checksum)
+        finally:
+            self.admin.assert_icommand(['irm', '-f', self.object_name])
+
+    def overwrite_register_good_no_checksum(self, filename, expected_checksum):
+        filename_tmp = filename + '_for_overwrite'
+        lib.make_file(filename_tmp, 4444, 'arbitrary')
+
+        try:
+            self.admin.assert_icommand(['iput', '-R', self.resource, filename_tmp, self.object_name])
+            self.assertEqual(self.get_checksum(self.object_name), '')
+
+            self.admin.assert_icommand(['iput', '-R', self.resource, '-f', '-k', filename, self.object_name])
+            self.assertEqual(self.get_checksum(self.object_name), expected_checksum)
+        finally:
+            os.unlink(filename_tmp)
+            self.admin.assert_icommand(['irm', '-f', self.object_name])
+
+    def overwrite_register_good_with_checksum(self, filename, expected_checksum):
+        filename_tmp = filename + '_for_overwrite'
+        lib.make_file(filename_tmp, 4444, 'arbitrary')
+        self.admin.assert_icommand(['iput', '-R', self.resource, '-K', filename_tmp])
+        tmp_checksum = self.get_checksum(filename_tmp)
+
+        try:
+            self.admin.assert_icommand(['iput', '-R', self.resource, '-k', filename_tmp, self.object_name])
+            self.assertEqual(self.get_checksum(self.object_name), tmp_checksum)
+
+            self.admin.assert_icommand(['iput', '-R', self.resource, '-f', '-k', filename, self.object_name])
+            self.assertEqual(self.get_checksum(self.object_name), expected_checksum)
+        finally:
+            os.unlink(filename_tmp)
+            self.admin.assert_icommand(['irm', '-f', self.object_name])
+            self.admin.assert_icommand(['irm', '-f', filename_tmp])
+
+    def overwrite_no_checksum_flag_good_with_checksum(self, filename, expected_checksum):
+        filename_tmp = filename + '_for_overwrite'
+        lib.make_file(filename_tmp, 4444, 'arbitrary')
+        self.admin.assert_icommand(['iput', '-R', self.resource, '-K', filename_tmp])
+        tmp_checksum = self.get_checksum(filename_tmp)
+
+        try:
+            self.admin.assert_icommand(['iput', '-R', self.resource, '-k', filename_tmp, self.object_name])
+            self.assertEqual(self.get_checksum(self.object_name), tmp_checksum)
+
+            self.admin.assert_icommand(['iput', '-R', self.resource, '-f', filename, self.object_name])
+            self.assertEqual(self.get_checksum(self.object_name), expected_checksum)
+        finally:
+            os.unlink(filename_tmp)
+            self.admin.assert_icommand(['irm', '-f', self.object_name])
+            self.admin.assert_icommand(['irm', '-f', filename_tmp])
+
+    def overwrite_register_stale_no_checksum(self, filename, expected_checksum):
+        pass
+
+    def overwrite_register_stale_with_checksum(self, filename, expected_checksum):
+        pass
+
+    def overwrite_verify_good_no_checksum(self, filename, expected_checksum):
+        filename_tmp = filename + '_for_overwrite'
+        lib.make_file(filename_tmp, 4444, 'arbitrary')
+
+        try:
+            self.admin.assert_icommand(['iput', '-R', self.resource, filename_tmp, self.object_name])
+            self.assertEqual(self.get_checksum(self.object_name), '')
+
+            self.admin.assert_icommand(['iput', '-R', self.resource, '-f', '-K', filename, self.object_name])
+            self.assertEqual(self.get_checksum(self.object_name), expected_checksum)
+        finally:
+            os.unlink(filename_tmp)
+            self.admin.assert_icommand(['irm', '-f', self.object_name])
+
+    def overwrite_verify_good_with_checksum(self, filename, expected_checksum):
+        filename_tmp = filename + '_for_overwrite'
+        lib.make_file(filename_tmp, 4444, 'arbitrary')
+        self.admin.assert_icommand(['iput', '-R', self.resource, '-K', filename_tmp])
+        tmp_checksum = self.get_checksum(filename_tmp)
+
+        try:
+            self.admin.assert_icommand(['iput', '-R', self.resource, '-k', filename_tmp, self.object_name])
+            self.assertEqual(self.get_checksum(self.object_name), tmp_checksum)
+
+            self.admin.assert_icommand(['iput', '-R', self.resource, '-f', '-K', filename, self.object_name])
+            self.assertEqual(self.get_checksum(self.object_name), expected_checksum)
+        finally:
+            os.unlink(filename_tmp)
+            self.admin.assert_icommand(['irm', '-f', self.object_name])
+            self.admin.assert_icommand(['irm', '-f', filename_tmp])
+
+    def overwrite_verify_stale_no_checksum(self, filename, expected_checksum):
+        pass
+
+    def overwrite_verify_stale_with_checksum(self, filename, expected_checksum):
+        pass
+

--- a/server/api/include/rsDataObjRepl.hpp
+++ b/server/api/include/rsDataObjRepl.hpp
@@ -8,7 +8,7 @@
 int rsDataObjRepl( rsComm_t *rsComm, dataObjInp_t *dataObjInp, transferStat_t **transferStat );
 int dataObjCopy( rsComm_t *rsComm, int l1descInx );
 int replToCacheRescOfCompObj( rsComm_t *rsComm, dataObjInp_t *dataObjInp, dataObjInfo_t *srcDataObjInfoHead, dataObjInfo_t *compObjInfo, dataObjInfo_t *oldDataObjInfo, dataObjInfo_t **outDestDataObjInfo );
-int unbunAndStageBunfileObj( rsComm_t *rsComm, char *bunfileObjPath, char **outCacheRescName );
+int unbunAndStageBunfileObj(rsComm_t* rsComm, const char* bunfileObjPath, char** outCacheRescName);
 int _unbunAndStageBunfileObj( rsComm_t *rsComm, dataObjInfo_t **bunfileObjInfoHead, keyValPair_t* condInput, char **outCacheRescName, int rmBunCopyFlag );
 int stageDataFromCompToCache( rsComm_t *rsComm, dataObjInfo_t *compObjInfo, dataObjInfo_t *outCacheObjInfo );
 int stageAndRequeDataToCache( rsComm_t *rsComm, dataObjInfo_t **compObjInfoHead );

--- a/server/api/src/rsDataObjClose.cpp
+++ b/server/api/src/rsDataObjClose.cpp
@@ -339,6 +339,11 @@ namespace
         }
         if (PHYMV_DEST == l1desc.oprType) {
             reg_param[REPL_NUM_KW] = std::to_string(source_replica.replica_number());
+            // TODO: This is only valid if the source replica was good. Need to get source replica's
+            // previous status from the replica state table, assuming implementation of unlink does not
+            // remove the entry in the future. Using the source replica's current status is not valid
+            // because logical locking would put it into write lock.
+            reg_param[REPL_STATUS_KW] = std::to_string(GOOD_REPLICA);
         }
         if (cond_input.contains(CHKSUM_KW)) {
             reg_param[CHKSUM_KW] = cond_input.at(CHKSUM_KW);

--- a/server/api/src/rsDataObjClose.cpp
+++ b/server/api/src/rsDataObjClose.cpp
@@ -11,7 +11,6 @@
 #include "key_value_proxy.hpp"
 #include "miscServerFunct.hpp"
 #include "modAVUMetadata.h"
-#include "modAVUMetadata.h"
 #include "modAccessControl.h"
 #include "modDataObjMeta.h"
 #include "objMetaOpr.hpp"
@@ -43,6 +42,7 @@
 #include "subStructFileStat.h"
 
 // =-=-=-=-=-=-=-
+#include "finalize_utilities.hpp"
 #include "irods_resource_backport.hpp"
 #include "irods_stacktrace.hpp"
 #include "irods_hierarchy_parser.hpp"
@@ -54,7 +54,9 @@
 #include "irods_at_scope_exit.hpp"
 #include "key_value_proxy.hpp"
 #include "replica_access_table.hpp"
-#include "replica_proxy.hpp"
+
+#define IRODS_REPLICA_ENABLE_SERVER_SIDE_API
+#include "data_object_proxy.hpp"
 
 #include <memory>
 #include <functional>
@@ -66,56 +68,37 @@ namespace
 {
     using replica_proxy = irods::experimental::replica::replica_proxy<DataObjInfo>;
 
-    auto apply_static_pep(RsComm& _comm, const int _fd, const int _operation_status, std::string_view _name)
-    {
-        auto& l1desc = L1desc[_fd];
-        ruleExecInfo_t rei{};
-        initReiWithDataObjInp(&rei, &_comm, l1desc.dataObjInp);
-        rei.doi = l1desc.dataObjInfo;
-        rei.status = _operation_status;
-
-        // make resource properties available as rule session variables
-        irods::get_resc_properties_as_kvp(rei.doi->rescHier, rei.condInputData);
-
-        rei.status = applyRule(_name.data(), NULL, &rei, NO_SAVE_REI );
-
-        /* doi might have changed */
-        l1desc.dataObjInfo = rei.doi;
-        clearKeyVal(rei.condInputData);
-        free(rei.condInputData);
-    } // apply_static_pep
-
     auto apply_static_peps(RsComm& _comm, openedDataObjInp_t& _close_inp, const int _fd, const int _operation_status) -> void
     {
         auto& l1desc = L1desc[_fd];
 
         /* note : this may overlap with acPostProcForPut or acPostProcForCopy */
         if ( l1desc.openType == CREATE_TYPE ) {
-            apply_static_pep(_comm, _fd, _operation_status, "acPostProcForCreate");
+            irods::apply_static_post_pep(_comm, l1desc, _operation_status, "acPostProcForCreate");
         }
         else if ( l1desc.openType == OPEN_FOR_READ_TYPE ||
                   l1desc.openType == OPEN_FOR_WRITE_TYPE ) {
-            apply_static_pep(_comm, _fd, _operation_status, "acPostProcForOpen");
+            irods::apply_static_post_pep(_comm, l1desc, _operation_status, "acPostProcForOpen");
         }
         else if ( l1desc.oprType == REPLICATE_DEST ) {
-            apply_static_pep(_comm, _fd, _operation_status, "acPostProcForRepl");
+            irods::apply_static_post_pep(_comm, l1desc, _operation_status, "acPostProcForRepl");
         }
 
         if ( l1desc.oprType == COPY_DEST ) {
             /* have to put copy first because the next test could
              * trigger put rule for copy operation */
-            apply_static_pep(_comm, _fd, _operation_status, "acPostProcForCopy");
+            irods::apply_static_post_pep(_comm, l1desc, _operation_status, "acPostProcForCopy");
         }
         else if ( l1desc.oprType == PUT_OPR ||
                   l1desc.openType == CREATE_TYPE ||
                   ( l1desc.openType == OPEN_FOR_WRITE_TYPE &&
                     ( l1desc.bytesWritten > 0 ||
                       _close_inp.bytesWritten > 0 ) ) ) {
-            apply_static_pep(_comm, _fd, _operation_status, "acPostProcForPut");
+            irods::apply_static_post_pep(_comm, l1desc, _operation_status, "acPostProcForPut");
         }
         else if ( l1desc.dataObjInp != NULL &&
                   l1desc.dataObjInp->oprType == PHYMV_OPR ) {
-            apply_static_pep(_comm, _fd, _operation_status, "acPostProcForPhymv");
+            irods::apply_static_post_pep(_comm, l1desc, _operation_status, "acPostProcForPhymv");
         }
     } // apply_static_peps
 
@@ -166,33 +149,26 @@ namespace
         }
     } // applyACLFromKVP
 
-    auto purge_cache(RsComm& _comm, const int _fd) -> int
+    bool bytes_written_in_operation(const l1desc_t& l1desc)
     {
-        auto& l1desc = L1desc[_fd];
+        return l1desc.bytesWritten >= 0 ||
+               REPLICATE_DEST == l1desc.oprType ||
+               PHYMV_DEST == l1desc.oprType ||
+               COPY_DEST == l1desc.oprType;
+    } // bytes_written_in_operation
 
-        if (l1desc.purgeCacheFlag <= 0) {
-            return 0;
-        }
+    auto cross_zone_write_operation(const openedDataObjInp_t& inp, const l1desc_t& l1desc) -> bool
+    {
+        return inp.bytesWritten > 0 && l1desc.bytesWritten <= 0;
+    } // cross_zone_write_operation
 
-        auto replica = replica_proxy{*l1desc.dataObjInfo};
-
-        dataObjInp_t inp{};
-        rstrcpy( inp.objPath, replica.logical_path().data(), MAX_NAME_LEN );
-
-        auto cond_input = irods::experimental::key_value_proxy{inp.condInput};
-        irods::at_scope_exit free_cond_input{[&cond_input] { clearKeyVal(cond_input.get()); }};
-        cond_input[COPIES_KW] = "1";
-        cond_input[REPL_NUM_KW] = std::to_string(replica.replica_number());
-        cond_input[RESC_HIER_STR_KW] = replica.hierarchy();
-
-        int status = rsDataObjTrim(&_comm, &inp);
-        if (status < 0) {
-            irods::log(LOG_ERROR, fmt::format(
-                "{}: error trimming replica on [{}] for [{}]",
-                __FUNCTION__, replica.hierarchy(), replica.logical_path()));
-        }
-        return status;
-    } // purge_cache
+    auto cross_zone_copy_operation(const l1desc_t& l1desc) -> bool
+    {
+        const auto cond_input = irods::experimental::make_key_value_proxy(l1desc.dataObjInp->condInput);
+        return l1desc.l3descInx < 3 &&
+               cond_input.contains(CROSS_ZONE_CREATE_KW) &&
+               INTERMEDIATE_REPLICA == l1desc.replStatus;
+    } // cross_zone_copy_operation
 
     auto perform_checksum_operation_for_finalize(RsComm& _comm, const int _fd) -> std::string
     {
@@ -221,6 +197,7 @@ namespace
 
                 if (const int ec = _dataObjChksum(&_comm, destination_replica.get(), &checksum_string); ec < 0) {
                     destination_replica.checksum("");
+
                     if (DIRECT_ARCHIVE_ACCESS == ec) {
                         destination_replica.checksum(source_replica.checksum());
                         return source_replica.checksum().data();
@@ -239,8 +216,8 @@ namespace
 
                 if (source_replica.checksum() != checksum_string) {
                     THROW(USER_CHKSUM_MISMATCH, fmt::format(
-                         "{}: chksum mismatch for {} src [{}] new [{}]",
-                         __FUNCTION__, destination_replica.logical_path(), source_replica.checksum(), checksum_string));
+                        "{}: chksum mismatch for {} src [{}] new [{}]",
+                        __FUNCTION__, destination_replica.logical_path(), source_replica.checksum(), checksum_string));
                 }
 
                 return destination_replica.checksum().data();
@@ -248,33 +225,19 @@ namespace
         }
 
         if (!l1desc.chksumFlag) {
-            if (destination_replica.checksum().length() <= 0) {
+            if (destination_replica.checksum().empty()) {
                 return {};
             }
             l1desc.chksumFlag = VERIFY_CHKSUM;
         }
 
         if (VERIFY_CHKSUM == l1desc.chksumFlag) {
-            if (std::string_view{l1desc.chksum}.length() > 0) {
-                destination_replica.cond_input()[ORIG_CHKSUM_KW] = l1desc.chksum;
-                if (const int ec = _dataObjChksum(&_comm, destination_replica.get(), &checksum_string); ec < 0) {
-                    THROW(ec, "failed in _dataObjChksum");
-                }
-                destination_replica.cond_input().erase(ORIG_CHKSUM_KW);
-
-                // verify against the input value
-                if (std::string_view{checksum_string} != l1desc.chksum) {
-                    THROW(USER_CHKSUM_MISMATCH, fmt::format(
-                        "{}: mismatch chksum for {}.inp={},compute {}",
-                        __FUNCTION__, destination_replica.logical_path(),
-                        l1desc.chksum, checksum_string));
-                }
-
-                return {checksum_string};
+            if (!std::string_view{l1desc.chksum}.empty()) {
+                return irods::verify_checksum(_comm, *destination_replica.get(), l1desc.chksum);
             }
 
             if (REPLICATE_DEST == oprType) {
-                if (destination_replica.checksum().length() > 0) {
+                if (!destination_replica.checksum().empty()) {
                     destination_replica.cond_input()[ORIG_CHKSUM_KW] = destination_replica.checksum();
                 }
 
@@ -340,26 +303,7 @@ namespace
             return {};
         }
 
-        if (std::string_view{l1desc.chksum}.length() > 0) {
-            destination_replica.cond_input()[ORIG_CHKSUM_KW] = l1desc.chksum;
-        }
-
-        if (const int ec = _dataObjChksum(&_comm, destination_replica.get(), &checksum_string ); ec < 0) {
-            THROW(ec, "failed in _dataObjChksum");
-        }
-
-        if (std::string_view{l1desc.chksum}.length() > 0) {
-            destination_replica.cond_input().erase(ORIG_CHKSUM_KW);
-        }
-
-        if (!checksum_string) {
-            irods::log(LOG_NOTICE, fmt::format(
-                "[{}] - checksum returned empty for [{}]",
-                __FUNCTION__, destination_replica.logical_path()));
-            return {};
-        }
-
-        return {checksum_string};
+        return irods::register_new_checksum(_comm, *destination_replica.get(), l1desc.chksum);
     } // perform_checksum_operation_for_finalize
 
     auto finalize_destination_replica_for_replication(RsComm& _comm, const openedDataObjInp_t& _inp, const int _fd) -> int
@@ -373,7 +317,7 @@ namespace
                 __FUNCTION__, srcL1descInx));
         }
 
-        auto source_replica = replica_proxy{*L1desc[srcL1descInx].dataObjInfo};
+        const auto source_replica = replica_proxy{*L1desc[srcL1descInx].dataObjInfo};
         auto destination_replica = replica_proxy{*l1desc.dataObjInfo};
 
         auto [reg_param, lm] = irods::experimental::make_key_value_proxy({{OPEN_TYPE_KW, std::to_string(l1desc.openType)}});
@@ -429,42 +373,52 @@ namespace
         return status;
     } // finalize_destination_replica_for_replication
 
-    auto finalize_destination_data_object_for_put_or_copy(RsComm& _comm, const openedDataObjInp_t& _inp, const int _fd, const rodsLong_t _vault_size) -> int
+    auto finalize_data_object_for_put_or_copy(RsComm& _comm, const openedDataObjInp_t& _inp, const int _fd) -> int
     {
         auto& l1desc = L1desc[_fd];
-        auto destination_replica = replica_proxy{*l1desc.dataObjInfo};
-        const auto cond_input = irods::experimental::make_key_value_proxy(l1desc.dataObjInp->condInput);
-        if (l1desc.l3descInx < 2 &&
-            cond_input.contains(CROSS_ZONE_CREATE_KW) &&
-            INTERMEDIATE_REPLICA == l1desc.replStatus) {
-            /* the comes from a cross zone copy. have not been registered yet */
-            // TODO: is there a test for this? can this be removed?
-            const int status = svrRegDataObj(&_comm, destination_replica.get());
-            if (status < 0) {
-                l1desc.oprStatus = status;
-                irods::log(LOG_NOTICE, fmt::format(
-                        "{}: svrRegDataObj for {} failed, status = {}",
-                        __FUNCTION__, destination_replica.logical_path(), status));
+
+        if (cross_zone_copy_operation(l1desc)) {
+            if (const int ec = svrRegDataObj(&_comm, l1desc.dataObjInfo); ec < 0) {
+                l1desc.oprStatus = ec;
+                THROW(ec, fmt::format(
+                    "{}: svrRegDataObj for {} failed, status = {}",
+                    __FUNCTION__, l1desc.dataObjInfo->objPath, ec));
             }
         }
 
-        auto [reg_param, lm] = irods::experimental::make_key_value_proxy({{OPEN_TYPE_KW, std::to_string(l1desc.openType)}});
-        if (destination_replica.size() != _vault_size) {
-            /* update this in case we need to replicate it */
-            reg_param[DATA_SIZE_KW] = std::to_string(_vault_size);
-            destination_replica.size(_vault_size);
+        try {
+            applyMetadataFromKVP(_comm, *l1desc.dataObjInp);
+            applyACLFromKVP(_comm, *l1desc.dataObjInp);
+        }
+        catch (const irods::exception& e) {
+            if (l1desc.dataObjInp->oprType == PUT_OPR ) {
+                rsDataObjUnlink(&_comm, l1desc.dataObjInp);
+            }
+            throw;
         }
 
-        // TODO: Here is where we need to update the replica statuses
+        auto replica = replica_proxy{*l1desc.dataObjInfo};
+        auto [reg_param, lm] = irods::experimental::make_key_value_proxy({{OPEN_TYPE_KW, std::to_string(l1desc.openType)}});
+
+        //const auto vault_size = replica::get_replica_size_from_storage(_comm, replica.logical_path(), replica.replica_number());
+        reg_param[DATA_SIZE_KW] = std::to_string(replica.size());
+
         if (OPEN_FOR_WRITE_TYPE == l1desc.openType) {
+            replica.replica_status(GOOD_REPLICA);
+            //replica.mtime(SET_TIME_TO_NOW_KW);
+            replica.mtime(std::to_string((int)time(nullptr)));
+
             reg_param[ALL_REPL_STATUS_KW] = "";
             reg_param[DATA_MODIFY_KW] = std::to_string((int)time(nullptr));
         }
         else {
+            replica.replica_status(GOOD_REPLICA);
             reg_param[REPL_STATUS_KW] = std::to_string(GOOD_REPLICA);
         }
 
+        const auto cond_input = irods::experimental::make_key_value_proxy(l1desc.dataObjInp->condInput);
         if (cond_input.contains(CHKSUM_KW)) {
+            replica.checksum(cond_input.at(CHKSUM_KW).value());
             reg_param[CHKSUM_KW] = cond_input.at(CHKSUM_KW);
         }
 
@@ -481,36 +435,28 @@ namespace
                 __FUNCTION__, status));
         }
 
-        try {
-            applyMetadataFromKVP(_comm, *l1desc.dataObjInp);
-            applyACLFromKVP(_comm, *l1desc.dataObjInp);
-        }
-        catch (const irods::exception& e) {
-            if (l1desc.dataObjInp->oprType == PUT_OPR ) {
-                rsDataObjUnlink(&_comm, l1desc.dataObjInp);
-            }
-            throw;
-        }
-
-        if (GOOD_REPLICA == l1desc.replStatus) {
+        if (GOOD_REPLICA == replica.replica_status()) {
             /* update quota overrun */
-            updatequotaOverrun(destination_replica.hierarchy().data(), _vault_size, ALL_QUOTA);
+            updatequotaOverrun(replica.hierarchy().data(), replica.size(), ALL_QUOTA);
         }
 
         return status;
-    } // finalize_destination_data_object_for_put_or_copy
+    } // finalize_data_object_for_put_or_copy
 
     auto finalize_replica_after_failed_operation(RsComm& _comm, const int _fd) -> int
     {
         auto& l1desc = L1desc[_fd];
 
-        if(l1desc.oprType == REPLICATE_OPR ||
-           l1desc.oprType == REPLICATE_DEST ||
-           l1desc.oprType == REPLICATE_SRC ) {
-            return l1desc.oprStatus;
+        auto replica = replica_proxy{*l1desc.dataObjInfo};
+
+        const auto accmode = l1desc.dataObjInp->openFlags & O_ACCMODE;
+        if (O_RDONLY != accmode) {
+            replica.replica_status(STALE_REPLICA);
+            //replica.mtime(SET_TIME_TO_NOW_KW);
+            replica.mtime(std::to_string((int)time(nullptr)));
         }
 
-        const rodsLong_t vault_size = getSizeInVault(&_comm, l1desc.dataObjInfo);
+        const rodsLong_t vault_size = getSizeInVault(&_comm, replica.get());
         if (vault_size < 0) {
             irods::log(LOG_ERROR, fmt::format(
                 "{} - getSizeInVault failed [{}]",
@@ -518,7 +464,6 @@ namespace
             return vault_size;
         }
 
-        auto replica = replica_proxy{*l1desc.dataObjInfo};
         replica.size(vault_size);
 
         auto cond_input = irods::experimental::make_key_value_proxy(l1desc.dataObjInp->condInput);
@@ -536,20 +481,22 @@ namespace
         mod_inp.regParam = reg_param.get();
         if (const int ec = rsModDataObjMeta(&_comm, &mod_inp); ec < 0) {
             irods::log(LOG_NOTICE, fmt::format(
-                    "{}: rsModDataObjMeta failed, dataSize [{}] status = {}",
-                    __FUNCTION__, replica.size(), ec));
+                "{}: rsModDataObjMeta failed, dataSize [{}] status = {}",
+                __FUNCTION__, replica.size(), ec));
             return ec;
         }
 
-        /* an error has occurred */
+        // return error code - this is a failure mode
         return L1desc[_fd].oprStatus;
     } // finalize_replica_after_failed_operation
 
     auto finalize_replica_with_no_bytes_written(RsComm& _comm, const int _fd) -> void
     {
-        purge_cache(_comm, _fd);
-
         l1desc_t& l1desc = L1desc[_fd];
+
+        if (L1desc[_fd].purgeCacheFlag) {
+            irods::purge_cache(_comm, *l1desc.dataObjInfo);
+        }
 
         try {
             applyMetadataFromKVP(_comm, *l1desc.dataObjInp);
@@ -562,9 +509,19 @@ namespace
             throw;
         }
 
+        // TODO: will need to restore original status for open-for-read replicas...
+        if (const auto accmode = l1desc.dataObjInp->openFlags & O_ACCMODE; O_RDONLY == accmode) {
+            return;
+        }
+
         auto replica = replica_proxy{*l1desc.dataObjInfo};
 
         auto [reg_param, lm] = irods::experimental::make_key_value_proxy({{OPEN_TYPE_KW, std::to_string(l1desc.openType)}});
+
+        if (l1desc.openType == CREATE_TYPE) {
+            replica.replica_status(GOOD_REPLICA);
+            reg_param[REPL_STATUS_KW] = std::to_string(replica.replica_status());
+        }
 
         if (PUT_OPR == l1desc.oprType && l1desc.chksumFlag) {
             const std::string checksum = perform_checksum_operation_for_finalize(_comm, _fd);
@@ -589,81 +546,6 @@ namespace
             irods::log(LOG_ERROR, fmt::format("[{}] - rsModDataObjMeta failed with [{}]", __FUNCTION__, ec));
         }
     } // finalize_replica_with_no_bytes_written
-
-    bool bytes_written_in_operation(const l1desc_t& l1desc)
-    {
-        return l1desc.bytesWritten >= 0 ||
-               REPLICATE_DEST == l1desc.oprType ||
-               PHYMV_DEST == l1desc.oprType ||
-               COPY_DEST == l1desc.oprType;
-    } // bytes_written_in_operation
-
-    auto cross_zone_write_operation(const openedDataObjInp_t& inp, const l1desc_t& l1desc) -> bool
-    {
-        return inp.bytesWritten > 0 && l1desc.bytesWritten <= 0;
-    } // cross_zone_write_operation
-
-    auto get_size_in_vault(RsComm& _comm, const int _fd) -> rodsLong_t
-    {
-        auto& l1desc = L1desc[_fd];
-
-        try {
-            rodsLong_t size_in_vault = getSizeInVault(&_comm, l1desc.dataObjInfo);
-
-            irods::log(LOG_DEBUG, fmt::format(
-                "[{}:{}] - l1desc.bytesWritten:[{}],l1desc.dataSize:[{}],l1desc.dataObjInfo->dataSize:[{}],size_in_vault:[{}]",
-                __FUNCTION__, __LINE__, l1desc.bytesWritten, l1desc.dataSize, l1desc.dataObjInfo->dataSize, size_in_vault));
-
-            // since we are not filtering out writes to archive resources, the
-            // archive plugins report UNKNOWN_FILE_SZ as their size since they may
-            // not be able to stat the file.  filter that out and trust the plugin
-            // in this instance
-            if (UNKNOWN_FILE_SZ == size_in_vault && l1desc.dataSize >= 0) {
-                return l1desc.dataSize;
-            }
-
-            if (size_in_vault < 0 && UNKNOWN_FILE_SZ != size_in_vault) {
-                THROW((int)size_in_vault,
-                    fmt::format("{}: getSizeInVault error for {}, status = {}",
-                    __FUNCTION__, l1desc.dataObjInfo->objPath, size_in_vault));
-            }
-
-            // check for consistency of the write operation
-            if (size_in_vault != l1desc.dataSize && l1desc.dataSize > 0 &&
-                !getValByKey(&l1desc.dataObjInp->condInput, NO_CHK_COPY_LEN_KW)) {
-                THROW(SYS_COPY_LEN_ERR,
-                    fmt::format("{}: size in vault {} != target size {}",
-                    __FUNCTION__, size_in_vault, l1desc.dataSize));
-            }
-
-            return size_in_vault;
-        }
-        catch (const irods::exception& e) {
-            l1desc.dataObjInfo->replStatus = STALE_REPLICA;
-
-            keyValPair_t regParam{};
-            auto kvp = irods::experimental::make_key_value_proxy(regParam);
-
-            kvp[IN_PDMO_KW] = l1desc.dataObjInfo->rescHier;
-            kvp[REPL_STATUS_KW] = std::to_string(l1desc.dataObjInfo->replStatus);
-
-            if (getValByKey(&L1desc[_fd].dataObjInp->condInput, ADMIN_KW)) {
-                kvp[ADMIN_KW] = "";
-            }
-
-            modDataObjMeta_t inp{};
-            inp.dataObjInfo = l1desc.dataObjInfo;
-            inp.regParam = kvp.get();
-
-            if (const int ec = rsModDataObjMeta(&_comm, &inp); ec < 0) {
-                irods::log(LOG_ERROR, fmt::format(
-                    "{} - rsModDataObjMeta failed [{}]",
-                    __FUNCTION__, ec));
-            }
-
-            throw;
-        }
-    } // get_size_in_vault
 
     auto close_physical_file(RsComm& _comm, const int _fd) -> void
     {
@@ -698,21 +580,7 @@ namespace
             return perform_checksum_operation_for_finalize(_comm, _fd);
         }
         catch (const irods::exception& e) {
-            l1desc.dataObjInfo->replStatus = STALE_REPLICA;
-
-            keyValPair_t regParam{};
-            auto kvp = irods::experimental::make_key_value_proxy(regParam);
-            kvp[IN_PDMO_KW] = l1desc.dataObjInfo->rescHier;
-            kvp[REPL_STATUS_KW] = std::to_string(l1desc.dataObjInfo->replStatus);
-            if (getValByKey(&L1desc[_fd].dataObjInp->condInput, ADMIN_KW)) {
-                kvp[ADMIN_KW] = "";
-            }
-
-            modDataObjMeta_t inp{};
-            inp.dataObjInfo = l1desc.dataObjInfo;
-            inp.regParam = kvp.get();
-
-            if (const int ec = rsModDataObjMeta(&_comm, &inp); ec < 0) {
+            if (const int ec = irods::stale_replica(_comm, l1desc, *l1desc.dataObjInfo); ec < 0) {
                 irods::log(LOG_ERROR, fmt::format(
                     "{} - rsModDataObjMeta failed [{}]",
                     __FUNCTION__, ec));
@@ -724,65 +592,71 @@ namespace
 
     int finalize_replica(RsComm& _comm, const int _fd, openedDataObjInp_t& _inp)
     {
+        auto& l1desc = L1desc[_fd];
+
+        auto opened_replica = replica_proxy{*l1desc.dataObjInfo};
+
+        if (l1desc.oprStatus < 0) {
+            return finalize_replica_after_failed_operation(_comm, _fd);
+        }
+
+        if (cross_zone_write_operation(_inp, l1desc)) {
+            l1desc.bytesWritten = _inp.bytesWritten;
+        }
+
         try {
-            auto& l1desc = L1desc[_fd];
-
-            auto opened_replica = replica_proxy{*l1desc.dataObjInfo};
-
-            if (l1desc.oprStatus < 0) {
-                return finalize_replica_after_failed_operation(_comm, _fd);
-            }
-
-            if (cross_zone_write_operation(_inp, l1desc)) {
-                l1desc.bytesWritten = _inp.bytesWritten;
-            }
-
             if (!bytes_written_in_operation(l1desc)) {
                 finalize_replica_with_no_bytes_written(_comm, _fd);
                 return 0;
             }
 
-            const auto size_in_vault = get_size_in_vault(_comm, _fd);
-
-            const auto checksum = update_checksum_if_needed(_comm, _fd);
-            irods::experimental::key_value_proxy{l1desc.dataObjInp->condInput}[CHKSUM_KW] = checksum;
-
-            int status{};
-            if (REPLICATE_DEST == l1desc.oprType || PHYMV_DEST == l1desc.oprType) {
-                status = finalize_destination_replica_for_replication(_comm, _inp, _fd);
-            }
-            else if (!opened_replica.special_collection_info()) {
-                status = finalize_destination_data_object_for_put_or_copy(_comm, _inp, _fd, size_in_vault);
-            }
-
-            l1desc.bytesWritten = size_in_vault;
+            const bool verify_size = !getValByKey(&l1desc.dataObjInp->condInput, NO_CHK_COPY_LEN_KW);
+            const auto size_in_vault = irods::get_size_in_vault(_comm, *l1desc.dataObjInfo, verify_size, l1desc.dataSize);
             opened_replica.size(size_in_vault);
-
-            purge_cache(_comm, _fd);
-
-            return status;
         }
         catch (const irods::exception& e) {
-            irods::log(e);
-            return e.code();
+            if (const int ec = irods::stale_replica(_comm, l1desc, *l1desc.dataObjInfo); ec < 0) {
+                irods::log(LOG_ERROR, fmt::format(
+                    "{} - rsModDataObjMeta failed [{}]",
+                    __FUNCTION__, ec));
+            }
+
+            throw;
         }
+
+        const auto checksum = update_checksum_if_needed(_comm, _fd);
+        irods::experimental::key_value_proxy{l1desc.dataObjInp->condInput}[CHKSUM_KW] = checksum;
+
+        int status{};
+        if (REPLICATE_DEST == l1desc.oprType || PHYMV_DEST == l1desc.oprType) {
+            status = finalize_destination_replica_for_replication(_comm, _inp, _fd);
+        }
+        else if (!opened_replica.special_collection_info()) {
+            status = finalize_data_object_for_put_or_copy(_comm, _inp, _fd);
+        }
+
+        l1desc.bytesWritten = l1desc.dataObjInfo->dataSize;
+        opened_replica.size(l1desc.dataObjInfo->dataSize); // no-op?
+
+        if (L1desc[_fd].purgeCacheFlag) {
+            irods::purge_cache(_comm, *l1desc.dataObjInfo);
+        }
+
+        return status;
     } // finalize_replica
 
-void unlock_file_descriptor(
-    rsComm_t* comm,
-    const int l1descInx)
-{
-    char fd_string[NAME_LEN]{};
-    snprintf(fd_string, sizeof( fd_string ), "%-d", L1desc[l1descInx].lockFd);
-    addKeyVal(&L1desc[l1descInx].dataObjInp->condInput, LOCK_FD_KW, fd_string);
-    irods::server_api_call(
-        DATA_OBJ_UNLOCK_AN,
-        comm,
-        L1desc[l1descInx].dataObjInp,
-        nullptr, (void**)nullptr, nullptr);
-    L1desc[l1descInx].lockFd = -1;
-} // unlock_file_descriptor
-
+    void unlock_file_descriptor(rsComm_t* comm, const int l1descInx)
+    {
+        char fd_string[NAME_LEN]{};
+        snprintf(fd_string, sizeof( fd_string ), "%-d", L1desc[l1descInx].lockFd);
+        addKeyVal(&L1desc[l1descInx].dataObjInp->condInput, LOCK_FD_KW, fd_string);
+        irods::server_api_call(
+            DATA_OBJ_UNLOCK_AN,
+            comm,
+            L1desc[l1descInx].dataObjInp,
+            nullptr, (void**)nullptr, nullptr);
+        L1desc[l1descInx].lockFd = -1;
+    } // unlock_file_descriptor
 } // anonymous namespace
 
 auto l3Close(RsComm* _comm, const int _fd) -> int
@@ -813,14 +687,34 @@ auto l3Close(RsComm* _comm, const int _fd) -> int
 
 int rsDataObjClose(rsComm_t* rsComm, openedDataObjInp_t* dataObjCloseInp)
 {
+    if (!rsComm) {
+        irods::log(LOG_ERROR, fmt::format("{}: rsComm is null", __FUNCTION__));
+        return USER__NULL_INPUT_ERR;
+    }
+
+    if (!dataObjCloseInp) {
+        irods::log(LOG_ERROR, fmt::format("{}: dataObjCloseInp is null", __FUNCTION__));
+        return USER__NULL_INPUT_ERR;
+    }
+
     const auto fd = dataObjCloseInp->l1descInx;
     if (fd < 3 || fd >= NUM_L1_DESC) {
-        rodsLog(LOG_NOTICE,
-            "rsDataObjClose: l1descInx %d out of range", fd);
+        irods::log(LOG_NOTICE, fmt::format("{}: l1descInx {} out of range", __FUNCTION__, fd));
         return SYS_FILE_DESC_OUT_OF_RANGE;
     }
 
     const auto& l1desc = L1desc[fd];
+
+    if(!l1desc.dataObjInp) {
+        irods::log(LOG_ERROR, fmt::format("{}: dataObjInp for index {} is null", __FUNCTION__, fd));
+        return SYS_INVALID_INPUT_PARAM;
+    }
+
+    if (!l1desc.dataObjInfo) {
+        irods::log(LOG_ERROR, fmt::format("[{}] - dataObjInfo for index {} is null", __FUNCTION__, fd));
+        return SYS_INTERNAL_NULL_INPUT_ERR;
+    }
+
     std::unique_ptr<irods::at_scope_exit<std::function<void()>>> restore_entry;
 
     int ec = 0;
@@ -877,20 +771,27 @@ int rsDataObjClose(rsComm_t* rsComm, openedDataObjInp_t* dataObjCloseInp)
     }
 
     try {
+        irods::at_scope_exit clean_up{[&fd, &rsComm]
+        {
+            auto& l1desc = L1desc[fd];
+
+            if (l1desc.lockFd > 0) {
+                unlock_file_descriptor(rsComm, fd);
+            }
+
+            freeL1desc(fd);
+        }};
+
         close_physical_file(*rsComm, fd);
 
         ec = finalize_replica(*rsComm, fd, *dataObjCloseInp);
-
-        if (l1desc.lockFd > 0) {
-            unlock_file_descriptor(rsComm, fd);
-        }
-
         if (ec < 0 || l1desc.oprStatus < 0) {
-            freeL1desc(fd);
             return ec;
         }
 
         apply_static_peps(*rsComm, *dataObjCloseInp, fd, ec);
+
+        return ec;
     }
     catch (const irods::exception& e) {
         irods::log(e);
@@ -898,14 +799,11 @@ int rsDataObjClose(rsComm_t* rsComm, openedDataObjInp_t* dataObjCloseInp)
     }
     catch (const std::exception& e) {
         irods::log(LOG_ERROR, e.what());
-        return ec = SYS_INTERNAL_ERR;
+        return ec = SYS_LIBRARY_ERROR;
     }
     catch (...) {
         irods::log(LOG_ERROR, fmt::format("an unknown error occurred in [{}]", __FUNCTION__));
         return ec = SYS_UNKNOWN_ERROR;
     }
-
-    freeL1desc(fd);
-    return ec;
 } // rsDataObjClose
 

--- a/server/api/src/rsDataObjOpen.cpp
+++ b/server/api/src/rsDataObjOpen.cpp
@@ -66,6 +66,7 @@
 #include "irods_at_scope_exit.hpp"
 #include "key_value_proxy.hpp"
 #include "replica_access_table.hpp"
+#include "replica_state_table.hpp"
 #include "scoped_privileged_client.hpp"
 
 #include "boost/format.hpp"
@@ -852,7 +853,7 @@ namespace
                     __FUNCTION__, dataObjInp->objPath));
             }
 
-            auto [obj, lm] = data_object::duplicate_data_object(*info_head);
+            irods::replica_state_table::instance().insert(*info_head);
 
             // sort replica list based on some set of criteria
             const auto open_for_write = getWriteFlag(dataObjInp->openFlags);

--- a/server/api/src/rsDataObjPut.cpp
+++ b/server/api/src/rsDataObjPut.cpp
@@ -1,35 +1,41 @@
 #include "dataObjPut.h"
-#include "rodsLog.h"
+#include "dataObjRepl.h"
+#include "dataObjUnlink.h"
 #include "dataPut.h"
 #include "filePut.h"
-#include "objMetaOpr.hpp"
-#include "physPath.hpp"
-#include "specColl.hpp"
-#include "dataObjOpen.h"
-#include "dataObjCreate.h"
-#include "dataObjClose.h"
-#include "regDataObj.h"
-#include "dataObjUnlink.h"
-#include "rsGlobalExtern.hpp"
-#include "rcGlobalExtern.h"
-#include "rsApiHandler.hpp"
-#include "subStructFilePut.h"
-#include "dataObjRepl.h"
 #include "getRemoteZoneResc.h"
 #include "icatHighLevelRoutines.hpp"
 #include "modDataObjMeta.h"
+#include "objMetaOpr.hpp"
+#include "physPath.hpp"
+#include "rcGlobalExtern.h"
+#include "regDataObj.h"
+#include "rodsLog.h"
+#include "rsApiHandler.hpp"
+#include "rsDataObjClose.hpp"
+#include "rsDataObjCreate.hpp"
+#include "rsDataObjOpen.hpp"
 #include "rsDataObjPut.hpp"
 #include "rsDataObjRepl.hpp"
-#include "rsDataObjCreate.hpp"
-#include "rsDataObjClose.hpp"
-#include "rsDataPut.hpp"
-#include "rsRegDataObj.hpp"
 #include "rsDataObjUnlink.hpp"
-#include "rsSubStructFilePut.hpp"
-#include "rsFilePut.hpp"
-#include "rsUnregDataObj.hpp"
-#include "rsDataObjOpen.hpp"
 #include "rsDataObjWrite.hpp"
+#include "rsDataPut.hpp"
+#include "rsFilePut.hpp"
+#include "rsGlobalExtern.hpp"
+#include "rsRegDataObj.hpp"
+#include "rsSubStructFilePut.hpp"
+#include "rsUnregDataObj.hpp"
+#include "specColl.hpp"
+#include "subStructFilePut.h"
+
+#include "finalize_utilities.hpp"
+#include "getRescQuota.h"
+#include "modAVUMetadata.h"
+#include "modAccessControl.h"
+#include "rsGetRescQuota.hpp"
+#include "rsModAVUMetadata.hpp"
+#include "rsModAccessControl.hpp"
+#include "rs_replica_close.hpp"
 
 #include "irods_at_scope_exit.hpp"
 #include "irods_exception.hpp"
@@ -39,335 +45,580 @@
 #include "irods_resource_redirect.hpp"
 #include "irods_serialization.hpp"
 #include "irods_server_properties.hpp"
-#include "irods_logger.hpp"
-#include "server_utilities.hpp"
 #include "scoped_privileged_client.hpp"
+#include "server_utilities.hpp"
 
 #define IRODS_FILESYSTEM_ENABLE_SERVER_SIDE_API
 #include "filesystem.hpp"
 
+#define IRODS_REPLICA_ENABLE_SERVER_SIDE_API
+#include "data_object_proxy.hpp"
+#include "replica_proxy.hpp"
+
 #include <chrono>
 
-namespace ix = irods::experimental;
-
-namespace {
-
-int parallel_transfer_put(
-    rsComm_t *rsComm,
-    dataObjInp_t *dataObjInp,
-    portalOprOut_t **portalOprOut)
+namespace
 {
-
-    // Parallel transfer
-    dataObjInp->openFlags |= O_CREAT | O_RDWR;
-    int l1descInx = rsDataObjOpen(rsComm, dataObjInp);
-    if ( l1descInx < 0 ) {
-        return l1descInx;
-    }
-
-    L1desc[l1descInx].oprType = PUT_OPR;
-    L1desc[l1descInx].dataSize = dataObjInp->dataSize;
-
-    if ( getStructFileType( L1desc[l1descInx].dataObjInfo->specColl ) >= 0 ) { // JMC - backport 4682
-        *portalOprOut = ( portalOprOut_t * ) malloc( sizeof( portalOprOut_t ) );
-        bzero( *portalOprOut,  sizeof( portalOprOut_t ) );
-        ( *portalOprOut )->l1descInx = l1descInx;
-        return l1descInx;
-    }
-
-    int status = preProcParaPut( rsComm, l1descInx, portalOprOut );
-
-    if ( status < 0 ) {
-        openedDataObjInp_t dataObjCloseInp{};
-        dataObjCloseInp.l1descInx = l1descInx;
-        L1desc[l1descInx].oprStatus = status;
-        rsDataObjClose( rsComm, &dataObjCloseInp );
-        return status;
-    }
-
-    int allFlag = 0;
-    if ( getValByKey( &dataObjInp->condInput, ALL_KW ) != NULL ) {
-        allFlag = 1;
-    }
-
-    dataObjInp_t replDataObjInp{};
-    if ( allFlag == 1 ) {
-        /* need to save dataObjInp. get freed in sendAndRecvBranchMsg */
-        rstrcpy( replDataObjInp.objPath, dataObjInp->objPath, MAX_NAME_LEN );
-        addKeyVal( &replDataObjInp.condInput, UPDATE_REPL_KW, "" );
-        addKeyVal( &replDataObjInp.condInput, ALL_KW, "" );
-    }
-    /* return portalOprOut to the client and wait for the rcOprComplete
-     * call. That is when the parallel I/O is done */
-    int retval = sendAndRecvBranchMsg( rsComm, rsComm->apiInx, status,
-            ( void * ) * portalOprOut, NULL );
-
-    if ( retval < 0 ) {
-        openedDataObjInp_t dataObjCloseInp{};
-        dataObjCloseInp.l1descInx = l1descInx;
-        L1desc[l1descInx].oprStatus = retval;
-        rsDataObjClose( rsComm, &dataObjCloseInp );
-        if ( allFlag == 1 ) {
-            clearKeyVal( &replDataObjInp.condInput );
+    auto apply_static_peps(RsComm& _comm, l1desc& _l1desc, const int _operation_status) -> void
+    {
+        if (_l1desc.openType == CREATE_TYPE) {
+            irods::apply_static_post_pep(_comm, _l1desc, _operation_status, "acPostProcForCreate");
         }
-    }
-    else if (1 == allFlag) {
-        transferStat_t *transStat = NULL;
-        status = rsDataObjRepl(rsComm, &replDataObjInp, &transStat);
-        free(transStat);
-        clearKeyVal(&replDataObjInp.condInput);
+        else if (_l1desc.openType == OPEN_FOR_WRITE_TYPE) {
+            irods::apply_static_post_pep(_comm, _l1desc, _operation_status, "acPostProcForOpen");
+        }
+
+        irods::apply_static_post_pep(_comm, _l1desc, _operation_status, "acPostProcForPut");
+    } // apply_static_peps
+
+    auto calculate_checksum(RsComm& _comm, l1desc& _l1desc, DataObjInfo& _info) -> std::string
+    {
+        if (!std::string_view{_info.chksum}.empty()) {
+            _l1desc.chksumFlag = REG_CHKSUM;
+        }
+
+        char* checksum_string = nullptr;
+        irods::at_scope_exit free_checksum_string{[&checksum_string] { free(checksum_string); }};
+
+        auto destination_replica = irods::experimental::replica::make_replica_proxy(_info);
+
+        if (!_l1desc.chksumFlag) {
+            if (destination_replica.checksum().empty()) {
+                return {};
+            }
+            _l1desc.chksumFlag = VERIFY_CHKSUM;
+        }
+
+        if (VERIFY_CHKSUM == _l1desc.chksumFlag) {
+            if (!std::string_view{_l1desc.chksum}.empty()) {
+                return irods::verify_checksum(_comm, _info, _l1desc.chksum);
+            }
+
+            return {};
+        }
+
+        return irods::register_new_checksum(_comm, _info, _l1desc.chksum);
+    } // calculate_checksum
+
+    auto finalize_on_failure(RsComm& _comm, DataObjInfo& _info, l1desc& _l1desc) -> int
+    {
+        auto replica = irods::experimental::replica::make_replica_proxy(_info);
+
+        replica.replica_status(STALE_REPLICA);
+        replica.mtime(std::to_string((int)time(nullptr)));
+
+        const rodsLong_t vault_size = getSizeInVault(&_comm, replica.get());
+        if (vault_size < 0) {
+            irods::log(LOG_ERROR, fmt::format(
+                "{} - getSizeInVault failed [{}]",
+                __FUNCTION__, vault_size));
+            return vault_size;
+        }
+
+        replica.size(vault_size);
+
+        auto cond_input = irods::experimental::make_key_value_proxy(_l1desc.dataObjInp->condInput);
+        auto [reg_param, lm] = irods::experimental::make_key_value_proxy();
+        reg_param[DATA_SIZE_KW] = std::to_string(replica.size());
+        reg_param[IN_PDMO_KW] = replica.hierarchy();
+        reg_param[REPL_STATUS_KW] = std::to_string(STALE_REPLICA);
+        reg_param[STALE_ALL_INTERMEDIATE_REPLICAS_KW] = "";
+        if (cond_input.contains(ADMIN_KW)) {
+            reg_param[ADMIN_KW] = "";
+        }
+
+        modDataObjMeta_t mod_inp{};
+        mod_inp.dataObjInfo = replica.get();
+        mod_inp.regParam = reg_param.get();
+        if (const int ec = rsModDataObjMeta(&_comm, &mod_inp); ec < 0) {
+            irods::log(LOG_NOTICE, fmt::format(
+                "{}: rsModDataObjMeta failed, dataSize [{}] status = {}",
+                __FUNCTION__, replica.size(), ec));
+            return ec;
+        }
+
+        return 0;
+    } // finalize_on_failure
+
+    auto finalize_replica(RsComm& _comm, DataObjInfo& _info, l1desc& _l1desc) -> int
+    {
+        auto replica = irods::experimental::replica::make_replica_proxy(_info);
+
+        auto cond_input = irods::experimental::make_key_value_proxy(_l1desc.dataObjInp->condInput);
+        try {
+            const bool verify_size = !cond_input.contains(NO_CHK_COPY_LEN_KW);
+            const auto size_in_vault = irods::get_size_in_vault(_comm, _info, verify_size, _l1desc.dataSize);
+            replica.size(size_in_vault);
+
+            if (verify_size || !replica.checksum().empty()) {
+                const auto checksum = calculate_checksum(_comm, _l1desc, _info);
+                if (!checksum.empty()) {
+                    cond_input[CHKSUM_KW] = checksum;
+                }
+            }
+        }
+        catch (const irods::exception& e) {
+            if (const int ec = irods::stale_replica(_comm, _l1desc, _info); ec < 0) {
+                irods::log(LOG_ERROR, fmt::format(
+                    "{} - rsModDataObjMeta failed [{}]",
+                    __FUNCTION__, ec));
+            }
+            throw;
+        }
+
+        try {
+            irods::apply_metadata_from_cond_input(_comm, *_l1desc.dataObjInp);
+            irods::apply_acl_from_cond_input(_comm, *_l1desc.dataObjInp);
+        }
+        catch (const irods::exception& e) {
+            rsDataObjUnlink(&_comm, _l1desc.dataObjInp);
+            throw;
+        }
+
+        auto [reg_param, lm] = irods::experimental::make_key_value_proxy({{OPEN_TYPE_KW, std::to_string(_l1desc.openType)}});
+
+        //const auto vault_size = replica::get_replica_size_from_storage(_comm, replica.logical_path(), replica.replica_number());
+        reg_param[DATA_SIZE_KW] = std::to_string(replica.size());
+
+        if (OPEN_FOR_WRITE_TYPE == _l1desc.openType) {
+            replica.replica_status(GOOD_REPLICA);
+            //replica.mtime(SET_TIME_TO_NOW_KW);
+            replica.mtime(std::to_string((int)time(nullptr)));
+
+            reg_param[ALL_REPL_STATUS_KW] = "";
+            reg_param[DATA_MODIFY_KW] = std::to_string((int)time(nullptr));
+        }
+        else {
+            replica.replica_status(GOOD_REPLICA);
+            reg_param[REPL_STATUS_KW] = std::to_string(GOOD_REPLICA);
+        }
+
+        if (cond_input.contains(CHKSUM_KW)) {
+            replica.checksum(cond_input.at(CHKSUM_KW).value());
+            reg_param[CHKSUM_KW] = cond_input.at(CHKSUM_KW);
+        }
+
+        reg_param[SELECTED_HIERARCHY_KW] = cond_input.at(SELECTED_HIERARCHY_KW);
+
+        modDataObjMeta_t mod_inp{};
+        mod_inp.dataObjInfo = &_info;
+        mod_inp.regParam = reg_param.get();
+        const int status = rsModDataObjMeta(&_comm, &mod_inp);
         if (status < 0) {
-            const auto err{ERROR(status, "rsDataObjRepl failed")};
-            irods::log(err);
-            return err.code();
+            THROW(status,
+                fmt::format("{}: rsModDataObjMeta failed with {}",
+                __FUNCTION__, status));
         }
-    }
 
-    /* already send the client the status */
-    return SYS_NO_HANDLER_REPLY_MSG;
-} // parallel_transfer_put
-
-int single_buffer_put(
-    rsComm_t* rsComm,
-    dataObjInp_t* dataObjInp,
-    bytesBuf_t* dataObjInpBBuf)
-{
-
-    dataObjInp->openFlags |= (O_CREAT | O_RDWR | O_TRUNC);
-    int l1descInx = rsDataObjOpen(rsComm, dataObjInp);
-    if (l1descInx <= 2) {
-        if ( l1descInx >= 0 ) {
-            rodsLog( LOG_ERROR,
-                    "%s: rsDataObjOpen of %s error, status = %d",
-                    __FUNCTION__,
-                    dataObjInp->objPath,
-                    l1descInx );
-            return SYS_FILE_DESC_OUT_OF_RANGE;
+        if (GOOD_REPLICA == replica.replica_status()) {
+            /* update quota overrun */
+            updatequotaOverrun(replica.hierarchy().data(), replica.size(), ALL_QUOTA);
         }
-        return l1descInx;
-    }
 
-    dataObjInfo_t *myDataObjInfo = L1desc[l1descInx].dataObjInfo;
-    openedDataObjInp_t dataObjWriteInp{};
-    dataObjWriteInp.len = dataObjInpBBuf->len;
-    dataObjWriteInp.l1descInx = l1descInx;
-
-    bytesBuf_t dataObjWriteInpBBuf{};
-    dataObjWriteInpBBuf.buf = dataObjInpBBuf->buf;
-    dataObjWriteInpBBuf.len = dataObjInpBBuf->len;
-    int bytesWritten = rsDataObjWrite(rsComm, &dataObjWriteInp, &dataObjWriteInpBBuf);
-    if ( bytesWritten < 0 ) {
-        rodsLog(LOG_NOTICE,
-                "%s: rsDataObjWrite for %s failed with %d",
-                __FUNCTION__, L1desc[l1descInx].dataObjInfo->filePath, bytesWritten );
-        dataObjInfo_t* data_obj_info = L1desc[l1descInx].dataObjInfo;
-        const int unlink_status = dataObjUnlinkS(rsComm, L1desc[l1descInx].dataObjInp, data_obj_info);
-        if (unlink_status < 0) {
-            irods::log(ERROR(unlink_status,
-                (boost::format("dataObjUnlinkS failed for [%s] with [%d]") %
-                data_obj_info->filePath % unlink_status).str()));
-        }
-    }
-
-    if ( bytesWritten == 0 && myDataObjInfo->dataSize > 0 ) {
-        /* overwrite with 0 len file */
-        L1desc[l1descInx].bytesWritten = 1;
-    }
-    else {
-        L1desc[l1descInx].bytesWritten = bytesWritten;
-    }
-
-    L1desc[l1descInx].dataSize = dataObjInp->dataSize;
-
-    openedDataObjInp_t dataObjCloseInp{};
-    dataObjCloseInp.l1descInx = l1descInx;
-    L1desc[l1descInx].oprStatus = bytesWritten;
-    L1desc[l1descInx].oprType = PUT_OPR;
-    int status = rsDataObjClose(rsComm, &dataObjCloseInp);
-    if ( status < 0 ) {
-        rodsLog( LOG_DEBUG,
-                "%s: rsDataObjClose of %d error, status = %d",
-                __FUNCTION__, l1descInx, status );
-    }
-
-    if ( bytesWritten < 0 ) {
-        return bytesWritten;
-    }
-
-    if (status < 0) {
         return status;
-    }
+    } // finalize_replica
 
-    if (getValByKey(&dataObjInp->condInput, ALL_KW)) {
-        /* update the rest of copies */
-        transferStat_t *transStat{};
-        status = rsDataObjRepl( rsComm, dataObjInp, &transStat );
-        if (transStat) {
-            free(transStat);
+    int single_buffer_put(RsComm& _comm, DataObjInp& _inp, BytesBuf& _bbuf)
+    {
+        _inp.openFlags = O_CREAT | O_RDWR | O_TRUNC;
+        const int fd = rsDataObjOpen(&_comm, &_inp);
+        if (fd < 3) {
+            if (fd >= 0) {
+                irods::log(LOG_ERROR, fmt::format(
+                    "{}: rsDataObjOpen of {} error, status = {}",
+                    __FUNCTION__, _inp.objPath, fd));
+                return SYS_FILE_DESC_OUT_OF_RANGE;
+            }
+            irods::log(LOG_ERROR, fmt::format(
+                "[{}] - failed to open data object [{}]; ec:[{}]",
+                __FUNCTION__, _inp.objPath, fd));
+            return fd;
         }
-    }
-    if (status >= 0) {
-        status = applyRuleForPostProcForWrite(
-                rsComm, dataObjInpBBuf, dataObjInp->objPath);
+
+        auto& l1desc = L1desc[fd];
+        auto opened_replica = irods::experimental::replica::make_replica_proxy(*l1desc.dataObjInfo);
+        const std::string hier = opened_replica.hierarchy().data();
+
+        const auto [begin_object, begin_object_lm] = irods::experimental::data_object::duplicate_data_object(*l1desc.dataObjInfo);
+
+        OpenedDataObjInp write_inp{};
+        write_inp.len = _bbuf.len;
+        write_inp.l1descInx = fd;
+
+        BytesBuf write_bbuf{};
+        write_bbuf.buf = _bbuf.buf;
+        write_bbuf.len = _bbuf.len;
+
+        const int bytes_written = rsDataObjWrite(&_comm, &write_inp, &write_bbuf);
+        if (bytes_written < 0) {
+            irods::log(LOG_NOTICE, fmt::format(
+                "{}: rsDataObjWrite for {} failed with {}",
+                __FUNCTION__, opened_replica.physical_path(), bytes_written));
+            if (const int ec = dataObjUnlinkS(&_comm, l1desc.dataObjInp, opened_replica.get()); ec < 0) {
+                irods::log(LOG_ERROR, fmt::format(
+                    "dataObjUnlinkS failed for [{}] with [{}]",
+                    opened_replica.physical_path(), ec));
+            }
+        }
+
+        if ( bytes_written == 0 && opened_replica.size() > 0 ) {
+            /* overwrite with 0 len file */
+            l1desc.bytesWritten = 1;
+        }
+        else {
+            l1desc.bytesWritten = bytes_written;
+        }
+
+        l1desc.dataSize = _inp.dataSize;
+
+        int status = 0;
+        if (getStructFileType(l1desc.dataObjInfo->specColl) >= 0) {
+            // special collections are not handled by replica_close
+			OpenedDataObjInp close_inp{};
+			close_inp.l1descInx = fd;
+			l1desc.oprStatus = bytes_written;
+			l1desc.oprType = PUT_OPR;
+			const int status = rsDataObjClose(&_comm, &close_inp);
+			if (status < 0) {
+                irods::log(LOG_DEBUG, fmt::format(
+						"[{}:{}]: rsDataObjClose of [{}] error, status = [{}]",
+						__FUNCTION__, __LINE__, fd, status));
+			}
+
+			if ( bytes_written < 0 ) {
+				return bytes_written;
+			}
+
+			if (status < 0) {
+				return status;
+			}
+        }
+        else {
+            auto [final_object, final_object_lm] = irods::experimental::data_object::duplicate_data_object(*l1desc.dataObjInfo);
+
+            struct l1desc l1desc_cache = irods::duplicate_l1_descriptor(l1desc);
+            const irods::at_scope_exit free_fd{[&l1desc_cache] { freeL1desc_struct(l1desc_cache); }};
+
+            // close the replica, free L1 descriptor
+            nlohmann::json in_json;
+            in_json["fd"] = fd;
+            in_json["send_notifications"] = false;
+            in_json["update_size"] = false;
+            in_json["update_status"] = false;
+            const auto input = in_json.dump();
+
+            if (const int ec = rs_replica_close(&_comm, input.data()); ec < 0) {
+                irods::log(LOG_ERROR, fmt::format(
+                    "[{}:{}] - error closing replica; ec:[{}]",
+                    __FUNCTION__, __LINE__, ec));
+
+                return ec;
+            }
+
+            if (bytes_written < 0) {
+                // finalize object for failure case
+                if (const auto ec = finalize_on_failure(_comm, *final_object.get(), l1desc_cache); ec < 0) {
+                    irods::log(LOG_ERROR, fmt::format(
+                        "[{}] - failed while finalizing object [{}]; ec:[{}]",
+                        __FUNCTION__, _inp.objPath, ec));
+                }
+                // TODO: continue to finalize
+                return bytes_written;
+            }
+            else {
+                // finalize object for successful transfer
+                try {
+                    irods::log(LOG_DEBUG8, fmt::format("[{}:{}] - finalizing replica", __FUNCTION__, __LINE__));
+
+                    // TODO: temporary...
+                    if (!irods::experimental::data_object::find_replica(final_object, hier)->special_collection_info()) {
+                        if (const auto ec = finalize_replica(_comm, *final_object.get(), l1desc_cache); ec < 0) {
+                            irods::log(LOG_ERROR, fmt::format(
+                                "[{}] - error finalizing replica; ec:[{}]",
+                                __FUNCTION__, ec));
+
+                            status = ec;
+                        }
+                    }
+                }
+                catch (const irods::exception& e) {
+                    irods::log(LOG_ERROR, fmt::format(
+                        "[{}] - error finalizing replica; ec:[{}]",
+                        __FUNCTION__, e.code()));
+
+                    status = e.code();
+                }
+            }
+
+            // TODO: call finalize
+
+            if (l1desc_cache.purgeCacheFlag) {
+                irods::purge_cache(_comm, *final_object.get());
+            }
+
+            if (status < 0) {
+                return status;
+            }
+            else {
+                apply_static_peps(_comm, l1desc_cache, status);
+            }
+        }
+
+        if (getValByKey(&_inp.condInput, ALL_KW)) {
+            /* update the rest of copies */
+            transferStat_t *transStat{};
+            status = rsDataObjRepl(&_comm, &_inp, &transStat);
+            if (transStat) {
+                free(transStat);
+            }
+        }
+
         if (status >= 0) {
-            status = 0;
-        }
-    }
-    return status;
-} // single_buffer_put
-
-void throw_if_force_put_to_new_resource(
-    rsComm_t* comm,
-    dataObjInp_t& data_obj_inp,
-    irods::file_object_ptr file_obj)
-{
-    char* dst_resc_kw   = getValByKey( &data_obj_inp.condInput, DEST_RESC_NAME_KW );
-    char* force_flag_kw = getValByKey( &data_obj_inp.condInput, FORCE_FLAG_KW );
-    if (file_obj->replicas().empty()  ||
-        !dst_resc_kw   ||
-        !force_flag_kw ||
-        strlen( dst_resc_kw ) == 0) {
-        return;
-    }
-
-    const auto hier_match{
-        [&dst_resc_kw, &replicas = file_obj->replicas()]()
-        {
-            return std::any_of(replicas.cbegin(), replicas.cend(),
-            [&dst_resc_kw](const auto& r) {
-                return irods::hierarchy_parser{r.resc_hier()}.first_resc() == dst_resc_kw;
-            });
-        }()
-    };
-    if (!hier_match) {
-        THROW(HIERARCHY_ERROR, fmt::format(
-            "cannot force put [{}] to a different resource [{}]",
-            data_obj_inp.objPath, dst_resc_kw));
-    }
-} // throw_if_force_put_to_new_resource
-
-int rsDataObjPut_impl(
-    rsComm_t *rsComm,
-    dataObjInp_t *dataObjInp,
-    bytesBuf_t *dataObjInpBBuf,
-    portalOprOut_t **portalOprOut)
-{
-    try {
-        if (irods::is_force_flag_required(*rsComm, *dataObjInp)) {
-            return OVERWRITE_WITHOUT_FORCE_FLAG;
-        }
-    }
-    catch (const irods::experimental::filesystem::filesystem_error& e) {
-        irods::experimental::log::api::error(e.what());
-        return e.code().value();
-    }
-
-    rodsServerHost_t *rodsServerHost{};
-    specCollCache_t *specCollCache{};
-
-    resolveLinkedPath( rsComm, dataObjInp->objPath, &specCollCache,
-                       &dataObjInp->condInput );
-    int remoteFlag = getAndConnRemoteZone( rsComm, dataObjInp, &rodsServerHost,
-                                       REMOTE_CREATE );
-
-    if (const char* acl_string = getValByKey( &dataObjInp->condInput, ACL_INCLUDED_KW)) {
-        try {
-            irods::deserialize_acl(acl_string);
-        }
-        catch (const irods::exception& e) {
-            rodsLog(LOG_ERROR, "%s", e.what());
-            return e.code();
-        }
-    }
-    if (const char* metadata_string = getValByKey(&dataObjInp->condInput, METADATA_INCLUDED_KW)) {
-        try {
-            irods::deserialize_metadata( metadata_string );
-        }
-        catch (const irods::exception& e) {
-            rodsLog(LOG_ERROR, "%s", e.what());
-            return e.code();
-        }
-    }
-
-    if (remoteFlag < 0) {
-        return remoteFlag;
-    }
-    else if (LOCAL_HOST != remoteFlag) {
-        int status = _rcDataObjPut( rodsServerHost->conn, dataObjInp, dataObjInpBBuf, portalOprOut );
-        if (status < 0 ||
-            getValByKey(&dataObjInp->condInput, DATA_INCLUDED_KW)) {
-            return status;
+            status = applyRuleForPostProcForWrite(&_comm, &_bbuf, _inp.objPath);
+            if (status >= 0) {
+                status = 0;
+            }
         }
 
-        /* have to allocate a local l1descInx to keep track of things
-         * since the file is in remote zone. It sets remoteL1descInx,
-         * oprType = REMOTE_ZONE_OPR and remoteZoneHost so that
-         * rsComplete knows what to do */
-        int l1descInx = allocAndSetL1descForZoneOpr(
-                        ( *portalOprOut )->l1descInx, dataObjInp, rodsServerHost, NULL );
+        return status;
+    } // single_buffer_put
+
+    int parallel_transfer_put(RsComm *rsComm, DataObjInp *dataObjInp, portalOprOut **portalOprOut)
+    {
+        // Parallel transfer
+        dataObjInp->openFlags |= O_CREAT | O_RDWR;
+        int l1descInx = rsDataObjOpen(rsComm, dataObjInp);
         if ( l1descInx < 0 ) {
             return l1descInx;
         }
-        ( *portalOprOut )->l1descInx = l1descInx;
-        return status;
-    }
 
-    try {
-        dataObjInfo_t* dataObjInfoHead{};
-        irods::file_object_ptr file_obj(new irods::file_object());
-        file_obj->logical_path(dataObjInp->objPath);
-        irods::error fac_err = irods::file_object_factory(rsComm, dataObjInp, file_obj, &dataObjInfoHead);
+        L1desc[l1descInx].oprType = PUT_OPR;
+        L1desc[l1descInx].dataSize = dataObjInp->dataSize;
 
-        throw_if_force_put_to_new_resource(rsComm, *dataObjInp, file_obj);
-
-        std::string hier{};
-        const char* h{getValByKey(&dataObjInp->condInput, RESC_HIER_STR_KW)};
-        if (!h) {
-            auto fobj_tuple = std::make_tuple(file_obj, fac_err);
-            std::tie(file_obj, hier) = irods::resolve_resource_hierarchy(
-                rsComm,
-                irods::CREATE_OPERATION,
-                *dataObjInp,
-                fobj_tuple);
-            addKeyVal(&dataObjInp->condInput, RESC_HIER_STR_KW, hier.c_str());
+        if ( getStructFileType( L1desc[l1descInx].dataObjInfo->specColl ) >= 0 ) { // JMC - backport 4682
+            *portalOprOut = ( portalOprOut_t * ) malloc( sizeof( portalOprOut_t ) );
+            bzero( *portalOprOut,  sizeof( portalOprOut_t ) );
+            ( *portalOprOut )->l1descInx = l1descInx;
+            return l1descInx;
         }
-        else {
-            if (!fac_err.ok() && CAT_NO_ROWS_FOUND != fac_err.code()) {
-                irods::log(fac_err);
+
+        int status = preProcParaPut( rsComm, l1descInx, portalOprOut );
+
+        if ( status < 0 ) {
+            openedDataObjInp_t dataObjCloseInp{};
+            dataObjCloseInp.l1descInx = l1descInx;
+            L1desc[l1descInx].oprStatus = status;
+            rsDataObjClose( rsComm, &dataObjCloseInp );
+            return status;
+        }
+
+        int allFlag = 0;
+        if ( getValByKey( &dataObjInp->condInput, ALL_KW ) != NULL ) {
+            allFlag = 1;
+        }
+
+        dataObjInp_t replDataObjInp{};
+        if ( allFlag == 1 ) {
+            /* need to save dataObjInp. get freed in sendAndRecvBranchMsg */
+            rstrcpy( replDataObjInp.objPath, dataObjInp->objPath, MAX_NAME_LEN );
+            addKeyVal( &replDataObjInp.condInput, UPDATE_REPL_KW, "" );
+            addKeyVal( &replDataObjInp.condInput, ALL_KW, "" );
+        }
+        /* return portalOprOut to the client and wait for the rcOprComplete
+         * call. That is when the parallel I/O is done */
+        int retval = sendAndRecvBranchMsg( rsComm, rsComm->apiInx, status,
+                ( void * ) * portalOprOut, NULL );
+
+        if ( retval < 0 ) {
+            openedDataObjInp_t dataObjCloseInp{};
+            dataObjCloseInp.l1descInx = l1descInx;
+            L1desc[l1descInx].oprStatus = retval;
+            rsDataObjClose( rsComm, &dataObjCloseInp );
+            if ( allFlag == 1 ) {
+                clearKeyVal( &replDataObjInp.condInput );
             }
-            hier = h;
+        }
+        else if (1 == allFlag) {
+            transferStat_t *transStat = NULL;
+            status = rsDataObjRepl(rsComm, &replDataObjInp, &transStat);
+            free(transStat);
+            clearKeyVal(&replDataObjInp.condInput);
+            if (status < 0) {
+                const auto err{ERROR(status, "rsDataObjRepl failed")};
+                irods::log(err);
+                return err.code();
+            }
         }
 
-        const auto hier_has_replica{[&hier, &replicas = file_obj->replicas()]() {
-            return std::any_of(replicas.begin(), replicas.end(),
-                [&](const irods::physical_object& replica) {
-                    return replica.resc_hier() == hier;
+        /* already send the client the status */
+        return SYS_NO_HANDLER_REPLY_MSG;
+    } // parallel_transfer_put
+
+    void throw_if_force_put_to_new_resource(
+        rsComm_t* comm,
+        dataObjInp_t& data_obj_inp,
+        irods::file_object_ptr file_obj)
+    {
+        char* dst_resc_kw   = getValByKey( &data_obj_inp.condInput, DEST_RESC_NAME_KW );
+        char* force_flag_kw = getValByKey( &data_obj_inp.condInput, FORCE_FLAG_KW );
+        if (file_obj->replicas().empty()  ||
+            !dst_resc_kw   ||
+            !force_flag_kw ||
+            strlen( dst_resc_kw ) == 0) {
+            return;
+        }
+
+        const auto hier_match{
+            [&dst_resc_kw, &replicas = file_obj->replicas()]()
+            {
+                return std::any_of(replicas.cbegin(), replicas.cend(),
+                [&dst_resc_kw](const auto& r) {
+                    return irods::hierarchy_parser{r.resc_hier()}.first_resc() == dst_resc_kw;
                 });
-            }()};
-
-        if (hier_has_replica && !getValByKey(&dataObjInp->condInput, FORCE_FLAG_KW)) {
-            return OVERWRITE_WITHOUT_FORCE_FLAG;
+            }()
+        };
+        if (!hier_match) {
+            THROW(HIERARCHY_ERROR, fmt::format(
+                "cannot force put [{}] to a different resource [{}]",
+                data_obj_inp.objPath, dst_resc_kw));
         }
-    }
-    catch (const irods::exception& e) {
-        irods::log(LOG_ERROR, e.what());
-        return e.code();
-    }
+    } // throw_if_force_put_to_new_resource
 
-    int status2 = applyRuleForPostProcForWrite( rsComm, dataObjInpBBuf, dataObjInp->objPath );
-    if ( status2 < 0 ) {
-        return ( status2 );
-    }
+    int rsDataObjPut_impl(
+        rsComm_t *rsComm,
+        dataObjInp_t *dataObjInp,
+        bytesBuf_t *dataObjInpBBuf,
+        portalOprOut_t **portalOprOut)
+    {
+        try {
+            if (irods::is_force_flag_required(*rsComm, *dataObjInp)) {
+                return OVERWRITE_WITHOUT_FORCE_FLAG;
+            }
+        }
+        catch (const irods::experimental::filesystem::filesystem_error& e) {
+            irods::experimental::log::api::error(e.what());
+            return e.code().value();
+        }
 
-    dataObjInp->openFlags = O_RDWR;
+        rodsServerHost_t *rodsServerHost{};
+        specCollCache_t *specCollCache{};
 
-    if (getValByKey(&dataObjInp->condInput, DATA_INCLUDED_KW)) {
-        return single_buffer_put(rsComm, dataObjInp, dataObjInpBBuf);
-    }
+        resolveLinkedPath( rsComm, dataObjInp->objPath, &specCollCache,
+                           &dataObjInp->condInput );
+        int remoteFlag = getAndConnRemoteZone( rsComm, dataObjInp, &rodsServerHost,
+                                           REMOTE_CREATE );
 
-    return parallel_transfer_put( rsComm, dataObjInp, portalOprOut );
-} // rsDataObjPut
+        if (const char* acl_string = getValByKey( &dataObjInp->condInput, ACL_INCLUDED_KW)) {
+            try {
+                irods::deserialize_acl(acl_string);
+            }
+            catch (const irods::exception& e) {
+                rodsLog(LOG_ERROR, "%s", e.what());
+                return e.code();
+            }
+        }
+        if (const char* metadata_string = getValByKey(&dataObjInp->condInput, METADATA_INCLUDED_KW)) {
+            try {
+                irods::deserialize_metadata( metadata_string );
+            }
+            catch (const irods::exception& e) {
+                rodsLog(LOG_ERROR, "%s", e.what());
+                return e.code();
+            }
+        }
 
+        if (remoteFlag < 0) {
+            return remoteFlag;
+        }
+        else if (LOCAL_HOST != remoteFlag) {
+            int status = _rcDataObjPut( rodsServerHost->conn, dataObjInp, dataObjInpBBuf, portalOprOut );
+            if (status < 0 ||
+                getValByKey(&dataObjInp->condInput, DATA_INCLUDED_KW)) {
+                return status;
+            }
+
+            /* have to allocate a local l1descInx to keep track of things
+             * since the file is in remote zone. It sets remoteL1descInx,
+             * oprType = REMOTE_ZONE_OPR and remoteZoneHost so that
+             * rsComplete knows what to do */
+            int l1descInx = allocAndSetL1descForZoneOpr(
+                            ( *portalOprOut )->l1descInx, dataObjInp, rodsServerHost, NULL );
+            if ( l1descInx < 0 ) {
+                return l1descInx;
+            }
+            ( *portalOprOut )->l1descInx = l1descInx;
+            return status;
+        }
+
+        try {
+            dataObjInfo_t* dataObjInfoHead{};
+            irods::file_object_ptr file_obj(new irods::file_object());
+            file_obj->logical_path(dataObjInp->objPath);
+            irods::error fac_err = irods::file_object_factory(rsComm, dataObjInp, file_obj, &dataObjInfoHead);
+
+            throw_if_force_put_to_new_resource(rsComm, *dataObjInp, file_obj);
+
+            std::string hier{};
+            const char* h{getValByKey(&dataObjInp->condInput, RESC_HIER_STR_KW)};
+            if (!h) {
+                auto fobj_tuple = std::make_tuple(file_obj, fac_err);
+                std::tie(file_obj, hier) = irods::resolve_resource_hierarchy(
+                    rsComm,
+                    irods::CREATE_OPERATION,
+                    *dataObjInp,
+                    fobj_tuple);
+                addKeyVal(&dataObjInp->condInput, RESC_HIER_STR_KW, hier.c_str());
+            }
+            else {
+                if (!fac_err.ok() && CAT_NO_ROWS_FOUND != fac_err.code()) {
+                    irods::log(fac_err);
+                }
+                hier = h;
+            }
+
+            const auto hier_has_replica{[&hier, &replicas = file_obj->replicas()]() {
+                return std::any_of(replicas.begin(), replicas.end(),
+                    [&](const irods::physical_object& replica) {
+                        return replica.resc_hier() == hier;
+                    });
+                }()};
+
+            if (hier_has_replica && !getValByKey(&dataObjInp->condInput, FORCE_FLAG_KW)) {
+                return OVERWRITE_WITHOUT_FORCE_FLAG;
+            }
+        }
+        catch (const irods::exception& e) {
+            irods::log(LOG_ERROR, e.what());
+            return e.code();
+        }
+
+        int status2 = applyRuleForPostProcForWrite( rsComm, dataObjInpBBuf, dataObjInp->objPath );
+        if ( status2 < 0 ) {
+            return ( status2 );
+        }
+
+        dataObjInp->openFlags = O_RDWR;
+
+        try {
+            if (getValByKey(&dataObjInp->condInput, DATA_INCLUDED_KW)) {
+                return single_buffer_put(*rsComm, *dataObjInp, *dataObjInpBBuf);
+            }
+
+            return parallel_transfer_put( rsComm, dataObjInp, portalOprOut );
+        }
+        catch (const irods::exception& e) {
+            irods::log(e);
+            return e.code();
+        }
+        catch (const std::exception& e) {
+            irods::log(LOG_ERROR, fmt::format("[{}] - [{}]", __FUNCTION__, e.what()));
+            return SYS_LIBRARY_ERROR;
+        }
+        catch (...) {
+            irods::log(LOG_ERROR, fmt::format("[{}] - unknown error occurred", __FUNCTION__));
+            return SYS_UNKNOWN_ERROR;
+        }
+    } // rsDataObjPut_impl
 } // anonymous namespace
 
 int preProcParaPut(
@@ -405,6 +656,7 @@ int rsDataObjPut(rsComm_t* rsComm,
                  bytesBuf_t* dataObjInpBBuf,
                  portalOprOut_t** portalOprOut)
 {
+    namespace ix = irods::experimental;
     namespace fs = ix::filesystem;
 
     const auto ec = rsDataObjPut_impl(rsComm, dataObjInp, dataObjInpBBuf, portalOprOut);

--- a/server/api/src/rsDataObjRepl.cpp
+++ b/server/api/src/rsDataObjRepl.cpp
@@ -605,10 +605,7 @@ int dataObjCopy(rsComm_t* rsComm, int _destination_l1descInx)
     return status;
 } // dataObjCopy
 
-int unbunAndStageBunfileObj(
-    rsComm_t* rsComm,
-    char* bunfileObjPath,
-    char** outCacheRescName) {
+int unbunAndStageBunfileObj(rsComm_t* rsComm, const char* bunfileObjPath, char** outCacheRescName) {
 
     /* query the bundle dataObj */
     dataObjInp_t dataObjInp{};

--- a/server/api/src/rsDataObjRepl.cpp
+++ b/server/api/src/rsDataObjRepl.cpp
@@ -11,6 +11,7 @@
 #include "fileStageToCache.h"
 #include "fileSyncToArch.h"
 #include "getRemoteZoneResc.h"
+#include "getRescQuota.h"
 #include "icatDefines.h"
 #include "l3FileGetSingleBuf.h"
 #include "l3FilePutSingleBuf.h"
@@ -31,13 +32,16 @@
 #include "rsDataObjWrite.hpp"
 #include "rsFileStageToCache.hpp"
 #include "rsFileSyncToArch.hpp"
+#include "rsGetRescQuota.hpp"
 #include "rsL3FileGetSingleBuf.hpp"
 #include "rsL3FilePutSingleBuf.hpp"
 #include "rsUnbunAndRegPhyBunfile.hpp"
 #include "rsUnregDataObj.hpp"
+#include "rs_replica_close.hpp"
 #include "specColl.hpp"
 #include "unbunAndRegPhyBunfile.h"
 
+#include "finalize_utilities.hpp"
 #include "irods_at_scope_exit.hpp"
 #include "irods_log.hpp"
 #include "irods_logger.hpp"
@@ -53,263 +57,590 @@
 #include "replica_access_table.hpp"
 #include "voting.hpp"
 
+#define IRODS_REPLICA_ENABLE_SERVER_SIDE_API
+#include "data_object_proxy.hpp"
+#include "replica_proxy.hpp"
+
 #include <string_view>
 #include <vector>
 
-#include <boost/lexical_cast.hpp>
-#include <boost/format.hpp>
-
 #include "fmt/format.h"
 
-namespace ix = irods::experimental;
-
-namespace {
-
-namespace ix = irods::experimental;
-using log = irods::experimental::log;
-
-using repl_input_tuple = std::tuple<dataObjInp_t, irods::file_object_ptr>;
-repl_input_tuple init_destination_replica_input(RsComm& _comm, const DataObjInp& _inp)
+namespace
 {
-    DataObjInp destination_data_obj_inp = _inp;
-    replKeyVal(&_inp.condInput, &destination_data_obj_inp.condInput);
-    auto cond_input = irods::experimental::make_key_value_proxy(destination_data_obj_inp.condInput);
-
-    // Remove existing keywords used for source resource
-    cond_input.erase(RESC_NAME_KW);
-    cond_input.erase(RESC_HIER_STR_KW);
-
-    if (cond_input.contains(DEST_RESC_HIER_STR_KW)) {
-        cond_input[RESC_HIER_STR_KW] = cond_input.at(DEST_RESC_HIER_STR_KW).value();
-        irods::file_object_ptr obj{new irods::file_object()};
-        irods::error err = irods::file_object_factory(&_comm, &destination_data_obj_inp, obj);
-        if (!err.ok()) {
-            THROW(err.code(), err.result());
+    auto apply_static_peps(RsComm& _comm, l1desc& _l1desc, const int _operation_status) -> void
+    {
+        if (_l1desc.openType == CREATE_TYPE) {
+            irods::apply_static_post_pep(_comm, _l1desc, _operation_status, "acPostProcForCreate");
         }
-        return {destination_data_obj_inp, obj};
-    }
-
-    std::string replica_number;
-    if (cond_input.contains(REPL_NUM_KW)) {
-        replica_number = cond_input[REPL_NUM_KW].value();
-
-        // This keyword must be removed temporarily so that the voting mechanism does
-        // not misinterpret it and change the operation from a CREATE to a WRITE.
-        // See server/core/src/irods_resource_redirect.cpp for details.
-        rmKeyVal(&destination_data_obj_inp.condInput, REPL_NUM_KW);
-    }
-
-    irods::at_scope_exit restore_replica_number_keyword{[&replica_number, &cond_input] {
-        cond_input[REPL_NUM_KW] = replica_number;
-    }};
-
-    // Get the destination resource that the client specified, or use the default resource
-    if (!cond_input.contains(DEST_RESC_HIER_STR_KW) &&
-        !cond_input.contains(DEST_RESC_NAME_KW) &&
-        cond_input.contains(DEF_RESC_NAME_KW)) {
-        cond_input[DEST_RESC_NAME_KW] = cond_input.at(DEF_RESC_NAME_KW).value();
-    }
-
-    auto [obj, hier] = irods::resolve_resource_hierarchy(
-        irods::CREATE_OPERATION, &_comm, destination_data_obj_inp);
-
-    cond_input[RESC_HIER_STR_KW] = hier;
-    cond_input[DEST_RESC_HIER_STR_KW] = hier;
-
-    return {destination_data_obj_inp, obj};
-} // init_destination_replica_input
-
-repl_input_tuple init_source_replica_input(RsComm& _comm, const DataObjInp& _inp)
-{
-    DataObjInp source_data_obj_inp = _inp;
-    replKeyVal(&_inp.condInput, &source_data_obj_inp.condInput);
-    auto cond_input = irods::experimental::make_key_value_proxy(source_data_obj_inp.condInput);
-
-    // Remove existing keywords used for destination resource
-    cond_input.erase(DEST_RESC_NAME_KW);
-    cond_input.erase(DEST_RESC_HIER_STR_KW);
-
-    if (cond_input.contains(RESC_HIER_STR_KW)) {
-        irods::file_object_ptr obj{new irods::file_object()};
-        irods::error err = irods::file_object_factory(&_comm, &source_data_obj_inp, obj);
-        if (!err.ok()) {
-            THROW(err.code(), err.result());
+        else if (_l1desc.openType == OPEN_FOR_WRITE_TYPE) {
+            irods::apply_static_post_pep(_comm, _l1desc, _operation_status, "acPostProcForOpen");
         }
-        return {source_data_obj_inp, obj};
-    }
 
-    auto [obj, hier] = irods::resolve_resource_hierarchy(irods::OPEN_OPERATION, &_comm, source_data_obj_inp);
+        // Calling acPostProcForPut after replication is legacy behavior.
+        // Keep this here even though it is wrong.
+        irods::apply_static_post_pep(_comm, _l1desc, _operation_status, "acPostProcForPut");
+    } // apply_static_peps
 
-    cond_input[RESC_HIER_STR_KW] = hier;
+    auto finalize_source_replica(RsComm& _comm, l1desc& _l1desc, DataObjInfo& _info) -> int
+    {
+        if (_l1desc.purgeCacheFlag) {
+            irods::purge_cache(_comm, _info);
+        }
 
-    return {source_data_obj_inp, obj};
-} // init_source_replica_input
+        irods::apply_metadata_from_cond_input(_comm, *_l1desc.dataObjInp);
+        irods::apply_acl_from_cond_input(_comm, *_l1desc.dataObjInp);
 
-int close_replica(RsComm& _comm, const int _inx, const int _status)
-{
-    openedDataObjInp_t dataObjCloseInp{};
-    dataObjCloseInp.l1descInx = _inx;
-    L1desc[dataObjCloseInp.l1descInx].oprStatus = _status;
-    char* pdmo_kw = getValByKey(&L1desc[_inx].dataObjInp->condInput, IN_PDMO_KW);
-    if (pdmo_kw) {
-        addKeyVal(&dataObjCloseInp.condInput, IN_PDMO_KW, pdmo_kw);
-    }
-    const int status = rsDataObjClose(&_comm, &dataObjCloseInp);
-    if (status < 0) {
-        rodsLog(LOG_ERROR, "[%s] - rsDataObjClose failed with [%d]", __FUNCTION__, status);
-    }
-    clearKeyVal( &dataObjCloseInp.condInput );
-    return status;
-} // close_replica
+        // TODO: set replica state...?
 
-int open_source_replica(
-    rsComm_t* rsComm,
-    dataObjInp_t& source_data_obj_inp)
-{
-    source_data_obj_inp.oprType = REPLICATE_SRC;
-    source_data_obj_inp.openFlags = O_RDONLY;
-    int source_l1descInx = rsDataObjOpen(rsComm, &source_data_obj_inp);
-    if (source_l1descInx < 0) {
-        return source_l1descInx;
-    }
-    const auto* info = L1desc[source_l1descInx].dataObjInfo;
-    log::server::debug("[{}:{}] - opened source replica [{}] on [{}] (repl [{}])", __FUNCTION__, __LINE__, info->objPath, info->rescHier, info->replNum);
-    // TODO: Consider using force flag and making this part of the voting process
-    if (GOOD_REPLICA != L1desc[source_l1descInx].dataObjInfo->replStatus) {
-        const int status = SYS_NO_GOOD_REPLICA;
-        close_replica(*rsComm, source_l1descInx, status);
+        return 0;
+    } // finalize_source_replica
+
+    auto calculate_checksum(
+        RsComm& _comm,
+        l1desc& _l1desc,
+        DataObjInfo& _source_info,
+        DataObjInfo& _destination_info) -> std::string
+    {
+        if (!std::string_view{_destination_info.chksum}.empty()) {
+            _l1desc.chksumFlag = REG_CHKSUM;
+        }
+
+        char* checksum_string = nullptr;
+        irods::at_scope_exit free_checksum_string{[&checksum_string] { free(checksum_string); }};
+
+        auto destination_replica = irods::experimental::replica::make_replica_proxy(_destination_info);
+        auto source_replica = irods::experimental::replica::make_replica_proxy(_source_info);
+
+        if (source_replica.checksum().length() > 0 && STALE_REPLICA != source_replica.replica_status()) {
+            destination_replica.cond_input()[ORIG_CHKSUM_KW] = source_replica.checksum();
+
+            irods::log(LOG_DEBUG, fmt::format(
+                "[{}:{}] - verifying checksum for [{}],source:[{}]",
+                __FUNCTION__, __LINE__, destination_replica.logical_path(), source_replica.checksum()));
+
+            if (const int ec = _dataObjChksum(&_comm, destination_replica.get(), &checksum_string); ec < 0) {
+                destination_replica.checksum("");
+
+                if (DIRECT_ARCHIVE_ACCESS == ec) {
+                    destination_replica.checksum(source_replica.checksum());
+                    return source_replica.checksum().data();
+                }
+
+                THROW(ec, fmt::format(
+                    "{}: _dataObjChksum error for {}, status = {}",
+                    __FUNCTION__, destination_replica.logical_path(), ec));
+            }
+
+            if (!checksum_string) {
+                THROW(SYS_INTERNAL_NULL_INPUT_ERR, "checksum_string is NULL");
+            }
+
+            destination_replica.checksum(checksum_string);
+
+            if (source_replica.checksum() != checksum_string) {
+                THROW(USER_CHKSUM_MISMATCH, fmt::format(
+                    "{}: chksum mismatch for {} src [{}] new [{}]",
+                    __FUNCTION__, destination_replica.logical_path(), source_replica.checksum(), checksum_string));
+            }
+
+            return destination_replica.checksum().data();
+        }
+
+        if (!_l1desc.chksumFlag) {
+            if (destination_replica.checksum().empty()) {
+                return {};
+            }
+            _l1desc.chksumFlag = VERIFY_CHKSUM;
+        }
+
+        if (VERIFY_CHKSUM == _l1desc.chksumFlag) {
+            if (!std::string_view{_l1desc.chksum}.empty()) {
+                return irods::verify_checksum(_comm, *destination_replica.get(), _l1desc.chksum);
+            }
+
+            if (!destination_replica.checksum().empty()) {
+                destination_replica.cond_input()[ORIG_CHKSUM_KW] = destination_replica.checksum();
+            }
+
+            if (const int ec = _dataObjChksum(&_comm, destination_replica.get(), &checksum_string); ec < 0) {
+                THROW(ec, "failed in _dataObjChksum");
+            }
+
+            if (!checksum_string) {
+                THROW(SYS_INTERNAL_NULL_INPUT_ERR, "checksum_string is NULL");
+            }
+
+            if (!destination_replica.checksum().empty()) {
+                destination_replica.cond_input().erase(ORIG_CHKSUM_KW);
+
+                /* for replication, the chksum in dataObjInfo was duplicated */
+                if (destination_replica.checksum() != checksum_string) {
+                    THROW(USER_CHKSUM_MISMATCH, fmt::format(
+                        "{}:mismach chksum for {}.Rcat={},comp {}",
+                        __FUNCTION__, destination_replica.logical_path(), destination_replica.checksum(), checksum_string));
+                }
+            }
+
+            return {checksum_string};
+        }
+
+        return irods::register_new_checksum(_comm, *destination_replica.get(), _l1desc.chksum);
+    } // calculate_checksum
+
+    auto finalize_destination_replica(
+        RsComm& _comm,
+        l1desc& _l1desc,
+        DataObjInfo& _source_info,
+        DataObjInfo& _destination_info) -> int
+    {
+        auto source_replica = irods::experimental::replica::make_replica_proxy(_source_info);
+        auto destination_replica = irods::experimental::replica::make_replica_proxy(_destination_info);
+
+        auto cond_input = irods::experimental::make_key_value_proxy(_l1desc.dataObjInp->condInput);
+        try {
+            const bool verify_size = !getValByKey(&_l1desc.dataObjInp->condInput, NO_CHK_COPY_LEN_KW);
+            const auto size_in_vault = irods::get_size_in_vault(_comm, _destination_info, verify_size, _l1desc.dataSize);
+            destination_replica.size(size_in_vault);
+
+            if (const bool update_checksum = verify_size || !destination_replica.checksum().empty(); update_checksum) {
+                const auto checksum = calculate_checksum(_comm, _l1desc, _source_info, _destination_info);
+                if (!checksum.empty()) {
+                    cond_input[CHKSUM_KW] = checksum;
+                }
+            }
+        }
+        catch (const irods::exception& e) {
+            if (const int ec = irods::stale_replica(_comm, _l1desc, _destination_info); ec < 0) {
+                irods::log(LOG_ERROR, fmt::format(
+                    "{} - rsModDataObjMeta failed [{}]",
+                    __FUNCTION__, ec));
+            }
+
+            throw;
+        }
+
+        auto [reg_param, lm] = irods::experimental::make_key_value_proxy({{OPEN_TYPE_KW, std::to_string(_l1desc.openType)}});
+        reg_param[REPL_STATUS_KW] = std::to_string(source_replica.replica_status());
+        reg_param[DATA_SIZE_KW] = std::to_string(source_replica.size());
+        reg_param[DATA_MODIFY_KW] = std::to_string((int)time(nullptr));
+        reg_param[FILE_PATH_KW] = destination_replica.physical_path();
+        destination_replica.size(source_replica.size());
+
+        if (cond_input.contains(ADMIN_KW)) {
+            reg_param[ADMIN_KW] = cond_input.at(ADMIN_KW);
+        }
+        if (cond_input.contains(IN_PDMO_KW)) {
+            reg_param[IN_PDMO_KW] = cond_input.at(IN_PDMO_KW);
+        }
+        if (cond_input.contains(SYNC_OBJ_KW)) {
+            reg_param[SYNC_OBJ_KW] = cond_input.at(SYNC_OBJ_KW);
+        }
+        if (cond_input.contains(CHKSUM_KW)) {
+            reg_param[CHKSUM_KW] = cond_input.at(CHKSUM_KW);
+        }
+
+        modDataObjMeta_t mod_inp{};
+        mod_inp.dataObjInfo = destination_replica.get();
+        mod_inp.regParam = reg_param.get();
+        const int status = rsModDataObjMeta(&_comm, &mod_inp);
+
+        if (CREATE_TYPE == _l1desc.openType) {
+            updatequotaOverrun(destination_replica.hierarchy().data(), destination_replica.size(), ALL_QUOTA);
+        }
+
+        if (status < 0) {
+            _l1desc.oprStatus = status;
+
+            if (CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME != status) {
+                l3Unlink(&_comm, destination_replica.get());
+            }
+
+            irods::log(LOG_NOTICE, fmt::format(
+                "{}: RegReplica/ModDataObjMeta {} err. stat = {}",
+                __FUNCTION__, destination_replica.logical_path(), status));
+        }
+
         return status;
-    }
-    return source_l1descInx;
-} // open_source_replica
+    } // finalize_destination_replica
 
-int open_destination_replica(
-    rsComm_t* rsComm,
-    dataObjInp_t& destination_data_obj_inp,
-    const int source_l1desc_inx)
-{
-    auto kvp = ix::make_key_value_proxy(destination_data_obj_inp.condInput);
-    kvp[REG_REPL_KW] = "";
-    kvp[DATA_ID_KW] = std::to_string(L1desc[source_l1desc_inx].dataObjInfo->dataId);
-    kvp[SOURCE_L1_DESC_KW] = std::to_string(source_l1desc_inx);
-    kvp.erase(PURGE_CACHE_KW);
-    destination_data_obj_inp.oprType = REPLICATE_DEST;
-    destination_data_obj_inp.openFlags = O_CREAT | O_WRONLY | O_TRUNC;
-    log::server::debug(
+    auto finalize_destination_replica_on_failure(RsComm& _comm, l1desc& _l1desc, DataObjInfo& _info) -> int
+    {
+        auto replica = irods::experimental::replica::make_replica_proxy(_info);
+
+        replica.replica_status(STALE_REPLICA);
+        replica.mtime(std::to_string((int)time(nullptr)));
+
+        const rodsLong_t vault_size = getSizeInVault(&_comm, replica.get());
+        if (vault_size < 0) {
+            irods::log(LOG_ERROR, fmt::format(
+                "{} - getSizeInVault failed [{}]",
+                __FUNCTION__, vault_size));
+            return vault_size;
+        }
+
+        replica.size(vault_size);
+
+        auto cond_input = irods::experimental::make_key_value_proxy(_l1desc.dataObjInp->condInput);
+        auto [reg_param, lm] = irods::experimental::make_key_value_proxy();
+        reg_param[DATA_SIZE_KW] = std::to_string(replica.size());
+        reg_param[IN_PDMO_KW] = replica.hierarchy();
+        reg_param[REPL_STATUS_KW] = std::to_string(STALE_REPLICA);
+        reg_param[STALE_ALL_INTERMEDIATE_REPLICAS_KW] = "";
+        if (cond_input.contains(ADMIN_KW)) {
+            reg_param[ADMIN_KW] = "";
+        }
+
+        modDataObjMeta_t mod_inp{};
+        mod_inp.dataObjInfo = replica.get();
+        mod_inp.regParam = reg_param.get();
+        if (const int ec = rsModDataObjMeta(&_comm, &mod_inp); ec < 0) {
+            irods::log(LOG_NOTICE, fmt::format(
+                "{}: rsModDataObjMeta failed, dataSize [{}] status = {}",
+                __FUNCTION__, replica.size(), ec));
+            return ec;
+        }
+
+        return 0;
+    } // finalize_destination_replica_on_failure
+
+    int close_replica(RsComm& _comm, const int _fd)
+    {
+        nlohmann::json in_json;
+        in_json["fd"] = _fd;
+        in_json["send_notifications"] = false;
+        in_json["update_size"] = false;
+        in_json["update_status"] = false;
+        const auto input = in_json.dump();
+
+        if (const int ec = rs_replica_close(&_comm, input.data()); ec < 0) {
+            irods::log(LOG_ERROR, fmt::format(
+                "[{}] - error closing replica; ec:[{}]",
+                __FUNCTION__, ec));
+
+            return ec;
+        }
+
+        return 0;
+    } // close_replica
+
+    DataObjInp init_source_replica_input(RsComm& _comm, const DataObjInp& _inp)
+    {
+        DataObjInp source_data_obj_inp = _inp;
+        replKeyVal(&_inp.condInput, &source_data_obj_inp.condInput);
+        auto cond_input = irods::experimental::make_key_value_proxy(source_data_obj_inp.condInput);
+
+        // Remove existing keywords used for destination resource
+        cond_input.erase(DEST_RESC_NAME_KW);
+        cond_input.erase(DEST_RESC_HIER_STR_KW);
+
+        return source_data_obj_inp;
+    } // init_source_replica_input
+
+    irods::file_object_ptr get_source_replica_info(RsComm& _comm, DataObjInp& _inp)
+    {
+        auto cond_input = irods::experimental::make_key_value_proxy(_inp.condInput);
+
+        if (cond_input.contains(RESC_HIER_STR_KW)) {
+            irods::file_object_ptr obj{new irods::file_object()};
+            irods::error err = irods::file_object_factory(&_comm, &_inp, obj);
+            if (!err.ok()) {
+                THROW(err.code(), err.result());
+            }
+            return obj;
+        }
+
+        auto [obj, hier] = irods::resolve_resource_hierarchy(irods::OPEN_OPERATION, &_comm, _inp);
+
+        cond_input[RESC_HIER_STR_KW] = hier;
+
+        return obj;
+    } // get_source_replica_info
+
+    DataObjInp init_destination_replica_input(RsComm& _comm, const DataObjInp& _inp)
+    {
+        DataObjInp destination_data_obj_inp = _inp;
+        replKeyVal(&_inp.condInput, &destination_data_obj_inp.condInput);
+        auto cond_input = irods::experimental::make_key_value_proxy(destination_data_obj_inp.condInput);
+
+        // Remove existing keywords used for source resource
+        cond_input.erase(RESC_NAME_KW);
+        cond_input.erase(RESC_HIER_STR_KW);
+
+        return destination_data_obj_inp;
+    } // init_destination_replica_input
+
+    irods::file_object_ptr get_destination_replica_info(RsComm& _comm, DataObjInp& _inp)
+    {
+        auto cond_input = irods::experimental::make_key_value_proxy(_inp.condInput);
+
+        if (cond_input.contains(DEST_RESC_HIER_STR_KW)) {
+            cond_input[RESC_HIER_STR_KW] = cond_input.at(DEST_RESC_HIER_STR_KW).value();
+            irods::file_object_ptr obj{new irods::file_object()};
+            irods::error err = irods::file_object_factory(&_comm, &_inp, obj);
+            if (!err.ok()) {
+                THROW(err.code(), err.result());
+            }
+            return obj;
+        }
+
+        std::string replica_number;
+        if (cond_input.contains(REPL_NUM_KW)) {
+            replica_number = cond_input[REPL_NUM_KW].value();
+
+            // This keyword must be removed temporarily so that the voting mechanism does
+            // not misinterpret it and change the operation from a CREATE to a WRITE.
+            // See server/core/src/irods_resource_redirect.cpp for details.
+            cond_input.erase(REPL_NUM_KW);
+        }
+
+        irods::at_scope_exit restore_replica_number_keyword{[&replica_number, &cond_input] {
+            if (!replica_number.empty()) {
+                cond_input[REPL_NUM_KW] = replica_number;
+            }
+        }};
+
+        // Get the destination resource that the client specified, or use the default resource
+        if (!cond_input.contains(DEST_RESC_HIER_STR_KW) &&
+            !cond_input.contains(DEST_RESC_NAME_KW) &&
+            cond_input.contains(DEF_RESC_NAME_KW)) {
+            cond_input[DEST_RESC_NAME_KW] = cond_input.at(DEF_RESC_NAME_KW).value();
+        }
+
+        auto [obj, hier] = irods::resolve_resource_hierarchy(
+            irods::CREATE_OPERATION, &_comm, _inp);
+
+        cond_input[RESC_HIER_STR_KW] = hier;
+        cond_input[DEST_RESC_HIER_STR_KW] = hier;
+
+        return obj;
+    } // get_destination_replica_info
+
+    int open_source_replica(RsComm& _comm, DataObjInp& _inp)
+    {
+        _inp.oprType = REPLICATE_SRC;
+        _inp.openFlags = O_RDONLY;
+        int source_l1descInx = rsDataObjOpen(&_comm, &_inp);
+        if (source_l1descInx < 0) {
+            return source_l1descInx;
+        }
+
+        const auto* info = L1desc[source_l1descInx].dataObjInfo;
+
+        irods::log(LOG_DEBUG, fmt::format(
+            "[{}:{}] - opened source replica [{}] on [{}] (repl [{}])",
+            __FUNCTION__, __LINE__, info->objPath, info->rescHier, info->replNum));
+
+        // TODO: Consider using force flag and making this part of the voting process
+        if (GOOD_REPLICA != L1desc[source_l1descInx].dataObjInfo->replStatus) {
+            close_replica(_comm, source_l1descInx);
+            // TODO: need to stale-ify?
+            return SYS_NO_GOOD_REPLICA;
+        }
+
+        return source_l1descInx;
+    } // open_source_replica
+
+    int open_destination_replica(RsComm& _comm, DataObjInp& _inp, const int _fd)
+    {
+        auto kvp = irods::experimental::make_key_value_proxy(_inp.condInput);
+        kvp[REG_REPL_KW] = "";
+        kvp[DATA_ID_KW] = std::to_string(L1desc[_fd].dataObjInfo->dataId);
+        kvp[SOURCE_L1_DESC_KW] = std::to_string(_fd);
+        kvp.erase(PURGE_CACHE_KW);
+
+        _inp.oprType = REPLICATE_DEST;
+        _inp.openFlags = O_CREAT | O_WRONLY | O_TRUNC;
+
+        irods::log(LOG_DEBUG, fmt::format(
             "[{}:{}] - opening destination replica for [{}] (id:[{}]) on [{}]",
             __FUNCTION__,
             __LINE__,
-            destination_data_obj_inp.objPath,
+            _inp.objPath,
             kvp.at(DATA_ID_KW).value(),
-            kvp.at(RESC_HIER_STR_KW).value());
-    return rsDataObjOpen(rsComm, &destination_data_obj_inp);
-} // open_destination_replica
+            kvp.at(RESC_HIER_STR_KW).value()));
 
-int replicate_data(
-    rsComm_t* rsComm,
-    dataObjInp_t& source_inp,
-    dataObjInp_t& destination_inp)
-{
-    // Open source replica
-    int source_l1descInx = open_source_replica(rsComm, source_inp);
-    if (source_l1descInx < 0) {
-        THROW(source_l1descInx, "Failed opening source replica");
-    }
+        return rsDataObjOpen(&_comm, &_inp);
+    } // open_destination_replica
 
-    // Open destination replica
-    int destination_l1descInx = open_destination_replica(rsComm, destination_inp, source_l1descInx);
-    if (destination_l1descInx < 0) {
-        close_replica(*rsComm, source_l1descInx, source_l1descInx);
-        THROW(destination_l1descInx, "Failed opening destination replica");
-    }
-    L1desc[destination_l1descInx].srcL1descInx = source_l1descInx;
-    L1desc[destination_l1descInx].dataSize = L1desc[source_l1descInx].dataObjInfo->dataSize;
-
-    // Copy data from source to destination
-    int status = dataObjCopy(rsComm, destination_l1descInx);
-    if (status < 0) {
-        rodsLog(LOG_ERROR, "[%s] - dataObjCopy failed for [%s]", __FUNCTION__, destination_inp.objPath);
-    }
-    else {
-        L1desc[destination_l1descInx].bytesWritten = L1desc[destination_l1descInx].dataObjInfo->dataSize;
-    }
-
-    // Save the token for the replica access table so that it can be removed
-    // in the event of a failure in close. On failure, the entry is restored,
-    // but this will prevent retries of the operation as the token information
-    // is lost by the time we have returned to the caller.
-    const auto token = L1desc[destination_l1descInx].replica_token;
-
-    // Close destination replica
-    int close_status = close_replica(*rsComm, destination_l1descInx, status);
-    if (close_status < 0) {
-        irods::log(LOG_ERROR, fmt::format(
-            "[{}] - closing destination replica [{}] failed with [{}]",
-            __FUNCTION__, destination_inp.objPath, close_status));
-
-        if (status >= 0) {
-            status = close_status;
+    int replicate_data(RsComm& _comm, DataObjInp& _source_inp, DataObjInp& _destination_inp)
+    {
+        // Open source replica
+        int source_l1descInx = open_source_replica(_comm, _source_inp);
+        if (source_l1descInx < 0) {
+            THROW(source_l1descInx, "Failed opening source replica");
         }
 
-        auto& rat = irods::experimental::replica_access_table::instance();
-        rat.erase_pid(token, getpid());
-    }
-    // Close source replica
-    close_status = close_replica(*rsComm, source_l1descInx, 0);
-    if (close_status < 0) {
-        irods::log(LOG_ERROR, fmt::format(
-            "[{}] - closing source replica [{}] failed with [{}]",
-            __FUNCTION__, source_inp.objPath, close_status));
-
-        if (status >= 0) {
-            status = close_status;
+        // Open destination replica
+        int destination_l1descInx = open_destination_replica(_comm, _destination_inp, source_l1descInx);
+        if (destination_l1descInx < 0) {
+            close_replica(_comm, source_l1descInx);
+            // TODO: mark as stale?
+            THROW(destination_l1descInx, "Failed opening destination replica");
         }
-    }
+        L1desc[destination_l1descInx].srcL1descInx = source_l1descInx;
+        L1desc[destination_l1descInx].dataSize = L1desc[source_l1descInx].dataObjInfo->dataSize;
 
-    return status;
-} // replicate_data
+        // Copy data from source to destination
+        int status = dataObjCopy(&_comm, destination_l1descInx);
+        if (status < 0) {
+            rodsLog(LOG_ERROR, "[%s] - dataObjCopy failed for [%s]", __FUNCTION__, _destination_inp.objPath);
+            L1desc[destination_l1descInx].bytesWritten = status;
+        }
+        else {
+            L1desc[destination_l1descInx].bytesWritten = L1desc[destination_l1descInx].dataObjInfo->dataSize;
+        }
+        const rodsLong_t bytes_written = L1desc[destination_l1descInx].bytesWritten;
 
-int repl_data_obj(
-    rsComm_t* rsComm,
-    const dataObjInp_t& dataObjInp)
-{
-    namespace irv = irods::experimental::resource::voting;
+        // Save the token for the replica access table so that it can be removed
+        // in the event of a failure in close. On failure, the entry is restored,
+        // but this will prevent retries of the operation as the token information
+        // is lost by the time we have returned to the caller.
+        const auto token = L1desc[destination_l1descInx].replica_token;
 
-    // Make sure the requested source and destination resources are valid
-    dataObjInp_t destination_inp{};
-    dataObjInp_t source_inp{};
-    const irods::at_scope_exit free_cond_inputs{[&destination_inp, &source_inp]() {
-        clearKeyVal(&destination_inp.condInput);
-        clearKeyVal(&source_inp.condInput);
-    }};
-    auto dest_inp_tuple = init_destination_replica_input(*rsComm, dataObjInp);
-    destination_inp = std::get<dataObjInp_t>(dest_inp_tuple);
-    auto file_obj = std::get<irods::file_object_ptr>(dest_inp_tuple);
-
-    auto source_inp_tuple = init_source_replica_input(*rsComm, dataObjInp);
-    source_inp = std::get<dataObjInp_t>(source_inp_tuple);
-
-    int status{};
-    if (getValByKey(&dataObjInp.condInput, ALL_KW)) {
-        for (const auto& r : file_obj->replicas()) {
-            log::server::debug(
-                "[{}:{}] - hier:[{}],status:[{}],vote:[{}]",
-                __FUNCTION__, __LINE__,
-                r.resc_hier(),
-                r.replica_status(),
-                r.vote());
-            if (GOOD_REPLICA == (r.replica_status() & 0x0F)) {
-                continue;
+        auto source_fd = irods::duplicate_l1_descriptor(L1desc[source_l1descInx]);
+        auto destination_fd = irods::duplicate_l1_descriptor(L1desc[destination_l1descInx]);
+        irods::at_scope_exit free_fd{[&source_fd, &destination_fd]
+            {
+                freeL1desc_struct(source_fd);
+                freeL1desc_struct(destination_fd);
             }
-            if (r.vote() > irv::vote::zero) {
-                addKeyVal(&destination_inp.condInput, RESC_HIER_STR_KW, r.resc_hier().c_str());
-                status = replicate_data(rsComm, source_inp, destination_inp);
+        };
+
+        auto [source_replica, source_replica_lm] = irods::experimental::replica::duplicate_replica(*L1desc[source_l1descInx].dataObjInfo);
+        auto [destination_replica, destination_replica_lm] = irods::experimental::replica::duplicate_replica(*L1desc[destination_l1descInx].dataObjInfo);
+
+        // Close source replica
+        if (const int ec = close_replica(_comm, source_l1descInx); ec < 0) {
+            irods::log(LOG_ERROR, fmt::format(
+                "[{}:{}] - closing source replica [{}] failed with [{}]",
+                __FUNCTION__, __LINE__, _source_inp.objPath, ec));
+
+            if (status >= 0) {
+                status = ec;
             }
         }
-    }
-    else {
+
+        // Close destination replica
+        if (const int ec = close_replica(_comm, destination_l1descInx); ec < 0) {
+            irods::log(LOG_ERROR, fmt::format(
+                "[{}:{}] - closing destination replica [{}] failed with [{}]",
+                __FUNCTION__, __LINE__, _destination_inp.objPath, ec));
+
+            if (status >= 0) {
+                status = ec;
+            }
+
+            auto& rat = irods::experimental::replica_access_table::instance();
+            rat.erase_pid(token, getpid());
+        }
+
+        // finalize source replica
+        try {
+            if (const int ec = finalize_source_replica(_comm, source_fd, *source_replica.get()); ec < 0) {
+                irods::log(LOG_ERROR, fmt::format(
+                    "[{}:{}] - closing source replica [{}] failed with [{}]",
+                    __FUNCTION__, __LINE__, source_replica.logical_path(), ec));
+
+                if (status >= 0) {
+                    status = ec;
+                }
+            }
+        }
+        catch (const irods::exception& e) {
+            irods::log(LOG_ERROR, fmt::format(
+                "[{}:{}] - error finalizing replica; [{}], ec:[{}]",
+                __FUNCTION__, __LINE__, e.what(), e.code()));
+
+            if (status >= 0) {
+                status = e.code();
+            }
+        }
+
+        if (bytes_written < 0) {
+            if (const auto ec = finalize_destination_replica_on_failure(_comm, destination_fd, *destination_replica.get()); ec < 0) {
+                irods::log(LOG_ERROR, fmt::format(
+                    "[{}] - failed while finalizing object [{}]; ec:[{}]",
+                    __FUNCTION__, destination_replica.logical_path(), ec));
+            }
+            return bytes_written;
+        }
+
+        // finalize destination replica
+        try {
+            if (const int ec = finalize_destination_replica(_comm, destination_fd, *source_replica.get(), *destination_replica.get()); ec < 0) {
+                irods::log(LOG_ERROR, fmt::format(
+                    "[{}:{}] - closing destination replica [{}] failed with [{}]",
+                    __FUNCTION__, __LINE__, destination_replica.logical_path(), ec));
+
+                if (status >= 0) {
+                    status = ec;
+                }
+            }
+        }
+        catch (const irods::exception& e) {
+            irods::log(LOG_ERROR, fmt::format(
+                "[{}:{}] - error finalizing replica; [{}], ec:[{}]",
+                __FUNCTION__, __LINE__, e.what(), e.code()));
+
+            if (status >= 0) {
+                status = e.code();
+            }
+        }
+
+        if (destination_fd.purgeCacheFlag > 0) {
+            irods::purge_cache(_comm, *destination_replica.get());
+        }
+
+        if (status >= 0) {
+            apply_static_peps(_comm, destination_fd, status);
+        }
+
+        return status;
+    } // replicate_data
+
+    int repl_data_obj(RsComm& _comm, const dataObjInp_t& _inp)
+    {
+        namespace irv = irods::experimental::resource::voting;
+
+        // Make sure the requested source and destination resources are valid
+        dataObjInp_t destination_inp{};
+        dataObjInp_t source_inp{};
+        const irods::at_scope_exit free_cond_inputs{[&destination_inp, &source_inp]() {
+            clearKeyVal(&destination_inp.condInput);
+            clearKeyVal(&source_inp.condInput);
+        }};
+
+        source_inp = init_source_replica_input(_comm, _inp);
+        //auto source_cond_input = irods::experimental::make_key_value_proxy(source_inp.condInput);
+        auto source_obj = get_source_replica_info(_comm, source_inp);
+
+        destination_inp = init_destination_replica_input(_comm, _inp);
+        //auto destination_cond_input = irods::experimental::make_key_value_proxy(destination_inp.condInput);
+        auto destination_obj = get_destination_replica_info(_comm, destination_inp);
+
+        if (getValByKey(&_inp.condInput, ALL_KW)) {
+            int status{};
+            for (const auto& r : destination_obj->replicas()) {
+                irods::log(LOG_DEBUG, fmt::format(
+                    "[{}:{}] - hier:[{}],status:[{}],vote:[{}]",
+                    __FUNCTION__, __LINE__,
+                    r.resc_hier(),
+                    r.replica_status(),
+                    r.vote()));
+                if (GOOD_REPLICA == (r.replica_status() & 0x0F)) {
+                    continue;
+                }
+                if (r.vote() > irv::vote::zero) {
+                    addKeyVal(&destination_inp.condInput, RESC_HIER_STR_KW, r.resc_hier().c_str());
+                    status = replicate_data(_comm, source_inp, destination_inp);
+                }
+            }
+            return status;
+        }
+
         const char* dest_hier = getValByKey(&destination_inp.condInput, RESC_HIER_STR_KW);
-        for (const auto& r : file_obj->replicas()) {
+        for (const auto& r : destination_obj->replicas()) {
             // TODO: #4010 - This short-circuits resource logic for handling good replicas
             if (r.resc_hier() == dest_hier) {
                 if (GOOD_REPLICA == r.replica_status()) {
@@ -322,71 +653,66 @@ int repl_data_obj(
                 break;
             }
         }
-        status = replicate_data(rsComm, source_inp, destination_inp);
-    }
-    return status;
-} // repl_data_obj
+        return replicate_data(_comm, source_inp, destination_inp);
+    } // repl_data_obj
 
-int singleL1Copy(
-    rsComm_t *rsComm,
-    dataCopyInp_t& dataCopyInp) {
+    int singleL1Copy(rsComm_t *rsComm, dataCopyInp_t& dataCopyInp)
+    {
+        int trans_buff_size;
+        try {
+            trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
+        } catch ( const irods::exception& e ) {
+            irods::log(e);
+            return e.code();
+        }
 
-    int trans_buff_size;
-    try {
-        trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
-    } catch ( const irods::exception& e ) {
-        irods::log(e);
-        return e.code();
-    }
+        dataOprInp_t* dataOprInp = &dataCopyInp.dataOprInp;
+        int destL1descInx = dataCopyInp.portalOprOut.l1descInx;
+        int srcL1descInx = L1desc[destL1descInx].srcL1descInx;
 
-    dataOprInp_t* dataOprInp = &dataCopyInp.dataOprInp;
-    int destL1descInx = dataCopyInp.portalOprOut.l1descInx;
-    int srcL1descInx = L1desc[destL1descInx].srcL1descInx;
+        openedDataObjInp_t dataObjReadInp{};
+        dataObjReadInp.l1descInx = srcL1descInx;
+        dataObjReadInp.len = trans_buff_size;
 
-    openedDataObjInp_t dataObjReadInp{};
-    dataObjReadInp.l1descInx = srcL1descInx;
-    dataObjReadInp.len = trans_buff_size;
+        bytesBuf_t dataObjReadInpBBuf{};
+        dataObjReadInpBBuf.buf = malloc(dataObjReadInp.len);
+        dataObjReadInpBBuf.len = dataObjReadInp.len;
+        const irods::at_scope_exit free_data_obj_read_inp_bbuf{[&dataObjReadInpBBuf]() {
+            free(dataObjReadInpBBuf.buf);
+        }};
 
-    bytesBuf_t dataObjReadInpBBuf{};
-    dataObjReadInpBBuf.buf = malloc(dataObjReadInp.len);
-    dataObjReadInpBBuf.len = dataObjReadInp.len;
-    const irods::at_scope_exit free_data_obj_read_inp_bbuf{[&dataObjReadInpBBuf]() {
-        free(dataObjReadInpBBuf.buf);
-    }};
+        openedDataObjInp_t dataObjWriteInp{};
+        dataObjWriteInp.l1descInx = destL1descInx;
 
-    openedDataObjInp_t dataObjWriteInp{};
-    dataObjWriteInp.l1descInx = destL1descInx;
+        bytesBuf_t dataObjWriteInpBBuf{};
+        dataObjWriteInpBBuf.buf = dataObjReadInpBBuf.buf;
+        dataObjWriteInpBBuf.len = 0;
 
-    bytesBuf_t dataObjWriteInpBBuf{};
-    dataObjWriteInpBBuf.buf = dataObjReadInpBBuf.buf;
-    dataObjWriteInpBBuf.len = 0;
+        int bytesRead{};
+        rodsLong_t totalWritten = 0;
+        while ((bytesRead = rsDataObjRead(rsComm, &dataObjReadInp, &dataObjReadInpBBuf)) > 0) {
+            dataObjWriteInp.len = bytesRead;
+            dataObjWriteInpBBuf.len = bytesRead;
+            int bytesWritten = rsDataObjWrite(rsComm, &dataObjWriteInp, &dataObjWriteInpBBuf);
+            if (bytesWritten != bytesRead) {
+                rodsLog(LOG_ERROR,
+                        "%s: Read %d bytes, Wrote %d bytes.\n ",
+                        __FUNCTION__, bytesRead, bytesWritten );
+                return SYS_COPY_LEN_ERR;
+            }
+            totalWritten += bytesWritten;
+        }
 
-    int bytesRead{};
-    rodsLong_t totalWritten = 0;
-    while ((bytesRead = rsDataObjRead(rsComm, &dataObjReadInp, &dataObjReadInpBBuf)) > 0) {
-        dataObjWriteInp.len = bytesRead;
-        dataObjWriteInpBBuf.len = bytesRead;
-        int bytesWritten = rsDataObjWrite(rsComm, &dataObjWriteInp, &dataObjWriteInpBBuf);
-        if (bytesWritten != bytesRead) {
+        if (dataOprInp->dataSize > 0 &&
+            !getValByKey(&dataOprInp->condInput, NO_CHK_COPY_LEN_KW) &&
+            totalWritten != dataOprInp->dataSize) {
             rodsLog(LOG_ERROR,
-                    "%s: Read %d bytes, Wrote %d bytes.\n ",
-                    __FUNCTION__, bytesRead, bytesWritten );
+                    "%s: totalWritten %lld dataSize %lld mismatch",
+                    __FUNCTION__, totalWritten, dataOprInp->dataSize);
             return SYS_COPY_LEN_ERR;
         }
-        totalWritten += bytesWritten;
-    }
-
-    if (dataOprInp->dataSize > 0 &&
-        !getValByKey(&dataOprInp->condInput, NO_CHK_COPY_LEN_KW) &&
-        totalWritten != dataOprInp->dataSize) {
-        rodsLog(LOG_ERROR,
-                "%s: totalWritten %lld dataSize %lld mismatch",
-                __FUNCTION__, totalWritten, dataOprInp->dataSize);
-        return SYS_COPY_LEN_ERR;
-    }
-    return 0;
-} // singleL1Copy
-
+        return 0;
+    } // singleL1Copy
 } // anonymous namespace
 
 int rsDataObjRepl(
@@ -449,12 +775,20 @@ int rsDataObjRepl(
 
     try {
         addKeyVal(&dataObjInp->condInput, IN_REPL_KW, "");
-        status = repl_data_obj(rsComm, *dataObjInp);
+        status = repl_data_obj(*rsComm, *dataObjInp);
         rmKeyVal(&dataObjInp->condInput, IN_REPL_KW);
     }
     catch (const irods::exception& e) {
         irods::log(e);
         status = e.code();
+    }
+    catch (const std::exception& e) {
+        irods::log(LOG_ERROR, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, e.what()));
+        status = SYS_LIBRARY_ERROR;
+    }
+    catch (...) {
+        irods::log(LOG_ERROR, fmt::format("[{}:{}] - unknown error occurred", __FUNCTION__, __LINE__));
+        status = SYS_UNKNOWN_ERROR;
     }
 
     if (status < 0 && status != DIRECT_ARCHIVE_ACCESS) {

--- a/server/api/src/rsDataObjUnlink.cpp
+++ b/server/api/src/rsDataObjUnlink.cpp
@@ -443,7 +443,7 @@ int dataObjUnlinkS(rsComm_t* rsComm,
     {
         std::string vault_path;
         if (const auto err = irods::get_vault_path_for_hier_string(dataObjInfo->rescHier, vault_path); !err.ok()) {
-            return SYS_INTERNAL_ERR;
+            return err.code();
         }
 
         bool skip_vault_path_check = false;

--- a/server/api/src/rsModDataObjMeta.cpp
+++ b/server/api/src/rsModDataObjMeta.cpp
@@ -289,8 +289,7 @@ int _call_file_modified_for_modification(
         }
 
         // Use temporary as file_object_factory overwrites dataObjInfo pointer
-        dataObjInfo_t* tmpDataObjInfo{};
-        auto ret{file_object_factory(rsComm, &dataObjInp, file_obj, &tmpDataObjInfo)};
+        auto ret{file_object_factory(rsComm, &dataObjInp, file_obj)};
         if (!ret.ok()) {
             irods::log(ret);
             return ret.code();

--- a/server/api/src/rsModDataObjMeta.cpp
+++ b/server/api/src/rsModDataObjMeta.cpp
@@ -13,6 +13,7 @@
 #include "irods_file_object.hpp"
 #include "irods_stacktrace.hpp"
 #include "irods_configuration_keywords.hpp"
+#include "key_value_proxy.hpp"
 
 #include "boost/format.hpp"
 
@@ -300,22 +301,21 @@ int _call_file_modified_for_modification(
         if (getValByKey(regParam, ADMIN_KW)) {
             addKeyVal((keyValPair_t*)&file_obj->cond_input(), ADMIN_KW, "");
         }
-        const auto pdmo_kw{getValByKey(regParam, IN_PDMO_KW)};
-        if (pdmo_kw) {
+        if (const auto pdmo_kw = getValByKey(regParam, IN_PDMO_KW); pdmo_kw) {
             // TODO: log in_pdmo kw
             file_obj->in_pdmo(pdmo_kw);
         }
-        const auto open_type{getValByKey(regParam, OPEN_TYPE_KW)};
-        if (open_type) {
+        if (const auto open_type = getValByKey(regParam, OPEN_TYPE_KW); open_type) {
             addKeyVal((keyValPair_t*)&file_obj->cond_input(), OPEN_TYPE_KW, open_type);
         }
-        char* sync = getValByKey(regParam, SYNC_OBJ_KW );
-        if (sync) {
+        if (const char* sync = getValByKey(regParam, SYNC_OBJ_KW); sync) {
             addKeyVal((keyValPair_t*)&file_obj->cond_input(), SYNC_OBJ_KW, sync);
         }
-        const auto repl_status{getValByKey(regParam, REPL_STATUS_KW)};
-        if (repl_status) {
+        if (const auto repl_status = getValByKey(regParam, REPL_STATUS_KW); repl_status) {
             addKeyVal((keyValPair_t*)&file_obj->cond_input(), REPL_STATUS_KW, repl_status);
+        }
+        if (const char* selected_hier = getValByKey(regParam, SELECTED_HIERARCHY_KW); selected_hier) {
+            addKeyVal((keyValPair_t*)&file_obj->cond_input(), SELECTED_HIERARCHY_KW, selected_hier);
         }
         ret = fileModified(rsComm, file_obj);
         if (!ret.ok()) {

--- a/server/api/src/rsRegReplica.cpp
+++ b/server/api/src/rsRegReplica.cpp
@@ -139,7 +139,7 @@ namespace irods {
                 }
             }
 
-            // optional checksum verification, should one exist 
+            // optional checksum verification, should one exist
             // on the source replica
             std::string dst_checksum;
             if(strlen(src_info->chksum) > 0) {

--- a/server/core/include/collection.hpp
+++ b/server/core/include/collection.hpp
@@ -29,7 +29,7 @@ rsQueryCollInColl( rsComm_t *rsComm, char *collection,
 int
 isCollEmpty( rsComm_t *rsComm, char *collection );
 int
-collStat( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
+collStat( rsComm_t *rsComm, const dataObjInp_t *dataObjInp,
           rodsObjStat_t **rodsObjStatOut );
 int
 collStatAllKinds( rsComm_t *rsComm, dataObjInp_t *dataObjInp,

--- a/server/core/include/finalize_utilities.hpp
+++ b/server/core/include/finalize_utilities.hpp
@@ -1,0 +1,116 @@
+#ifndef IRODS_FINALIZE_UTILITIES_HPP
+#define IRODS_FINALIZE_UTILITIES_HPP
+
+#include "rodsType.h"
+
+#include <string_view>
+
+struct RsComm;
+struct DataObjInfo;
+struct DataObjInp;
+struct l1desc;
+
+namespace irods
+{
+    /// \brief Takes the ACLs included in the condInput and applies them to the objPath of _inp
+    ///
+    /// \param[in/out] _comm
+    /// \param[in] _inp Supplies the objPath and condInput
+    ///
+    /// \since 4.2.9
+    auto apply_acl_from_cond_input(RsComm& _comm, const DataObjInp& _inp) -> void;
+
+    /// \brief Takes the metadata included in the condInput and applies them to the objPath of _inp
+    ///
+    /// \param[in/out] _comm
+    /// \param[in] _inp Supplies the objPath and condInput
+    ///
+    /// \since 4.2.9
+    auto apply_metadata_from_cond_input(RsComm& _comm, const DataObjInp& _inp) -> void;
+
+    /// \brief Calls _dataObjChksum with the REGISTER_CHKSUM_KW
+    ///
+    /// \param[in/out] _comm
+    /// \param[in/out] _info Required for _dataObjChksum
+    /// \param[in] _original_checksum
+    ///
+    /// \returns std::string
+    /// \retval the computed checksum
+    ///
+    /// \throws irods::exception If checksum operation fails for any reason
+    ///
+    /// \since 4.2.9
+    auto register_new_checksum(RsComm& _comm, DataObjInfo& _info, std::string_view _original_checksum) -> std::string;
+
+    /// \brief Calls _dataObjChksum with the VERIFY_CHKSUM_KW
+    ///
+    /// \param[in/out] _comm
+    /// \param[in/out] _info Required for _dataObjChksum
+    /// \param[in] _original_checksum
+    ///
+    /// \returns std::string
+    /// \retval the computed checksum
+    /// \retval empty string if calculated checksum does not match the original
+    ///
+    /// \throws irods::exception If checksum operation fails for any reason
+    ///
+    /// \since 4.2.9
+    auto verify_checksum(RsComm& _comm, DataObjInfo& _info, std::string_view _original_checksum) -> std::string;
+
+    /// \brief Calls getSizeInVault and verifies the result depending on the inputs
+    ///
+    /// If UNKNOWN_FILE_SZ is returned by getSizeInVault, the _recorded size is returned as
+    /// the return value is likely the result of a resource which cannot stat its data in the
+    /// expected manner. In this case, the result recorded by the plugin is "trusted".
+    ///
+    /// \param[in/out] _comm
+    /// \param[in/out] _info
+    /// \parma[in] _verify_size Verify the recorded size against the size in the vault
+    /// \param[in] _recorded_size Size to verify against
+    ///
+    /// \returns rodsLong_t
+    /// \retval If UNKNOWN_FILE_SZ is returned, _recorded_size; else, size in the vault
+    ///
+    /// \throws irods::exception If an error occurs getting the size or verification fails
+    ///
+    /// \since 4.2.9
+    auto get_size_in_vault(RsComm& _comm, DataObjInfo& _info, const bool _verify_size, const rodsLong_t _recorded_size) -> rodsLong_t;
+
+    /// \param[in] _src
+    ///
+    /// \returns l1desc
+    /// \retval Copy of _src L1 descriptor including DataObjInp and DataObjInfo
+    ///
+    /// \since 4.2.9
+    auto duplicate_l1_descriptor(const l1desc& _src) -> l1desc;
+
+    /// \brief Marks the specified replica as stale in the catalog
+    ///
+    /// \param[in/out] _comm
+    /// \param[in] _l1desc
+    /// \param[in/out] _info Holds affected replica information
+    ///
+    /// \returns int
+    /// \retval Status returned by rsModDataObjMeta
+    ///
+    /// \since 4.2.9
+    auto stale_replica(RsComm& _comm, const l1desc& _l1desc, DataObjInfo& _info) -> int;
+
+    /// \brief Calls applyRule on the specified post-PEP name
+    ///
+    /// \param[in/out] _comm
+    /// \param[in/out] _l1desc
+    /// \param[in] _operation_status
+    /// \param[in] _pep_name
+    ///
+    /// \returns int
+    /// \retval REI status after calling applyRule
+    ///
+    /// \since 4.2.9
+    auto apply_static_post_pep(RsComm& _comm, l1desc& _l1desc, const int _operation_status, std::string_view _pep_name) -> int;
+
+    // TODO: ...remove this.
+    auto purge_cache(RsComm& _comm, DataObjInfo& _info) -> int;
+} // namespace irods
+
+#endif // IRODS_FINALIZE_UTILITIES_HPP

--- a/server/core/include/irods_resource_manager.hpp
+++ b/server/core/include/irods_resource_manager.hpp
@@ -70,9 +70,20 @@ namespace irods
             /// @brief create a list of resources who do not have parents ( roots )
             error get_root_resources( std::vector< std::string >& );
 
-            // =-=-=-=-=-=-=-
-            /// @brief create a partial hier string for a given resource to the root
+            /// \brief create a partial hier string for a given resource to the root
             error get_hier_to_root_for_resc( const std::string&, std::string& );
+
+            /// \brief create a partial hier string for a given resource to the root
+            ///
+            /// \param[in] _resource_name
+            ///
+            /// \returns std::string
+            /// \retval resource hierarchy from provided resource name to root resource
+            ///
+            /// \throws irods::exception
+            ///
+            /// \since 4.2.9
+            std::string get_hier_to_root_for_resc(std::string_view _resource_name);
 
             // =-=-=-=-=-=-=-
             /// @brief groups decedent leafs by child

--- a/server/core/include/objDesc.hpp
+++ b/server/core/include/objDesc.hpp
@@ -69,8 +69,9 @@ initL1Desc();
 int
 allocL1Desc();
 
-int
-freeL1Desc( int fileInx );
+int freeL1desc_struct(l1desc& _l1desc);
+
+int freeL1desc(const int l1descInx);
 
 int
 fillL1desc( int l1descInx, dataObjInp_t *dataObjInp,
@@ -88,8 +89,6 @@ int
 initDataObjInfoWithInp( dataObjInfo_t *dataObjInfo, dataObjInp_t *dataObjInp );
 int
 allocL1desc();
-int
-freeL1desc( int l1descInx );
 int
 closeAllL1desc( rsComm_t *rsComm );
 int

--- a/server/core/include/replica_state_table.hpp
+++ b/server/core/include/replica_state_table.hpp
@@ -1,0 +1,382 @@
+#ifndef IRODS_REPLICA_STATE_TABLE_HPP
+#define IRODS_REPLICA_STATE_TABLE_HPP
+
+#include "json.hpp"
+
+#include <string_view>
+
+struct DataObjInfo;
+
+namespace irods
+{
+    /// \brief Singleton which maintains a JSON structure describing the state of change of opened data objects.
+    ///
+    /// \since 4.2.9
+    class replica_state_table
+    {
+    public:
+        // Prevent copying replica_state_table
+        replica_state_table(const replica_state_table&) = delete;
+        auto operator=(const replica_state_table&) -> replica_state_table& = delete;
+
+        /// \brief Specify which version of the data object information to fetch from the map entry
+        ///
+        /// \since 4.2.9
+        enum class state_type
+        {
+            before,
+            after,
+            both
+        }; // enum class state_type
+
+        /// \brief Initialize the replica_state_table by making sure it is completely cleared out
+        ///
+        /// \since 4.2.9
+        static auto init() -> void;
+
+        /// \brief De-initialize the replica_state_table by making sure it is completely cleared out
+        ///
+        /// \since 4.2.9
+        static auto deinit() -> void;
+
+        /// \returns static Singleton instance
+        ///
+        /// \since 4.2.9
+        static auto instance() noexcept -> replica_state_table&;
+
+        /// \brief Create a new entry in the replica_state_table
+        ///
+        /// If the specified object already exists in the replica state table, nothing happens.
+        ///
+        /// \param[in] _obj Initial data object state to serve as both "before" and "after" at the start
+        ///
+        /// \since 4.2.9
+        auto insert(const DataObjInfo& _obj) -> void;
+
+        /// \brief Erase replica_state_table entry indicated by _logical_path
+        ///
+        /// \param[in] _logical_path
+        ///
+        /// \throws irods::exception If no key matches _logical_path
+        ///
+        /// \since 4.2.9
+        auto erase(const std::string_view _logical_path) -> void;
+
+        /// \brief Returns whether or not an entry in the replica state table keys on the provided logical path
+        ///
+        /// \param[in] _logical_path
+        ///
+        /// \retval true if replica state table contains key _logical_path
+        /// \retval false if replica state table does not contain key _logical_path
+        ///
+        /// \since 4.2.9
+        auto contains(const std::string_view _logical_path) const -> bool;
+
+        /// \brief return all information for all states of all replicas for a particular data object
+        ///
+        /// \param[in] _logical_path
+        ///
+        /// \returns JSON object of the following form: \parblock
+        /// \code{.js}
+        /// [
+        ///     {
+        ///         "before": {
+        ///             "data_id": <string>,
+        ///             "coll_id": <string>,
+        ///             "data_repl_num": <string>,
+        ///             "data_version": <string>,
+        ///             "data_type_name": <string>,
+        ///             "data_size": <string>,
+        ///             "data_path": <string>,
+        ///             "data_owner_name": <string>,
+        ///             "data_owner_zone": <string>,
+        ///             "data_is_dirty": <string>,
+        ///             "data_status": <string>,
+        ///             "data_checksum": <string>,
+        ///             "data_expiry_ts": <string>,
+        ///             "data_map_id": <string>,
+        ///             "data_mode": <string>,
+        ///             "r_comment": <string>,
+        ///             "create_ts": <string>,
+        ///             "modify_ts": <string>,
+        ///             "resc_id": <string>
+        ///         },
+        ///         "after": {
+        ///             "data_id": <string>,
+        ///             "coll_id": <string>,
+        ///             "data_repl_num": <string>,
+        ///             "data_version": <string>,
+        ///             "data_type_name": <string>,
+        ///             "data_size": <string>,
+        ///             "data_path": <string>,
+        ///             "data_owner_name": <string>,
+        ///             "data_owner_zone": <string>,
+        ///             "data_is_dirty": <string>,
+        ///             "data_status": <string>,
+        ///             "data_checksum": <string>,
+        ///             "data_expiry_ts": <string>,
+        ///             "data_map_id": <string>,
+        ///             "data_mode": <string>,
+        ///             "r_comment": <string>,
+        ///             "create_ts": <string>,
+        ///             "modify_ts": <string>,
+        ///             "resc_id": <string>
+        ///         }
+        ///   },
+        ///   ...
+        /// ]
+        /// \endcode
+        /// \endparblock
+        ///
+        /// \since 4.2.9
+        auto at(const std::string_view _logical_path) const -> nlohmann::json;
+
+        /// \brief return a specific replica by replica number with optional before/after specification (defaults to both)
+        ///
+        /// \param[in] _logical_path
+        /// \param[in] _replica_number Replica number in the "before" entry
+        /// \param[in] _state
+        ///
+        /// \returns JSON object of the following form: \parblock
+        /// - For state_type::both:
+        /// \code{.js}
+        ///     {
+        ///         "before": {
+        ///             "data_id": <string>,
+        ///             "coll_id": <string>,
+        ///             "data_repl_num": <string>,
+        ///             "data_version": <string>,
+        ///             "data_type_name": <string>,
+        ///             "data_size": <string>,
+        ///             "data_path": <string>,
+        ///             "data_owner_name": <string>,
+        ///             "data_owner_zone": <string>,
+        ///             "data_is_dirty": <string>,
+        ///             "data_status": <string>,
+        ///             "data_checksum": <string>,
+        ///             "data_expiry_ts": <string>,
+        ///             "data_map_id": <string>,
+        ///             "data_mode": <string>,
+        ///             "r_comment": <string>,
+        ///             "create_ts": <string>,
+        ///             "modify_ts": <string>,
+        ///             "resc_id": <string>
+        ///         },
+        ///         "after": {
+        ///             "data_id": <string>,
+        ///             "coll_id": <string>,
+        ///             "data_repl_num": <string>,
+        ///             "data_version": <string>,
+        ///             "data_type_name": <string>,
+        ///             "data_size": <string>,
+        ///             "data_path": <string>,
+        ///             "data_owner_name": <string>,
+        ///             "data_owner_zone": <string>,
+        ///             "data_is_dirty": <string>,
+        ///             "data_status": <string>,
+        ///             "data_checksum": <string>,
+        ///             "data_expiry_ts": <string>,
+        ///             "data_map_id": <string>,
+        ///             "data_mode": <string>,
+        ///             "r_comment": <string>,
+        ///             "create_ts": <string>,
+        ///             "modify_ts": <string>,
+        ///             "resc_id": <string>
+        ///         }
+        ///     }
+        /// \endcode
+        ///
+        /// - For state_type::before/state_type::after:
+        /// \code{.js}
+        ///     {
+        ///         "data_id": <string>,
+        ///         "coll_id": <string>,
+        ///         "data_repl_num": <string>,
+        ///         "data_version": <string>,
+        ///         "data_type_name": <string>,
+        ///         "data_size": <string>,
+        ///         "data_path": <string>,
+        ///         "data_owner_name": <string>,
+        ///         "data_owner_zone": <string>,
+        ///         "data_is_dirty": <string>,
+        ///         "data_status": <string>,
+        ///         "data_checksum": <string>,
+        ///         "data_expiry_ts": <string>,
+        ///         "data_map_id": <string>,
+        ///         "data_mode": <string>,
+        ///         "r_comment": <string>,
+        ///         "create_ts": <string>,
+        ///         "modify_ts": <string>,
+        ///         "resc_id": <string>
+        ///     }
+        /// \endcode
+        /// \endparblock
+        ///
+        /// \since 4.2.9
+        auto at(const std::string_view _logical_path,
+                const std::string_view _leaf_resource_name,
+                const state_type _state = state_type::both) const -> nlohmann::json;
+
+        /// \brief return a specific replica by replica number with optional before/after specification (defaults to both)
+        ///
+        /// \param[in] _logical_path
+        /// \param[in] _replica_number Replica number in the "before" entry
+        /// \param[in] _state
+        ///
+        /// \returns JSON object of the following form: \parblock
+        /// - For state_type::both...
+        /// \code{.js}
+        ///     {
+        ///         "before": {
+        ///             "data_id": <string>,
+        ///             "coll_id": <string>,
+        ///             "data_repl_num": <string>,
+        ///             "data_version": <string>,
+        ///             "data_type_name": <string>,
+        ///             "data_size": <string>,
+        ///             "data_path": <string>,
+        ///             "data_owner_name": <string>,
+        ///             "data_owner_zone": <string>,
+        ///             "data_is_dirty": <string>,
+        ///             "data_status": <string>,
+        ///             "data_checksum": <string>,
+        ///             "data_expiry_ts": <string>,
+        ///             "data_map_id": <string>,
+        ///             "data_mode": <string>,
+        ///             "r_comment": <string>,
+        ///             "create_ts": <string>,
+        ///             "modify_ts": <string>,
+        ///             "resc_id": <string>
+        ///         },
+        ///         "after": {
+        ///             "data_id": <string>,
+        ///             "coll_id": <string>,
+        ///             "data_repl_num": <string>,
+        ///             "data_version": <string>,
+        ///             "data_type_name": <string>,
+        ///             "data_size": <string>,
+        ///             "data_path": <string>,
+        ///             "data_owner_name": <string>,
+        ///             "data_owner_zone": <string>,
+        ///             "data_is_dirty": <string>,
+        ///             "data_status": <string>,
+        ///             "data_checksum": <string>,
+        ///             "data_expiry_ts": <string>,
+        ///             "data_map_id": <string>,
+        ///             "data_mode": <string>,
+        ///             "r_comment": <string>,
+        ///             "create_ts": <string>,
+        ///             "modify_ts": <string>,
+        ///             "resc_id": <string>
+        ///         }
+        ///     }
+        /// \endcode
+        ///
+        /// - For state_type::before/state_type::after...
+        /// \code{.js}
+        ///     {
+        ///         "data_id": <string>,
+        ///         "coll_id": <string>,
+        ///         "data_repl_num": <string>,
+        ///         "data_version": <string>,
+        ///         "data_type_name": <string>,
+        ///         "data_size": <string>,
+        ///         "data_path": <string>,
+        ///         "data_owner_name": <string>,
+        ///         "data_owner_zone": <string>,
+        ///         "data_is_dirty": <string>,
+        ///         "data_status": <string>,
+        ///         "data_checksum": <string>,
+        ///         "data_expiry_ts": <string>,
+        ///         "data_map_id": <string>,
+        ///         "data_mode": <string>,
+        ///         "r_comment": <string>,
+        ///         "create_ts": <string>,
+        ///         "modify_ts": <string>,
+        ///         "resc_id": <string>
+        ///     }
+        /// \endcode
+        /// \endparblock
+        ///
+        /// \since 4.2.9
+        auto at(const std::string_view _logical_path,
+                const int _replica_number,
+                const state_type _state = state_type::both) const -> nlohmann::json;
+
+        /// \brief Updates the specified replica with the specified changes (after state only)
+        ///
+        /// \param[in] _logical_path
+        /// \param[in] _replica_number Replica number in the "before" entry
+        /// \param[in] _updates JSON input representing changes to be made. \parblock
+        /// Must be of the following form (only fields which need updating need to be included):
+        /// \code{.js}
+        ///     {
+        ///         <r_data_main_column>: <string>,
+        ///         ...
+        ///     }
+        /// \endcode
+        /// \endparblock
+        ///
+        /// \since 4.2.9
+        auto update(const std::string_view _logical_path,
+                    const int _replica_number,
+                    const nlohmann::json& _updates) -> void;
+
+        /// \brief Updates the specified replica with the specified changes (after state only)
+        ///
+        /// \param[in] _logical_path
+        /// \param[in] _leaf_resource_name Leaf resource name in the "before" entry
+        /// \param[in] _updates JSON input representing changes to be made. \parblock
+        /// Must be of the following form (only fields which need updating need to be included):
+        /// \code{.js}
+        ///     {
+        ///         <r_data_main_column>: <string>,
+        ///         ...
+        ///     }
+        /// \endcode
+        /// \endparblock
+        ///
+        /// \since 4.2.9
+        auto update(const std::string_view _logical_path,
+                    const std::string_view _leaf_resource_name,
+                    const nlohmann::json& _updates) -> void;
+
+        /// \brief Returns the value of a given property of the given replica in the state table
+        ///
+        /// \param[in] _logical_path
+        /// \param[in] _replica_number Replica number in the "before" entry
+        /// \param[in] _property_name
+        /// \param[in] _state Must be state_type::before or state_type::after
+        ///
+        /// \throws irods::exception
+        ///
+        /// \since 4.2.9
+        auto get_property(
+            const std::string_view _logical_path,
+            const int _replica_number,
+            const std::string_view _property_name,
+            const state_type _state = state_type::before) const -> std::string;
+
+        /// \brief Returns the value of a given property of the given replica in the state table
+        ///
+        /// \param[in] _logical_path
+        /// \param[in] _leaf_resource_name Leaf resource name in the "before" entry
+        /// \param[in] _property_name
+        /// \param[in] _state Must be state_type::before or state_type::after
+        ///
+        /// \throws irods::exception
+        ///
+        /// \since 4.2.9
+        auto get_property(
+            const std::string_view _logical_path,
+            const std::string_view _leaf_resource_name,
+            const std::string_view _property_name,
+            const state_type _state = state_type::before) const -> std::string;
+
+    private:
+        // Disallow construction of the replica_state_table outside of member functions
+        replica_state_table() = default;
+    }; // class replica_state_table
+} // namespace irods
+
+#endif // IRODS_REPLICA_STATE_TABLE_HPP

--- a/server/core/include/specColl.hpp
+++ b/server/core/include/specColl.hpp
@@ -24,11 +24,11 @@ extern "C" {
     int
     querySpecColl( rsComm_t *rsComm, char *objPath, genQueryOut_t **genQueryOut );
     int
-    queueSpecCollCache( rsComm_t *rsComm, genQueryOut_t *genQueryOut, char *objPath ); // JMC - backport 4680
+    queueSpecCollCache( rsComm_t *rsComm, genQueryOut_t *genQueryOut, const char *objPath ); // JMC - backport 4680
     int
     queueSpecCollCacheWithObjStat( rodsObjStat_t *rodsObjStatOut );
     specCollCache_t *
-    matchSpecCollCache( char *objPath );
+    matchSpecCollCache(const char *objPath );
     int
     getSpecCollCache( rsComm_t *rsComm, char *objPath, int inCachOnly,
                       specCollCache_t **specCollCache );

--- a/server/core/src/collection.cpp
+++ b/server/core/src/collection.cpp
@@ -268,7 +268,7 @@ isCollEmpty( rsComm_t *rsComm, char *collection ) {
 /* collStat - query metaData of a collection. */
 
 int
-collStat( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
+collStat( rsComm_t *rsComm, const dataObjInp_t *dataObjInp,
           rodsObjStat_t **rodsObjStatOut ) {
     genQueryInp_t genQueryInp;
     genQueryOut_t *genQueryOut = NULL;
@@ -371,8 +371,7 @@ collStat( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
             if ( strlen( collType->value ) > 0 ) {
                 specCollCache_t *specCollCache = 0;
 
-                if ( ( specCollCache =
-                            matchSpecCollCache( dataObjInp->objPath ) ) != NULL ) {
+                if ( ( specCollCache = matchSpecCollCache( dataObjInp->objPath ) ) != NULL ) {
                     replSpecColl( &specCollCache->specColl,
                                   &( *rodsObjStatOut )->specColl );
                 }

--- a/server/core/src/finalize_utilities.cpp
+++ b/server/core/src/finalize_utilities.cpp
@@ -1,0 +1,251 @@
+#include "finalize_utilities.hpp"
+#include "irods_at_scope_exit.hpp"
+#include "irods_exception.hpp"
+#include "irods_re_structs.hpp"
+#include "irods_resource_backport.hpp"
+#include "irods_serialization.hpp"
+#include "objDesc.hpp"
+#include "physPath.hpp"
+#include "rcMisc.h"
+#include "rsDataObjTrim.hpp"
+#include "rsModAVUMetadata.hpp"
+#include "rsModAccessControl.hpp"
+
+#define IRODS_REPLICA_ENABLE_SERVER_SIDE_API
+#include "data_object_proxy.hpp"
+#include "replica_proxy.hpp"
+
+#include <string>
+#include <vector>
+
+namespace irods
+{
+    auto apply_metadata_from_cond_input(RsComm& _comm, const DataObjInp& _inp) -> void
+    {
+        if ( const char* serialized_metadata = getValByKey( &_inp.condInput, METADATA_INCLUDED_KW ) ) {
+            std::vector<std::string> deserialized_metadata = irods::deserialize_metadata( serialized_metadata );
+            for ( size_t i = 0; i + 2 < deserialized_metadata.size(); i += 3 ) {
+                modAVUMetadataInp_t modAVUMetadataInp;
+                memset( &modAVUMetadataInp, 0, sizeof( modAVUMetadataInp ) );
+
+                modAVUMetadataInp.arg0 = strdup( "add" );
+                modAVUMetadataInp.arg1 = strdup( "-d" );
+                modAVUMetadataInp.arg2 = strdup( _inp.objPath );
+                modAVUMetadataInp.arg3 = strdup( deserialized_metadata[i].c_str() );
+                modAVUMetadataInp.arg4 = strdup( deserialized_metadata[i + 1].c_str() );
+                modAVUMetadataInp.arg5 = strdup( deserialized_metadata[i + 2].c_str() );
+                int status = rsModAVUMetadata(&_comm, &modAVUMetadataInp );
+                clearModAVUMetadataInp( &modAVUMetadataInp );
+                if ( CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME != status && status < 0 ) {
+                    THROW( status, "rsModAVUMetadata failed" );
+                }
+            }
+        }
+    } // apply_metadata_from_cond_input
+
+    auto apply_acl_from_cond_input(RsComm& _comm, const DataObjInp& _inp) -> void
+    {
+        if ( const char* serialized_acl = getValByKey( &_inp.condInput, ACL_INCLUDED_KW ) ) {
+            std::vector<std::vector<std::string> > deserialized_acl = irods::deserialize_acl( serialized_acl );
+            for ( std::vector<std::vector<std::string> >::const_iterator iter = deserialized_acl.begin(); iter != deserialized_acl.end(); ++iter ) {
+                modAccessControlInp_t modAccessControlInp;
+                modAccessControlInp.recursiveFlag = 0;
+                modAccessControlInp.accessLevel = strdup( ( *iter )[0].c_str() );
+                modAccessControlInp.userName = ( char * )malloc( sizeof( char ) * NAME_LEN );
+                modAccessControlInp.zone = ( char * )malloc( sizeof( char ) * NAME_LEN );
+                const int status_parseUserName = parseUserName( ( *iter )[1].c_str(), modAccessControlInp.userName, modAccessControlInp.zone );
+                if ( status_parseUserName < 0 ) {
+                    THROW( status_parseUserName, "parseUserName failed" );
+                }
+                modAccessControlInp.path = strdup( _inp.objPath );
+                int status = rsModAccessControl(&_comm, &modAccessControlInp );
+                clearModAccessControlInp( &modAccessControlInp );
+                if ( status < 0 ) {
+                    THROW( status, "rsModAccessControl failed" );
+                }
+            }
+        }
+    } // apply_acl_from_cond_input
+
+    auto verify_checksum(RsComm& _comm, DataObjInfo& _info, std::string_view _original_checksum) -> std::string
+    {
+        if (_original_checksum.empty()) {
+            return {};
+        }
+
+        char* checksum_string = nullptr;
+        irods::at_scope_exit free_checksum_string{[&checksum_string] { free(checksum_string); }};
+
+        auto obj = irods::experimental::data_object::make_data_object_proxy(_info);
+        auto replica = irods::experimental::replica::make_replica_proxy(*obj.get());
+
+        replica.cond_input()[ORIG_CHKSUM_KW] = _original_checksum;
+
+        if (const int ec = _dataObjChksum(&_comm, replica.get(), &checksum_string); ec < 0) {
+            THROW(ec, "failed in _dataObjChksum");
+        }
+
+        replica.cond_input().erase(ORIG_CHKSUM_KW);
+
+        // verify against the input value
+        if (_original_checksum != checksum_string) {
+            THROW(USER_CHKSUM_MISMATCH, fmt::format(
+                "{}: mismatch chksum for {}.inp={},compute {}",
+                __FUNCTION__, replica.logical_path(), _original_checksum, checksum_string));
+        }
+
+        return {checksum_string};
+    } // verify_checksum
+
+    auto register_new_checksum(RsComm& _comm, DataObjInfo& _info, std::string_view _original_checksum) -> std::string
+    {
+        char* checksum_string = nullptr;
+        irods::at_scope_exit free_checksum_string{[&checksum_string] { free(checksum_string); }};
+
+        auto obj = irods::experimental::data_object::make_data_object_proxy(_info);
+        auto replica = irods::experimental::replica::make_replica_proxy(*obj.get());
+
+        if (!_original_checksum.empty()) {
+            replica.cond_input()[ORIG_CHKSUM_KW] = _original_checksum;
+        }
+
+        if (const int ec = _dataObjChksum(&_comm, replica.get(), &checksum_string ); ec < 0) {
+            THROW(ec, "failed in _dataObjChksum");
+        }
+
+        if (!_original_checksum.empty()) {
+            replica.cond_input().erase(ORIG_CHKSUM_KW);
+        }
+
+        if (!checksum_string) {
+            irods::log(LOG_NOTICE, fmt::format(
+                "[{}] - checksum returned empty for [{}]",
+                __FUNCTION__, replica.logical_path()));
+            return {};
+        }
+
+        return {checksum_string};
+    } // register_new_checksum
+
+    auto get_size_in_vault(RsComm& _comm, DataObjInfo& _info, const bool _verify_size, const rodsLong_t _recorded_size) -> rodsLong_t
+    {
+        const rodsLong_t size_in_vault = getSizeInVault(&_comm, &_info);
+
+        // since we are not filtering out writes to archive resources, the
+        // archive plugins report UNKNOWN_FILE_SZ as their size since they may
+        // not be able to stat the file.  filter that out and trust the plugin
+        // in this instance
+        if (UNKNOWN_FILE_SZ == size_in_vault && _recorded_size >= 0) {
+            return _recorded_size;
+        }
+
+        // an error occurred when getting size from storage
+        if (size_in_vault < 0 && UNKNOWN_FILE_SZ != size_in_vault) {
+            THROW(static_cast<int>(size_in_vault), fmt::format(
+                "{}: getSizeInVault error for {}, status = {}",
+                __FUNCTION__, _info.objPath, size_in_vault));
+        }
+
+        // check for consistency of the write operation
+        if (_verify_size && size_in_vault != _recorded_size && _recorded_size > 0) {
+            THROW(SYS_COPY_LEN_ERR, fmt::format(
+                "{}: size in vault {} != target size {}",
+                __FUNCTION__, size_in_vault, _recorded_size));
+        }
+
+        return size_in_vault;
+    } // get_size_in_vault
+
+    auto purge_cache(RsComm& _comm, DataObjInfo& _info) -> int
+    {
+        auto replica = irods::experimental::replica::make_replica_proxy(_info);
+
+        dataObjInp_t inp{};
+        rstrcpy( inp.objPath, replica.logical_path().data(), MAX_NAME_LEN );
+
+        auto cond_input = irods::experimental::key_value_proxy{inp.condInput};
+        irods::at_scope_exit free_cond_input{[&cond_input] { clearKeyVal(cond_input.get()); }};
+        cond_input[COPIES_KW] = "1";
+        cond_input[REPL_NUM_KW] = std::to_string(replica.replica_number());
+        cond_input[RESC_HIER_STR_KW] = replica.hierarchy();
+
+        int status = rsDataObjTrim(&_comm, &inp);
+        if (status < 0) {
+            irods::log(LOG_ERROR, fmt::format(
+                "{}: error trimming replica on [{}] for [{}]",
+                __FUNCTION__, replica.hierarchy(), replica.logical_path()));
+        }
+        return status;
+    } // purge_cache
+
+    auto duplicate_l1_descriptor(const l1desc& _src) -> l1desc
+    {
+        l1desc dest{};
+        std::memcpy(&dest, &_src, sizeof(l1desc));
+
+        if (_src.dataObjInp) {
+            DataObjInp* doi = static_cast<DataObjInp*>(std::malloc(sizeof(DataObjInp)));
+            replDataObjInp(_src.dataObjInp, doi);
+            dest.dataObjInp = doi;
+        }
+
+        if (_src.dataObjInfo) {
+            auto [obj, obj_lm] = irods::experimental::replica::duplicate_replica(*_src.dataObjInfo);
+            dest.dataObjInfo = obj_lm.release();
+        }
+
+        dest.remoteZoneHost = nullptr;
+        dest.otherDataObjInfo = nullptr;
+        dest.replDataObjInfo = nullptr;
+
+        // TODO: need duplication logic
+        //if (_src.remoteZoneHost) {
+            //rodsServerHost* rzh{};
+            //std::malloc(sizeof(rodsServerHost));
+        //}
+
+        return dest;
+    } // duplicate_l1_descriptor
+
+    auto stale_replica(RsComm& _comm, const l1desc& _l1desc, DataObjInfo& _info) -> int
+    {
+        _info.replStatus = STALE_REPLICA;
+
+        keyValPair_t regParam{};
+        auto kvp = irods::experimental::make_key_value_proxy(regParam);
+
+        kvp[IN_PDMO_KW] = _info.rescHier;
+        kvp[REPL_STATUS_KW] = std::to_string(_info.replStatus);
+
+        const auto cond_input = irods::experimental::make_key_value_proxy(_l1desc.dataObjInp->condInput);
+        if (cond_input.contains(ADMIN_KW)) {
+            kvp[ADMIN_KW] = "";
+        }
+
+        modDataObjMeta_t inp{};
+        inp.dataObjInfo = &_info;
+        inp.regParam = kvp.get();
+
+        return rsModDataObjMeta(&_comm, &inp);
+    } // stale_replica
+
+    auto apply_static_post_pep(RsComm& _comm, l1desc& _l1desc, const int _operation_status, std::string_view _pep_name) -> int
+    {
+        RuleExecInfo rei{};
+        initReiWithDataObjInp(&rei, &_comm, _l1desc.dataObjInp);
+        rei.doi = _l1desc.dataObjInfo;
+        rei.status = _operation_status;
+
+        // make resource properties available as rule session variables
+        irods::get_resc_properties_as_kvp(rei.doi->rescHier, rei.condInputData);
+
+        rei.status = applyRule(_pep_name.data(), NULL, &rei, NO_SAVE_REI );
+
+        /* doi might have changed */
+        _l1desc.dataObjInfo = rei.doi;
+        clearKeyVal(rei.condInputData);
+        free(rei.condInputData);
+
+        return rei.status;
+    } // apply_static_pep
+} // namespace irods

--- a/server/core/src/initServer.cpp
+++ b/server/core/src/initServer.cpp
@@ -1,37 +1,31 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-
-/* initServer.cpp - Server initialization routines
- */
-
-#include "rcMisc.h"
-#include "initServer.hpp"
-#include "rodsConnect.h"
-#include "rodsConnect.h"
-#include "procLog.h"
-#include "resource.hpp"
-#include "rsGlobalExtern.hpp"
-#include "rcGlobalExtern.h"
 #include "genQuery.h"
-#include "rsIcatOpr.hpp"
-#include "miscServerFunct.hpp"
 #include "getRemoteZoneResc.h"
 #include "getRescQuota.h"
+#include "initServer.hpp"
+#include "irods_stacktrace.hpp"
+#include "miscServerFunct.hpp"
 #include "physPath.hpp"
+#include "procLog.h"
+#include "rcGlobalExtern.h"
+#include "rcMisc.h"
+#include "resource.hpp"
+#include "rodsConnect.h"
+#include "rsExecCmd.hpp"
+#include "rsGenQuery.hpp"
+#include "rsGlobalExtern.hpp"
+#include "rsIcatOpr.hpp"
 #include "rsLog.hpp"
 #include "sockComm.h"
-#include "irods_stacktrace.hpp"
-#include "rsGenQuery.hpp"
-#include "rsExecCmd.hpp"
 
-#include "irods_get_full_path_for_config_file.hpp"
 #include "irods_configuration_parser.hpp"
-#include "irods_resource_backport.hpp"
-#include "irods_log.hpp"
 #include "irods_exception.hpp"
-#include "irods_threads.hpp"
-#include "irods_server_properties.hpp"
+#include "irods_get_full_path_for_config_file.hpp"
+#include "irods_log.hpp"
 #include "irods_random.hpp"
+#include "irods_resource_backport.hpp"
+#include "irods_server_properties.hpp"
+#include "irods_threads.hpp"
+#include "replica_state_table.hpp"
 
 #include <vector>
 #include <set>
@@ -457,6 +451,7 @@ initAgent( int processType, rsComm_t *rsComm ) {
         return status;
     }
 
+    irods::replica_state_table::init();
     initL1desc();
     initSpecCollDesc();
     status = initFileDesc();
@@ -546,6 +541,9 @@ cleanup() {
     if ( InitialState == INITIAL_DONE ) {
         /* close all opened descriptors */
         closeAllL1desc( ThisComm );
+
+        irods::replica_state_table::deinit();
+
         /* close any opened server to server connection */
         disconnectAllSvrToSvrConn();
     }

--- a/server/core/src/irods_file_object.cpp
+++ b/server/core/src/irods_file_object.cpp
@@ -121,15 +121,9 @@ namespace irods {
         repl_requested_ = _dataObjInfo->replNum;
         replicas_.clear();
         replKeyVal( &_dataObjInfo->condInput, &cond_input_ );
-        l1_desc_idx_ = getL1descIndexByDataObjInfo( _dataObjInfo );
         size_ = _dataObjInfo->dataSize;
-        if ( l1_desc_idx_ > 2 ) {
-            int l3descInx = L1desc[ l1_desc_idx_ ].l3descInx;
-            file_descriptor_ = FileDesc[ l3descInx ].fd;
-        }
-        else {
-            file_descriptor_ = -1;
-        }
+        l1_desc_idx_ = -1;
+        file_descriptor_ = -1;
     }
 
 // =-=-=-=-=-=-=-

--- a/server/core/src/irods_file_object.cpp
+++ b/server/core/src/irods_file_object.cpp
@@ -364,9 +364,11 @@ namespace irods {
 
         //delete head_ptr->rescInfo;
         //free( head_ptr );
-        //freeAllDataObjInfo( head_ptr );
         if (_data_obj_info) {
             *_data_obj_info = head_ptr;
+        }
+        else {
+            freeAllDataObjInfo( head_ptr );
         }
         return SUCCESS();
 

--- a/server/core/src/irods_resource_manager.cpp
+++ b/server/core/src/irods_resource_manager.cpp
@@ -447,6 +447,37 @@ namespace irods
                    _name );
     } // get_parent_name
 
+    std::string resource_manager::get_hier_to_root_for_resc(std::string_view _resource_name)
+    {
+        if (_resource_name.empty()) {
+            return {};
+        }
+
+        irods::hierarchy_parser hierarchy{_resource_name.data()};
+
+        for (std::string parent_name = _resource_name.data(); !parent_name.empty();) {
+            resource_ptr resc;
+
+            if (const auto ret = resolve(parent_name, resc); !ret.ok()) {
+                THROW(ret.code(), ret.result());
+            }
+
+            if (const auto ret = get_parent_name(resc, parent_name); !ret.ok()) {
+                if(HIERARCHY_ERROR == ret.code()) {
+                    break;
+                }
+
+                THROW(ret.code(), ret.result());
+            }
+
+            if(!parent_name.empty()) {
+                hierarchy.add_parent(parent_name);
+            }
+        }
+
+        return hierarchy.str();
+    } // get_hier_to_root_for_resc
+
     error resource_manager::get_hier_to_root_for_resc(
         const std::string& _resc_name,
         std::string&       _hierarchy ) {

--- a/server/core/src/objDesc.cpp
+++ b/server/core/src/objDesc.cpp
@@ -121,37 +121,42 @@ closeAllL1desc( rsComm_t *rsComm ) {
     return 0;
 }
 
-int
-freeL1desc( int l1descInx ) {
+int freeL1desc_struct(l1desc& _l1desc)
+{
+    if (_l1desc.dataObjInfo) {
+        freeDataObjInfo(_l1desc.dataObjInfo);
+        //freeAllDataObjInfo(_l1desc.dataObjInfo);
+    }
+
+    if (_l1desc.otherDataObjInfo) {
+        freeAllDataObjInfo(_l1desc.otherDataObjInfo);
+    }
+
+    if (_l1desc.replDataObjInfo) {
+        freeDataObjInfo(_l1desc.replDataObjInfo);
+        //freeAllDataObjInfo(_l1desc.replDataObjInfo);
+    }
+
+    if (_l1desc.dataObjInpReplFlag == 1 && _l1desc.dataObjInp) {
+        clearDataObjInp(_l1desc.dataObjInp);
+        free(_l1desc.dataObjInp);
+    }
+
+    _l1desc.replica_token.clear();
+
+    memset(&_l1desc, 0, sizeof(l1desc));
+
+    return 0;
+} // freeL1desc
+
+int freeL1desc(const int l1descInx) {
     if ( l1descInx < 3 || l1descInx >= NUM_L1_DESC ) {
         rodsLog( LOG_NOTICE, "freeL1desc: l1descInx %d out of range", l1descInx );
         return SYS_FILE_DESC_OUT_OF_RANGE;
     }
 
-    if ( L1desc[l1descInx].dataObjInfo != NULL ) {
-        freeDataObjInfo( L1desc[l1descInx].dataObjInfo );
-    }
-
-    if ( L1desc[l1descInx].otherDataObjInfo != NULL ) {
-        freeAllDataObjInfo( L1desc[l1descInx].otherDataObjInfo );
-    }
-
-    if ( L1desc[l1descInx].replDataObjInfo != NULL ) {
-        freeDataObjInfo( L1desc[l1descInx].replDataObjInfo );
-    }
-
-    if ( L1desc[l1descInx].dataObjInpReplFlag == 1 &&
-            L1desc[l1descInx].dataObjInp != NULL ) {
-        clearDataObjInp( L1desc[l1descInx].dataObjInp );
-        free( L1desc[l1descInx].dataObjInp );
-    }
-
-    L1desc[l1descInx].replica_token.clear();
-
-    memset( &L1desc[l1descInx], 0, sizeof( l1desc_t ) );
-
-    return 0;
-}
+    return freeL1desc_struct(L1desc[l1descInx]);
+} // freeL1desc
 
 int
 fillL1desc( int l1descInx, dataObjInp_t *dataObjInp,

--- a/server/core/src/replica_access_table.cpp
+++ b/server/core/src/replica_access_table.cpp
@@ -55,7 +55,7 @@ namespace irods::experimental
         using value_allocator_type = bi::allocator<value_type, segment_manager_type>;
         using map_type             = bi::map<key_type, mapped_type, std::less<key_type>, value_allocator_type>;
         // clang-format on
-        
+
         //
         // Global Variables
         //
@@ -159,13 +159,13 @@ namespace irods::experimental
 
         const key_type key{_token.data(), *g_allocator};
         auto iter = g_fd_info_map->find(key);
-        
+
         if (iter == g_fd_info_map->end()) {
             throw replica_access_table_error{"replica_access_table: Invalid token"};
         }
 
         auto& [k, v] = *iter;
-        
+
         if (v.data_id != _data_id || v.replica_number != _replica_number) {
             throw replica_access_table_error{"replica_access_table: Invalid data id or replica number"};
         }

--- a/server/core/src/replica_state_table.cpp
+++ b/server/core/src/replica_state_table.cpp
@@ -22,7 +22,7 @@ namespace irods
 
         auto index_of(const std::string_view _logical_path, const int _replica_number) -> int
         {
-            // NOTE: This function is not inherently thread-safe -- make sure to acquire the lock!
+            std::scoped_lock rst_lock{rst_mutex};
 
             int index = -1;
 
@@ -191,9 +191,10 @@ namespace irods
         const int _replica_number,
         const nlohmann::json& _updates) -> void
     {
+        const auto replica_index = index_of(_logical_path, _replica_number);
+
         std::scoped_lock rst_lock{rst_mutex};
 
-        const auto replica_index = index_of(_logical_path, _replica_number);
 
         auto& target_replica = replica_state_map.at(_logical_path.data()).at(replica_index).at("after");
 

--- a/server/core/src/replica_state_table.cpp
+++ b/server/core/src/replica_state_table.cpp
@@ -1,0 +1,237 @@
+#define IRODS_REPLICA_ENABLE_SERVER_SIDE_API
+#include "data_object_proxy.hpp"
+#include "irods_resource_manager.hpp"
+#include "replica_state_table.hpp"
+
+#include "fmt/format.h"
+
+#include <mutex>
+
+extern irods::resource_manager resc_mgr;
+
+namespace irods
+{
+    namespace
+    {
+        using state_type = replica_state_table::state_type;
+
+        // Global Variables
+        nlohmann::json replica_state_map;
+
+        std::mutex rst_mutex;
+
+        auto index_of(const std::string_view _logical_path, const int _replica_number) -> int
+        {
+            // NOTE: This function is not inherently thread-safe -- make sure to acquire the lock!
+
+            int index = -1;
+
+            for (const auto& e : replica_state_map.at(_logical_path.data())) {
+                ++index;
+                if (_replica_number == std::stoi(e.at("before").at("data_repl_num").get<std::string>())) {
+                    return index;
+                }
+            }
+
+            THROW(KEY_NOT_FOUND, fmt::format(
+                "[{}:{}] - replica number [{}] not found for [{}]",
+                __FUNCTION__, __LINE__, _replica_number, _logical_path));
+        } // index_of
+    } // anonymouse namespace
+
+    auto replica_state_table::init() -> void
+    {
+        std::scoped_lock rst_lock{rst_mutex};
+
+        irods::log(LOG_DEBUG9, fmt::format("[{}:{}] - initializing state table", __FUNCTION__, __LINE__));
+
+        replica_state_map.clear();
+    } // init
+
+    auto replica_state_table::deinit() -> void
+    {
+        std::scoped_lock rst_lock{rst_mutex};
+
+        irods::log(LOG_DEBUG9, fmt::format("[{}:{}] - de-initializing state table", __FUNCTION__, __LINE__));
+
+        replica_state_map.clear();
+    } // deinit
+
+    auto replica_state_table::instance() noexcept -> replica_state_table&
+    {
+        static replica_state_table instance;
+
+        irods::log(LOG_DEBUG9, fmt::format("[{}:{}] - retrieving instance of replica state table", __FUNCTION__, __LINE__));
+
+        return instance;
+    } // instance
+
+    auto replica_state_table::insert(const DataObjInfo& _obj) -> void
+    {
+        const std::string_view logical_path = _obj.objPath;
+
+        std::scoped_lock rst_lock{rst_mutex};
+
+        if (replica_state_map.contains(logical_path.data())) {
+            irods::log(LOG_DEBUG, fmt::format("[{}:{}] - entry exists;path:[{}]", __FUNCTION__, __LINE__, logical_path));
+            return;
+        }
+
+        const auto obj = irods::experimental::data_object::make_data_object_proxy(_obj);
+
+        nlohmann::json entry;
+
+        for (const auto& r : obj.replicas()) {
+            const auto json_replica = irods::experimental::replica::to_json(r);
+
+            entry.push_back({
+                {"before", json_replica},
+                {"after", json_replica}
+            });
+        }
+
+        replica_state_map[obj.logical_path().data()] = entry;
+    } // insert
+
+    auto replica_state_table::erase(const std::string_view _logical_path) -> void
+    {
+        std::scoped_lock rst_lock{rst_mutex};
+
+        if (replica_state_map.contains(_logical_path.data())) {
+            replica_state_map.erase(_logical_path.data());
+        }
+    } // erase
+
+    auto replica_state_table::contains(const std::string_view _logical_path) const -> bool
+    {
+        std::scoped_lock rst_lock{rst_mutex};
+
+        return replica_state_map.contains(_logical_path.data());
+    } // contains
+
+    auto replica_state_table::at(const std::string_view _logical_path) const -> nlohmann::json
+    {
+        std::scoped_lock rst_lock{rst_mutex};
+
+        return replica_state_map.at(_logical_path.data());
+    } // at
+
+    auto replica_state_table::at(
+        const std::string_view _logical_path,
+        const std::string_view _leaf_resource_name,
+        const state_type _state) const -> nlohmann::json
+    {
+        std::scoped_lock rst_lock{rst_mutex};
+
+        const auto resc_id = resc_mgr.hier_to_leaf_id(resc_mgr.get_hier_to_root_for_resc(_leaf_resource_name));
+
+        const auto& replica_json = [&_logical_path, &resc_id]
+        {
+            for (const auto& e : replica_state_map.at(_logical_path.data())) {
+                if (resc_id == std::stoll(e.at("before").at("resc_id").get<std::string>())) {
+                    return e;
+                }
+            }
+
+            THROW(KEY_NOT_FOUND, fmt::format(
+                "[{}:{}] - no resc id [{}] found for [{}]",
+                __FUNCTION__, __LINE__, resc_id, _logical_path));
+        }();
+
+        switch (_state) {
+            // clang-format off
+            case state_type::before:    return replica_json.at("before");   break;
+            case state_type::after:     return replica_json.at("after");    break;
+            case state_type::both:      return replica_json;                break;
+            // clang-format on
+
+            default:
+                THROW(SYS_INVALID_INPUT_PARAM, fmt::format(
+                    "[{}:{}] - invalid state_type:[{}]",
+                    __FUNCTION__, __LINE__, _state));
+        }
+    } // at
+
+    auto replica_state_table::at(
+        const std::string_view _logical_path,
+        const int _replica_number,
+        const state_type _state) const -> nlohmann::json
+    {
+        std::scoped_lock rst_lock{rst_mutex};
+
+        const auto& replica_json = [&_logical_path, &_replica_number]
+        {
+            for (const auto& e : replica_state_map.at(_logical_path.data())) {
+                if (_replica_number == std::stoi(e.at("before").at("data_repl_num").get<std::string>())) {
+                    return e;
+                }
+            }
+
+            THROW(KEY_NOT_FOUND, fmt::format(
+                "[{}:{}] - no replica number [{}] found for [{}]",
+                __FUNCTION__, __LINE__, _replica_number, _logical_path));
+        }();
+
+        switch (_state) {
+            // clang-format off
+            case state_type::before:    return replica_json.at("before");   break;
+            case state_type::after:     return replica_json.at("after");    break;
+            case state_type::both:      return replica_json;                break;
+            // clang-format on
+
+            default:
+                THROW(SYS_INVALID_INPUT_PARAM, fmt::format(
+                    "[{}:{}] - invalid state_type:[{}]",
+                    __FUNCTION__, __LINE__, _state));
+        }
+    } // at
+
+    auto replica_state_table::update(
+        const std::string_view _logical_path,
+        const int _replica_number,
+        const nlohmann::json& _updates) -> void
+    {
+        std::scoped_lock rst_lock{rst_mutex};
+
+        const auto replica_index = index_of(_logical_path, _replica_number);
+
+        auto& target_replica = replica_state_map.at(_logical_path.data()).at(replica_index).at("after");
+
+        target_replica.update(_updates);
+    } // update
+
+    auto replica_state_table::get_property(
+        const std::string_view _logical_path,
+        const int _replica_number,
+        const std::string_view _property_name,
+        const state_type _state) const -> std::string
+    {
+        if (state_type::both == _state) {
+            THROW(SYS_INVALID_INPUT_PARAM, fmt::format("state type must be before or after"));
+        }
+
+        auto& rst = irods::replica_state_table::instance();
+
+        const auto replica_json = rst.at(_logical_path, _replica_number, _state);
+
+        return replica_json.at(_property_name.data());
+    } // get_property
+
+    auto replica_state_table::get_property(
+        const std::string_view _logical_path,
+        const std::string_view _leaf_resource_name,
+        const std::string_view _property_name,
+        const state_type _state) const -> std::string
+    {
+        if (state_type::both == _state) {
+            THROW(SYS_INVALID_INPUT_PARAM, fmt::format("state type must be before or after"));
+        }
+
+        auto& rst = irods::replica_state_table::instance();
+
+        const auto replica_json = rst.at(_logical_path, _leaf_resource_name, _state);
+
+        return replica_json.at(_property_name.data());
+    } // get_property
+} // namespace irods
+

--- a/server/core/src/specColl.cpp
+++ b/server/core/src/specColl.cpp
@@ -81,7 +81,7 @@ querySpecColl( rsComm_t *rsComm, char *objPath, genQueryOut_t **genQueryOut ) {
  */
 
 int
-queueSpecCollCache( rsComm_t *rsComm, genQueryOut_t *genQueryOut, char *objPath ) { // JMC - backport 4680
+queueSpecCollCache( rsComm_t *rsComm, genQueryOut_t *genQueryOut, const char *objPath ) { // JMC - backport 4680
     int status;
     int i;
     sqlResult_t *dataId;
@@ -154,12 +154,11 @@ queueSpecCollCache( rsComm_t *rsComm, genQueryOut_t *genQueryOut, char *objPath 
 
     for ( i = 0; i <= genQueryOut->rowCnt; i++ ) {
         int len;
-        char *tmpPtr;
 
         tmpCollection = &collection->value[collection->len * i];
 
         len = strlen( tmpCollection );
-        tmpPtr = objPath + len;
+        const char* tmpPtr = objPath + len;
 
         if ( *tmpPtr == '\0' || *tmpPtr == '/' ) {
             specCollCache_t * tmpSpecCollCache = ( specCollCache_t* )malloc( sizeof( specCollCache_t ) );
@@ -234,14 +233,14 @@ queueSpecCollCacheWithObjStat( rodsObjStat_t *rodsObjStatOut ) {
 }
 
 specCollCache_t *
-matchSpecCollCache( char *objPath ) {
+matchSpecCollCache(const char *objPath ) {
     specCollCache_t *tmpSpecCollCache = SpecCollCacheHead;
 
     while ( tmpSpecCollCache != NULL ) {
         int len = strlen( tmpSpecCollCache->specColl.collection );
         if ( strncmp( tmpSpecCollCache->specColl.collection, objPath, len )
                 == 0 ) {
-            char *tmpPtr = objPath + len;
+            const char *tmpPtr = objPath + len;
 
             if ( *tmpPtr == '\0' || *tmpPtr == '/' ) {
                 return tmpSpecCollCache;

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -51,6 +51,7 @@ set(TEST_INCLUDE_LIST test_config/irods_atomic_apply_acl_operations
                       test_config/irods_replica
                       test_config/irods_replica_access_table
                       test_config/irods_replica_open_and_close
+                      test_config/irods_replica_state_table
                       test_config/irods_resource_administration
                       test_config/irods_scoped_client_identity
                       test_config/irods_scoped_privileged_client

--- a/unit_tests/cmake/test_config/irods_replica_state_table.cmake
+++ b/unit_tests/cmake/test_config/irods_replica_state_table.cmake
@@ -1,0 +1,19 @@
+set(IRODS_TEST_TARGET irods_replica_state_table)
+
+set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/src/test_replica_state_table.cpp)
+
+set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
+                            ${CMAKE_SOURCE_DIR}/lib/core/include
+                            ${CMAKE_SOURCE_DIR}/lib/api/include
+                            ${CMAKE_SOURCE_DIR}/lib/filesystem/include
+                            ${CMAKE_SOURCE_DIR}/plugins/api/include
+                            ${CMAKE_SOURCE_DIR}/server/api/include
+                            ${CMAKE_SOURCE_DIR}/server/core/include
+                            ${CMAKE_SOURCE_DIR}/server/icat/include
+                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
+
+set(IRODS_TEST_LINK_LIBRARIES irods_common
+                              irods_server)

--- a/unit_tests/src/test_rc_data_obj.cpp
+++ b/unit_tests/src/test_rc_data_obj.cpp
@@ -306,7 +306,7 @@ TEST_CASE("open,read,write,close")
             CHECK(STALE_REPLICA == replica_info.replica_status());
         }
 
-        SECTION("open for read x 2,close x2")
+        SECTION("open for read x2,close x2")
         {
             create_empty_replica(target_object);
 

--- a/unit_tests/src/test_replica_state_table.cpp
+++ b/unit_tests/src/test_replica_state_table.cpp
@@ -1,0 +1,219 @@
+#include "catch.hpp"
+
+#include "data_object_proxy.hpp"
+#include "irods_at_scope_exit.hpp"
+#include "replica_state_table.hpp"
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+    using state_type = irods::replica_state_table::state_type;
+    namespace data_object = irods::experimental::data_object;
+
+    constexpr int REPLICA_COUNT       = 3;
+    constexpr std::uint64_t SIZE_1    = 4000;
+    constexpr std::uint64_t SIZE_2    = 9999;
+    constexpr std::uint64_t DATA_ID_1 = 10101;
+    constexpr std::uint64_t DATA_ID_2 = 20202;
+    const std::string LOGICAL_PATH_1  = "/tempZone/home/rods/foo";
+
+    auto generate_data_object(
+        std::string_view _logical_path,
+        const std::uint64_t _data_id,
+        const std::uint64_t _size) -> std::array<DataObjInfo*, REPLICA_COUNT>
+    {
+        std::array<DataObjInfo*, REPLICA_COUNT> replicas;
+        DataObjInfo* head{};
+        DataObjInfo* prev{};
+        for (int i = 0; i < REPLICA_COUNT; ++i) {
+            auto [proxy, lm] = irods::experimental::replica::make_replica_proxy();
+            proxy.logical_path(_logical_path);
+            proxy.size(_size);
+            proxy.replica_number(i);
+            proxy.data_id(_data_id);
+            proxy.replica_status(GOOD_REPLICA);
+
+            DataObjInfo* curr = lm.release();
+            if (!head) {
+                head = curr;
+            }
+            else {
+                prev->next = curr;
+            }
+            prev = curr;
+            replicas[i] = curr;
+
+            const auto& r = replicas[i];
+            REQUIRE(_logical_path == r->objPath);
+            REQUIRE(_data_id      == r->dataId);
+            REQUIRE(i             == r->replNum);
+            REQUIRE(_size         == r->dataSize);
+        }
+
+        return replicas;
+    } // generate_data_object
+}
+
+TEST_CASE("replica state table", "[basic]")
+{
+    const auto replicas = generate_data_object(LOGICAL_PATH_1, DATA_ID_1, SIZE_1);
+    const auto* head = replicas[0];
+
+    // ensure that the linked list is valid and will be freed upon exit
+    REQUIRE(head);
+    const auto replica_list_lm = irods::experimental::lifetime_manager{*head};
+
+    auto& rst = irods::replica_state_table::instance();
+
+    // create before entry for the data object
+    REQUIRE_NOTHROW(rst.insert(*head));
+    REQUIRE(rst.contains(LOGICAL_PATH_1));
+
+    SECTION("access by logical path (data object)")
+    {
+        const auto data_object_json = rst.at(LOGICAL_PATH_1);
+
+        REQUIRE(REPLICA_COUNT == data_object_json.size());
+
+        // ensure that information matches
+        for (int i = 0; i < REPLICA_COUNT; ++i) {
+            const auto original_replica = irods::experimental::replica::make_replica_proxy(*replicas.at(i));
+
+            const auto& replica_json = data_object_json.at(i).at("before");
+            const auto [before, lm] = irods::experimental::replica::make_replica_proxy(LOGICAL_PATH_1, replica_json);
+
+            CHECK(before.data_id()        == original_replica.data_id());
+            CHECK(before.logical_path()   == original_replica.logical_path());
+            CHECK(before.replica_number() == original_replica.replica_number());
+            CHECK(before.size()           == original_replica.size());
+        }
+    }
+
+    SECTION("access by replica number")
+    {
+        constexpr int replica_number = REPLICA_COUNT - 1;
+        const auto original_replica = irods::experimental::replica::make_replica_proxy(*replicas.at(replica_number));
+        const auto replica_json = rst.at(LOGICAL_PATH_1, replica_number, state_type::before);
+        const auto [before, lm] = irods::experimental::replica::make_replica_proxy(LOGICAL_PATH_1, replica_json);
+
+        CHECK(before.data_id()        == original_replica.data_id());
+        CHECK(before.logical_path()   == original_replica.logical_path());
+        CHECK(before.replica_number() == original_replica.replica_number());
+        CHECK(before.size()           == original_replica.size());
+    }
+
+    SECTION("modify entry by replica number")
+    {
+        constexpr int target_replica_number = 1;
+
+        const nlohmann::json updates{
+            {"data_id", std::to_string(DATA_ID_2)},
+            {"data_size", std::to_string(SIZE_2)},
+            {"data_is_dirty", std::to_string(STALE_REPLICA)}
+        };
+
+        REQUIRE_NOTHROW(rst.update(LOGICAL_PATH_1, target_replica_number, updates));
+
+        for (int i = 0; i < REPLICA_COUNT; ++i) {
+            const auto original_replica = irods::experimental::replica::make_replica_proxy(*replicas.at(i));
+            const auto replica_json = rst.at(LOGICAL_PATH_1, original_replica.replica_number(), state_type::after);
+            const auto [replica, lm] = irods::experimental::replica::make_replica_proxy(LOGICAL_PATH_1, replica_json);
+
+            if (target_replica_number == i) {
+                // ensure that the after states updated
+                CHECK(replica.data_id()        == DATA_ID_2);
+                CHECK(replica.logical_path()   == LOGICAL_PATH_1);
+                CHECK(replica.replica_number() == target_replica_number);
+                CHECK(replica.size()           == SIZE_2);
+                CHECK(replica.replica_status() == STALE_REPLICA);
+
+                // ensure that "before" states remained the same
+                const auto replica_json = rst.at(LOGICAL_PATH_1, original_replica.replica_number(), state_type::before);
+                const auto [before, before_lm] = irods::experimental::replica::make_replica_proxy(LOGICAL_PATH_1, replica_json);
+                CHECK(before.data_id()        == original_replica.data_id());
+                CHECK(before.logical_path()   == original_replica.logical_path());
+                CHECK(before.replica_number() == original_replica.replica_number());
+                CHECK(before.size()           == original_replica.size());
+                CHECK(before.replica_status() == original_replica.replica_status());
+            }
+            else {
+                // ensure that the other replicas did not update
+                CHECK(replica.data_id()        == original_replica.data_id());
+                CHECK(replica.logical_path()   == original_replica.logical_path());
+                CHECK(replica.replica_number() == original_replica.replica_number());
+                CHECK(replica.size()           == original_replica.size());
+                CHECK(replica.replica_status() == original_replica.replica_status());
+            }
+        }
+
+        SECTION("property accessors")
+        {
+            const auto& rst = irods::replica_state_table::instance();
+            CHECK(target_replica_number == std::stoi(rst.get_property(LOGICAL_PATH_1, target_replica_number, "data_repl_num", state_type::after)));
+            CHECK(DATA_ID_2 == std::stoll(rst.get_property(LOGICAL_PATH_1, target_replica_number, "data_id", state_type::after)));
+            CHECK(SIZE_2 == std::stoll(rst.get_property(LOGICAL_PATH_1, target_replica_number, "data_size", state_type::after)));
+            CHECK(STALE_REPLICA == std::stoi(rst.get_property(LOGICAL_PATH_1, target_replica_number, "data_is_dirty", state_type::after)));
+        }
+    }
+
+    SECTION("access by leaf resource name")
+    {
+        // TODO: this requires a running iRODS server and catalog -- skip
+    }
+
+    SECTION("update by leaf resource name")
+    {
+        // TODO: this requires a running iRODS server and catalog -- skip
+    }
+
+    SECTION("track multiple data objects")
+    {
+        const std::string LOGICAL_PATH_2  = "/tempZone/home/rods/goo";
+
+        const auto replicas_2 = generate_data_object(LOGICAL_PATH_2, DATA_ID_2, SIZE_2);
+        const auto* head_2 = replicas_2[0];
+
+        // ensure that the linked list is valid and will be freed upon exit
+        REQUIRE(head_2);
+        const auto replica_list_2_lm = irods::experimental::lifetime_manager{*head_2};
+
+        REQUIRE_NOTHROW(rst.insert(*head_2));
+        REQUIRE(rst.contains(LOGICAL_PATH_2));
+
+        for (int i = 0; i < REPLICA_COUNT; ++i) {
+            const auto original_replica = irods::experimental::replica::make_replica_proxy(*replicas_2.at(i));
+
+            const auto replica_json = rst.at(LOGICAL_PATH_2, original_replica.replica_number(), state_type::before);
+            const auto [before, lm] = irods::experimental::replica::make_replica_proxy(LOGICAL_PATH_2, replica_json);
+
+            // ensure that the replicas match
+            CHECK(before.data_id()        == original_replica.data_id());
+            CHECK(before.logical_path()   == original_replica.logical_path());
+            CHECK(before.replica_number() == original_replica.replica_number());
+            CHECK(before.size()           == original_replica.size());
+        }
+
+        CHECK_NOTHROW(rst.erase(LOGICAL_PATH_2));
+        CHECK_FALSE(rst.contains(LOGICAL_PATH_2));
+    }
+
+    CHECK_NOTHROW(rst.erase(LOGICAL_PATH_1));
+    CHECK_FALSE(rst.contains(LOGICAL_PATH_1));
+    rst.deinit();
+}
+
+TEST_CASE("invalid_keys", "[basic]")
+{
+    auto& rst = irods::replica_state_table::instance();
+    CHECK_FALSE(rst.contains("nope"));
+    CHECK_THROWS(rst.at("nope"));
+    CHECK_THROWS(rst.get_property("whatever", 0, "whatever", state_type::both));
+    rst.deinit();
+}
+

--- a/unit_tests/unit_tests_list.json
+++ b/unit_tests/unit_tests_list.json
@@ -17,6 +17,7 @@
     "irods_metadata",
     "irods_parallel_transfer_engine",
     "irods_query_builder",
+    "irods_rc_data_obj",
     "irods_replica",
     "irods_replica_access_table",
     "irods_replica_open_and_close",

--- a/unit_tests/unit_tests_list.json
+++ b/unit_tests/unit_tests_list.json
@@ -20,6 +20,7 @@
     "irods_replica",
     "irods_replica_access_table",
     "irods_replica_open_and_close",
+    "irods_replica_state_table",
     "irods_resource_administration",
     "irods_scoped_client_identity",
     "irods_scoped_privileged_client",


### PR DESCRIPTION
CI tests running.

For reviewing purposes, I'd like eyeballs on `server/core/src/replica_state_table.cp  p`/`server/core/include/replica_state_table.hpp` and the accompanying unit test. Basically, the last two commits. Everything up to that point is mainly a refactor of single buffer puts and rsDataObjRepl (again). This will be needed in the transition to using the `data_object_finalize` API plugin in the various APIs as well as holding the replica state table in logical locking while multiple replicas of the same data object are being held open. Of course, those should be reviewed as well, but this is a large PR :)