### PR TITLE
[#5319] Filesystem library deallocates memory correctly for C structures (4-2-stable)

### DIFF
--- a/lib/filesystem/src/filesystem.cpp
+++ b/lib/filesystem/src/filesystem.cpp
@@ -236,6 +236,7 @@ namespace irods::experimental::filesystem::NAMESPACE_IMPL
 
             if (is_data_object(s)) {
                 dataObjInp_t input{};
+                at_scope_exit free_memory{[&input] { clearKeyVal(&input.condInput); }};
 
                 std::strncpy(input.objPath, _p.c_str(), std::strlen(_p.c_str()));
 
@@ -252,6 +253,7 @@ namespace irods::experimental::filesystem::NAMESPACE_IMPL
                 }
 
                 collInp_t input{};
+                at_scope_exit free_memory{[&input] { clearKeyVal(&input.condInput); }};
 
                 std::strncpy(input.collName, _p.c_str(), std::strlen(_p.c_str()));
 
@@ -403,6 +405,11 @@ namespace irods::experimental::filesystem::NAMESPACE_IMPL
 
         dataObjCopyInp_t input{};
 
+        at_scope_exit free_memory{[&input] {
+            clearKeyVal(&input.srcDataObjInp.condInput);
+            clearKeyVal(&input.destDataObjInp.condInput);
+        }};
+
         const auto s = status(_comm, _to);
 
         if (exists(s)) {
@@ -501,6 +508,7 @@ namespace irods::experimental::filesystem::NAMESPACE_IMPL
         }
 
         collInp_t input{};
+        at_scope_exit free_memory{[&input] { clearKeyVal(&input.condInput); }};
         std::strncpy(input.collName, _p.c_str(), std::strlen(_p.c_str()));
         addKeyVal(&input.condInput, RECURSIVE_OPR__KW, "");
 
@@ -735,6 +743,7 @@ namespace irods::experimental::filesystem::NAMESPACE_IMPL
         const auto timestamp = fmt::format("{:011}", _new_time.time_since_epoch().count());
 
         collInp_t input{};
+        at_scope_exit free_memory{[&input] { clearKeyVal(&input.condInput); }};
         std::strncpy(input.collName, _p.c_str(), std::strlen(_p.c_str()));
         addKeyVal(&input.condInput, COLLECTION_MTIME_KW, timestamp.c_str());
 


### PR DESCRIPTION
Needs to be tested