### PR TITLE
[#4761] Added test for ilocate case-insensitive search (4-2-stable)

### DIFF
--- a/scripts/irods/test/test_catalog.py
+++ b/scripts/irods/test/test_catalog.py
@@ -208,6 +208,23 @@ class Test_Catalog(ResourceBase, unittest.TestCase):
             os.unlink(file_with_spaces)
             os.unlink(otherfile)
 
+    def test_ilocate_supports_case_insensitive_search__issue_4761(self):
+        data_object = 'foo'
+        self.admin.assert_icommand(['istream', 'write', data_object], input='object 1')
+
+        data_object_upper = data_object.upper()
+        self.admin.assert_icommand(['istream', 'write', data_object_upper], input='object 2')
+
+        data_object_mixed = 'fOo'
+        self.admin.assert_icommand(['istream', 'write', data_object_mixed], input='object 3')
+
+        expected_output = [
+            os.path.join(self.admin.session_collection, data_object),
+            os.path.join(self.admin.session_collection, data_object_upper),
+            os.path.join(self.admin.session_collection, data_object_mixed)
+        ]
+        self.admin.assert_icommand(['ilocate', '-i', data_object], 'STDOUT', expected_output)
+
     ###################
     # iquest
     ###################


### PR DESCRIPTION
Passed at bench.

CI not required.

Depends on https://github.com/irods/irods_client_icommands/pull/185