### PR TITLE
Fixed memory leaks and ichksum -r output (4-2-stable)

### DIFF
--- a/lib/api/include/specificQuery.h
+++ b/lib/api/include/specificQuery.h
@@ -5,7 +5,7 @@
 #include "objInfo.h"
 #include "rodsGenQuery.h"
 
-typedef struct {
+typedef struct SpecificQueryInp {
     char *sql;
     char *args[10];  // optional arguments (bind variables)
 

--- a/lib/core/include/irods_query.hpp
+++ b/lib/core/include/irods_query.hpp
@@ -143,40 +143,6 @@ namespace irods {
         class gen_query_impl : public query_impl_base
         {
         public:
-            virtual ~gen_query_impl() {
-                if(this->gen_output_ && this->gen_output_->continueInx) {
-                    // Close statements for this query
-                    gen_input_.continueInx = this->gen_output_->continueInx;
-                    freeGenQueryOut(&this->gen_output_);
-                    gen_input_.maxRows = 0;
-                    auto err = gen_query_fcn(
-                                   this->comm_,
-                                   &gen_input_,
-                                   &this->gen_output_);
-                    if (CAT_NO_ROWS_FOUND != err && err < 0) {
-                        irods::log(ERROR(err, (boost::format(
-                                    "[%s] - Failed to close statement with continueInx [%d]") %
-                                    __FUNCTION__ % gen_input_.continueInx).str()));
-                    }
-                }
-                freeGenQueryOut(&this->gen_output_);
-                clearGenQueryInp(&gen_input_);
-            }
-
-            void reset_for_page_boundary() override {
-                if(this->gen_output_) {
-                    gen_input_.continueInx = this->gen_output_->continueInx;
-                    freeGenQueryOut(&this->gen_output_);
-                }
-            }
-
-            int fetch_page() override {
-                return gen_query_fcn(
-                           this->comm_,
-                           &gen_input_,
-                           &this->gen_output_);
-            } // fetch_page
-
             gen_query_impl(connection_type*   _comm,
                            int                _query_limit,
                            int                _row_offset,
@@ -203,6 +169,41 @@ namespace irods {
                 }
             } // ctor
 
+            virtual ~gen_query_impl() {
+                if(this->gen_output_ && this->gen_output_->continueInx) {
+                    // Close statements for this query
+                    gen_input_.continueInx = this->gen_output_->continueInx;
+                    freeGenQueryOut(&this->gen_output_);
+                    gen_input_.maxRows = 0;
+                    auto err = gen_query_fcn(
+                                   this->comm_,
+                                   &gen_input_,
+                                   &this->gen_output_);
+                    if (CAT_NO_ROWS_FOUND != err && err < 0) {
+                        irods::log(ERROR(err, (boost::format(
+                                    "[%s] - Failed to close statement with continueInx [%d]") %
+                                    __FUNCTION__ % gen_input_.continueInx).str()));
+                    }
+                }
+
+                freeGenQueryOut(&this->gen_output_);
+                clearGenQueryInp(&gen_input_);
+            }
+
+            void reset_for_page_boundary() override {
+                if(this->gen_output_) {
+                    gen_input_.continueInx = this->gen_output_->continueInx;
+                    freeGenQueryOut(&this->gen_output_);
+                }
+            }
+
+            int fetch_page() override {
+                return gen_query_fcn(
+                           this->comm_,
+                           &gen_input_,
+                           &this->gen_output_);
+            } // fetch_page
+
         private:
             genQueryInp_t gen_input_;
 #ifdef IRODS_QUERY_ENABLE_SERVER_SIDE_API
@@ -220,42 +221,9 @@ namespace irods {
 #endif // IRODS_QUERY_ENABLE_SERVER_SIDE_API
         }; // class gen_query_impl
 
-        class spec_query_impl : public query_impl_base {
-            public:
-            virtual ~spec_query_impl() {
-                if(this->gen_output_ && this->gen_output_->continueInx) {
-                    // Close statement for this query
-                    spec_input_.continueInx = this->gen_output_->continueInx;
-                    freeGenQueryOut(&this->gen_output_);
-                    spec_input_.maxRows = 0;
-                    auto err = spec_query_fcn(
-                                   this->comm_,
-                                   &spec_input_,
-                                   &this->gen_output_);
-                    if (CAT_NO_ROWS_FOUND != err && err < 0) {
-                        irods::log(ERROR(
-                                    err, (boost::format(
-                                    "[%s] - Failed to close statement with continueInx [%d]") %
-                                    __FUNCTION__ % spec_input_.continueInx).str()));
-                    }
-                }
-                freeGenQueryOut(&this->gen_output_);
-            }
-
-            void reset_for_page_boundary() override {
-                if(this->gen_output_) {
-                    spec_input_.continueInx = this->gen_output_->continueInx;
-                    freeGenQueryOut(&this->gen_output_);
-                }
-            }
-
-            int fetch_page() override {
-                return spec_query_fcn(
-                           this->comm_,
-                           &spec_input_,
-                           &this->gen_output_);
-            } // fetch_page
-
+        class spec_query_impl : public query_impl_base
+        {
+        public:
             spec_query_impl(connection_type*                _comm,
                             int                             _query_limit,
                             int                             _row_offset,
@@ -289,7 +257,43 @@ namespace irods {
                 }
             } // ctor
 
-            private:
+            virtual ~spec_query_impl() {
+                if(this->gen_output_ && this->gen_output_->continueInx) {
+                    // Close statement for this query
+                    spec_input_.continueInx = this->gen_output_->continueInx;
+                    freeGenQueryOut(&this->gen_output_);
+                    spec_input_.maxRows = 0;
+                    auto err = spec_query_fcn(
+                                   this->comm_,
+                                   &spec_input_,
+                                   &this->gen_output_);
+                    if (CAT_NO_ROWS_FOUND != err && err < 0) {
+                        irods::log(ERROR(
+                                    err, (boost::format(
+                                    "[%s] - Failed to close statement with continueInx [%d]") %
+                                    __FUNCTION__ % spec_input_.continueInx).str()));
+                    }
+                }
+
+                freeGenQueryOut(&this->gen_output_);
+                clearKeyVal(&spec_input_.condInput);
+            }
+
+            void reset_for_page_boundary() override {
+                if(this->gen_output_) {
+                    spec_input_.continueInx = this->gen_output_->continueInx;
+                    freeGenQueryOut(&this->gen_output_);
+                }
+            }
+
+            int fetch_page() override {
+                return spec_query_fcn(
+                           this->comm_,
+                           &spec_input_,
+                           &this->gen_output_);
+            } // fetch_page
+
+        private:
             specificQueryInp_t spec_input_;
 #ifdef IRODS_QUERY_ENABLE_SERVER_SIDE_API
             const std::function<

--- a/lib/core/include/query_processor.hpp
+++ b/lib/core/include/query_processor.hpp
@@ -27,7 +27,44 @@ namespace irods
         using query_type   = typename query<ConnectionType>::query_type;
         // clang-format on
 
-        query_processor(const std::string& _query, job _job, uint32_t _limit = 0, query_type _type = query_type::GENERAL)
+        class future
+        {
+        public:
+            auto get() -> errors
+            {
+                errors errs;
+                errs.reserve(promises.size());
+
+                for (auto&& p : promises) {
+                    auto&& e = p->get_future().get();
+                    if (std::get<0>(e) < 0) {
+                        errs.push_back(std::move(e));
+                    }
+                }
+
+                return errs;
+            }
+
+            auto size() const noexcept -> std::uint32_t
+            {
+                return promises.size();
+            }
+
+            friend query_processor;
+
+        private:
+            auto push_back(std::shared_ptr<std::promise<error>> p) -> void
+            {
+                promises.push_back(p);
+            }
+
+            std::vector<std::shared_ptr<std::promise<error>>> promises;
+        }; // class future
+
+        query_processor(const std::string& _query,
+                        job _job,
+                        uint32_t _limit = 0,
+                        query_type _type = query_type::GENERAL)
             : query_{_query}
             , job_{_job}
             , limit_{_limit}
@@ -37,45 +74,17 @@ namespace irods
 
         query_processor(const query_processor&) = delete;
         query_processor& operator=(const query_processor&) = delete;
-        uint32_t size() { return size_; }
 
-        class future
-        {
-            friend query_processor;
-
-            std::vector<std::shared_ptr<std::promise<error>>> promises;
-
-            void push_back(std::shared_ptr<std::promise<error>> p) {
-                promises.push_back(p);
-            }
-
-            public:
-            auto get() {
-                errors errs{};
-                errs.reserve(promises.size());
-                for(auto&& p : promises) {
-                    auto&& e = p->get_future().get();
-                    if(std::get<0>(e) < 0) {
-                        errs.push_back(std::move(e));
-                    }
-                }
-
-                return errs;
-            }
-        };
-
-        auto execute(thread_pool& _thread_pool, ConnectionType& _conn)
+        auto execute(thread_pool& _thread_pool, ConnectionType& _conn) -> future
         {
             future f;
             query<ConnectionType> q{&_conn, query_, limit_, 0, type_};
-
-            size_ = q.size();
 
             for (auto&& r : q) {
                auto p = std::make_shared<std::promise<error>>();
                f.push_back(p);
 
-               thread_pool::post(_thread_pool, [this, p, r]() mutable {
+               thread_pool::post(_thread_pool, [this, p, r]() mutable noexcept {
                     try {
                         job_(r);
                         p->set_value({0, ""});
@@ -97,12 +106,11 @@ namespace irods
         }
 
     private:
-        uint32_t size_;
         std::string query_;
         job job_;
         uint32_t limit_;
         query_type type_;
-    };
+    }; // class query_processor
 } // namespace irods
 
 #endif // IRODS_QUERY_PROCESSOR_HPP

--- a/lib/core/include/replica.hpp
+++ b/lib/core/include/replica.hpp
@@ -30,6 +30,7 @@
 #include "objInfo.h"
 #include "query_builder.hpp"
 #include "rcConnect.h"
+#include "rcMisc.h"
 
 #include "fmt/format.h"
 
@@ -301,6 +302,7 @@ namespace irods::experimental::replica
             std::snprintf(info.rescHier, sizeof(info.rescHier), "%s", _resource_hierarchy.data());
 
             keyValPair_t kvp{};
+            at_scope_exit free_memory{[&kvp] { clearKeyVal(&kvp); }};
             auto reg_params = make_key_value_proxy(kvp);
             reg_params[DATA_MODIFY_KW] = new_time.str();
 
@@ -568,6 +570,7 @@ namespace irods::experimental::replica
         detail::throw_if_replica_number_is_invalid(_replica_number);
 
         dataObjInp_t input{};
+        at_scope_exit free_memory{[&input] { clearKeyVal(&input.condInput); }};
         auto cond_input = make_key_value_proxy(input.condInput);
         cond_input[REPL_NUM_KW] = std::to_string(_replica_number);
 
@@ -584,6 +587,7 @@ namespace irods::experimental::replica
         detail::throw_if_replica_resource_name_is_invalid(_leaf_resource_name);
 
         dataObjInp_t input{};
+        at_scope_exit free_memory{[&input] { clearKeyVal(&input.condInput); }};
         auto cond_input = make_key_value_proxy(input.condInput);
         cond_input[LEAF_RESOURCE_NAME_KW] = _leaf_resource_name;
 

--- a/unit_tests/src/filesystem/test_filesystem.cpp
+++ b/unit_tests/src/filesystem/test_filesystem.cpp
@@ -16,6 +16,7 @@
 
 #include "rodsClient.h"
 #include "dataObjRepl.h"
+#include "rcMisc.h"
 
 #include "client_connection.hpp"
 #include "connection_pool.hpp"
@@ -772,6 +773,7 @@ auto add_ufs_resource(const std::string_view _resc_name, const std::string_view 
 auto replicate_data_object(const std::string_view _path, const std::string_view _resc_name) -> void
 {
     dataObjInp_t repl_input{};
+    irods::at_scope_exit free_memory{[&repl_input] { clearKeyVal(&repl_input.condInput); }};
     std::strncpy(repl_input.objPath, _path.data(), _path.size());
     addKeyVal(&repl_input.condInput, DEST_RESC_NAME_KW, _resc_name.data());
 

--- a/unit_tests/src/test_get_file_descriptor_info.cpp
+++ b/unit_tests/src/test_get_file_descriptor_info.cpp
@@ -38,6 +38,12 @@ TEST_CASE("get_file_descriptor_info")
     const auto path = sandbox / "data_object.txt";
     char* json_output = nullptr;
 
+    irods::at_scope_exit free_memory{[&json_output] {
+        if (json_output) {
+            std::free(json_output);
+        }
+    }};
+
     // Guarantees that the stream is closed before clean up.
     {
         io::client::default_transport tp{conn};


### PR DESCRIPTION
This change will likely break code using the `query_processor` due to a change in the interface. Fixing the broken plugins, etc. should be an easy fix.