### PR TITLE
[#5018] add msiDataObjCreate/Close test (4-2-stable)

### DIFF
--- a/scripts/irods/test/rule_texts_for_tests.py
+++ b/scripts/irods/test/rule_texts_for_tests.py
@@ -556,8 +556,17 @@ rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Rulebase']['tes
 test_msiDataObjWrite__3236 {
     msiTakeThreeArgumentsAndDoNothing(*arg1, *arg2, *arg3);
     writeLine("stdout", "AFTER arg1=*arg1 arg2=*arg2 arg3=*arg3");
-}                                                                                                   
+}
 INPUT *arg1="abc", *arg2="def", *arg3="ghi"
+OUTPUT ruleExecOut
+'''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Rulebase']['test_create_close__issue_5018'] = '''
+test_create_close__issue_5018 {{
+    msiDataObjCreate("{logical_path}", "destRescName=demoResc", *fd)
+    msiDataObjClose(*fd, *status)
+    writeLine("stdout", "created [{logical_path}]");
+}}
+INPUT null
 OUTPUT ruleExecOut
 '''
 
@@ -1147,3 +1156,13 @@ OUTPUT ruleExecOut
 #INPUT *arg1="abc", *arg2="def", *arg3="ghi"
 #OUTPUT ruleExecOut
 #'''
+rule_texts['irods_rule_engine_plugin-python']['Test_Rulebase']['test_create_close__issue_5018'] = '''
+def main(rule_args, callback, rei):
+    out_dict = callback.msiDataObjCreate('{logical_path}', 'destRescName=demoResc', 0)
+    fd = out_dict['arguments'][2]
+    out_dict = callback.msiDataObjClose(fd, 0)
+    callback.writeLine('stdout', 'created [{logical_path}]');
+
+INPUT null
+OUTPUT ruleExecOut
+'''

--- a/scripts/irods/test/test_rulebase.py
+++ b/scripts/irods/test/test_rulebase.py
@@ -361,6 +361,22 @@ OUTPUT ruleExecOut
                     msg='TEST_MARKER_test_acPreProcForExecCmd__3867',
                     start_index=initial_log_size))
 
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only run for native rule language')
+    def test_create_close__issue_5018(self):
+        parameters = {}
+        logical_path = os.path.join(self.admin.session_collection, 'test_create_close__issue_5018')
+        parameters['logical_path'] = logical_path
+        rule_file = os.path.join(self.admin.local_session_dir, 'test_create_close__issue_5018.r')
+        rule_string = rule_texts[self.plugin_name][self.class_name][inspect.currentframe().f_code.co_name].format(**parameters)
+        with open(rule_file, 'w') as f:
+            f.write(rule_string)
+
+        self.admin.assert_icommand(['irule', '-F', rule_file], 'STDOUT', 'created [{}]'.format(logical_path))
+        os.unlink(rule_file)
+
+        self.admin.assert_icommand(['iadmin', 'ls', 'logical_path', logical_path, 'replica_number', '0'], 'STDOUT', 'DATA_REPL_STATUS: 1')
+
+
 @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'Skip for topology testing from resource server: reads rods server log')
 class Test_Resource_Session_Vars__3024(ResourceBase, unittest.TestCase):
     plugin_name = IrodsConfig().default_rule_engine_plugin


### PR DESCRIPTION
Adds a test which creates a data object and closes it without writing to
it using the microservices in a rule. The resultant replica should be
marked as good. The python version of this rule was implemented but not
tested.