### PR TITLE
[#4331] Update data_object_finalize/RST interfaces (4-2-stable)

### DIFF
--- a/lib/api/include/data_object_finalize.h
+++ b/lib/api/include/data_object_finalize.h
@@ -16,8 +16,6 @@ extern "C" {
 /// desired modifications is required in the form of a JSON structure. Each replica can also
 /// have "file_modified" key which holds a set of key-value pairs for the file_modified plugin operation.
 ///
-/// The data_id is used to identify the data object being finalized.
-///
 /// The file_modified field is a boolean indicating whether the file_modified plugin operation
 /// should be called after the data object has been finalized.
 /// \endparblock
@@ -25,60 +23,58 @@ extern "C" {
 /// \p json_input must have the following JSON structure:
 /// \code{.js}
 /// {
-///   "data_id": string,
-///   "file_modified": bool,
-///   "replicas": [
-///     {
-///       "before": {
-///         "data_id": string,
-///         "coll_id": string
-///         "data_name": string
-///         "data_repl_num": string
-///         "data_version": string
-///         "data_type_name": string
-///         "data_size": string
-///         "data_path": string
-///         "data_owner_name": string
-///         "data_owner_zone": string
-///         "data_is_dirty": string
-///         "data_status": string
-///         "data_checksum": string
-///         "data_expiry_ts": string
-///         "data_map_id": string
-///         "data_mode": string
-///         "r_comment": string
-///         "create_ts": string
-///         "modify_ts": string
-///         "resc_id: string
-///       },
-///       "after": {
-///         "data_id": string,
-///         "coll_id": string
-///         "data_name": string
-///         "data_repl_num": string
-///         "data_version": string
-///         "data_type_name": string
-///         "data_size": string
-///         "data_path": string
-///         "data_owner_name": string
-///         "data_owner_zone": string
-///         "data_is_dirty": string
-///         "data_status": string
-///         "data_checksum": string
-///         "data_expiry_ts": string
-///         "data_map_id": string
-///         "data_mode": string
-///         "r_comment": string
-///         "create_ts": string
-///         "modify_ts": string
-///         "resc_id: string
-///       },
-///       "file_modified": {
-///          <string>: string,
-///          ...
-///       }
-///     }
-///   ]
+///     "replicas": [
+///         {
+///             "before": {
+///                 "data_id": <string>,
+///                 "coll_id": <string>,
+///                 "data_repl_num": <string>,
+///                 "data_version": <string>,
+///                 "data_type_name": <string>,
+///                 "data_size": <string>,
+///                 "data_path": <string>,
+///                 "data_owner_name": <string>,
+///                 "data_owner_zone": <string>,
+///                 "data_is_dirty": <string>,
+///                 "data_status": <string>,
+///                 "data_checksum": <string>,
+///                 "data_expiry_ts": <string>,
+///                 "data_map_id": <string>,
+///                 "data_mode": <string>,
+///                 "r_comment": <string>,
+///                 "create_ts": <string>,
+///                 "modify_ts": <string>,
+///                 "resc_id": <string>
+///             },
+///             "after": {
+///                 "data_id": <string>,
+///                 "coll_id": <string>,
+///                 "data_repl_num": <string>,
+///                 "data_version": <string>,
+///                 "data_type_name": <string>,
+///                 "data_size": <string>,
+///                 "data_path": <string>,
+///                 "data_owner_name": <string>,
+///                 "data_owner_zone": <string>,
+///                 "data_is_dirty": <string>,
+///                 "data_status": <string>,
+///                 "data_checksum": <string>,
+///                 "data_expiry_ts": <string>,
+///                 "data_map_id": <string>,
+///                 "data_mode": <string>,
+///                 "r_comment": <string>,
+///                 "create_ts": <string>,
+///                 "modify_ts": <string>,
+///                 "resc_id": <string>
+///             },
+///             "file_modified": {
+///                 <string>: <string>,
+///                 ...
+///             }
+///         },
+///         ...
+///     ],
+///     "trigger_file_modified": <bool>
 /// }
 /// \endcode
 ///

--- a/plugins/api/src/data_object_finalize.cpp
+++ b/plugins/api/src/data_object_finalize.cpp
@@ -119,7 +119,6 @@ namespace
 
     auto set_replica_state(
         nanodbc::connection& _db_conn,
-        std::string_view _data_id,
         const json& _before,
         const json& _after) -> void
     {
@@ -159,7 +158,7 @@ namespace
             index++;
         }
 
-        const auto data_id = std::stoul(_data_id.data());
+        const auto data_id = std::stoul(_before.at("data_id").get<std::string>());
         irods::log(LOG_DEBUG9, fmt::format("binding data_id:[{}] at [{}]", data_id, index));
         statement.bind(index++, &data_id);
 
@@ -173,7 +172,6 @@ namespace
     auto set_data_object_state(
         nanodbc::connection& _db_conn,
         nanodbc::transaction& _trans,
-        std::string_view _data_id,
         json& _replicas) -> void
     {
         try {
@@ -181,7 +179,7 @@ namespace
                 auto& after = r.at("after");
                 validate_values(after);
 
-                set_replica_state(_db_conn, _data_id, r.at("before"), after);
+                set_replica_state(_db_conn, r.at("before"), after);
             }
 
             irods::log(LOG_DEBUG10, "committing transaction");
@@ -226,17 +224,15 @@ namespace
         }
     } // set_file_object_keywords
 
-    auto send_notifications(
-        RsComm& _comm,
-        std::string_view _data_id,
-        json& _replicas) -> int
+    auto invoke_file_modified(RsComm& _comm, json& _replicas) -> int
     {
         try {
             for (auto&& replica : _replicas) {
                 irods::log(LOG_DEBUG9, fmt::format("[{}:{}] - replica:[{}]", __FUNCTION__, __LINE__, replica.dump()));
 
                 if (replica.contains(FILE_MODIFIED_KW)) {
-                    auto obj = irods::file_object_factory(_comm, std::stoll(_data_id.data()));
+                    const auto data_id = std::stoll(replica.at("after").at("data_id").get<std::string>());
+                    auto obj = irods::file_object_factory(_comm, data_id);
 
                     const auto leaf_resource_id = std::stoll(replica.at("after").at("resc_id").get<std::string>());
                     obj->resc_hier(resc_mgr.leaf_id_to_hier(leaf_resource_id));
@@ -285,7 +281,7 @@ namespace
             irods::log(LOG_ERROR, fmt::format("[{}:{}] - unknown error occurred", __FUNCTION__, __LINE__));
             return SYS_UNKNOWN_ERROR;
         }
-    } // send_notifications
+    } // invoke_file_modified
 
     auto rs_data_object_finalize(
         RsComm* _comm,
@@ -332,14 +328,12 @@ namespace
             return INPUT_ARG_NOT_WELL_FORMED_ERR;
         }
 
-        std::string data_id;
         json replicas;
-        bool file_modified;
+        bool trigger_file_modified;
 
         try {
-            data_id = input.at("data_id").get<std::string>();
             replicas = input.at("replicas");
-            file_modified = input.contains("file_modified") && input.at("file_modified").get<bool>();
+            trigger_file_modified = input.contains("trigger_file_modified") && input.at("trigger_file_modified").get<bool>();
         }
         catch (const json::type_error& e) {
             *_output = to_bytes_buffer(make_error_object(e.what()).dump());
@@ -365,16 +359,16 @@ namespace
         try {
             const auto ec = ic::execute_transaction(db_conn, [&](auto& _trans) -> int
             {
-                set_data_object_state(db_conn, _trans, data_id, replicas);
+                set_data_object_state(db_conn, _trans, replicas);
                 *_output = to_bytes_buffer("{}");
                 return 0;
             });
 
-            if (ec < 0 || !file_modified) {
+            if (ec < 0 || !trigger_file_modified) {
                 return ec;
             }
 
-            return send_notifications(*_comm, data_id, replicas);
+            return invoke_file_modified(*_comm, replicas);
         }
         catch (const irods::exception& e) {
             irods::log(LOG_ERROR, e.what());

--- a/plugins/api/src/replica_close.cpp
+++ b/plugins/api/src/replica_close.cpp
@@ -234,7 +234,7 @@ namespace
         // If nothing has been written, the status is restored from the replica state table
         // so that the replica is not mistakenly marked as good when it is in fact stale.
         else {
-            const auto previous_status = std::stoi(rst::get_property(_l1desc.dataObjInfo->objPath, _l1desc.dataObjInfo->replNum, "data_is_dirty"));
+            const auto previous_status = std::stoi(rst::get_property(_l1desc.dataObjInfo->dataId, _l1desc.dataObjInfo->replNum, "data_is_dirty"));
 
             addKeyVal(&reg_params, REPL_STATUS_KW, std::to_string(previous_status).data());
             addKeyVal(&reg_params, DATA_MODIFY_KW, current_time_in_seconds().data());
@@ -385,7 +385,7 @@ namespace
 
             const auto is_write_operation = (O_RDONLY != (l1desc.dataObjInp->openFlags & O_ACCMODE));
 
-            const std::string logical_path = l1desc.dataObjInfo->objPath;
+            const auto data_id = l1desc.dataObjInfo->dataId;
 
             // Allow updates to the replica's catalog information if the stream supports
             // write operations (i.e. the stream is opened in write-only or read-write mode).
@@ -395,10 +395,10 @@ namespace
                 const auto compute_checksum = json_input.contains("compute_checksum") && json_input.at("compute_checksum").get<bool>();
                 const auto update_catalog = update_size || update_status || compute_checksum || send_notifications;
 
-                const irods::at_scope_exit remove_from_rst{[&logical_path, &update_catalog]
+                const irods::at_scope_exit remove_from_rst{[&data_id, &update_catalog]
                     {
-                        if (update_catalog && rst::contains(logical_path)) {
-                            rst::erase(logical_path);
+                        if (update_catalog && rst::contains(data_id)) {
+                            rst::erase(data_id);
                         }
                     }
                 };
@@ -433,7 +433,7 @@ namespace
                              l1desc.bytesWritten <= 0 &&
                              CREATE_TYPE != l1desc.openType) {
                         // If nothing changed, the replica status should be restored to the original status.
-                        new_status = std::stoi(rst::get_property(l1desc.dataObjInfo->objPath, l1desc.dataObjInfo->replNum, "data_is_dirty"));
+                        new_status = std::stoi(rst::get_property(l1desc.dataObjInfo->dataId, l1desc.dataObjInfo->replNum, "data_is_dirty"));
                     }
 
                     if (const auto ec = update_replica_status(*_comm, l1desc, std::to_string(new_status), send_notifications); ec != 0) {

--- a/scripts/irods/test/resource_suite.py
+++ b/scripts/irods/test/resource_suite.py
@@ -262,7 +262,26 @@ class ResourceSuite(ResourceBase):
         lib.touch("file.txt")
         for i in range(0, 100):
             self.user0.assert_icommand("iput file.txt " + str(i) + ".txt", "EMPTY")
-        self.admin.assert_icommand("iphymv -r -M -n0 -R " + self.testresc + " " + self.admin.session_collection)  # creates replica
+
+        listing1,_,_ = self.user0.run_icommand(['ils', '-l', self.user0.session_collection])
+        print(listing1)
+
+        # scan each line of the ils and ensure that nothing is on TestResc
+        for item in listing1.splitlines()[2:]:
+            self.assertNotIn(self.testresc, item,
+                'expected not to find [{0}] in line [{1}]'.format(self.testresc, item))
+
+        self.admin.assert_icommand("iphymv -r -M -n0 -R " + self.testresc + " " + self.user0.session_collection)  # creates replica
+
+        listing2,_,_ = self.user0.run_icommand(['ils', '-l', self.user0.session_collection])
+        print(listing2)
+
+        # scan each line of the ils and ensure that everything moved to TestResc
+        replica_0 = 'alice             0'
+        for item in listing2.splitlines():
+            if replica_0 in item:
+                self.assertIn(self.testresc, item,
+                    'expected to find [{0}] in line [{1}]'.format(self.testresc, item))
 
     ###################
     # iput

--- a/server/api/include/rs_data_object_finalize.hpp
+++ b/server/api/include/rs_data_object_finalize.hpp
@@ -11,7 +11,7 @@ struct RsComm;
 extern "C" {
 #endif
 
-/// Set the state of every replica for a data object in the catalog, atomically.
+/// \brief Set the state of every replica for a data object in the catalog, atomically.
 ///
 /// A complete set of the columns in their current state as well as the desired modifications
 /// is required in the form of a JSON structure.
@@ -19,55 +19,58 @@ extern "C" {
 /// \p json_input must have the following JSON structure:
 /// \code{.js}
 /// {
-///   "data_id": string,
-///   "replicas": [
-///     {
-///       "before": {
-///         "data_id": string,
-///         "coll_id": string
-///         "data_name": string
-///         "data_repl_num": string
-///         "data_version": string
-///         "data_type_name": string
-///         "data_size": string
-///         "data_path": string
-///         "data_owner_name": string
-///         "data_owner_zone": string
-///         "data_is_dirty": string
-///         "data_status": string
-///         "data_checksum": string
-///         "data_expiry_ts": string
-///         "data_map_id": string
-///         "data_mode": string
-///         "r_comment": string
-///         "create_ts": string
-///         "modify_ts": string
-///         "resc_id: string
-///       },
-///       "after": {
-///         "data_id": string,
-///         "coll_id": string
-///         "data_name": string
-///         "data_repl_num": string
-///         "data_version": string
-///         "data_type_name": string
-///         "data_size": string
-///         "data_path": string
-///         "data_owner_name": string
-///         "data_owner_zone": string
-///         "data_is_dirty": string
-///         "data_status": string
-///         "data_checksum": string
-///         "data_expiry_ts": string
-///         "data_map_id": string
-///         "data_mode": string
-///         "r_comment": string
-///         "create_ts": string
-///         "modify_ts": string
-///         "resc_id: string
-///       }
-///     }
-///   ]
+///     "replicas": [
+///         {
+///             "before": {
+///                 "data_id": <string>,
+///                 "coll_id": <string>,
+///                 "data_repl_num": <string>,
+///                 "data_version": <string>,
+///                 "data_type_name": <string>,
+///                 "data_size": <string>,
+///                 "data_path": <string>,
+///                 "data_owner_name": <string>,
+///                 "data_owner_zone": <string>,
+///                 "data_is_dirty": <string>,
+///                 "data_status": <string>,
+///                 "data_checksum": <string>,
+///                 "data_expiry_ts": <string>,
+///                 "data_map_id": <string>,
+///                 "data_mode": <string>,
+///                 "r_comment": <string>,
+///                 "create_ts": <string>,
+///                 "modify_ts": <string>,
+///                 "resc_id": <string>
+///             },
+///             "after": {
+///                 "data_id": <string>,
+///                 "coll_id": <string>,
+///                 "data_repl_num": <string>,
+///                 "data_version": <string>,
+///                 "data_type_name": <string>,
+///                 "data_size": <string>,
+///                 "data_path": <string>,
+///                 "data_owner_name": <string>,
+///                 "data_owner_zone": <string>,
+///                 "data_is_dirty": <string>,
+///                 "data_status": <string>,
+///                 "data_checksum": <string>,
+///                 "data_expiry_ts": <string>,
+///                 "data_map_id": <string>,
+///                 "data_mode": <string>,
+///                 "r_comment": <string>,
+///                 "create_ts": <string>,
+///                 "modify_ts": <string>,
+///                 "resc_id": <string>
+///             },
+///             "file_modified": {
+///                 <string>: <string>,
+///                 ...
+///             }
+///         },
+///         ...
+///     ],
+///     "trigger_file_modified": <bool>
 /// }
 /// \endcode
 ///

--- a/server/api/src/rsDataObjClose.cpp
+++ b/server/api/src/rsDataObjClose.cpp
@@ -357,13 +357,13 @@ namespace
             replica.mtime(SET_TIME_TO_NOW_KW);
 
             // stale other replicas because the truth has moved
-            for (auto& rj : rst::at(replica.logical_path())) {
+            for (auto& rj : rst::at(replica.data_id())) {
                 const auto replica_number = std::stoi(std::string{rj.at("after").at("data_repl_num")});
 
                 if (replica.replica_number() != replica_number) {
                     const nlohmann::json update{{"data_is_dirty", std::to_string(STALE_REPLICA)}};
 
-                    rst::update(replica.logical_path(), replica_number,
+                    rst::update(replica.data_id(), replica_number,
                         nlohmann::json{{"replicas", update}});
                 }
             }
@@ -376,12 +376,10 @@ namespace
             replica.checksum(cond_input.at(CHKSUM_KW).value());
         }
 
-        replica.cond_input()[FILE_MODIFIED_KW] = irods::to_json(cond_input.get()).dump();
-
         // Write it out to the catalog
-        rst::update(replica.logical_path(), replica);
+        rst::update(replica.data_id(), replica);
 
-        if (const int ec = rst::publish_to_catalog(_comm, replica.logical_path(), rst::trigger_file_modified::yes); ec < 0) {
+        if (const int ec = rst::publish_to_catalog(_comm, replica.data_id(), replica.replica_number(), irods::to_json(cond_input.get())); ec < 0) {
             THROW(ec, fmt::format("failed to publish to catalog:[{}]", ec));
         }
 
@@ -541,7 +539,7 @@ namespace
             reg_param[REPL_STATUS_KW] = std::to_string(replica.replica_status());
         }
         else if (l1desc.openType == OPEN_FOR_WRITE_TYPE) {
-            replica.replica_status(std::stoi(rst::get_property(replica.logical_path(), replica.replica_number(), "data_is_dirty")));
+            replica.replica_status(std::stoi(rst::get_property(replica.data_id(), replica.replica_number(), "data_is_dirty")));
             reg_param[REPL_STATUS_KW] = std::to_string(replica.replica_status());
             reg_param[DATA_MODIFY_KW] = std::to_string((int)time(nullptr));
         }
@@ -805,12 +803,13 @@ int rsDataObjClose(rsComm_t* rsComm, openedDataObjInp_t* dataObjCloseInp)
                 unlock_file_descriptor(rsComm, fd);
             }
 
-            const std::string logical_path = l1desc.dataObjInfo->objPath;
+            //const rst::key_type key = rst::get_key(*l1desc.dataObjInfo);
+            const rst::key_type key = l1desc.dataObjInfo->dataId;
 
             freeL1desc(fd);
 
-            if (rst::contains(logical_path)) {
-                rst::erase(logical_path);
+            if (rst::contains(key)) {
+                rst::erase(key);
             }
         }};
 

--- a/server/api/src/rsDataObjOpen.cpp
+++ b/server/api/src/rsDataObjOpen.cpp
@@ -458,21 +458,19 @@ namespace
         auto registered_replica = irods::experimental::replica::make_replica_proxy(*l1desc.dataObjInfo);
 
         if (!l1desc.dataObjInfo->specColl) {
-            if (rst::contains(registered_replica.logical_path())) {
+            if (rst::contains(registered_replica.data_id())) {
                 if (_existing_replica_list) {
                     auto obj = irods::experimental::data_object::make_data_object_proxy(*_existing_replica_list);
                     obj.add_replica(*registered_replica.get());
                 }
-                rst::insert(registered_replica.logical_path(), registered_replica);
-                //rst::insert(l1desc.dataObjInfo->objPath, *l1desc.dataObjInfo);
+                rst::insert(registered_replica);
             }
             else {
                 auto obj = irods::experimental::data_object::make_data_object_proxy(*registered_replica.get());
                 rst::insert(obj);
-                //rst::insert(*l1desc.dataObjInfo);
             }
 
-            if (const int ec = rst::publish_to_catalog(_comm, registered_replica.logical_path(), rst::trigger_file_modified::no); ec < 0) {
+            if (const int ec = rst::publish_to_catalog(_comm, registered_replica.data_id(), registered_replica.replica_number(), nlohmann::json{}); ec < 0) {
                 THROW(ec, fmt::format("[{}:{}] - failed to update replica statuses", __FUNCTION__, __LINE__));
             }
         }
@@ -1020,19 +1018,17 @@ namespace
             if (const auto open_for_write = getWriteFlag(dataObjInp->openFlags); open_for_write) {
                 replica.replica_status(INTERMEDIATE_REPLICA);
 
-                const nlohmann::json update{{"data_is_dirty", std::to_string(replica.replica_status())}};
+                rst::update(replica.data_id(), replica.replica_number(),
+                    nlohmann::json{{"data_is_dirty", std::to_string(replica.replica_status())}});
 
-                rst::update(replica.logical_path(), replica.replica_number(),
-                    nlohmann::json{{"replicas", update}});
-
-                if (const int ec = rst::publish_to_catalog(*rsComm, replica.logical_path(), rst::trigger_file_modified::no); ec < 0) {
-                    const irods::at_scope_exit erase_rst_entry{[&replica] { rst::erase(replica.logical_path()); }};
+                if (const int ec = rst::publish_to_catalog(*rsComm, replica.data_id(), replica.replica_number(), nlohmann::json{}); ec < 0) {
+                    const irods::at_scope_exit erase_rst_entry{[&replica] { rst::erase(replica.data_id()); }};
 
                     irods::log(LOG_ERROR, fmt::format("failed to update replica status to intermediate"));
 
                     replica.replica_status(old_replica_status);
 
-                    if (const int ec = rst::publish_to_catalog(*rsComm, replica.logical_path(), rst::trigger_file_modified::no); ec < 0) {
+                    if (const int ec = rst::publish_to_catalog(*rsComm, replica.data_id(), replica.replica_number(), nlohmann::json{}); ec < 0) {
                         irods::log(LOG_ERROR, fmt::format(
                             "Failed to restore the replica's replica status "
                             "[error_code={}, path={}, hierarchy={}, original_replica_status={}]",

--- a/server/api/src/rsDataObjRepl.cpp
+++ b/server/api/src/rsDataObjRepl.cpp
@@ -103,7 +103,7 @@ namespace
         irods::apply_metadata_from_cond_input(_comm, *_l1desc.dataObjInp);
         irods::apply_acl_from_cond_input(_comm, *_l1desc.dataObjInp);
 
-        irods::replica_state_table::erase(_info.logical_path());
+        rst::erase(_info.data_id());
 
         return 0;
     } // finalize_source_replica
@@ -234,11 +234,13 @@ namespace
         // resource triggering replication while performing a PDMO replication).
         cond_input.erase(IN_REPL_KW);
 
-        _destination_replica.cond_input()[FILE_MODIFIED_KW] = irods::to_json(cond_input.get()).dump();
-
         // Write it out to the catalog
-        rst::update(_destination_replica.logical_path(), _destination_replica);
-        const int ec = rst::publish_to_catalog(_comm, _destination_replica.logical_path(), rst::trigger_file_modified::yes);
+        rst::update(_destination_replica.data_id(), _destination_replica);
+
+        const int ec = rst::publish_to_catalog(_comm,
+                                               _destination_replica.data_id(),
+                                               _destination_replica.replica_number(),
+                                               irods::to_json(cond_input.get()));
 
         if (CREATE_TYPE == _l1desc.openType) {
             updatequotaOverrun(_destination_replica.hierarchy().data(), _destination_replica.size(), ALL_QUOTA);
@@ -256,8 +258,8 @@ namespace
                 __FUNCTION__, _destination_replica.logical_path(), ec));
         }
 
-        if (rst::contains(_destination_replica.logical_path())) {
-            rst::erase(_destination_replica.logical_path());
+        if (rst::contains(_destination_replica.data_id())) {
+            rst::erase(_destination_replica.data_id());
         }
 
         return ec;
@@ -278,9 +280,12 @@ namespace
         _destination_replica.size(vault_size);
 
         // Write it out to the catalog
-        rst::update(_destination_replica.logical_path(), _destination_replica);
+        rst::update(_destination_replica.data_id(), _destination_replica);
 
-        const int ec = rst::publish_to_catalog(_comm, _destination_replica.logical_path(), irods::replica_state_table::trigger_file_modified::no);
+        const int ec = rst::publish_to_catalog(_comm,
+                                               _destination_replica.data_id(),
+                                               _destination_replica.replica_number(),
+                                               nlohmann::json{});
 
         if (ec < 0) {
             irods::log(LOG_ERROR, fmt::format("failed to publish to catalog:[{}]", ec));

--- a/server/api/src/rsModDataObjMeta.cpp
+++ b/server/api/src/rsModDataObjMeta.cpp
@@ -229,8 +229,8 @@ int _call_file_modified_for_modification(
     }
 
     // The replica state table entry needs to be removed before triggering fileModified
-    if (rst::contains(dataObjInfo->objPath)) {
-        rst::erase(dataObjInfo->objPath);
+    if (rst::contains(dataObjInfo->dataId)) {
+        rst::erase(dataObjInfo->dataId);
     }
 
     if ( getValByKey( regParam, ALL_KW ) != NULL ) {

--- a/server/core/src/initServer.cpp
+++ b/server/core/src/initServer.cpp
@@ -91,7 +91,7 @@ namespace
 
         auto replica = ir::make_replica_proxy(_info);
 
-        if (!rst::contains(replica.logical_path())) {
+        if (!rst::contains(replica.data_id())) {
             irods::log(LOG_ERROR, fmt::format(
                 "[{}:{}] - no entry found in replica state table for [{}]",
                 __FUNCTION__, __LINE__, replica.logical_path()));
@@ -127,9 +127,9 @@ namespace
             replica.checksum(cond_input.at(CHKSUM_KW).value());
         }
 
-        rst::update(replica.logical_path(), replica);
+        rst::update(replica.data_id(), replica);
 
-        if (const int ec = rst::publish_to_catalog(_comm, replica.logical_path(), rst::trigger_file_modified::no); ec < 0) {
+        if (const int ec = rst::publish_to_catalog(_comm, replica.data_id(), replica.replica_number(), nlohmann::json{}); ec < 0) {
             irods::log(LOG_ERROR, fmt::format(
                 "[{}:{}] - failed to publish to catalog:[{}]",
                 __FUNCTION__, __LINE__, ec));

--- a/server/core/src/replica_state_table.cpp
+++ b/server/core/src/replica_state_table.cpp
@@ -1,3 +1,4 @@
+#include "json_serialization.hpp"
 #include "irods_at_scope_exit.hpp"
 #include "irods_resource_manager.hpp"
 #include "replica_state_table.hpp"
@@ -8,6 +9,7 @@
 
 #include "fmt/format.h"
 
+#include <map>
 #include <mutex>
 
 extern irods::resource_manager resc_mgr;
@@ -17,24 +19,51 @@ namespace irods::replica_state_table
     namespace
     {
         // clang-format off
-        namespace id     = irods::experimental::data_object;
-        namespace ir     = irods::experimental::replica;
-        using json       = nlohmann::json;
+        namespace id = irods::experimental::data_object;
+        namespace ir = irods::experimental::replica;
+        using json   = nlohmann::json;
         // clang-format on
 
+        // Global Constants
+        static const std::string BEFORE_KW = "before";
+        static const std::string AFTER_KW = "after";
+        static const std::string REPLICAS_KW = "replicas";
+
         // Global Variables
-        json replica_state_json_map;
+        std::map<key_type, json> replica_state_json_map;
 
         std::mutex rst_mutex;
 
-        auto index_of(const std::string_view _logical_path, const int _replica_number) -> int
+        // Local functions
+        // extracts the key information from the replica_proxy and returns
+        // the string-ified key for use with the JSON map.
+        auto get_key(const ir::replica_proxy_t& _r) -> key_type
+        {
+            return _r.data_id();
+        } // get_key
+
+        // extracts the key information from the data_object_proxy and returns
+        // the string-ified key for use with the JSON map.
+        auto get_key(const id::data_object_proxy_t& _o) -> key_type
+        {
+            return _o.data_id();
+        } // get_key
+
+        // convenience function for accessing the ref_count
+        // NOTE: no lock acquisition
+        auto get_ref_count(const key_type& _key) -> int
+        {
+            return replica_state_json_map.at(_key).at("ref_count");
+        } // get_ref_count
+
+        auto index_of(const key_type& _key, const int _replica_number) -> int
         {
             std::scoped_lock rst_lock{rst_mutex};
 
-            if (replica_state_json_map.contains(_logical_path.data())) {
+            if (std::end(replica_state_json_map) != replica_state_json_map.find(_key)) {
                 int index = -1;
 
-                for (const auto& e : replica_state_json_map.at(_logical_path.data()).at(REPLICAS_KW)) {
+                for (const auto& e : replica_state_json_map.at(_key).at(REPLICAS_KW)) {
                     ++index;
                     if (_replica_number == std::stoi(e.at(BEFORE_KW).at("data_repl_num").get<std::string>())) {
                         return index;
@@ -44,19 +73,17 @@ namespace irods::replica_state_table
 
             THROW(KEY_NOT_FOUND, fmt::format(
                 "[{}:{}] - replica number [{}] not found for [{}]",
-                __FUNCTION__, __LINE__, _replica_number, _logical_path));
+                __FUNCTION__, __LINE__, _replica_number, _key));
         } // index_of
 
-        auto index_of(
-            const std::string_view _logical_path,
-            const rodsLong_t _leaf_resource_id) -> int
+        auto index_of(const key_type& _key, const rodsLong_t _leaf_resource_id) -> int
         {
             std::scoped_lock rst_lock{rst_mutex};
 
-            if (replica_state_json_map.contains(_logical_path.data())) {
+            if (std::end(replica_state_json_map) != replica_state_json_map.find(_key)) {
                 int index = -1;
 
-                for (const auto& e : replica_state_json_map.at(_logical_path.data()).at(REPLICAS_KW)) {
+                for (const auto& e : replica_state_json_map.at(_key).at(REPLICAS_KW)) {
                     ++index;
                     if (_leaf_resource_id == std::stoi(e.at(BEFORE_KW).at("resc_id").get<std::string>())) {
                         return index;
@@ -66,21 +93,19 @@ namespace irods::replica_state_table
 
             THROW(KEY_NOT_FOUND, fmt::format(
                 "[{}:{}] - resource id [{}] not found for [{}]",
-                __FUNCTION__, __LINE__, _leaf_resource_id, _logical_path));
+                __FUNCTION__, __LINE__, _leaf_resource_id, _key));
         } // index_of
 
-        auto index_of(
-            const std::string_view _logical_path,
-            const std::string_view _leaf_resource_name) -> int
+        auto index_of(const key_type& _key, const std::string_view _leaf_resource_name) -> int
         {
             std::scoped_lock rst_lock{rst_mutex};
 
-            if (replica_state_json_map.contains(_logical_path.data())) {
+            if (std::end(replica_state_json_map) != replica_state_json_map.find(_key)) {
                 int index = -1;
 
                 const auto resc_id = resc_mgr.hier_to_leaf_id(resc_mgr.get_hier_to_root_for_resc(_leaf_resource_name));
 
-                for (const auto& e : replica_state_json_map.at(_logical_path.data()).at(REPLICAS_KW)) {
+                for (const auto& e : replica_state_json_map.at(_key).at(REPLICAS_KW)) {
                     ++index;
                     if (resc_id == std::stoi(e.at(BEFORE_KW).at("resc_id").get<std::string>())) {
                         return index;
@@ -90,43 +115,70 @@ namespace irods::replica_state_table
 
             THROW(KEY_NOT_FOUND, fmt::format(
                 "[{}:{}] - resource name [{}] not found for [{}]",
-                __FUNCTION__, __LINE__, _leaf_resource_name, _logical_path));
+                __FUNCTION__, __LINE__, _leaf_resource_name, _key));
         } // index_of
 
-        // convenience function for accessing the ref_count
-        // NOTE: no lock acquisition
-        auto get_ref_count(const std::string_view _logical_path) -> int
-        {
-            return replica_state_json_map.at(_logical_path.data()).at("ref_count");
-        } // get_ref_count
-
         auto update_impl(
-            const std::string_view _logical_path,
+            const key_type& _key,
             const int _replica_index,
             const json& _updates) -> void
         {
             try {
                 std::scoped_lock rst_lock{rst_mutex};
 
-                auto& target_replica = replica_state_json_map.at(_logical_path.data()).at(REPLICAS_KW).at(_replica_index);
+                auto& target_replica = replica_state_json_map.at(_key).at(REPLICAS_KW).at(_replica_index);
 
                 irods::log(LOG_DEBUG9, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, target_replica.dump()));
 
-                if (_updates.contains(REPLICAS_KW)) {
-                    target_replica.at(AFTER_KW).update(_updates.at(REPLICAS_KW));
-                }
-
-                if (_updates.contains(FILE_MODIFIED_KW)) {
-                    irods::log(LOG_DEBUG9, fmt::format("[{}:{}] - file_modified:[{}]", __FUNCTION__, __LINE__, _updates.at(FILE_MODIFIED_KW).dump()));
-                    //target_replica[FILE_MODIFIED_KW].update(_updates.at(FILE_MODIFIED_KW));
-                    target_replica.erase(FILE_MODIFIED_KW);
-                    target_replica[FILE_MODIFIED_KW] = _updates.at(FILE_MODIFIED_KW);
-                }
+                target_replica.at(AFTER_KW).update(_updates);
             }
             catch (const json::exception& e) {
                 THROW(SYS_LIBRARY_ERROR, fmt::format("[{}:{}] - JSON error:[{}]", __FUNCTION__, __LINE__, e.what()));
             }
         } // update_impl
+
+        auto publish_to_catalog_impl(
+            RsComm& _comm,
+            const key_type& _key,
+            const int _replica_index,
+            const json& _file_modified_parameters) -> int
+        {
+            const bool trigger_file_modified = !_file_modified_parameters.empty();
+
+            const auto input = [&]() -> json
+            {
+                std::scoped_lock rst_lock{rst_mutex};
+
+                auto& target_entry = replica_state_json_map.at(_key);
+
+                if (trigger_file_modified) {
+                    target_entry.at(REPLICAS_KW).at(_replica_index)[FILE_MODIFIED_KW] = _file_modified_parameters;
+                }
+
+                return json{
+                    {REPLICAS_KW, target_entry.at(REPLICAS_KW)},
+                    {"trigger_file_modified", trigger_file_modified}
+                };
+            }();
+
+            // Completely erase the replica state table entry -- file_modified could open other replicas
+            if (trigger_file_modified) {
+                std::scoped_lock rst_lock{rst_mutex};
+
+                replica_state_json_map.erase(_key);
+            }
+
+            char* error_string{};
+            const irods::at_scope_exit free_error_string{[&error_string] { free(error_string); }};
+
+            const int ec = rs_data_object_finalize(&_comm, input.dump().data(), &error_string);
+
+            if (ec < 0) {
+                irods::log(LOG_ERROR, fmt::format("failed to publish replica states for [{}]", _key));
+            }
+
+            return ec;
+        } // publish_to_catalog_impl
     } // anonymouse namespace
 
     auto init() -> void
@@ -149,13 +201,15 @@ namespace irods::replica_state_table
 
     auto insert(const id::data_object_proxy_t& _obj) -> void
     {
+        const auto& key = get_key(_obj);
+
         try {
             std::scoped_lock rst_lock{rst_mutex};
 
-            if (replica_state_json_map.contains(_obj.logical_path().data())) {
+            if (std::end(replica_state_json_map) != replica_state_json_map.find(key)) {
                 irods::log(LOG_DEBUG, fmt::format("[{}:{}] - entry exists;path:[{}]", __FUNCTION__, __LINE__, _obj.logical_path()));
 
-                replica_state_json_map.at(_obj.logical_path().data())["ref_count"] = get_ref_count(_obj.logical_path()) + 1;
+                replica_state_json_map.at(key)["ref_count"] = get_ref_count(key) + 1;
 
                 return;
             }
@@ -173,31 +227,31 @@ namespace irods::replica_state_table
 
             const json entry{{REPLICAS_KW, replica_list}, {"ref_count", 1}};
 
-            irods::log(LOG_DEBUG9, fmt::format("entry:[{}]", entry.dump()));
+            irods::log(LOG_DEBUG9, fmt::format("[{}:{}] - entry:[{}]", __FUNCTION__, __LINE__, entry.dump()));
 
-            replica_state_json_map[_obj.logical_path().data()] = entry;
+            replica_state_json_map[key] = entry;
         }
         catch (const json::exception& e) {
             THROW(SYS_LIBRARY_ERROR, fmt::format("[{}:{}] - JSON error:[{}]", __FUNCTION__, __LINE__, e.what()));
         }
     } // insert
 
-    auto insert(
-        const std::string_view _logical_path,
-        const ir::replica_proxy_t& _replica) -> void
+    auto insert(const ir::replica_proxy_t& _replica) -> void
     {
         try {
-            std::scoped_lock rst_lock{rst_mutex};
-
-            if (!replica_state_json_map.contains(_logical_path.data())) {
+            if (!contains(_replica.data_id())) {
                 const auto obj = id::make_data_object_proxy(*_replica.get());
                 return insert(obj);
             }
 
+            const auto& key = get_key(_replica);
+
+            std::scoped_lock rst_lock{rst_mutex};
+
             const auto json_replica = ir::to_json(_replica);
 
-            auto& entry = replica_state_json_map.at(_logical_path.data());
-            entry["ref_count"] = get_ref_count(_logical_path) + 1;
+            auto& entry = replica_state_json_map.at(key);
+            entry["ref_count"] = get_ref_count(key) + 1;
             entry.at(REPLICAS_KW).push_back(
                 {
                     {BEFORE_KW, json_replica},
@@ -210,36 +264,34 @@ namespace irods::replica_state_table
         }
     } // insert
 
-    auto erase(const std::string_view _logical_path) -> void
+    auto erase(const key_type& _key) -> void
     {
-        if (!contains(_logical_path)) {
-            THROW(KEY_NOT_FOUND, fmt::format(
-                "[{}:{}] - no key found for [{}]",
-                __FUNCTION__, __LINE__, _logical_path));
-        }
-
         std::scoped_lock rst_lock{rst_mutex};
 
-        if (const auto ref_count = get_ref_count(_logical_path); ref_count > 1) {
-            replica_state_json_map.at(_logical_path.data())["ref_count"] = ref_count - 1;
+        if (std::end(replica_state_json_map) == replica_state_json_map.find(_key)) {
+            THROW(KEY_NOT_FOUND, fmt::format(
+                "[{}:{}] - no key found for [{}]",
+                __FUNCTION__, __LINE__, _key));
+        }
+
+        if (const auto ref_count = get_ref_count(_key); ref_count > 1) {
+            replica_state_json_map.at(_key)["ref_count"] = ref_count - 1;
         }
         else {
-            replica_state_json_map.erase(_logical_path.data());
+            replica_state_json_map.erase(_key);
         }
     } // erase
 
-    auto contains(const std::string_view _logical_path) -> bool
+    auto contains(const key_type& _key) -> bool
     {
         std::scoped_lock rst_lock{rst_mutex};
 
-        return replica_state_json_map.contains(_logical_path.data());
+        return std::end(replica_state_json_map) != replica_state_json_map.find(_key);
     } // contains
 
-    auto contains(
-        const std::string_view _logical_path,
-        const std::string_view _leaf_resource_name) -> bool
+    auto contains(const key_type& _key, const std::string_view _leaf_resource_name) -> bool
     {
-        if (!contains(_logical_path)) {
+        if (!contains(_key)) {
             return false;
         }
 
@@ -247,7 +299,7 @@ namespace irods::replica_state_table
 
         std::scoped_lock rst_lock{rst_mutex};
 
-        for (const auto& e : replica_state_json_map.at(_logical_path.data()).at(REPLICAS_KW)) {
+        for (const auto& e : replica_state_json_map.at(_key).at(REPLICAS_KW)) {
             if (resc_id == std::stoll(e.at(BEFORE_KW).at("resc_id").get<std::string>())) {
                 return true;
             }
@@ -256,17 +308,15 @@ namespace irods::replica_state_table
         return false;
     } // contains
 
-    auto contains(
-        const std::string_view _logical_path,
-        const int _replica_number) -> bool
+    auto contains(const key_type& _key, const int _replica_number) -> bool
     {
-        if (!contains(_logical_path)) {
+        if (!contains(_key)) {
             return false;
         }
 
         std::scoped_lock rst_lock{rst_mutex};
 
-        for (const auto& e : replica_state_json_map.at(_logical_path.data()).at(REPLICAS_KW)) {
+        for (const auto& e : replica_state_json_map.at(_key).at(REPLICAS_KW)) {
             if (_replica_number == std::stoi(e.at(BEFORE_KW).at("data_repl_num").get<std::string>())) {
                 return true;
             }
@@ -275,15 +325,21 @@ namespace irods::replica_state_table
         return false;
     } // contains
 
-    auto at(const std::string_view _logical_path) -> json
+    auto at(const key_type& _key) -> json
     {
         std::scoped_lock rst_lock{rst_mutex};
 
-        return replica_state_json_map.at(_logical_path.data()).at(REPLICAS_KW);
+        if (std::end(replica_state_json_map) == replica_state_json_map.find(_key)) {
+            THROW(KEY_NOT_FOUND, fmt::format(
+                "[{}:{}] - no key found for [{}]",
+                __FUNCTION__, __LINE__, _key));
+        }
+
+        return replica_state_json_map.at(_key).at(REPLICAS_KW);
     } // at
 
     auto at(
-        const std::string_view _logical_path,
+        const key_type& _key,
         const std::string_view _leaf_resource_name,
         const state_type _state) -> json
     {
@@ -291,9 +347,9 @@ namespace irods::replica_state_table
 
         const auto resc_id = resc_mgr.hier_to_leaf_id(resc_mgr.get_hier_to_root_for_resc(_leaf_resource_name));
 
-        const auto& replica_json = [&_logical_path, &resc_id]
+        const auto& replica_json = [&_key, &resc_id]
         {
-            for (const auto& e : replica_state_json_map.at(_logical_path.data()).at(REPLICAS_KW)) {
+            for (const auto& e : replica_state_json_map.at(_key).at(REPLICAS_KW)) {
                 if (resc_id == std::stoll(e.at(BEFORE_KW).at("resc_id").get<std::string>())) {
                     return e;
                 }
@@ -301,14 +357,14 @@ namespace irods::replica_state_table
 
             THROW(KEY_NOT_FOUND, fmt::format(
                 "[{}:{}] - no resc id [{}] found for [{}]",
-                __FUNCTION__, __LINE__, resc_id, _logical_path));
+                __FUNCTION__, __LINE__, resc_id, _key));
         }();
 
         switch (_state) {
             // clang-format off
             case state_type::before:    return replica_json.at(BEFORE_KW);   break;
             case state_type::after:     return replica_json.at(AFTER_KW);    break;
-            case state_type::both:      return replica_json;                break;
+            case state_type::both:      return replica_json;                 break;
             // clang-format on
 
             default:
@@ -319,15 +375,15 @@ namespace irods::replica_state_table
     } // at
 
     auto at(
-        const std::string_view _logical_path,
+        const key_type& _key,
         const int _replica_number,
         const state_type _state) -> json
     {
         std::scoped_lock rst_lock{rst_mutex};
 
-        const auto& replica_json = [&_logical_path, &_replica_number]
+        const auto& replica_json = [&_key, &_replica_number]
         {
-            for (const auto& e : replica_state_json_map.at(_logical_path.data()).at(REPLICAS_KW)) {
+            for (const auto& e : replica_state_json_map.at(_key).at(REPLICAS_KW)) {
                 if (_replica_number == std::stoi(e.at(BEFORE_KW).at("data_repl_num").get<std::string>())) {
                     return e;
                 }
@@ -335,14 +391,14 @@ namespace irods::replica_state_table
 
             THROW(KEY_NOT_FOUND, fmt::format(
                 "[{}:{}] - no replica number [{}] found for [{}]",
-                __FUNCTION__, __LINE__, _replica_number, _logical_path));
+                __FUNCTION__, __LINE__, _replica_number, _key));
         }();
 
         switch (_state) {
             // clang-format off
             case state_type::before:    return replica_json.at(BEFORE_KW);   break;
             case state_type::after:     return replica_json.at(AFTER_KW);    break;
-            case state_type::both:      return replica_json;                break;
+            case state_type::both:      return replica_json;                 break;
             // clang-format on
 
             default:
@@ -353,43 +409,37 @@ namespace irods::replica_state_table
     } // at
 
     auto update(
-        const std::string_view _logical_path,
+        const key_type& _key,
         const std::string_view _leaf_resource_name,
         const json& _updates) -> void
     {
-        const auto replica_index = index_of(_logical_path, _leaf_resource_name);
+        const auto replica_index = index_of(_key, _leaf_resource_name);
 
-        return update_impl(_logical_path, replica_index, _updates);
+        return update_impl(_key, replica_index, _updates);
     } // update
 
     auto update(
-        const std::string_view _logical_path,
+        const key_type& _key,
         const int _replica_number,
         const json& _updates) -> void
     {
-        const auto replica_index = index_of(_logical_path, _replica_number);
+        const auto replica_index = index_of(_key, _replica_number);
 
-        return update_impl(_logical_path, replica_index, _updates);
+        return update_impl(_key, replica_index, _updates);
     } // update
 
     auto update(
-        const std::string_view _logical_path,
+        const key_type& _key,
         const ir::replica_proxy_t& _replica) -> void
     {
-        const json replica_json{ir::to_json(_replica)};
-        json updates{{REPLICAS_KW, replica_json}};
 
-        if (_replica.cond_input().contains(FILE_MODIFIED_KW)) {
-            updates[FILE_MODIFIED_KW] = json::parse(_replica.cond_input().at(FILE_MODIFIED_KW).value().data());
-        }
+        const auto replica_index = index_of(_key, _replica.resource_id());
 
-        const auto replica_index = index_of(_logical_path, _replica.resource_id());
-
-        return update_impl(_logical_path, replica_index, updates);
+        return update_impl(_key, replica_index, ir::to_json(_replica));
     } // update
 
     auto get_property(
-        const std::string_view _logical_path,
+        const key_type& _key,
         const int _replica_number,
         const std::string_view _property_name,
         const state_type _state) -> std::string
@@ -398,13 +448,13 @@ namespace irods::replica_state_table
             THROW(SYS_INVALID_INPUT_PARAM, fmt::format("state type must be before or after"));
         }
 
-        const auto replica_json = at(_logical_path, _replica_number, _state);
+        const auto replica_json = at(_key, _replica_number, _state);
 
         return replica_json.at(_property_name.data());
     } // get_property
 
     auto get_property(
-        const std::string_view _logical_path,
+        const key_type& _key,
         const std::string_view _leaf_resource_name,
         const std::string_view _property_name,
         const state_type _state) -> std::string
@@ -413,49 +463,63 @@ namespace irods::replica_state_table
             THROW(SYS_INVALID_INPUT_PARAM, fmt::format("state type must be before or after"));
         }
 
-        const auto replica_json = at(_logical_path, _leaf_resource_name, _state);
+        const auto replica_json = at(_key, _leaf_resource_name, _state);
 
         return replica_json.at(_property_name.data());
     } // get_property
 
     auto publish_to_catalog(
         RsComm& _comm,
-        const std::string_view _logical_path,
-        const trigger_file_modified _trigger_file_modified) -> int
+        const key_type& _key,
+        const int _replica_number_for_file_modified,
+        const json& _file_modified_parameters) -> int
     {
         try {
-            const auto input = [&]() -> json
-            {
-                std::scoped_lock rst_lock{rst_mutex};
+            const auto replica_index = index_of(_key, _replica_number_for_file_modified);
 
-                auto& target_entry = replica_state_json_map.at(_logical_path.data());
+            return publish_to_catalog_impl(_comm, _key, replica_index, _file_modified_parameters);
+        }
+        catch (const json::exception& e) {
+            THROW(SYS_LIBRARY_ERROR, fmt::format("[{}:{}] - JSON error:[{}]", __FUNCTION__, __LINE__, e.what()));
+        }
+        catch (const std::exception& e) {
+            THROW(SYS_INTERNAL_ERR, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, e.what()));
+        }
+        catch (...) {
+            THROW(SYS_UNKNOWN_ERROR, fmt::format("[{}:{}] - unknown error occurred", __FUNCTION__, __LINE__));
+        }
+    } // publish_to_catalog
 
-                irods::log(LOG_DEBUG9, fmt::format(
-                    "[{}:{}] - target:[{}]",
-                    __FUNCTION__, __LINE__, target_entry.dump()));
+    auto publish_to_catalog(
+        RsComm& _comm,
+        const key_type& _key,
+        const std::string_view _leaf_resource_name_for_file_modified,
+        const json& _file_modified_parameters) -> int
+    {
+        try {
+            const auto replica_index = index_of(_key, _leaf_resource_name_for_file_modified);
 
-                return json{
-                    {"data_id", target_entry.at(REPLICAS_KW).at(0).at(AFTER_KW).at("data_id")},
-                    {REPLICAS_KW, target_entry.at(REPLICAS_KW)},
-                    {FILE_MODIFIED_KW, trigger_file_modified::yes == _trigger_file_modified}
-                };
-            }();
+            return publish_to_catalog_impl(_comm, _key, replica_index, _file_modified_parameters);
+        }
+        catch (const json::exception& e) {
+            THROW(SYS_LIBRARY_ERROR, fmt::format("[{}:{}] - JSON error:[{}]", __FUNCTION__, __LINE__, e.what()));
+        }
+        catch (const std::exception& e) {
+            THROW(SYS_INTERNAL_ERR, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, e.what()));
+        }
+        catch (...) {
+            THROW(SYS_UNKNOWN_ERROR, fmt::format("[{}:{}] - unknown error occurred", __FUNCTION__, __LINE__));
+        }
+    } // publish_to_catalog
 
-            // Completely erase the replica state table entry -- file_modified could open other replicas
-            if (trigger_file_modified::yes == _trigger_file_modified) {
-                std::scoped_lock rst_lock{rst_mutex};
-                replica_state_json_map.erase(_logical_path.data());
-            }
+    auto publish_to_catalog(RsComm& _comm, const ir::replica_proxy_t& _replica) -> int
+    {
+        try {
+            const auto& key = get_key(_replica);
 
-            char* error_string{};
-            const irods::at_scope_exit free_error_string{[&error_string] { free(error_string); }};
+            const auto replica_index = index_of(key, _replica.resource_id());
 
-            const int ec = rs_data_object_finalize(&_comm, input.dump().data(), &error_string);
-            if (ec < 0) {
-                irods::log(LOG_ERROR, fmt::format("failed to publish replica states for [{}]", _logical_path));
-            }
-
-            return ec;
+            return publish_to_catalog_impl(_comm, key, replica_index, irods::to_json(_replica.cond_input().get()));
         }
         catch (const json::exception& e) {
             THROW(SYS_LIBRARY_ERROR, fmt::format("[{}:{}] - JSON error:[{}]", __FUNCTION__, __LINE__, e.what()));

--- a/unit_tests/src/test_data_object_finalize.cpp
+++ b/unit_tests/src/test_data_object_finalize.cpp
@@ -111,7 +111,6 @@ TEST_CASE("finalize", "[finalize]")
         {
             // Get data object info, modify some fields in each replica, and stamp the catalog
             json input;
-            input["data_id"] = std::to_string(og_op.data_id());
 
             for (auto& repl : og_op.replicas()) {
                 const auto before = replica::to_json(repl);

--- a/unit_tests/src/test_replica_state_table.cpp
+++ b/unit_tests/src/test_replica_state_table.cpp
@@ -13,7 +13,6 @@
 
 namespace
 {
-    using state_type = irods::replica_state_table::state_type;
     namespace data_object = irods::experimental::data_object;
     namespace rst = irods::replica_state_table;
 
@@ -23,10 +22,12 @@ namespace
     constexpr std::uint64_t DATA_ID_1 = 10101;
     constexpr std::uint64_t DATA_ID_2 = 20202;
     const std::string LOGICAL_PATH_1  = "/tempZone/home/rods/foo";
+    const std::string LOGICAL_PATH_2  = "/tempZone/home/rods/goo";
+    const std::string UPDATED_COMMENT = "updated";
 
     auto generate_data_object(
-        std::string_view _logical_path,
         const std::uint64_t _data_id,
+        std::string_view _logical_path,
         const std::uint64_t _size) -> std::array<DataObjInfo*, REPLICA_COUNT>
     {
         std::array<DataObjInfo*, REPLICA_COUNT> replicas;
@@ -65,9 +66,7 @@ namespace
 
 TEST_CASE("replica state table", "[basic]")
 {
-    //const auto replicas = generate_data_object(LOGICAL_PATH_1, DATA_ID_1, SIZE_1);
-    //const auto* head = replicas[0];
-    auto replicas = generate_data_object(LOGICAL_PATH_1, DATA_ID_1, SIZE_1);
+    auto replicas = generate_data_object(DATA_ID_1, LOGICAL_PATH_1, SIZE_1);
     auto* head = replicas[0];
 
     // ensure that the linked list is valid and will be freed upon exit
@@ -77,12 +76,12 @@ TEST_CASE("replica state table", "[basic]")
 
     // create before entry for the data object
     REQUIRE_NOTHROW(rst::insert(obj));
-    REQUIRE(rst::contains(LOGICAL_PATH_1));
-    REQUIRE(REPLICA_COUNT == rst::at(LOGICAL_PATH_1).size());
+    REQUIRE(rst::contains(DATA_ID_1));
+    REQUIRE(REPLICA_COUNT == rst::at(DATA_ID_1).size());
 
     SECTION("access by logical path (data object)")
     {
-        const auto data_object_json = rst::at(LOGICAL_PATH_1);
+        const auto data_object_json = rst::at(DATA_ID_1);
 
         REQUIRE(REPLICA_COUNT == data_object_json.size());
 
@@ -104,7 +103,7 @@ TEST_CASE("replica state table", "[basic]")
     {
         constexpr int replica_number = REPLICA_COUNT - 1;
         const auto original_replica = irods::experimental::replica::make_replica_proxy(*replicas.at(replica_number));
-        const auto replica_json = rst::at(LOGICAL_PATH_1, replica_number, state_type::before);
+        const auto replica_json = rst::at(DATA_ID_1, replica_number, rst::state_type::before);
         const auto [before, lm] = irods::experimental::replica::make_replica_proxy(LOGICAL_PATH_1, replica_json);
 
         CHECK(before.data_id()        == original_replica.data_id());
@@ -119,28 +118,29 @@ TEST_CASE("replica state table", "[basic]")
 
         auto [r, r_lm] = irods::experimental::replica::duplicate_replica(*replicas.at(target_replica_number));
 
-        r.data_id(DATA_ID_2);
+        r.comments(UPDATED_COMMENT);
         r.size(SIZE_2);
         r.replica_status(STALE_REPLICA);
 
-        REQUIRE_NOTHROW(rst::update(LOGICAL_PATH_1, r));
+        REQUIRE_NOTHROW(rst::update(DATA_ID_1, r));
 
         for (int i = 0; i < REPLICA_COUNT; ++i) {
             const auto original_replica = irods::experimental::replica::make_replica_proxy(*replicas.at(i));
-            const auto replica_json = rst::at(LOGICAL_PATH_1, original_replica.replica_number(), state_type::after);
+            const auto replica_json = rst::at(DATA_ID_1, original_replica.replica_number(), rst::state_type::after);
             const auto [replica, lm] = irods::experimental::replica::make_replica_proxy(LOGICAL_PATH_1, replica_json);
 
             if (target_replica_number == i) {
                 // ensure that the after states updated
-                CHECK(replica.data_id()        == DATA_ID_2);
+                CHECK(replica.data_id()        == DATA_ID_1);
                 CHECK(replica.logical_path()   == LOGICAL_PATH_1);
                 CHECK(replica.replica_number() == target_replica_number);
                 CHECK(replica.size()           == SIZE_2);
                 CHECK(replica.replica_status() == STALE_REPLICA);
                 CHECK(replica.resource_id()    == original_replica.resource_id());
+                CHECK(replica.comments()       == UPDATED_COMMENT);
 
                 // ensure that "before" states remained the same
-                const auto replica_json = rst::at(LOGICAL_PATH_1, original_replica.replica_number(), state_type::before);
+                const auto replica_json = rst::at(DATA_ID_1, original_replica.replica_number(), rst::state_type::before);
                 const auto [before, before_lm] = irods::experimental::replica::make_replica_proxy(LOGICAL_PATH_1, replica_json);
                 CHECK(before.data_id()        == original_replica.data_id());
                 CHECK(before.logical_path()   == original_replica.logical_path());
@@ -148,6 +148,7 @@ TEST_CASE("replica state table", "[basic]")
                 CHECK(before.size()           == original_replica.size());
                 CHECK(before.replica_status() == original_replica.replica_status());
                 CHECK(before.resource_id()    == original_replica.resource_id());
+                CHECK(before.comments()       == original_replica.comments());
             }
             else {
                 // ensure that the other replicas did not update
@@ -157,15 +158,16 @@ TEST_CASE("replica state table", "[basic]")
                 CHECK(replica.size()           == original_replica.size());
                 CHECK(replica.replica_status() == original_replica.replica_status());
                 CHECK(replica.resource_id()    == original_replica.resource_id());
+                CHECK(replica.comments()       == original_replica.comments());
             }
         }
 
         SECTION("property accessors")
         {
-            CHECK(target_replica_number == std::stoi(rst::get_property(LOGICAL_PATH_1, target_replica_number, "data_repl_num", state_type::after)));
-            CHECK(DATA_ID_2 == std::stoll(rst::get_property(LOGICAL_PATH_1, target_replica_number, "data_id", state_type::after)));
-            CHECK(SIZE_2 == std::stoll(rst::get_property(LOGICAL_PATH_1, target_replica_number, "data_size", state_type::after)));
-            CHECK(STALE_REPLICA == std::stoi(rst::get_property(LOGICAL_PATH_1, target_replica_number, "data_is_dirty", state_type::after)));
+            CHECK(target_replica_number == std::stoi(rst::get_property(DATA_ID_1, target_replica_number, "data_repl_num", rst::state_type::after)));
+            CHECK(DATA_ID_1 == std::stoll(rst::get_property(DATA_ID_1, target_replica_number, "data_id", rst::state_type::after)));
+            CHECK(SIZE_2 == std::stoll(rst::get_property(DATA_ID_1, target_replica_number, "data_size", rst::state_type::after)));
+            CHECK(STALE_REPLICA == std::stoi(rst::get_property(DATA_ID_1, target_replica_number, "data_is_dirty", rst::state_type::after)));
         }
     }
 
@@ -173,37 +175,37 @@ TEST_CASE("replica state table", "[basic]")
     {
         constexpr int target_replica_number = 1;
 
-        const nlohmann::json updates{{
-            "replicas", nlohmann::json{
-                {"data_id", std::to_string(DATA_ID_2)},
-                {"data_size", std::to_string(SIZE_2)},
-                {"data_is_dirty", std::to_string(STALE_REPLICA)}
-            }
+        const auto updates = nlohmann::json{nlohmann::json{
+            {"r_comment", UPDATED_COMMENT},
+            {"data_size", std::to_string(SIZE_2)},
+            {"data_is_dirty", std::to_string(STALE_REPLICA)}
         }};
 
-        REQUIRE_NOTHROW(rst::update(LOGICAL_PATH_1, target_replica_number, updates));
+        REQUIRE_NOTHROW(rst::update(DATA_ID_1, target_replica_number, updates));
 
         for (int i = 0; i < REPLICA_COUNT; ++i) {
             const auto original_replica = irods::experimental::replica::make_replica_proxy(*replicas.at(i));
-            const auto replica_json = rst::at(LOGICAL_PATH_1, original_replica.replica_number(), state_type::after);
+            const auto replica_json = rst::at(DATA_ID_1, original_replica.replica_number(), rst::state_type::after);
             const auto [replica, lm] = irods::experimental::replica::make_replica_proxy(LOGICAL_PATH_1, replica_json);
 
             if (target_replica_number == i) {
                 // ensure that the after states updated
-                CHECK(replica.data_id()        == DATA_ID_2);
+                CHECK(replica.data_id()        == DATA_ID_1);
                 CHECK(replica.logical_path()   == LOGICAL_PATH_1);
                 CHECK(replica.replica_number() == target_replica_number);
                 CHECK(replica.size()           == SIZE_2);
                 CHECK(replica.replica_status() == STALE_REPLICA);
+                CHECK(replica.comments()       == UPDATED_COMMENT);
 
                 // ensure that "before" states remained the same
-                const auto replica_json = rst::at(LOGICAL_PATH_1, original_replica.replica_number(), state_type::before);
+                const auto replica_json = rst::at(DATA_ID_1, original_replica.replica_number(), rst::state_type::before);
                 const auto [before, before_lm] = irods::experimental::replica::make_replica_proxy(LOGICAL_PATH_1, replica_json);
                 CHECK(before.data_id()        == original_replica.data_id());
                 CHECK(before.logical_path()   == original_replica.logical_path());
                 CHECK(before.replica_number() == original_replica.replica_number());
                 CHECK(before.size()           == original_replica.size());
                 CHECK(before.replica_status() == original_replica.replica_status());
+                CHECK(before.comments()       == original_replica.comments());
             }
             else {
                 // ensure that the other replicas did not update
@@ -212,36 +214,21 @@ TEST_CASE("replica state table", "[basic]")
                 CHECK(replica.replica_number() == original_replica.replica_number());
                 CHECK(replica.size()           == original_replica.size());
                 CHECK(replica.replica_status() == original_replica.replica_status());
+                CHECK(replica.comments()       == original_replica.comments());
             }
         }
 
         SECTION("property accessors")
         {
-            CHECK(DATA_ID_2 == std::stoll(rst::get_property(LOGICAL_PATH_1, target_replica_number, "data_id", state_type::after)));
-            CHECK(SIZE_2 == std::stoll(rst::get_property(LOGICAL_PATH_1, target_replica_number, "data_size", state_type::after)));
-            CHECK(STALE_REPLICA == std::stoi(rst::get_property(LOGICAL_PATH_1, target_replica_number, "data_is_dirty", state_type::after)));
+            CHECK(DATA_ID_1 == std::stoll(rst::get_property(DATA_ID_1, target_replica_number, "data_id", rst::state_type::after)));
+            CHECK(SIZE_2 == std::stoll(rst::get_property(DATA_ID_1, target_replica_number, "data_size", rst::state_type::after)));
+            CHECK(STALE_REPLICA == std::stoi(rst::get_property(DATA_ID_1, target_replica_number, "data_is_dirty", rst::state_type::after)));
         }
     }
 
-#if 0
-    SECTION("access by leaf resource name")
-    {
-        // TODO: this requires a running iRODS server and catalog (not a unit test) -- skip
-    }
-
-    SECTION("update by leaf resource name")
-    {
-        // TODO: this requires a running iRODS server and catalog (not a unit test) -- skip
-    }
-#endif
-
     SECTION("track multiple data objects")
     {
-        const std::string LOGICAL_PATH_2  = "/tempZone/home/rods/goo";
-
-        //const auto replicas_2 = generate_data_object(LOGICAL_PATH_2, DATA_ID_2, SIZE_2);
-        //const auto* head_2 = replicas_2[0];
-        auto replicas_2 = generate_data_object(LOGICAL_PATH_2, DATA_ID_2, SIZE_2);
+        auto replicas_2 = generate_data_object(DATA_ID_2, LOGICAL_PATH_2, SIZE_2);
         auto* head_2 = replicas_2[0];
 
         // ensure that the linked list is valid and will be freed upon exit
@@ -251,12 +238,12 @@ TEST_CASE("replica state table", "[basic]")
         const auto obj_2 = irods::experimental::data_object::make_data_object_proxy(*head_2);
 
         REQUIRE_NOTHROW(rst::insert(obj_2));
-        REQUIRE(rst::contains(LOGICAL_PATH_2));
+        REQUIRE(rst::contains(DATA_ID_2));
 
         for (int i = 0; i < REPLICA_COUNT; ++i) {
             const auto original_replica = irods::experimental::replica::make_replica_proxy(*replicas_2.at(i));
 
-            const auto replica_json = rst::at(LOGICAL_PATH_2, original_replica.replica_number(), state_type::before);
+            const auto replica_json = rst::at(DATA_ID_2, original_replica.replica_number(), rst::state_type::before);
             const auto [before, lm] = irods::experimental::replica::make_replica_proxy(LOGICAL_PATH_2, replica_json);
 
             // ensure that the replicas match
@@ -266,8 +253,8 @@ TEST_CASE("replica state table", "[basic]")
             CHECK(before.size()           == original_replica.size());
         }
 
-        CHECK_NOTHROW(rst::erase(LOGICAL_PATH_2));
-        CHECK_FALSE(rst::contains(LOGICAL_PATH_2));
+        CHECK_NOTHROW(rst::erase(DATA_ID_2));
+        CHECK_FALSE(rst::contains(DATA_ID_2));
     }
 
     SECTION("insert replica for existing entry")
@@ -275,39 +262,41 @@ TEST_CASE("replica state table", "[basic]")
         constexpr int REPL_NUM = 7;
 
         auto [proxy, lm] = irods::experimental::replica::make_replica_proxy();
+        proxy.data_id(DATA_ID_1);
         proxy.logical_path(LOGICAL_PATH_1);
         proxy.replica_number(REPL_NUM);
 
-        CHECK_FALSE(rst::contains(proxy.logical_path(), proxy.replica_number()));
+        CHECK_FALSE(rst::contains(proxy.data_id(), proxy.replica_number()));
 
-        REQUIRE_NOTHROW(rst::insert(proxy.logical_path(), proxy));
+        REQUIRE_NOTHROW(rst::insert(proxy));
 
-        CHECK(rst::contains(proxy.logical_path(), proxy.replica_number()));
-        CHECK(REPLICA_COUNT + 1 == rst::at(proxy.logical_path()).size());
-        CHECK(REPL_NUM == std::stoi(rst::get_property(proxy.logical_path(), REPL_NUM, "data_repl_num")));
+        CHECK(rst::contains(proxy.data_id(), proxy.replica_number()));
+        CHECK(REPLICA_COUNT + 1 == rst::at(proxy.data_id()).size());
+        CHECK(REPL_NUM == std::stoi(rst::get_property(proxy.data_id(), REPL_NUM, "data_repl_num")));
 
-        CHECK_NOTHROW(rst::erase(LOGICAL_PATH_1));
-        CHECK(rst::contains(LOGICAL_PATH_1));
+        CHECK_NOTHROW(rst::erase(DATA_ID_1));
+        CHECK(rst::contains(DATA_ID_1));
     }
 
     SECTION("test ref_count")
     {
-        REQUIRE(rst::contains(LOGICAL_PATH_1));
+        REQUIRE(rst::contains(DATA_ID_1));
         REQUIRE_NOTHROW(rst::insert(obj));
-        CHECK_NOTHROW(rst::erase(LOGICAL_PATH_1));
-        CHECK(rst::contains(LOGICAL_PATH_1));
+        CHECK_NOTHROW(rst::erase(DATA_ID_1));
+        CHECK(rst::contains(DATA_ID_1));
     }
 
-    CHECK_NOTHROW(rst::erase(LOGICAL_PATH_1));
-    CHECK_FALSE(rst::contains(LOGICAL_PATH_1));
+    CHECK_NOTHROW(rst::erase(DATA_ID_1));
+    CHECK_FALSE(rst::contains(DATA_ID_1));
     rst::deinit();
 }
 
 TEST_CASE("invalid_keys", "[basic]")
 {
-    CHECK_FALSE(rst::contains("nope"));
-    CHECK_THROWS(rst::at("nope"));
-    CHECK_THROWS(rst::get_property("whatever", 0, "whatever", state_type::both));
+    constexpr rst::key_type BOGUS_KEY = 42;
+    CHECK_FALSE(rst::contains(BOGUS_KEY));
+    CHECK_THROWS(rst::at(BOGUS_KEY));
+    CHECK_THROWS(rst::get_property(BOGUS_KEY, 0, "whatever", rst::state_type::both));
     rst::deinit();
 }
 


### PR DESCRIPTION
The data_object_finalize and replica_state_table interfaces are very
closely related and so the JSON passed between the two has been modified
to bring a sense of consistency and clarity to their usage.

The RST interfaces underwent the following changes:
    - RST is now a std::map<std::uint64_t, nlohmann::json> instead of
      simply a JSON map for key-type flexibility
    - Entries are keyed by data_id instead of logical path
    - update now takes only a list of r_data_main column-string pairs
    - publish_to_catalog:
        - now takes a replica number and a JSON object which, if
          present, indicates that file_modified should be triggered
        - JSON object is added as a field to the replica indicated
          by the replica number input

The data_object_finalize API underwent the following changes:
    - data_id field was removed as it served no purpose - this should be
      retrieved from the replica information
    - fileModified is now triggered in finalize by the presence of
      trigger_file_modified boolean
    - The file_modified entry will remain on the affected replica as
      a JSON object

---
CI tests running.