### PR TITLE
[#5494] Remove use of PHYOPEN_BY_SIZE_KW in server (4-2-stable)

### DIFF
--- a/server/api/include/rsDataObjGet.hpp
+++ b/server/api/include/rsDataObjGet.hpp
@@ -7,7 +7,5 @@
 
 int rsDataObjGet( rsComm_t *rsComm, dataObjInp_t *dataObjInp, portalOprOut_t **portalOprOut, bytesBuf_t *dataObjOutBBuf );
 int preProcParaGet( rsComm_t *rsComm, int l1descInx, portalOprOut_t **portalOprOut );
-int l3DataGetSingleBuf( rsComm_t *rsComm, int l1descInx, bytesBuf_t *dataObjOutBBuf, portalOprOut_t **portalOprOut );
-int l3FileGetSingleBuf( rsComm_t *rsComm, int l1descInx, bytesBuf_t *dataObjOutBBuf );
 
 #endif

--- a/server/api/src/rsDataObjOpen.cpp
+++ b/server/api/src/rsDataObjOpen.cpp
@@ -632,20 +632,6 @@ namespace
             return l1_index;
         }
 
-        if (_replica.cond_input().contains(PHYOPEN_BY_SIZE_KW)) {
-            try {
-                const auto single_buffer_size = irods::get_advanced_setting<const int>(irods::CFG_MAX_SIZE_FOR_SINGLE_BUFFER) * 1024 * 1024;
-                if (_replica.size() <= single_buffer_size &&
-                    (UNKNOWN_FILE_SZ != _replica.size() || _replica.cond_input().contains(DATA_INCLUDED_KW))) {
-                    return l1_index;
-                }
-            }
-            catch (const irods::exception& e) {
-                freeL1desc(l1_index);
-                throw;
-            }
-        }
-
         const int l3_index = l3Open(&_comm, l1_index);
         if (l3_index <= 0) {
             freeL1desc(l1_index);

--- a/server/api/src/rsDataObjRepl.cpp
+++ b/server/api/src/rsDataObjRepl.cpp
@@ -13,8 +13,6 @@
 #include "getRemoteZoneResc.h"
 #include "getRescQuota.h"
 #include "icatDefines.h"
-#include "l3FileGetSingleBuf.h"
-#include "l3FilePutSingleBuf.h"
 #include "miscServerFunct.hpp"
 #include "objMetaOpr.hpp"
 #include "physPath.hpp"

--- a/server/api/src/rsL3FileGetSingleBuf.cpp
+++ b/server/api/src/rsL3FileGetSingleBuf.cpp
@@ -15,7 +15,66 @@
 #include "objMetaOpr.hpp"
 #include "getRemoteZoneResc.h"
 #include "rsL3FileGetSingleBuf.hpp"
-#include "rsDataObjGet.hpp"
+#include "physPath.hpp"
+#include "rsFileGet.hpp"
+#include "rsSubStructFileGet.hpp"
+
+#include "irods_resource_backport.hpp"
+
+/* l3FileGetSingleBuf - Get the content of a small file into a single buffer
+ * in dataObjOutBBuf->buf for an opened data obj in l1descInx.
+ * Return value - int - number of bytes read.
+ */
+
+int
+l3FileGetSingleBuf( rsComm_t *rsComm, int l1descInx,
+                    bytesBuf_t *dataObjOutBBuf ) {
+    // =-=-=-=-=-=-=-
+    // extract the host location from the resource hierarchy
+    dataObjInfo_t* dataObjInfo = L1desc[l1descInx].dataObjInfo;
+    std::string location{};
+    irods::error ret = irods::get_loc_for_hier_string( dataObjInfo->rescHier, location );
+    if ( !ret.ok() ) {
+        irods::log( PASSMSG( "l3FileGetSingleBuf - failed in get_loc_for_hier_string", ret ) );
+        return -1;
+    }
+
+    if ( getStructFileType( dataObjInfo->specColl ) >= 0 ) {
+        subFile_t subFile;
+        memset( &subFile, 0, sizeof( subFile ) );
+        rstrcpy( subFile.subFilePath, dataObjInfo->subPath,
+                 MAX_NAME_LEN );
+        rstrcpy( subFile.addr.hostAddr, location.c_str(), NAME_LEN );
+
+        subFile.specColl = dataObjInfo->specColl;
+        subFile.mode = getFileMode( L1desc[l1descInx].dataObjInp );
+        subFile.flags = O_RDONLY;
+        subFile.offset = dataObjInfo->dataSize;
+        return rsSubStructFileGet( rsComm, &subFile, dataObjOutBBuf );
+    }
+
+    fileOpenInp_t fileGetInp{};
+    dataObjInp_t* dataObjInp = L1desc[l1descInx].dataObjInp;
+    rstrcpy( fileGetInp.addr.hostAddr,  location.c_str(), NAME_LEN );
+    rstrcpy( fileGetInp.fileName, dataObjInfo->filePath, MAX_NAME_LEN );
+    rstrcpy( fileGetInp.resc_name_, dataObjInfo->rescName, MAX_NAME_LEN );
+    rstrcpy( fileGetInp.resc_hier_, dataObjInfo->rescHier, MAX_NAME_LEN );
+    rstrcpy( fileGetInp.objPath,    dataObjInfo->objPath,  MAX_NAME_LEN );
+    fileGetInp.mode = getFileMode( dataObjInp );
+    fileGetInp.flags = O_RDONLY;
+    fileGetInp.dataSize = dataObjInfo->dataSize;
+
+    copyKeyVal(
+        &dataObjInfo->condInput,
+        &fileGetInp.condInput );
+
+    /* XXXXX need to be able to handle structured file */
+    int bytesRead = rsFileGet( rsComm, &fileGetInp, dataObjOutBBuf );
+
+    clearKeyVal( &fileGetInp.condInput );
+
+    return bytesRead;
+}
 
 int
 rsL3FileGetSingleBuf( rsComm_t *rsComm, int *l1descInx,


### PR DESCRIPTION
Implements single buffer gets (that is, gets of replicas whose size is
under the configured maximum_size_for_single_buffer_in_megabytes value)
as an open/read/close rather than using l3GetDataSingleBuf and
determining whether to perform a physical file open via the
PHYOPEN_BY_SIZE_KW. The open is now performed as normal and the size
information included in the L1 descriptor table is used to determine if
the get will be single buffer or parallel.

---
cherry-picked from ef80a36583bfb6f77856d47163f4662b8c620a39 

CI tests running