### PR TITLE
[#2759] Delay server now honors a rule's priority (4-2-stable)

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -39,9 +39,11 @@
 #include "rods.h"
 #include "rcMisc.h"
 #include "miscServerFunct.hpp"
+#include "rodsErrorTable.h"
 
 // =-=-=-=-=-=-=-
 // stl includes
+#include <cstring>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -3579,7 +3581,26 @@ irods::error db_mod_rule_exec_op(
 
     for ( i = 0, j = 0; strcmp( regParamNames[i], "END" ); i++ ) {
         theVal = getValByKey( _reg_param, regParamNames[i] );
-        if ( theVal != NULL ) {
+
+        if (theVal) {
+            if (std::string_view{regParamNames[i]} == RULE_PRIORITY_KW) {
+                if (std::strlen(theVal) == 0) {
+                    return ERROR(SYS_INVALID_INPUT_PARAM,
+                                 "Delay rule priority cannot be empty. Delay rule priority must "
+                                 "satisfy the following requirement: 1 <= P <= 9.");
+                }
+
+                try {
+                    if (const auto p = std::stoi(theVal); p < 1 || p > 9) {
+                        return ERROR(SYS_INVALID_INPUT_PARAM,
+                                     "Delay rule priority must satisfy the following requirement: 1 <= P <= 9.");
+                    }
+                }
+                catch (...) {
+                    return ERROR(SYS_INVALID_INPUT_PARAM, "Delay rule priority is not an integer.");
+                }
+            }
+
             if ( j > 0 ) {
                 rstrcat( tSQL, "," , MAX_SQL_SIZE );
             }

--- a/scripts/core_tests_list.json
+++ b/scripts/core_tests_list.json
@@ -23,6 +23,7 @@
     "test_iput",
     "test_iput_options",
     "test_ipwd",
+    "test_iqmod",
     "test_iquest",
     "test_ireg",
     "test_irepl",

--- a/scripts/irods/test/test_delay_queue.py
+++ b/scripts/irods/test/test_delay_queue.py
@@ -571,6 +571,36 @@ class Test_Delay_Queue(session.make_sessions_mixin([('otherrods', 'rods')], [('a
         # Restore the server's configuration settings.
         IrodsController().restart()
 
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Skip for PREP and Topology Testing')
+    def test_delay_rule_priority_level_defaults_to_5_when_no_priority_level_is_specified__issue_2759(self):
+        # Schedule a delay rule without a <PRIORITY> tag.
+        rep_name = 'irods_rule_engine_plugin-irods_rule_language-instance'
+        delay_rule = 'delay("<INST_NAME>{0}</INST_NAME><EF>1s</EF>") {{ 1 + 1; }}'.format(rep_name)
+        self.admin.assert_icommand(['irule', '-r', rep_name, delay_rule, 'null', 'ruleExecOut'])
+
+        try:
+            # Show that the rule was stored in the catalog with a priority level of 5.
+            self.admin.assert_icommand(['iquest', 'select RULE_EXEC_PRIORITY'], 'STDOUT', ['RULE_EXEC_PRIORITY = 5'])
+        finally:
+            self.admin.run_icommand(['iqdel', '-a'])
+
+        self.admin.assert_icommand(['iquest', 'select RULE_EXEC_ID'], 'STDOUT', ['CAT_NO_ROWS_FOUND'])
+
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Skip for PREP and Topology Testing')
+    def test_delay_rule_does_not_support_PRI_tag__issue_2759(self):
+        rep_name = 'irods_rule_engine_plugin-irods_rule_language-instance'
+        delay_rule = 'delay("<INST_NAME>{0}</INST_NAME><EF>1s</EF><PRI>5</PRI>") {{ 1 + 1; }}'.format(rep_name)
+        self.admin.assert_icommand(['irule', '-r', rep_name, delay_rule, 'null', 'ruleExecOut'], 'STDERR', ['-130000 SYS_INVALID_INPUT_PARAM'])
+        self.admin.assert_icommand(['iquest', 'select RULE_EXEC_ID'], 'STDOUT', ['CAT_NO_ROWS_FOUND']) # Show that no rules exist.
+
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Skip for PREP and Topology Testing')
+    def test_delay_rule_does_not_accept_invalid_priority_levels__issue_2759(self):
+        rep_name = 'irods_rule_engine_plugin-irods_rule_language-instance'
+        delay_rule = 'delay("<INST_NAME>{0}</INST_NAME><EF>1s</EF><PRIORITY>{1}</PRIORITY>") {{ 1 + 1; }}'
+        expected_output = ['-130000 SYS_INVALID_INPUT_PARAM']
+        self.admin.assert_icommand(['irule', '-r', rep_name, delay_rule.format(rep_name, '0'), 'null', 'ruleExecOut'], 'STDERR', expected_output)
+        self.admin.assert_icommand(['irule', '-r', rep_name, delay_rule.format(rep_name, '10'), 'null', 'ruleExecOut'], 'STDERR', expected_output)
+        self.admin.assert_icommand(['iquest', 'select RULE_EXEC_ID'], 'STDOUT', ['CAT_NO_ROWS_FOUND']) # Show that no rules exist.
 
 @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'Skip for topology testing from resource server: reads server log')
 class Test_Execution_Frequency(resource_suite.ResourceBase, unittest.TestCase):

--- a/scripts/irods/test/test_iqmod.py
+++ b/scripts/irods/test/test_iqmod.py
@@ -1,0 +1,43 @@
+from __future__ import print_function
+import sys
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from . import session
+from .. import test
+
+class Test_Iqmod(session.make_sessions_mixin([('otherrods', 'rods')], []), unittest.TestCase):
+
+    def setUp(self):
+        super(Test_Iqmod, self).setUp()
+        self.admin = self.admin_sessions[0]
+
+    def tearDown(self):
+        super(Test_Iqmod, self).tearDown()
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing")
+    def test_iqmod_does_not_accept_invalid_priority_levels__issue_2759(self):
+        # Schedule a delay rule.
+        rep_name = 'irods_rule_engine_plugin-irods_rule_language-instance'
+        delay_rule = 'delay("<INST_NAME>{0}</INST_NAME><EF>1s</EF>") {{ 1 + 1; }}'.format(rep_name)
+        self.admin.assert_icommand(['irule', '-r', rep_name, delay_rule, 'null', 'ruleExecOut'])
+
+        try:
+            # Get the delay rule's ID.
+            delay_rule_id, err, ec = self.admin.run_icommand(['iquest', '%s', 'select RULE_EXEC_ID'])
+            self.assertEqual(ec, 0)
+            self.assertEqual(len(err), 0)
+            self.assertGreater(len(delay_rule_id.strip()), 0)
+
+            # Show that the priority cannot be set to a value outside of the accepted range [0-9].
+            self.admin.assert_icommand(['iqmod', delay_rule_id.strip(), 'priority', '-1'], 'STDERR', ['-318000 USER_INPUT_OPTION_ERR'])
+            self.admin.assert_icommand(['iqmod', delay_rule_id.strip(), 'priority',  '0'], 'STDERR', ['-130000 SYS_INVALID_INPUT_PARAM'])
+            self.admin.assert_icommand(['iqmod', delay_rule_id.strip(), 'priority', '10'], 'STDERR', ['-130000 SYS_INVALID_INPUT_PARAM'])
+        finally:
+            self.admin.run_icommand(['iqdel', '-a'])
+
+        self.admin.assert_icommand(['iquest', 'select RULE_EXEC_ID'], 'STDOUT', ['CAT_NO_ROWS_FOUND'])
+

--- a/server/re/src/irods_re_structs.cpp
+++ b/server/re/src/irods_re_structs.cpp
@@ -8,6 +8,7 @@
 #include "dataObjClose.h"
 #include "dataObjLseek.h"
 #include "fileLseek.h"
+#include "rodsErrorTable.h"
 #include "ruleExecSubmit.h"
 #include "rsDataObjOpen.hpp"
 #include "rsDataObjLseek.hpp"
@@ -528,6 +529,12 @@ fillSubmitConditions( const char *action, const char *inDelayCondition,
     }
 
     it = taggedValues->find("PRI");
+    if ( it != taggedValues->end() ) {
+        rodsLog(LOG_ERROR, "Invalid delay rule tag: <PRI>. Use <PRIORITY>.");
+        return SYS_INVALID_INPUT_PARAM;
+    }
+
+    it = taggedValues->find("PRIORITY");
     if ( it != taggedValues->end() ) {
         strncpy(ruleSubmitInfo->priority, it->second.front().c_str(), NAME_LEN);
         taggedValues->erase(it);


### PR DESCRIPTION
Valid priority levels are defined by the following range: [1 - 9]

The delay server gathers and schedules rules in descending order of
priority level.

`<PRI>` tag is no longer supported by the delay(). Use `<PRIORITY>` instead.
Attempting to use `<PRI>` will result in an error.

Reoccurring rules that have an empty priority level will be updated to have a
priority level of 5 following successful execution. This also applies to
rules that have an invalid priority level.