### PR TITLE
[#2759] Delay server now honors a rule's priority (master)

### DIFF
--- a/scripts/core_tests_list.json
+++ b/scripts/core_tests_list.json
@@ -23,6 +23,7 @@
     "test_iput",
     "test_iput_options",
     "test_ipwd",
+    "test_iqmod",
     "test_iquest",
     "test_ireg",
     "test_irepl",

--- a/scripts/irods/test/test_iqmod.py
+++ b/scripts/irods/test/test_iqmod.py
@@ -1,0 +1,43 @@
+from __future__ import print_function
+import sys
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from . import session
+from .. import test
+
+class Test_Iqmod(session.make_sessions_mixin([('otherrods', 'rods')], []), unittest.TestCase):
+
+    def setUp(self):
+        super(Test_Iqmod, self).setUp()
+        self.admin = self.admin_sessions[0]
+
+    def tearDown(self):
+        super(Test_Iqmod, self).tearDown()
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing")
+    def test_iqmod_does_not_accept_invalid_priority_levels__issue_2759(self):
+        # Schedule a delay rule.
+        rep_name = 'irods_rule_engine_plugin-irods_rule_language-instance'
+        delay_rule = 'delay("<INST_NAME>{0}</INST_NAME><EF>1s</EF>") {{ 1 + 1; }}'.format(rep_name)
+        self.admin.assert_icommand(['irule', '-r', rep_name, delay_rule, 'null', 'ruleExecOut'])
+
+        try:
+            # Get the delay rule's ID.
+            delay_rule_id, err, ec = self.admin.run_icommand(['iquest', '%s', 'select RULE_EXEC_ID'])
+            self.assertEqual(ec, 0)
+            self.assertEqual(len(err), 0)
+            self.assertGreater(len(delay_rule_id.strip()), 0)
+
+            # Show that the priority cannot be set to a value outside of the accepted range [0-9].
+            self.admin.assert_icommand(['iqmod', delay_rule_id.strip(), 'priority', '-1'], 'STDERR', ['-318000 USER_INPUT_OPTION_ERR'])
+            self.admin.assert_icommand(['iqmod', delay_rule_id.strip(), 'priority',  '0'], 'STDERR', ['-130000 SYS_INVALID_INPUT_PARAM'])
+            self.admin.assert_icommand(['iqmod', delay_rule_id.strip(), 'priority', '10'], 'STDERR', ['-130000 SYS_INVALID_INPUT_PARAM'])
+        finally:
+            self.admin.run_icommand(['iqdel', '-a'])
+
+        self.admin.assert_icommand(['iquest', 'select RULE_EXEC_ID'], 'STDOUT', ['CAT_NO_ROWS_FOUND'])
+

--- a/server/core/src/irodsReServer.cpp
+++ b/server/core/src/irodsReServer.cpp
@@ -199,6 +199,25 @@ namespace {
             ruleExecModInp_t rule_exec_mod_inp{};
             rstrcpy(rule_exec_mod_inp.ruleId, _inp.ruleExecId, NAME_LEN);
 
+            if (std::strlen(_inp.priority) > 0) {
+                // The priority string is not empty, but it could be invalid.
+                // If the priority cannot be parsed into a valid signed integer, set it
+                // to the default priority level of 5.
+                try {
+                    if (const auto p = std::stoi(_inp.priority); p < 1 || p > 9) {
+                        addKeyVal(&rule_exec_mod_inp.condInput, RULE_PRIORITY_KW, "5");
+                    }
+                }
+                catch (...) {
+                    addKeyVal(&rule_exec_mod_inp.condInput, RULE_PRIORITY_KW, "5");
+                }
+            }
+            else {
+                // An empty priority is an indicator that the rule existed prior to iRODS v4.2.9
+                // and that it needs to be set to the default priority level of 5.
+                addKeyVal(&rule_exec_mod_inp.condInput, RULE_PRIORITY_KW, "5");
+            }
+
             addKeyVal(&rule_exec_mod_inp.condInput, RULE_LAST_EXE_TIME_KW, current_time);
             addKeyVal(&rule_exec_mod_inp.condInput, RULE_EXE_TIME_KW, next_time);
             if(repeat_rule) {
@@ -479,7 +498,8 @@ namespace {
             });
         };
 
-        const auto qstr = fmt::format("SELECT RULE_EXEC_ID WHERE RULE_EXEC_TIME <= '{}'", std::time(nullptr));
+        const auto qstr = fmt::format("SELECT RULE_EXEC_ID, ORDER_DESC(RULE_EXEC_PRIORITY) "
+                                      "WHERE RULE_EXEC_TIME <= '{}'", std::time(nullptr));
 
         return {qstr, job};
     }

--- a/server/re/src/irods_re_structs.cpp
+++ b/server/re/src/irods_re_structs.cpp
@@ -8,6 +8,7 @@
 #include "dataObjClose.h"
 #include "dataObjLseek.h"
 #include "fileLseek.h"
+#include "rodsErrorTable.h"
 #include "ruleExecSubmit.h"
 #include "rsDataObjOpen.hpp"
 #include "rsDataObjLseek.hpp"
@@ -541,6 +542,12 @@ fillSubmitConditions( const char *action, const char *inDelayCondition,
     }
 
     it = taggedValues->find("PRI");
+    if ( it != taggedValues->end() ) {
+        rodsLog(LOG_ERROR, "Invalid delay rule tag: <PRI>. Use <PRIORITY>.");
+        return SYS_INVALID_INPUT_PARAM;
+    }
+
+    it = taggedValues->find("PRIORITY");
     if ( it != taggedValues->end() ) {
         strncpy(ruleSubmitInfo->priority, it->second.front().c_str(), NAME_LEN);
         taggedValues->erase(it);


### PR DESCRIPTION
Valid priority levels are defined by the following range: [1 - 9]

The delay server gathers and schedules rules in descending order of
priority level.

`<PRI>` tag is no longer supported by the delay(). Use `<PRIORITY>` instead.
Attempting to use `<PRI>` will result in an error.

Reoccurring rules that have an empty priority level will be updated to
have a priority level of 5 following successful execution. This also
applies to rules that have an invalid priority level.