### PR TITLE
[5520] use BinBytesBuf_PI for new API's (4-2-stable)

### DIFF
--- a/plugins/api/src/atomic_apply_acl_operations.cpp
+++ b/plugins/api/src/atomic_apply_acl_operations.cpp
@@ -532,8 +532,8 @@ auto plugin_factory(const std::string& _instance_name,
                         RODS_API_VERSION,                           // API version
                         NO_USER_AUTH,                               // Client auth
                         NO_USER_AUTH,                               // Proxy auth
-                        "BytesBuf_PI", 0,                           // In PI / bs flag
-                        "BytesBuf_PI", 0,                           // Out PI / bs flag
+                        "BinBytesBuf_PI", 0,                        // In PI / bs flag
+                        "BinBytesBuf_PI", 0,                        // Out PI / bs flag
                         op,                                         // Operation
                         "api_atomic_apply_acl_operations",          // Operation name
                         nullptr,                                    // Null clear function
@@ -542,10 +542,10 @@ auto plugin_factory(const std::string& _instance_name,
 
     auto* api = new irods::api_entry{def};
 
-    api->in_pack_key = "BytesBuf_PI";
+    api->in_pack_key = "BinBytesBuf_PI";
     api->in_pack_value = BytesBuf_PI;
 
-    api->out_pack_key = "BytesBuf_PI";
+    api->out_pack_key = "BinBytesBuf_PI";
     api->out_pack_value = BytesBuf_PI;
 
     return api;

--- a/plugins/api/src/atomic_apply_metadata_operations.cpp
+++ b/plugins/api/src/atomic_apply_metadata_operations.cpp
@@ -498,8 +498,8 @@ auto plugin_factory(const std::string& _instance_name,
                         RODS_API_VERSION,                           // API version
                         NO_USER_AUTH,                               // Client auth
                         NO_USER_AUTH,                               // Proxy auth
-                        "BytesBuf_PI", 0,                           // In PI / bs flag
-                        "BytesBuf_PI", 0,                           // Out PI / bs flag
+                        "BinBytesBuf_PI", 0,                        // In PI / bs flag
+                        "BinBytesBuf_PI", 0,                        // Out PI / bs flag
                         op,                                         // Operation
                         "api_atomic_apply_metadata_operations",     // Operation name
                         nullptr,                                    // Null clear function
@@ -508,10 +508,10 @@ auto plugin_factory(const std::string& _instance_name,
 
     auto* api = new irods::api_entry{def};
 
-    api->in_pack_key = "BytesBuf_PI";
+    api->in_pack_key = "BinBytesBuf_PI";
     api->in_pack_value = BytesBuf_PI;
 
-    api->out_pack_key = "BytesBuf_PI";
+    api->out_pack_key = "BinBytesBuf_PI";
     api->out_pack_value = BytesBuf_PI;
 
     return api;

--- a/plugins/api/src/data_object_finalize.cpp
+++ b/plugins/api/src/data_object_finalize.cpp
@@ -409,8 +409,8 @@ auto plugin_factory(const std::string& _instance_name,
                         RODS_API_VERSION,                           // API version
                         NO_USER_AUTH,                               // Client auth
                         NO_USER_AUTH,                               // Proxy auth
-                        "BytesBuf_PI", 0,                           // In PI / bs flag
-                        "BytesBuf_PI", 0,                           // Out PI / bs flag
+                        "BinBytesBuf_PI", 0,                        // In PI / bs flag
+                        "BinBytesBuf_PI", 0,                        // Out PI / bs flag
                         op,                                         // Operation
                         "data_object_finalize",                     // Operation name
                         nullptr,                                    // Null clear function
@@ -419,10 +419,10 @@ auto plugin_factory(const std::string& _instance_name,
 
     auto* api = new irods::api_entry{def};
 
-    api->in_pack_key = "BytesBuf_PI";
+    api->in_pack_key = "BinBytesBuf_PI";
     api->in_pack_value = BytesBuf_PI;
 
-    api->out_pack_key = "BytesBuf_PI";
+    api->out_pack_key = "BinBytesBuf_PI";
     api->out_pack_value = BytesBuf_PI;
 
     return api;

--- a/plugins/api/src/get_file_descriptor_info.cpp
+++ b/plugins/api/src/get_file_descriptor_info.cpp
@@ -361,8 +361,8 @@ auto plugin_factory(const std::string& _instance_name,
                         RODS_API_VERSION,                // API version
                         NO_USER_AUTH,                    // Client auth
                         NO_USER_AUTH,                    // Proxy auth
-                        "BytesBuf_PI", 0,                // In PI / bs flag
-                        "BytesBuf_PI", 0,                // Out PI / bs flag
+                        "BinBytesBuf_PI", 0,             // In PI / bs flag
+                        "BinBytesBuf_PI", 0,             // Out PI / bs flag
                         op,                              // Operation
                         "api_get_file_descriptor_info",  // Operation name
                         nullptr,                         // Null clear function
@@ -371,10 +371,10 @@ auto plugin_factory(const std::string& _instance_name,
 
     auto* api = new irods::api_entry{def};
 
-    api->in_pack_key = "BytesBuf_PI";
+    api->in_pack_key = "BinBytesBuf_PI";
     api->in_pack_value = BytesBuf_PI;
 
-    api->out_pack_key = "BytesBuf_PI";
+    api->out_pack_key = "BinBytesBuf_PI";
     api->out_pack_value = BytesBuf_PI;
 
     return api;

--- a/plugins/api/src/replica_close.cpp
+++ b/plugins/api/src/replica_close.cpp
@@ -531,7 +531,7 @@ auto plugin_factory(const std::string& _instance_name,
                         RODS_API_VERSION,                 // API version
                         NO_USER_AUTH,                     // Client auth
                         NO_USER_AUTH,                     // Proxy auth
-                        "BytesBuf_PI", 0,                 // In PI / bs flag
+                        "BinBytesBuf_PI", 0,              // In PI / bs flag
                         nullptr, 0,                       // Out PI / bs flag
                         op,                               // Operation
                         "api_replica_close",              // Operation name
@@ -541,7 +541,7 @@ auto plugin_factory(const std::string& _instance_name,
 
     auto* api = new irods::api_entry{def};
 
-    api->in_pack_key = "BytesBuf_PI";
+    api->in_pack_key = "BinBytesBuf_PI";
     api->in_pack_value = BytesBuf_PI;
 
     return api;

--- a/plugins/api/src/replica_open.cpp
+++ b/plugins/api/src/replica_open.cpp
@@ -136,7 +136,7 @@ auto plugin_factory(const std::string& _instance_name,
                         NO_USER_AUTH,                    // Client auth
                         NO_USER_AUTH,                    // Proxy auth
                         "DataObjInp_PI", 0,              // In PI / bs flag
-                        "BytesBuf_PI", 0,                // Out PI / bs flag
+                        "BinBytesBuf_PI", 0,             // Out PI / bs flag
                         op,                              // Operation
                         "api_replica_open",              // Operation name
                         clearDataObjInp,                 // Clear function
@@ -148,7 +148,7 @@ auto plugin_factory(const std::string& _instance_name,
     api->in_pack_key = "DataObjInp_PI";
     api->in_pack_value = DataObjInp_PI;
 
-    api->out_pack_key = "BytesBuf_PI";
+    api->out_pack_key = "BinBytesBuf_PI";
     api->out_pack_value = BytesBuf_PI;
 
     return api;

--- a/plugins/api/src/touch.cpp
+++ b/plugins/api/src/touch.cpp
@@ -504,7 +504,7 @@ auto plugin_factory(const std::string& _instance_name,
                         RODS_API_VERSION,       // API version
                         NO_USER_AUTH,           // Client auth
                         NO_USER_AUTH,           // Proxy auth
-                        "BytesBuf_PI", 0,       // In PI / bs flag
+                        "BinBytesBuf_PI", 0,    // In PI / bs flag
                         nullptr, 0,             // Out PI / bs flag
                         op,                     // Operation
                         "api_touch",            // Operation name
@@ -514,7 +514,7 @@ auto plugin_factory(const std::string& _instance_name,
 
     auto* api = new irods::api_entry{def};
 
-    api->in_pack_key = "BytesBuf_PI";
+    api->in_pack_key = "BinBytesBuf_PI";
     api->in_pack_value = BytesBuf_PI;
 
     return api;

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -66,6 +66,7 @@ set(TEST_INCLUDE_LIST test_config/irods_atomic_apply_acl_operations
                       test_config/irods_user_administration
                       test_config/irods_version
                       test_config/irods_with_durability
+                      test_config/irods_json_apis_from_client
                       test_config/irods_zone_report)
 
 foreach(IRODS_TEST_CONFIG ${TEST_INCLUDE_LIST})

--- a/unit_tests/cmake/test_config/irods_json_apis_from_client.cmake
+++ b/unit_tests/cmake/test_config/irods_json_apis_from_client.cmake
@@ -1,0 +1,21 @@
+set(IRODS_TEST_TARGET irods_json_apis_from_client)
+
+set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/src/test_json_apis_from_client.cpp)
+
+set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
+                            ${CMAKE_SOURCE_DIR}/lib/core/include
+                            ${CMAKE_SOURCE_DIR}/lib/api/include
+                            ${CMAKE_SOURCE_DIR}/lib/filesystem/include
+                            ${CMAKE_SOURCE_DIR}/plugins/api/include
+                            ${CMAKE_SOURCE_DIR}/server/core/include
+                            ${CMAKE_SOURCE_DIR}/server/icat/include
+                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
+                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
+
+set(IRODS_TEST_LINK_LIBRARIES irods_common
+                              irods_client
+                              ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so
+                              ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
+                              ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)

--- a/unit_tests/src/test_json_apis_from_client.cpp
+++ b/unit_tests/src/test_json_apis_from_client.cpp
@@ -1,0 +1,124 @@
+#include "catch.hpp"
+
+#include "atomic_apply_metadata_operations.h"
+#include "connection_pool.hpp"
+#include "dstream.hpp"
+#include "filesystem.hpp"
+#include "irods_at_scope_exit.hpp"
+#include "irods_query.hpp"
+#include "replica.hpp"
+#include "rodsClient.h"
+#include "client_connection.hpp"
+#include "transport/default_transport.hpp"
+
+#include <boost/filesystem.hpp>
+#include <fmt/format.h>
+
+#include <chrono>
+#include <string_view>
+#include <string>
+#include <stdexcept>
+
+#include <unistd.h>
+#include <cstdlib>
+
+#include "json.hpp"
+
+
+namespace ix = irods::experimental;
+namespace fs = irods::experimental::filesystem;
+
+using nlohmann::json;
+using namespace std::string_literals;
+
+#undef  NON_EXISTENT_ENV_VAR
+#define NON_EXISTENT_ENV_VAR "<null-env-var>"
+
+namespace {
+
+    class error_setting_environment : public std::runtime_error {
+        public:
+        explicit error_setting_environment(const std::string & msg) : std::runtime_error{msg} {
+        }
+    };
+
+    void change_environment_variable (const char* env_var_name, std::string & tmpStr, const char* new_value) {
+        char *tmp = getenv(env_var_name);
+        if (nullptr != tmp) { tmpStr = tmp; }
+        if (0 != setenv(env_var_name,new_value,1)) {
+            throw error_setting_environment {"cannot change environment variable: "s + env_var_name};
+        }
+    }
+
+    void restore_environment_variable (const char *env_var_name, const std::string & tmp) {
+        if (tmp != NON_EXISTENT_ENV_VAR) {
+            if (0 != setenv(env_var_name, tmp.c_str(), 1)) {
+                throw error_setting_environment {"cannot restore environment variable: "s + env_var_name};
+            }
+        }
+    }
+}
+
+TEST_CASE("test atomic metadata with BinBytesBuf", "[xml]")
+{
+    std::string save_protocol {NON_EXISTENT_ENV_VAR};
+
+    change_environment_variable("irodsProt",save_protocol,"1");
+
+    load_client_api_plugins();
+
+    auto conn_pool = irods::make_connection_pool(2);
+
+    rodsEnv env;
+    _getRodsEnv(env);
+
+    const auto sandbox = fs::path{env.rodsHome} / "unit_testing_sandbox";
+
+    ix::client_connection conn{env.rodsHost,
+                               env.rodsPort,
+                               env.rodsUserName,
+                               env.rodsZone};
+
+    REQUIRE(fs::client::create_collection(conn, sandbox));
+
+    irods::at_scope_exit remove_sandbox{[&conn, &sandbox] {
+        namespace fs = ix::filesystem;
+        fs::client::remove_all(conn, sandbox, fs::remove_options::no_trash);
+    }};
+
+    const auto json_input = json{
+        {"entity_name", sandbox.string()},
+        {"entity_type", "collection"},
+        {"operations", json::array({
+            {
+                {"operation", "add"},
+                {"attribute", "the_attr"},
+                {"value", "the_val"},
+                {"units", "the_units"}
+            },
+            {
+                {"operation", "add"},
+                {"attribute", "name"},
+                {"value", "john <&doe&>"},
+                {"units", ""}
+            }
+        })}
+    }.dump();
+
+    char* json_error_string{};
+    irods::at_scope_exit free_memory{[&json_error_string] { std::free(json_error_string); }};
+
+    auto* conn_ptr = static_cast<rcComm_t*>(conn);
+    REQUIRE(rc_atomic_apply_metadata_operations(conn_ptr, json_input.c_str(), &json_error_string) == 0);
+    REQUIRE(json_error_string == "{}"s);
+
+    restore_environment_variable("irodsProt",save_protocol);
+
+    const auto gql = fmt::format("select COUNT(COLL_ID) where COLL_NAME = '{}' and META_COLL_ATTR_VALUE like '{}'",
+                                 sandbox.c_str(), 
+                                 ("%" "<&" "%" "&>" "%"));
+
+    for (auto&& row : irods::query{static_cast<rcComm_t*>(conn), gql}) {
+        REQUIRE(row[0] == "1");
+    }
+}

--- a/unit_tests/unit_tests_list.json
+++ b/unit_tests/unit_tests_list.json
@@ -13,6 +13,7 @@
     "irods_hierarchy_parser",
     "irods_hostname_cache",
     "irods_key_value_proxy",
+    "irods_json_apis_from_client",
     "irods_lifetime_manager",
     "irods_linked_list_iterator",
     "irods_logical_paths_and_special_characters",


### PR DESCRIPTION
Use `BinBytesBuf_PI` (instead of `BytesBuf_PI`) as packing instructions when contained text fields are likely to contain XML special characters (ie `<`, `>`, `&`) or other arbitrary content possibly unsuitable for use with iRODS `XML_PROT` (JSON api requests and/or responses for example).