### PR TITLE
[#5187][#5422] Stale sibling replicas on write (master)

### DIFF
--- a/plugins/api/src/replica_close.cpp
+++ b/plugins/api/src/replica_close.cpp
@@ -163,9 +163,9 @@ namespace
         const l1desc& _l1desc,
         const bool _send_notifications) -> int
     {
-        // The status of the locked replicas should be restored in a create situation but stale in an overwrite
-        // because the source of truth has moved in that case.
-        constexpr auto unlock_statuses = ill::restore_status;
+        // The sibling replicas are always marked stale because replica_close considers itself to be the new
+        // truth when it is given permission to finalize the replica.
+        constexpr auto unlock_statuses = STALE_REPLICA;
 
         // Unlock the data object but do not publish to catalog because we may want to trigger file_modified.
         if (const int ec = ill::unlock(_replica.data_id(), _replica.replica_number(), _replica.replica_status(), unlock_statuses); ec < 0) {

--- a/plugins/api/src/replica_open.cpp
+++ b/plugins/api/src/replica_open.cpp
@@ -23,13 +23,18 @@
 #include "irods_re_serialization.hpp"
 #include "rsDataObjOpen.hpp"
 #include "rsDataObjClose.hpp"
+#include "rsDataObjUnlink.hpp"
 #include "rs_get_file_descriptor_info.hpp"
 #include "rs_replica_close.hpp"
 #include "irods_logger.hpp"
+#include "key_value_proxy.hpp"
+#include "finalize_utilities.hpp"
 
 #include <json.hpp>
 
 #include <string>
+
+extern l1desc_t L1desc[NUM_L1_DESC];
 
 namespace
 {
@@ -82,10 +87,39 @@ namespace
             log::api::error("Could not get L1 descriptor information for replica [error_code={}]", ec);
             log::api::trace("Closing replica ...");
 
-            // Although the JSON input does not include the "update_catalog" option, the
-            // catalog will be updated because the option defaults to "true".
-            if (const auto ec0 = rs_replica_close(_comm, json_input.data()); ec0 != 0) {
-                log::api::error("Could not close replica [error_code={}]", ec0);
+            auto& l1desc = L1desc[fd];
+
+            if (OPEN_FOR_READ_TYPE == l1desc.openType) {
+                // Although the JSON input does not include the "update_catalog" option, the
+                // catalog will be updated because the option defaults to "true".
+                if (const auto ec0 = rs_replica_close(_comm, json_input.data()); ec0 != 0) {
+                    log::api::error("Could not close replica [error_code={}]", ec0);
+                }
+            }
+            else {
+                const auto hierarchy = std::string{l1desc.dataObjInfo->rescHier};
+                const auto open_for_create = CREATE_TYPE == l1desc.openType;
+
+                if (const auto unlock_ec = irods::close_replica_and_unlock_data_object(*_comm, fd, STALE_REPLICA); unlock_ec < 0) {
+                    irods::log(LOG_ERROR, fmt::format(
+                        "[{}:{}] - failed to unlock data object "
+                        "[error_code=[{}], path=[{}]]",
+                        __FUNCTION__, __LINE__, unlock_ec, _input->objPath));
+                }
+
+                if (open_for_create) {
+                    DataObjInp unlink_inp{};
+                    std::snprintf(unlink_inp.objPath, MAX_NAME_LEN, "%s", _input->objPath);
+                    auto cond_input = irods::experimental::make_key_value_proxy(unlink_inp.condInput);
+                    cond_input[RESC_HIER_STR_KW] = hierarchy;
+
+                    if (const auto unlink_ec = rsDataObjUnlink(_comm, &unlink_inp); unlink_ec) {
+                        irods::log(LOG_ERROR, fmt::format(
+                            "[{}:{}] - failed to unlink replica "
+                            "[error_code=[{}], path=[{}], hierarchy=[{}]]",
+                            __FUNCTION__, __LINE__, unlink_ec, _input->objPath, cond_input.at(RESC_HIER_STR_KW).value()));
+                    }
+                }
             }
 
             return ec;


### PR DESCRIPTION
When replica_close is finalizing a newly created replica or a replica
which has been overwritten, sibling replicas should be marked as stale
because the newest replica reflects a potentially different truth from
that of the existing replicas. As part of this effort, replica_open has
been modified to handle failures from rs_get_file_descriptor_info a bit
more gracefully by unlocking the replica which was opened and unlinking
in the event that the open was meant for a create.

Add istream test for sibling replica marked stale on overwrite and
create.

Also makes sure that all exceptions in rs_get_file_descriptor_info are
caught.

---

CI tests are running.