### PR TITLE
[#5554] Add test for reg_data_obj dynamic post-PEP (master)

### DIFF
--- a/scripts/irods/test/rule_texts_for_tests.py
+++ b/scripts/irods/test/rule_texts_for_tests.py
@@ -40,6 +40,24 @@ INPUT *File="{logical_path_to_tar_file}", *Coll="{logical_path_to_untar_coll}", 
 OUTPUT ruleExecOut
 '''
 
+#===== Test_Dynamic_PEPs =====
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Dynamic_PEPs'] = {}
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Dynamic_PEPs']['test_data_obj_info_parameters_in_pep_database_reg_data_obj_post__issue_5554'] = '''
+pep_database_reg_data_obj_post(*INSTANCE, *CONTEXT, *OUT, *DATA_OBJ_INFO) {{
+    *logical_path = *DATA_OBJ_INFO.logical_path;
+    *create_time = *DATA_OBJ_INFO.data_create;
+    *owner_name = *DATA_OBJ_INFO.data_owner_name;
+    *owner_zone = *DATA_OBJ_INFO.data_owner_zone;
+
+    msiAddKeyVal(*key_val_pair,'{attribute}::{path_attr}',         '*logical_path');
+    msiAddKeyVal(*key_val_pair,'{attribute}::{create_time_attr}',  '*create_time');
+    msiAddKeyVal(*key_val_pair,'{attribute}::{owner_name_attr}',   '*owner_name');
+    msiAddKeyVal(*key_val_pair,'{attribute}::{owner_zone_attr}',   '*owner_zone');
+
+    msiAssociateKeyValuePairsToObj(*key_val_pair,'{resource}','-R');
+}}
+'''
+
 #===== Test_ICommands_File_Operations =====
 
 rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_ICommands_File_Operations'] = {}

--- a/scripts/irods/test/test_dynamic_peps.py
+++ b/scripts/irods/test/test_dynamic_peps.py
@@ -8,6 +8,7 @@ else:
     import unittest
 
 from . import session
+from .rule_texts_for_tests import rule_texts
 from .. import test
 from .. import lib
 from .. import paths
@@ -136,4 +137,58 @@ class Test_Dynamic_PEPs(session.make_sessions_mixin([('otherrods', 'rods')], [])
                     self.admin.assert_icommand(['irm', '-f', logical_path])
                     self.admin.assert_icommand(['iadmin', 'rum'])
 
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python' or test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing")
+    def test_data_obj_info_parameters_in_pep_database_reg_data_obj_post__issue_5554(self):
+        name = 'test_data_obj_info_parameters_in_pep_database_reg_data_obj_post__issue_5554'
+        resource = 'metadata_attr_resource'
+        config = IrodsConfig()
+
+        with lib.file_backed_up(config.server_config_path):
+            core_re_path = os.path.join(config.core_re_directory, 'core.re')
+
+            with lib.file_backed_up(core_re_path):
+                parameters = {}
+                parameters['attribute'] = name
+                parameters['path_attr'] = 'path_attr'
+                parameters['create_time_attr'] = 'create_time_attr'
+                parameters['owner_name_attr'] = 'owner_name_attr'
+                parameters['owner_zone_attr'] = 'owner_zone_attr'
+                parameters['resource'] = resource
+                rule_str = rule_texts[self.plugin_name]['Test_Dynamic_PEPs'][name].format(**parameters)
+
+                with open(core_re_path, 'a') as core_re:
+                    core_re.write(rule_str)
+
+                local_file = lib.create_local_testfile(os.path.join(self.admin.local_session_dir, name))
+                logical_path = os.path.join(self.admin.session_collection, name)
+
+                try:
+                    self.admin.assert_icommand(['iadmin', 'mkresc', resource, 'passthru'], 'STDOUT', resource)
+
+                    self.admin.assert_icommand(['ireg', local_file, logical_path])
+
+                    create_time = self.admin.run_icommand(['iquest', '%s',
+                        '''"select DATA_CREATE_TIME where COLL_NAME = '{0}' and DATA_NAME = '{1}'"'''.format(
+                        os.path.dirname(logical_path), os.path.basename(logical_path))])[0]
+
+                    lib.metadata_attr_with_value_exists(self.admin,
+                                                        '::'.join([parameters['attribute'], parameters['path_attr']]),
+                                                        logical_path),
+
+                    lib.metadata_attr_with_value_exists(self.admin,
+                                                        '::'.join([parameters['attribute'], parameters['create_time_attr']]),
+                                                        create_time),
+
+                    lib.metadata_attr_with_value_exists(self.admin,
+                                                        '::'.join([parameters['attribute'], parameters['owner_name_attr']]),
+                                                        self.admin.username),
+
+                    lib.metadata_attr_with_value_exists(self.admin,
+                                                        '::'.join([parameters['attribute'], parameters['owner_zone_attr']]),
+                                                        self.admin.zone_name),
+
+                finally:
+                    self.admin.assert_icommand(['iadmin', 'rmresc', resource])
+                    self.admin.assert_icommand(['irm', '-f', logical_path])
+                    self.admin.assert_icommand(['iadmin', 'rum'])
 


### PR DESCRIPTION
The dataObjInfo struct was not being fully populated when registering a
data object in the database. In particular, the user name, zone name,
and create time were not populated so PEPs which look inside these
structs were not able to extract the appropriate information. This has
been fixed but needed a test which this change provides.

---

Test passes