### PR TITLE
[#5421] Enforce ILL in unlink/rename/trim (master)

### DIFF
--- a/lib/core/include/data_object_proxy.hpp
+++ b/lib/core/include/data_object_proxy.hpp
@@ -449,6 +449,33 @@ namespace irods::experimental::data_object
 
         return std::nullopt;
     } // find_replica
+
+    /// \brief Finds a replica in the list based on replica number
+    ///
+    /// \param[in] _obj data_object_proxy to search in
+    /// \param[in] _replica_number
+    ///
+    /// \retval replica_proxy if found
+    /// \retval std::nullopt if no replica is found with the provided replica number
+    ///
+    /// \since 4.2.9
+    template<typename doi_type>
+    static auto find_replica(const data_object_proxy<doi_type>& _obj, const int _replica_number)
+        -> std::optional<replica::replica_proxy<doi_type>>
+    {
+        auto itr = std::find_if(
+            std::cbegin(_obj.replicas()), std::cend(_obj.replicas()),
+            [&_replica_number](const auto& _r)
+            {
+                return _r.replica_number() == _replica_number;
+            });
+
+        if (std::end(_obj.replicas()) != itr) {
+            return *itr;
+        }
+
+        return std::nullopt;
+    } // find_replica
 } // namespace irods::experimental::data_object
 
 #endif // #ifndef IRODS_DATA_OBJECT_PROXY_HPP

--- a/server/api/src/rsDataObjRename.cpp
+++ b/server/api/src/rsDataObjRename.cpp
@@ -1,7 +1,3 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-/* rsDataObjRename.c - rename a data object.
- */
 #include "dataObjRename.h"
 #include "objMetaOpr.hpp"
 #include "dataObjOpr.hpp"
@@ -39,6 +35,8 @@
 #include "irods_configuration_keywords.hpp"
 #include "irods_re_structs.hpp"
 #include "irods_logger.hpp"
+#include "key_value_proxy.hpp"
+#include "logical_locking.hpp"
 #include "scoped_privileged_client.hpp"
 
 #define IRODS_FILESYSTEM_ENABLE_SERVER_SIDE_API
@@ -50,6 +48,9 @@ using logger = irods::experimental::log;
 
 namespace
 {
+    namespace fs = irods::experimental::filesystem;
+    namespace ill = irods::logical_locking;
+
     int _rsDataObjRename(
             rsComm_t *rsComm,
             dataObjCopyInp_t *dataObjRenameInp) {
@@ -91,6 +92,8 @@ namespace
 
         srcDataObjInp = &dataObjRenameInp->srcDataObjInp;
         destDataObjInp = &dataObjRenameInp->destDataObjInp;
+        auto source_cond_input = irods::experimental::make_key_value_proxy(srcDataObjInp->condInput);
+        auto destination_cond_input = irods::experimental::make_key_value_proxy(destDataObjInp->condInput);
 
         // Separate source collection/object names and destination collection/object names
         if ( ( status = splitPathByKey(
@@ -129,19 +132,41 @@ namespace
         }
         else {
             if ( ( status = isData( rsComm, srcDataObjInp->objPath, &srcId ) ) >= 0 ) {
-                if ( isData( rsComm, destDataObjInp->objPath, &destId ) >= 0 &&
-                        getValByKey( &srcDataObjInp->condInput, FORCE_FLAG_KW ) != NULL ) {
-                    /* dest exist */
-                    rsDataObjUnlink( rsComm, destDataObjInp );
-                }
                 srcDataObjInp->oprType = destDataObjInp->oprType = RENAME_DATA_OBJ;
                 status = getDataObjInfo( rsComm, srcDataObjInp, &dataObjInfoHead, ACCESS_DELETE_OBJECT, 0 );
-
                 if ( status < 0 ) {
                     rodsLog( LOG_ERROR,
                             "%s: src data %s does not exist, status = %d",
                             __FUNCTION__, srcDataObjInp->objPath, status );
                     return status;
+                }
+
+                if (const auto ret = ill::try_lock(*dataObjInfoHead, ill::lock_type::write); ret < 0) {
+                    const auto msg = fmt::format(
+                        "rename not allowed because source data object is locked "
+                        "[error code=[{}], source path=[{}]",
+                        ret, srcDataObjInp->objPath);
+
+                    irods::log(LOG_NOTICE, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, msg));
+
+                    return ret;
+                }
+
+                const auto force_flag_provided = source_cond_input.contains(FORCE_FLAG_KW) || destination_cond_input.contains(FORCE_FLAG_KW);
+                if (isData(rsComm, destDataObjInp->objPath, &destId) >= 0 && force_flag_provided) {
+                    // The force flag ensures that unlink will not send the object to the trash.
+                    destination_cond_input[FORCE_FLAG_KW] = "";
+
+                    if (const auto ec = rsDataObjUnlink(rsComm, destDataObjInp); ec < 0) {
+                        const auto msg = fmt::format(
+                            "failed to unlink destination data object for overwrite via rename "
+                            "[error code=[{}], source path=[{}], destination path=[{}]]",
+                            ec, srcDataObjInp->objPath, destDataObjInp->objPath);
+
+                        irods::log(LOG_NOTICE, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, msg));
+
+                        return ec;
+                    }
                 }
             }
             else if ( ( status = isColl( rsComm, srcDataObjInp->objPath, &srcId ) ) >= 0 ) {
@@ -410,8 +435,6 @@ int rsDataObjRename(rsComm_t *rsComm, dataObjCopyInp_t *dataObjRenameInp)
 
     // Update the mtime of the parent collections.
     if (ec == 0) {
-        namespace fs = irods::experimental::filesystem;
-
         const auto src_parent_path = fs::path{dataObjRenameInp->srcDataObjInp.objPath}.parent_path();
         const auto dst_parent_path = fs::path{dataObjRenameInp->destDataObjInp.objPath}.parent_path();
 

--- a/server/api/src/rsDataObjRepl.cpp
+++ b/server/api/src/rsDataObjRepl.cpp
@@ -94,10 +94,6 @@ namespace
 
     auto finalize_source_replica(RsComm& _comm, l1desc& _l1desc, ir::replica_proxy_t& _info) -> int
     {
-        if (_l1desc.purgeCacheFlag) {
-            irods::purge_cache(_comm, *_info.get());
-        }
-
         irods::apply_metadata_from_cond_input(_comm, *_l1desc.dataObjInp);
         irods::apply_acl_from_cond_input(_comm, *_l1desc.dataObjInp);
 
@@ -614,6 +610,7 @@ namespace
                     "[{}] - failed while finalizing object [{}]; ec:[{}]",
                     __FUNCTION__, destination_replica.logical_path(), ec));
             }
+
             return destination_fd.bytesWritten;
         }
 
@@ -638,7 +635,10 @@ namespace
                 status = e.code();
             }
         }
-        // break here for lib
+
+        if (source_fd.purgeCacheFlag > 0) {
+            irods::purge_cache(_comm, *source_replica.get());
+        }
 
         if (destination_fd.purgeCacheFlag > 0) {
             irods::purge_cache(_comm, *destination_replica.get());

--- a/server/api/src/rsDataObjTrim.cpp
+++ b/server/api/src/rsDataObjTrim.cpp
@@ -1,7 +1,3 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-/* See dataObjTrim.h for a description of this API call.*/
-
 #include "dataObjTrim.h"
 #include "dataObjUnlink.h"
 #include "dataObjOpr.hpp"
@@ -19,10 +15,14 @@
 #include "irods_hierarchy_parser.hpp"
 #include "irods_at_scope_exit.hpp"
 #include "irods_linked_list_iterator.hpp"
+#include "logical_locking.hpp"
 
 #include <tuple>
 
-namespace {
+namespace
+{
+    namespace ill = irods::logical_locking;
+
     dataObjInfo_t convert_physical_object_to_dataObjInfo_t(const irods::physical_object obj) {
         dataObjInfo_t info{};
 
@@ -90,31 +90,36 @@ namespace {
         }
     }
 
-    std::vector<irods::physical_object> get_replica_list(
-        rsComm_t *rsComm,
-        dataObjInp_t& dataObjInp) {
+    auto get_data_object_info(rsComm_t *rsComm, dataObjInp_t& dataObjInp) -> std::tuple<irods::file_object_ptr, DataObjInfo*>
+    {
+        DataObjInfo* info{};
         if (!getValByKey(&dataObjInp.condInput, RESC_HIER_STR_KW)) {
-            auto result = irods::resolve_resource_hierarchy(irods::UNLINK_OPERATION, rsComm, dataObjInp);
+            auto result = irods::resolve_resource_hierarchy(irods::UNLINK_OPERATION, rsComm, dataObjInp, &info);
             auto file_obj = std::get<irods::file_object_ptr>(result);
-            return file_obj->replicas();
+            return {file_obj, info};
         }
         else {
             irods::file_object_ptr file_obj( new irods::file_object() );
-            irods::error fac_err = irods::file_object_factory(rsComm, &dataObjInp, file_obj);
+            irods::error fac_err = irods::file_object_factory(rsComm, &dataObjInp, file_obj, &info);
             if (!fac_err.ok()) {
                 THROW(fac_err.code(), "file_object_factory failed");
             }
-            return file_obj->replicas();
+            return {file_obj, info};
         }
-    }
+    } // get_data_object_info
 
-    std::vector<irods::physical_object> get_list_of_replicas_to_trim(
+    auto get_list_of_replicas_to_trim(
         dataObjInp_t& _inp,
-        const std::vector<irods::physical_object>& _list) {
+        const irods::file_object_ptr _obj,
+        const DataObjInfo& _info)
+    {
+        const auto& list = _obj->replicas();
+
         std::vector<irods::physical_object> trim_list;
-        const unsigned long good_replica_count = std::count_if(_list.begin(), _list.end(),
+
+        const unsigned long good_replica_count = std::count_if(list.begin(), list.end(),
             [](const auto& repl) {
-                return (repl.replica_status() & 0x0F) == GOOD_REPLICA;
+                return GOOD_REPLICA == repl.replica_status();
             });
 
         const auto minimum_replica_count = get_minimum_replica_count(getValByKey(&_inp.condInput, COPIES_KW));
@@ -128,19 +133,33 @@ namespace {
         if (repl_num) {
             try {
                 const auto num = std::stoi(repl_num);
-                const auto repl = std::find_if(_list.begin(), _list.end(),
+
+                const auto repl = std::find_if(list.begin(), list.end(),
                     [&num](const auto& repl) {
                         return num == repl.repl_num();
                     });
-                if (repl == _list.end()) {
+
+                if (repl == list.end()) {
                     THROW(SYS_REPLICA_DOES_NOT_EXIST, "target replica does not exist");
                 }
+
+                if (const auto ret = ill::try_lock(_info, ill::lock_type::write, num); ret < 0) {
+                    const auto msg = fmt::format(
+                        "trim not allowed because data object is locked "
+                        "[path=[{}], hierarchy=[{}]]",
+                        _obj->logical_path(), repl->resc_hier());
+
+                    THROW(ret, msg);
+                }
+
                 if (expired(*repl)) {
                     THROW(USER_INCOMPATIBLE_PARAMS, "target replica is not old enough for removal");
                 }
-                if (good_replica_count <= minimum_replica_count && (repl->replica_status() & 0x0F) == GOOD_REPLICA) {
+
+                if (good_replica_count <= minimum_replica_count && GOOD_REPLICA == repl->replica_status()) {
                     THROW(USER_INCOMPATIBLE_PARAMS, "cannot remove the last good replica");
                 }
+
                 trim_list.push_back(*repl);
                 return trim_list;
             }
@@ -154,13 +173,24 @@ namespace {
             }
         }
 
+        // Do not try the lock for a replica specified by RESC_NAME_KW because it could
+        // be referring to a root resource which would not be a particular replica but
+        // potentially a number of different replicas.
+        if (const auto ret = ill::try_lock(_info, ill::lock_type::write); ret < 0) {
+            const auto msg = fmt::format(
+                "trim not allowed because data object is locked [path=[{}]]",
+                _obj->logical_path());
+
+            THROW(ret, msg);
+        }
+
         const char* resc_name = getValByKey(&_inp.condInput, RESC_NAME_KW);
         const auto matches_target_resource = [&resc_name](const irods::physical_object& obj) {
             return resc_name && irods::hierarchy_parser{obj.resc_hier()}.first_resc() == resc_name;
         };
 
         // Walk list and add stale replicas to the list
-        for (const auto& obj : _list) {
+        for (const auto& obj : list) {
             if ((obj.replica_status() & 0x0F) == STALE_REPLICA) {
                 if (expired(obj) || (resc_name && !matches_target_resource(obj))) {
                     continue;
@@ -174,7 +204,7 @@ namespace {
 
         // If we have not reached the minimum count, walk list again and add good replicas
         unsigned long good_replicas_to_be_trimmed = 0;
-        for (const auto& obj : _list) {
+        for (const auto& obj : list) {
             if ((obj.replica_status() & 0x0F) == GOOD_REPLICA) {
                 if (expired(obj) || (resc_name && !matches_target_resource(obj))) {
                     continue;
@@ -227,11 +257,23 @@ int rsDataObjTrim(
             repl_num_str = repl_num;
             rmKeyVal(&dataObjInp->condInput, REPL_NUM_KW);
         }
-        const std::vector<irods::physical_object> repl_list = get_replica_list(rsComm, *dataObjInp);
+
+        const auto [file_obj, info] = get_data_object_info(rsComm, *dataObjInp);
+
+        if (!info) {
+            irods::log(LOG_ERROR, fmt::format(
+                "[{}:{}] - DataObjInfo is null without an error from API",
+                __FUNCTION__, __LINE__));
+
+            return SYS_INTERNAL_ERR;
+        }
+
         if (!repl_num_str.empty()) {
             addKeyVal(&dataObjInp->condInput, REPL_NUM_KW, repl_num_str.c_str());
         }
-        const auto trim_list = get_list_of_replicas_to_trim(*dataObjInp, repl_list);
+
+        const auto trim_list = get_list_of_replicas_to_trim(*dataObjInp, file_obj, *info);
+
         for (const auto& obj : trim_list) {
             if (getValByKey(&dataObjInp->condInput, DRYRUN_KW)) {
                 retVal = 1;
@@ -255,7 +297,7 @@ int rsDataObjTrim(
         return USER_INCOMPATIBLE_PARAMS;
     }
     catch (const irods::exception& e) {
-        irods::log(LOG_NOTICE, e.what());
+        irods::log(LOG_NOTICE, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, e.client_display_what()));
         return e.code();
     }
     return retVal;

--- a/server/core/include/logical_locking.hpp
+++ b/server/core/include/logical_locking.hpp
@@ -3,6 +3,8 @@
 
 #include <string_view>
 
+struct DataObjInfo;
+struct DataObjInp;
 struct RsComm;
 
 namespace irods::logical_locking
@@ -229,6 +231,75 @@ namespace irods::logical_locking
         RsComm&             _comm,
         const std::uint64_t _data_id,
         const int           _replica_statuses) -> int;
+
+    /// \brief Check to see if the data object will lock out some operation.
+    ///
+    /// \parblock
+    /// This overload does not target a specific replica and so if any replica of the
+    /// specified data object is locked or intermediate, the lock will be tripped.
+    /// \endparblock
+    ///
+    /// \param[in] _obj The data object on which we are checking for a lock
+    /// \param[in] _lock_type Type of lock to test for
+    ///
+    /// \returns An error code describing the access violation or 0 if no violation
+    /// \retval 0 The data object is not locked
+    /// \retval LOCKED_DATA_OBJECT_ACCESS Another replica for the data object is locked
+    ///
+    /// \since 4.2.9
+    auto try_lock(const DataObjInfo& _obj, const lock_type _lock_type) -> int;
+
+    /// \brief Check to see if the data object will lock out some operation.
+    ///
+    /// \parblock
+    /// This overload targets a specific replica based on resource hierarchy. If the
+    /// target replica is in the intermediate state and the replica token does not match,
+    /// the lock will be tripped with a specific error. If any replica is locked or any
+    /// sibling replica is intermediate, the lock will be tripped.
+    /// \endparblock
+    ///
+    /// \param[in] _obj The data object being tested for a lock
+    /// \param[in] _lock_type Type of lock to test for
+    /// \param[in] _target_replica_hierarchy Resource hierarchy for the target replica
+    /// \param[in] _target_replica_token Replica token for target replica (can be empty)
+    ///
+    /// \returns An error code describing the access violation or 0 if no violation
+    /// \retval 0 The data object is not locked
+    /// \retval INTERMEDIATE_REPLICA_ACCESS The targeted replica is intermediate
+    /// \retval LOCKED_DATA_OBJECT_ACCESS Another replica for the data object is locked
+    ///
+    /// \since 4.2.9
+    auto try_lock(
+        const DataObjInfo&     _obj,
+        const lock_type        _lock_type,
+        const std::string_view _target_replica_hierarchy,
+        const std::string_view _target_replica_token = "") -> int;
+
+    /// \brief Check to see if the data object will lock out some operation.
+    ///
+    /// \parblock
+    /// This overload targets a specific replica based on resource hierarchy. If the
+    /// target replica is in the intermediate state and the replica token does not match,
+    /// the lock will be tripped with a specific error. If any replica is locked or any
+    /// sibling replica is intermediate, the lock will be tripped.
+    /// \endparblock
+    ///
+    /// \param[in] _obj The data object being tested for a lock
+    /// \param[in] _lock_type Type of lock to test for
+    /// \param[in] _target_replica_number Replica number for the target replica
+    /// \param[in] _target_replica_token Replica token for target replica (can be empty)
+    ///
+    /// \returns An error code describing the access violation or 0 if no violation
+    /// \retval 0 The data object is not locked
+    /// \retval INTERMEDIATE_REPLICA_ACCESS The targeted replica is intermediate
+    /// \retval LOCKED_DATA_OBJECT_ACCESS Another replica for the data object is locked
+    ///
+    /// \since 4.2.9
+    auto try_lock(
+        const DataObjInfo&     _obj,
+        const lock_type        _lock_type,
+        const int              _target_replica_number,
+        const std::string_view _target_replica_token = "") -> int;
 } // namespace irods::logical_locking
 
 #endif // #ifndef IRODS_LOGICAL_LOCKING_HPP

--- a/server/core/src/voting.cpp
+++ b/server/core/src/voting.cpp
@@ -50,6 +50,12 @@ namespace {
         }
 
         const auto& r = repl->get();
+
+        // TODO: READ_LOCKED should consider the operation
+        if (WRITE_LOCKED == r.replica_status() || READ_LOCKED == r.replica_status()) {
+            return vote::zero;
+        }
+
         if (INTERMEDIATE_REPLICA == r.replica_status()) {
             // Because the replica is in an intermediate state, we must check if the client
             // provided a replica token. The replica token represents a piece of information that

--- a/unit_tests/src/test_logical_locking.cpp
+++ b/unit_tests/src/test_logical_locking.cpp
@@ -27,20 +27,45 @@ namespace adm   = irods::experimental::administration;
 namespace fs    = irods::experimental::filesystem;
 namespace io    = irods::experimental::io;
 namespace ir    = irods::experimental::replica;
+
+using namespace std::string_literals;
 // clang-format on
 
-TEST_CASE("basic write lock")
+namespace
 {
-    using namespace std::string_literals;
-
-    load_client_api_plugins();
-
+    // global constants
     static const std::string resc_0 = "logical_locking_resc_0";
     static const std::string resc_1 = "logical_locking_resc_1";
     static const std::string resc_2 = "logical_locking_resc_2";
+    static const auto resc_names = std::vector{resc_0, resc_1, resc_2};
+    static const auto& opened_replica_resc = resc_0;
+    static const auto& other_replica_resc = resc_1;
 
-    static const auto& resc_names = std::vector{resc_0, resc_1, resc_2};
+    inline auto get_sandbox_name() -> fs::path
+    {
+        rodsEnv env;
+        _getRodsEnv(env);
+        return fs::path{env.rodsHome} / "test_logical_locking";
+    } // get_sandbox_name
 
+    auto mkresc(const std::string_view _name) -> void
+    {
+        irods::experimental::client_connection conn;
+        RcComm& comm = static_cast<RcComm&>(conn);
+
+        if (const auto [ec, exists] = adm::client::resource_exists(comm, _name); exists) {
+            REQUIRE(adm::client::remove_resource(comm, _name));
+        }
+
+        REQUIRE(unit_test_utils::add_ufs_resource(comm, _name, "vault_for_"s + _name.data()));
+    } // mkresc
+} // anonymous namespace
+
+TEST_CASE("open and close", "[write_lock]")
+{
+    load_client_api_plugins();
+
+    // Make sure that the test resources created below are removed upon test completion
     irods::at_scope_exit remove_resources{[] {
         // reset connection to ensure resource manager is current
         irods::experimental::client_connection conn;
@@ -51,18 +76,7 @@ TEST_CASE("basic write lock")
         }
     }};
 
-    const auto mkresc = [](std::string_view _name)
-    {
-        irods::experimental::client_connection conn;
-        RcComm& comm = static_cast<RcComm&>(conn);
-
-        if (const auto [ec, exists] = adm::client::resource_exists(comm, _name); exists) {
-            REQUIRE(adm::client::remove_resource(comm, _name));
-        }
-
-        REQUIRE(unit_test_utils::add_ufs_resource(comm, _name, "vault_for_"s + _name.data()));
-    };
-
+    // Create resources to use for test cases
     for (const auto& r : resc_names) {
         mkresc(r);
     }
@@ -71,16 +85,16 @@ TEST_CASE("basic write lock")
     irods::experimental::client_connection conn;
     RcComm& comm = static_cast<RcComm&>(conn);
 
-    // create data object on one resource
-    rodsEnv env;
-    _getRodsEnv(env);
+    // Construct some paths for use in tests
+    const auto sandbox = get_sandbox_name();
+    const auto target_object = sandbox / "target_object";
 
-    const auto sandbox = fs::path{env.rodsHome} / "test_logical_locking";
-
+    // Create a target collection for the test data
     if (!fs::client::exists(comm, sandbox)) {
         REQUIRE(fs::client::create_collection(comm, sandbox));
     }
 
+    // Clean up test collection after tests complete
     irods::at_scope_exit remove_sandbox{[&sandbox] {
         irods::experimental::client_connection conn;
         RcComm& comm = static_cast<RcComm&>(conn);
@@ -88,90 +102,37 @@ TEST_CASE("basic write lock")
         REQUIRE(fs::client::remove_all(comm, sandbox, fs::remove_options::no_trash));
     }};
 
-    const auto target_object = sandbox / "target_object";
-
+    // Create a test data object
     {
         io::client::default_transport tp{comm};
         io::odstream{tp, target_object, io::root_resource_name{resc_0}};
     }
-
     REQUIRE(fs::client::exists(comm, target_object));
-    REQUIRE(GOOD_REPLICA == ir::replica_status(comm, target_object, 0));
+    REQUIRE(GOOD_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
 
+    // Replicate the test data object so that it has multiple replicas
     REQUIRE(unit_test_utils::replicate_data_object(comm, target_object.c_str(), resc_1));
+    REQUIRE(GOOD_REPLICA == ir::replica_status(comm, target_object, other_replica_resc));
 
-    SECTION("attempt opening locked data object")
+    // Open the test data object so that it will be write-locked
+    DataObjInp open_inp{};
+    auto cond_input = irods::experimental::make_key_value_proxy(open_inp.condInput);
+    const auto free_cond_input = irods::at_scope_exit{[&cond_input] { cond_input.clear(); }};
+    std::snprintf(open_inp.objPath, sizeof(open_inp.objPath), "%s", target_object.c_str());
+    cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
+    open_inp.openFlags = O_WRONLY;
+
+    // Ensure that open successfully locked data object
+    const auto fd = rcDataObjOpen(&comm, &open_inp);
+    REQUIRE(fd > 2);
+    REQUIRE(INTERMEDIATE_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+    REQUIRE(WRITE_LOCKED == ir::replica_status(comm, target_object, other_replica_resc));
+
+    // This is done in an irods::at_scope_exit because catch will return immediately if
+    // a REQUIRE clause fails. This ensures that the data object is properly closed for
+    // cleanup purposes.
+    const auto close_object = irods::at_scope_exit{[&]
     {
-        const auto opened_replica_resc = resc_0;
-        const auto other_replica_resc = resc_1;
-
-        REQUIRE(GOOD_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
-        REQUIRE(GOOD_REPLICA == ir::replica_status(comm, target_object, other_replica_resc));
-
-        dataObjInp_t open_inp{};
-        auto cond_input = irods::experimental::make_key_value_proxy(open_inp.condInput);
-        std::snprintf(open_inp.objPath, sizeof(open_inp.objPath), "%s", target_object.c_str());
-        cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
-        open_inp.openFlags = O_WRONLY;
-
-        const auto fd = rcDataObjOpen(&comm, &open_inp);
-        REQUIRE(fd > 2);
-
-        REQUIRE(INTERMEDIATE_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
-        REQUIRE(WRITE_LOCKED == ir::replica_status(comm, target_object, other_replica_resc));
-
-        {
-            irods::experimental::client_connection new_conn;
-            RcComm& new_comm = static_cast<RcComm&>(new_conn);
-
-            dataObjInp_t fail_open_inp{};
-            auto fail_cond_input = irods::experimental::make_key_value_proxy(fail_open_inp.condInput);
-            std::snprintf(fail_open_inp.objPath, sizeof(fail_open_inp.objPath), "%s", target_object.c_str());
-
-            SECTION("attempt open for read")
-            {
-                fail_open_inp.openFlags = O_RDONLY;
-
-                // open existing, currently opened replica
-                fail_cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
-                REQUIRE(INTERMEDIATE_REPLICA_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
-
-                // open existing, currently locked replica
-                fail_cond_input[RESC_HIER_STR_KW] = other_replica_resc;
-                REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
-            }
-
-            SECTION("attempt open for write")
-            {
-                fail_open_inp.openFlags = O_WRONLY;
-
-                // open existing, currently opened replica
-                fail_cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
-                REQUIRE(INTERMEDIATE_REPLICA_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
-
-                // open existing, currently locked replica
-                fail_cond_input[RESC_HIER_STR_KW] = other_replica_resc;
-                REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
-            }
-
-            SECTION("attempt creating new replica")
-            {
-                fail_open_inp.openFlags = O_CREAT | O_WRONLY | O_TRUNC;
-
-                // attempt overwriting existing, currently opened replica with new replica
-                fail_cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
-                REQUIRE(INTERMEDIATE_REPLICA_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
-
-                // attempt overwriting existing, currently locked replica with new replica
-                fail_cond_input[RESC_HIER_STR_KW] = other_replica_resc;
-                REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
-
-                // Attempt opening a new replica on locked object
-                fail_cond_input[RESC_HIER_STR_KW] = resc_2;
-                REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
-            }
-        }
-
         openedDataObjInp_t close_inp{};
         close_inp.l1descInx = fd;
         REQUIRE(rcDataObjClose(&comm, &close_inp) >= 0);
@@ -179,33 +140,597 @@ TEST_CASE("basic write lock")
         // Make sure everything unlocked properly
         CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
         CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, other_replica_resc));
+    }};
+
+    // Use a separate connection to run the tests from that used in the setup
+    irods::experimental::client_connection new_conn;
+    RcComm& new_comm = static_cast<RcComm&>(new_conn);
+
+    // Prepare input to rcDataObjOpen for the test cases
+    DataObjInp fail_open_inp{};
+    auto fail_cond_input = irods::experimental::make_key_value_proxy(fail_open_inp.condInput);
+    std::snprintf(fail_open_inp.objPath, sizeof(fail_open_inp.objPath), "%s", target_object.c_str());
+
+    //SECTION("open for read")
+    {
+        fail_open_inp.openFlags = O_RDONLY;
+
+        // open existing, currently opened replica
+        fail_cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
+        REQUIRE(INTERMEDIATE_REPLICA_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
+
+        // open existing, currently locked replica
+        fail_cond_input[RESC_HIER_STR_KW] = other_replica_resc;
+        REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
     }
 
-#if 0
-    SECTION("open without close")
+    //SECTION("open for write")
     {
+        fail_open_inp.openFlags = O_WRONLY;
+
+        // open existing, currently opened replica
+        fail_cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
+        REQUIRE(INTERMEDIATE_REPLICA_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
+
+        // open existing, currently locked replica
+        fail_cond_input[RESC_HIER_STR_KW] = other_replica_resc;
+        REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
+    }
+
+    //SECTION("open for create")
+    {
+        fail_open_inp.openFlags = O_CREAT | O_WRONLY | O_TRUNC;
+
+        // attempt overwriting existing, currently opened replica with new replica
+        fail_cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
+        REQUIRE(INTERMEDIATE_REPLICA_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
+
+        // attempt overwriting existing, currently locked replica with new replica
+        fail_cond_input[RESC_HIER_STR_KW] = other_replica_resc;
+        REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
+
+        // Attempt opening a new replica on locked object
+        fail_cond_input[RESC_HIER_STR_KW] = resc_2;
+        REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjOpen(&new_comm, &fail_open_inp));
+    }
+}
+
+TEST_CASE("unlink", "[write_lock]")
+{
+    load_client_api_plugins();
+
+    // Make sure that the test resources created below are removed upon test completion
+    irods::at_scope_exit remove_resources{[] {
+        // reset connection to ensure resource manager is current
+        irods::experimental::client_connection conn;
+        RcComm& comm = static_cast<RcComm&>(conn);
+
+        for (const auto& r : resc_names) {
+            adm::client::remove_resource(comm, r);
+        }
+    }};
+
+    // Create resources to use for test cases
+    for (const auto& r : resc_names) {
+        mkresc(r);
+    }
+
+    // reset connection so resources exist
+    irods::experimental::client_connection conn;
+    RcComm& comm = static_cast<RcComm&>(conn);
+
+    // Construct some paths for use in tests
+    const auto sandbox = get_sandbox_name();
+    const auto target_object = sandbox / "target_object";
+
+    // Create a target collection for the test data
+    if (!fs::client::exists(comm, sandbox)) {
+        REQUIRE(fs::client::create_collection(comm, sandbox));
+    }
+
+    // Clean up test collection after tests complete
+    irods::at_scope_exit remove_sandbox{[&sandbox] {
+        irods::experimental::client_connection conn;
+        RcComm& comm = static_cast<RcComm&>(conn);
+
+        REQUIRE(fs::client::remove_all(comm, sandbox, fs::remove_options::no_trash));
+    }};
+
+    // Create a test data object
+    {
+        io::client::default_transport tp{comm};
+        io::odstream{tp, target_object, io::root_resource_name{resc_0}};
+    }
+    REQUIRE(fs::client::exists(comm, target_object));
+    REQUIRE(GOOD_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+
+    // Replicate the test data object so that it has multiple replicas
+    REQUIRE(unit_test_utils::replicate_data_object(comm, target_object.c_str(), resc_1));
+    REQUIRE(GOOD_REPLICA == ir::replica_status(comm, target_object, other_replica_resc));
+
+    // Open the test data object so that it will be write-locked
+    DataObjInp open_inp{};
+    auto cond_input = irods::experimental::make_key_value_proxy(open_inp.condInput);
+    const auto free_cond_input = irods::at_scope_exit{[&cond_input] { cond_input.clear(); }};
+    std::snprintf(open_inp.objPath, sizeof(open_inp.objPath), "%s", target_object.c_str());
+    cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
+    open_inp.openFlags = O_WRONLY;
+
+    // Ensure that open successfully locked data object
+    const auto fd = rcDataObjOpen(&comm, &open_inp);
+    REQUIRE(fd > 2);
+    REQUIRE(INTERMEDIATE_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+    REQUIRE(WRITE_LOCKED == ir::replica_status(comm, target_object, other_replica_resc));
+
+    // This is done in an irods::at_scope_exit because catch will return immediately if
+    // a REQUIRE clause fails. This ensures that the data object is properly closed for
+    // cleanup purposes.
+    const auto close_object = irods::at_scope_exit{[&]
+    {
+        openedDataObjInp_t close_inp{};
+        close_inp.l1descInx = fd;
+        REQUIRE(rcDataObjClose(&comm, &close_inp) >= 0);
+
+        // Make sure everything unlocked properly
+        CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+        CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, other_replica_resc));
+    }};
+
+    // Use a separate connection to run the tests from that used in the setup
+    irods::experimental::client_connection new_conn;
+    RcComm& new_comm = static_cast<RcComm&>(new_conn);
+
+    // Prepare input to rcDataObjUnlink for the test cases
+    DataObjInp unlink_inp{};
+    auto unlink_cond_input = irods::experimental::make_key_value_proxy(unlink_inp.condInput);
+    const auto free_unlink_cond_input = irods::at_scope_exit{[&unlink_cond_input] { unlink_cond_input.clear(); }};
+    std::snprintf(unlink_inp.objPath, sizeof(unlink_inp.objPath), "%s", target_object.c_str());
+
+    // When no flags are passed to rcDataObjUnlink, the default behavior will move the object
+    // to the trash. Moving to the trash is a logical operation, so don't provide a target replica.
+    {
+        REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjUnlink(&new_comm, &unlink_inp));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), opened_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), other_replica_resc));
+    }
+
+    // Providing the force flag skips putting the object in the trash (different code path)
+    {
+        unlink_cond_input[FORCE_FLAG_KW] = "";
+
+        REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjUnlink(&new_comm, &unlink_inp));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), opened_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), other_replica_resc));
+
+        unlink_cond_input.erase(FORCE_FLAG_KW);
+    }
+
+    // Providing REPL_NUM_KW is deprecated in the API, but will act like rsDataObjTrim
+    {
+        const auto opened_replica_number = ir::to_replica_number(new_comm, target_object.c_str(), opened_replica_resc);
+        unlink_cond_input[REPL_NUM_KW] = std::to_string(*opened_replica_number);
+
+        REQUIRE(INTERMEDIATE_REPLICA_ACCESS == rcDataObjUnlink(&new_comm, &unlink_inp));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), opened_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), other_replica_resc));
+
+        const auto other_replica_number = ir::to_replica_number(new_comm, target_object.c_str(), other_replica_resc);
+        unlink_cond_input[REPL_NUM_KW] = std::to_string(*other_replica_number);
+
+        REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjUnlink(&new_comm, &unlink_inp));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), opened_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), other_replica_resc));
+
+        unlink_cond_input.erase(REPL_NUM_KW);
+    }
+
+    // The UNREG_OPR type means that the replica(s) should not be physically unlinked. This
+    // will take the same code path as the force flag and replica number cases.
+    {
+        unlink_inp.oprType = UNREG_OPR;
+
+        REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjUnlink(&new_comm, &unlink_inp));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), opened_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), other_replica_resc));
+    }
+}
+
+TEST_CASE("trim", "[write_lock]")
+{
+    load_client_api_plugins();
+
+    // Make sure that the test resources created below are removed upon test completion
+    irods::at_scope_exit remove_resources{[] {
+        // reset connection to ensure resource manager is current
+        irods::experimental::client_connection conn;
+        RcComm& comm = static_cast<RcComm&>(conn);
+
+        for (const auto& r : resc_names) {
+            adm::client::remove_resource(comm, r);
+        }
+    }};
+
+    // Create resources to use for test cases
+    for (const auto& r : resc_names) {
+        mkresc(r);
+    }
+
+    // reset connection so resources exist
+    irods::experimental::client_connection conn;
+    RcComm& comm = static_cast<RcComm&>(conn);
+
+    // Construct some paths for use in tests
+    const auto sandbox = get_sandbox_name();
+    const auto target_object = sandbox / "target_object";
+
+    // Create a target collection for the test data
+    if (!fs::client::exists(comm, sandbox)) {
+        REQUIRE(fs::client::create_collection(comm, sandbox));
+    }
+
+    // Clean up test collection after tests complete
+    irods::at_scope_exit remove_sandbox{[&sandbox] {
+        irods::experimental::client_connection conn;
+        RcComm& comm = static_cast<RcComm&>(conn);
+
+        REQUIRE(fs::client::remove_all(comm, sandbox, fs::remove_options::no_trash));
+    }};
+
+    // Create a test data object
+    {
+        io::client::default_transport tp{comm};
+        io::odstream{tp, target_object, io::root_resource_name{resc_0}};
+    }
+    REQUIRE(fs::client::exists(comm, target_object));
+    REQUIRE(GOOD_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+
+    // Replicate the test data object so that it has multiple replicas
+    REQUIRE(unit_test_utils::replicate_data_object(comm, target_object.c_str(), other_replica_resc));
+    REQUIRE(GOOD_REPLICA == ir::replica_status(comm, target_object, other_replica_resc));
+
+    const auto& another_replica_resc = resc_2;
+    REQUIRE(unit_test_utils::replicate_data_object(comm, target_object.c_str(), another_replica_resc));
+    REQUIRE(GOOD_REPLICA == ir::replica_status(comm, target_object, another_replica_resc));
+
+    // Open the test data object so that it will be write-locked
+    DataObjInp open_inp{};
+    auto cond_input = irods::experimental::make_key_value_proxy(open_inp.condInput);
+    const auto free_cond_input = irods::at_scope_exit{[&cond_input] { cond_input.clear(); }};
+    std::snprintf(open_inp.objPath, sizeof(open_inp.objPath), "%s", target_object.c_str());
+    cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
+    open_inp.openFlags = O_WRONLY;
+
+    // Ensure that open successfully locked data object
+    const auto fd = rcDataObjOpen(&comm, &open_inp);
+    REQUIRE(fd > 2);
+    REQUIRE(INTERMEDIATE_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+    REQUIRE(WRITE_LOCKED == ir::replica_status(comm, target_object, other_replica_resc));
+    REQUIRE(WRITE_LOCKED == ir::replica_status(comm, target_object, another_replica_resc));
+
+    // This is done in an irods::at_scope_exit because catch will return immediately if
+    // a REQUIRE clause fails. This ensures that the data object is properly closed for
+    // cleanup purposes.
+    const auto close_object = irods::at_scope_exit{[&]
+    {
+        openedDataObjInp_t close_inp{};
+        close_inp.l1descInx = fd;
+        REQUIRE(rcDataObjClose(&comm, &close_inp) >= 0);
+
+        // Make sure everything unlocked properly
+        CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+        CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, other_replica_resc));
+        CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, another_replica_resc));
+    }};
+
+    // Use a separate connection to run the tests from that used in the setup
+    irods::experimental::client_connection new_conn;
+    RcComm& new_comm = static_cast<RcComm&>(new_conn);
+
+    // Prepare input to rcDataObjTrim for the test cases
+    DataObjInp trim_inp{};
+    auto trim_cond_input = irods::experimental::make_key_value_proxy(trim_inp.condInput);
+    const auto free_trim_cond_input = irods::at_scope_exit{[&trim_cond_input] { trim_cond_input.clear(); }};
+    std::snprintf(trim_inp.objPath, sizeof(trim_inp.objPath), "%s", target_object.c_str());
+
+    // When no flags are passed to rsDataObjTrim, the default behavior will trim the number of replicas
+    // down to the minimum number of good replicas (default: 2). In this case, no replicas should be
+    // trimmed because it is locked, but it would also take us below the minimum number of good replicas.
+    {
+        REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjTrim(&new_comm, &trim_inp));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), opened_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), other_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), another_replica_resc));
+    }
+
+    // Providing the RESC_NAME_KW targets a resource hierarchy from which to trim replicas. Because it
+    // could be pointed at the root of a hierarchy, specific errors for trimming intermediate replicas
+    // should not be expected.
+    {
+        // Target the currently open replica
+        trim_cond_input[RESC_NAME_KW] = opened_replica_resc;
+        REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjTrim(&new_comm, &trim_inp));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), opened_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), other_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), another_replica_resc));
+
+        // Target a sibling of the currently open replica
+        trim_cond_input[RESC_NAME_KW] = other_replica_resc;
+        REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjTrim(&new_comm, &trim_inp));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), opened_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), other_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), another_replica_resc));
+
+        trim_cond_input.erase(RESC_NAME_KW);
+    }
+
+    // Providing REPL_NUM_KW will target a particular replica number.
+    {
+        // Target the currently open replica
+        const auto opened_replica_number = ir::to_replica_number(new_comm, target_object.c_str(), opened_replica_resc);
+        trim_cond_input[REPL_NUM_KW] = std::to_string(*opened_replica_number);
+        REQUIRE(INTERMEDIATE_REPLICA_ACCESS == rcDataObjTrim(&new_comm, &trim_inp));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), opened_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), other_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), another_replica_resc));
+
+        // Target a sibling of the currently open replica
+        const auto other_replica_number = ir::to_replica_number(new_comm, target_object.c_str(), other_replica_resc);
+        trim_cond_input[REPL_NUM_KW] = std::to_string(*other_replica_number);
+        REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjTrim(&new_comm, &trim_inp));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), opened_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), other_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), another_replica_resc));
+
+        trim_cond_input.erase(REPL_NUM_KW);
+    }
+}
+
+TEST_CASE("rename", "[write_lock]")
+{
+    load_client_api_plugins();
+
+    // Make sure that the test resources created below are removed upon test completion
+    irods::at_scope_exit remove_resources{[] {
+        // reset connection to ensure resource manager is current
+        irods::experimental::client_connection conn;
+        RcComm& comm = static_cast<RcComm&>(conn);
+
+        for (const auto& r : resc_names) {
+            adm::client::remove_resource(comm, r);
+        }
+    }};
+
+    // Create resources to use for test cases
+    for (const auto& r : resc_names) {
+        mkresc(r);
+    }
+
+    // reset connection so resources exist
+    irods::experimental::client_connection conn;
+    RcComm& comm = static_cast<RcComm&>(conn);
+
+    // Construct some paths for use in tests
+    const auto sandbox = get_sandbox_name();
+    const auto target_object = sandbox / "target_object";
+
+    // Create a target collection for the test data
+    if (!fs::client::exists(comm, sandbox)) {
+        REQUIRE(fs::client::create_collection(comm, sandbox));
+    }
+
+    // Clean up test collection after tests complete
+    irods::at_scope_exit remove_sandbox{[&sandbox] {
+        irods::experimental::client_connection conn;
+        RcComm& comm = static_cast<RcComm&>(conn);
+
+        REQUIRE(fs::client::remove_all(comm, sandbox, fs::remove_options::no_trash));
+    }};
+
+    // Create a test data object
+    {
+        io::client::default_transport tp{comm};
+        io::odstream{tp, target_object, io::root_resource_name{resc_0}};
+    }
+    REQUIRE(fs::client::exists(comm, target_object));
+    REQUIRE(GOOD_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+
+    // Replicate the test data object so that it has multiple replicas
+    REQUIRE(unit_test_utils::replicate_data_object(comm, target_object.c_str(), resc_1));
+    REQUIRE(GOOD_REPLICA == ir::replica_status(comm, target_object, other_replica_resc));
+
+    // Use a separate connection to run the tests from that used in the setup
+    irods::experimental::client_connection new_conn;
+    RcComm& new_comm = static_cast<RcComm&>(new_conn);
+
+    const auto other_target_object = sandbox / "other_target_object";
+    DataObjInp source_inp{};
+    DataObjInp dest_inp{};
+    std::snprintf(source_inp.objPath, sizeof(source_inp.objPath), "%s", target_object.c_str());
+    std::snprintf(dest_inp.objPath, sizeof(dest_inp.objPath), "%s", other_target_object.c_str());
+
+    DataObjCopyInp rename_inp{};
+    rename_inp.srcDataObjInp = source_inp;
+    rename_inp.destDataObjInp = dest_inp;
+    auto source_cond_input = irods::experimental::make_key_value_proxy(rename_inp.srcDataObjInp.condInput);
+    const auto free_source_cond_input = irods::at_scope_exit{[&source_cond_input] { source_cond_input.clear(); }};
+
+    SECTION("new data object")
+    {
+        // Open source object to lock it
+        DataObjInp source_open_inp{};
+        auto source_open_cond_input = irods::experimental::make_key_value_proxy(source_open_inp.condInput);
+        std::snprintf(source_open_inp.objPath, sizeof(source_open_inp.objPath), "%s", target_object.c_str());
+        source_open_cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
+        source_open_inp.openFlags = O_WRONLY;
+
+        const auto fd = rcDataObjOpen(&comm, &source_open_inp);
+        REQUIRE(fd > 2);
+        REQUIRE(INTERMEDIATE_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+        REQUIRE(WRITE_LOCKED == ir::replica_status(comm, target_object, other_replica_resc));
+
+        // This is done in an irods::at_scope_exit because catch will return immediately if
+        // a REQUIRE clause fails. This ensures that the data object is properly closed for
+        // cleanup purposes.
+        const auto close_source_object = irods::at_scope_exit{[&]
         {
-            irods::experimental::client_connection new_conn;
-            RcComm& new_comm = static_cast<RcComm&>(new_conn);
+            openedDataObjInp_t close_inp{};
+            close_inp.l1descInx = fd;
+            REQUIRE(rcDataObjClose(&comm, &close_inp) >= 0);
 
-            dataObjInp_t open_inp{};
-            auto cond_input = irods::experimental::make_key_value_proxy(open_inp.condInput);
-            std::snprintf(open_inp.objPath, sizeof(open_inp.objPath), "%s", target_object.c_str());
-            cond_input[REPL_NUM_KW] = std::to_string(0);
-            open_inp.openFlags = O_WRONLY;
-            const auto fd = rcDataObjOpen(&new_comm, &open_inp);
-            REQUIRE(fd > 2);
+            // Make sure everything unlocked properly
+            CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+            CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, other_replica_resc));
+        }};
 
-            CHECK(INTERMEDIATE_REPLICA == ir::replica_status(new_comm, target_object, 0));
-            CHECK(WRITE_LOCKED == ir::replica_status(new_comm, target_object, 1));
+        // Attempt renaming source object
+        REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjRename(&new_comm, &rename_inp));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), opened_replica_resc));
+        REQUIRE(ir::replica_exists(new_comm, target_object.c_str(), other_replica_resc));
+        REQUIRE(!fs::client::exists(comm, other_target_object));
+    }
 
-            // no close
+    SECTION("existing data object")
+    {
+        source_cond_input[FORCE_FLAG_KW] = "";
+
+        const std::string contents = "something different";
+
+        {
+            io::client::default_transport tp{comm};
+            io::odstream{tp, other_target_object, io::root_resource_name{resc_0}} << contents;
         }
 
-        // Make sure everything unlocked properly on agent teardown
-        CHECK(STALE_REPLICA == ir::replica_status(comm, target_object, 0));
-        CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, 1));
+        REQUIRE(fs::client::exists(comm, other_target_object));
+        REQUIRE(GOOD_REPLICA == ir::replica_status(comm, other_target_object, 0));
+
+        // source locked, destination unlocked
+        {
+            // Open source object to lock it
+            DataObjInp source_open_inp{};
+            auto source_open_cond_input = irods::experimental::make_key_value_proxy(source_open_inp.condInput);
+            const auto free_source_cond_input = irods::at_scope_exit{[&source_open_cond_input] { source_open_cond_input.clear(); }};
+            std::snprintf(source_open_inp.objPath, sizeof(source_open_inp.objPath), "%s", target_object.c_str());
+            source_open_cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
+            source_open_inp.openFlags = O_WRONLY;
+
+            const auto fd = rcDataObjOpen(&comm, &source_open_inp);
+            REQUIRE(fd > 2);
+            REQUIRE(INTERMEDIATE_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+            REQUIRE(WRITE_LOCKED == ir::replica_status(comm, target_object, other_replica_resc));
+
+            // This is done in an irods::at_scope_exit because catch will return immediately if
+            // a REQUIRE clause fails. This ensures that the data object is properly closed for
+            // cleanup purposes.
+            const auto close_source_object = irods::at_scope_exit{[&]
+            {
+                openedDataObjInp_t close_inp{};
+                close_inp.l1descInx = fd;
+                REQUIRE(rcDataObjClose(&comm, &close_inp) >= 0);
+
+                // Make sure everything unlocked properly
+                CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+                CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, other_replica_resc));
+            }};
+
+            REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjRename(&new_comm, &rename_inp));
+            REQUIRE(fs::client::exists(comm, target_object));
+            REQUIRE(fs::client::exists(comm, other_target_object));
+            REQUIRE(contents.size() == fs::client::data_object_size(new_comm, other_target_object));
+        }
+
+        // source unlocked, destination locked
+        {
+            // Open destination object to lock it
+            DataObjInp dest_open_inp{};
+            auto dest_open_cond_input = irods::experimental::make_key_value_proxy(dest_open_inp.condInput);
+            const auto free_dest_cond_input = irods::at_scope_exit{[&dest_open_cond_input] { dest_open_cond_input.clear(); }};
+            std::snprintf(dest_open_inp.objPath, sizeof(dest_open_inp.objPath), "%s", other_target_object.c_str());
+            dest_open_inp.openFlags = O_WRONLY;
+
+            const auto dest_fd = rcDataObjOpen(&comm, &dest_open_inp);
+            REQUIRE(dest_fd > 2);
+            REQUIRE(INTERMEDIATE_REPLICA == ir::replica_status(comm, other_target_object, opened_replica_resc));
+
+            // This is done in an irods::at_scope_exit because catch will return immediately if
+            // a REQUIRE clause fails. This ensures that the data object is properly closed for
+            // cleanup purposes.
+            const auto close_dest_object = irods::at_scope_exit{[&]
+            {
+                openedDataObjInp_t close_inp{};
+                close_inp.l1descInx = dest_fd;
+                REQUIRE(rcDataObjClose(&comm, &close_inp) >= 0);
+
+                // Make sure everything unlocked properly and destination was not updated
+                CHECK(GOOD_REPLICA == ir::replica_status(comm, other_target_object, opened_replica_resc));
+                CHECK(contents.size() == fs::client::data_object_size(comm, other_target_object));
+            }};
+
+            // Attempt renaming source object to destination object
+            REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjRename(&new_comm, &rename_inp));
+            REQUIRE(fs::client::exists(comm, target_object));
+            REQUIRE(fs::client::exists(comm, other_target_object));
+        }
+
+        // source locked, destination locked
+        {
+            // Open source object to lock it
+            DataObjInp source_open_inp{};
+            auto source_open_cond_input = irods::experimental::make_key_value_proxy(source_open_inp.condInput);
+            const auto free_source_cond_input = irods::at_scope_exit{[&source_open_cond_input] { source_open_cond_input.clear(); }};
+            std::snprintf(source_open_inp.objPath, sizeof(source_open_inp.objPath), "%s", target_object.c_str());
+            source_open_cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
+            source_open_inp.openFlags = O_WRONLY;
+
+            const auto fd = rcDataObjOpen(&comm, &source_open_inp);
+            REQUIRE(fd > 2);
+            REQUIRE(INTERMEDIATE_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+            REQUIRE(WRITE_LOCKED == ir::replica_status(comm, target_object, other_replica_resc));
+
+            // This is done in an irods::at_scope_exit because catch will return immediately if
+            // a REQUIRE clause fails. This ensures that the data object is properly closed for
+            // cleanup purposes.
+            const auto close_source_object = irods::at_scope_exit{[&]
+            {
+                openedDataObjInp_t close_inp{};
+                close_inp.l1descInx = fd;
+                REQUIRE(rcDataObjClose(&comm, &close_inp) >= 0);
+
+                // Make sure everything unlocked properly
+                CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, opened_replica_resc));
+                CHECK(GOOD_REPLICA == ir::replica_status(comm, target_object, other_replica_resc));
+            }};
+
+            // Open destination object to lock it
+            DataObjInp dest_open_inp{};
+            auto dest_open_cond_input = irods::experimental::make_key_value_proxy(dest_open_inp.condInput);
+            const auto free_dest_cond_input = irods::at_scope_exit{[&dest_open_cond_input] { dest_open_cond_input.clear(); }};
+            std::snprintf(dest_open_inp.objPath, sizeof(dest_open_inp.objPath), "%s", other_target_object.c_str());
+            dest_open_cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
+            dest_open_inp.openFlags = O_WRONLY;
+
+            const auto dest_fd = rcDataObjOpen(&comm, &dest_open_inp);
+            REQUIRE(dest_fd > 2);
+            REQUIRE(INTERMEDIATE_REPLICA == ir::replica_status(comm, other_target_object, opened_replica_resc));
+
+            // This is done in an irods::at_scope_exit because catch will return immediately if
+            // a REQUIRE clause fails. This ensures that the data object is properly closed for
+            // cleanup purposes.
+            const auto close_dest_object = irods::at_scope_exit{[&]
+            {
+                openedDataObjInp_t close_inp{};
+                close_inp.l1descInx = dest_fd;
+                REQUIRE(rcDataObjClose(&comm, &close_inp) >= 0);
+
+                // Make sure everything unlocked properly and destination was not updated
+                CHECK(GOOD_REPLICA == ir::replica_status(comm, other_target_object, opened_replica_resc));
+                REQUIRE(contents.size() == fs::client::data_object_size(comm, other_target_object));
+            }};
+
+            // Attempt renaming source object to destination object
+            REQUIRE(LOCKED_DATA_OBJECT_ACCESS == rcDataObjRename(&new_comm, &rename_inp));
+            REQUIRE(fs::client::exists(comm, target_object));
+            REQUIRE(fs::client::exists(comm, other_target_object));
+        }
     }
-#endif
 }
 


### PR DESCRIPTION
This passed CI tests except for 1 test which passes at the bench... and the failure doesn't seem... wrong, necessarily...

`irods.test.test_resource_types.Test_Resource_ReplicationToTwoCompoundResourcesWithPreferArchive.test_iget_with_purgec`

```
...

 --- IrodsSession: icommand executed by [otherrods] [iput purgecgetfile.txt] --- 
Assert Command: iput purgecgetfile.txt
Expecting EMPTY: ['']
  stdout:
    | 
  stderr:
    | 
Output found

 --- IrodsSession: icommand executed by [otherrods] [iget -f --purgec purgecgetfile.txt] --- 
Assert Command: iget -f --purgec purgecgetfile.txt
Expecting EMPTY: ['']
  stdout:
    | 
  stderr:
    | 
Output found

 --- IrodsSession: icommand executed by [otherrods] [ils -L purgecgetfile.txt] --- 
Assert FAIL Command: ils -L purgecgetfile.txt
Expecting STDOUT_SINGLELINE: [' 0 ', 'purgecgetfile.txt']
  stdout:
    |   otherrods         0 demoResc;compResc2;cacheResc2           54 2021-05-03.20:40 & purgecgetfile.txt
    |         generic    /var/lib/irods/cacheResc2Vault/home/otherrods/2021-05-04Z00:40:06--irods-testing-Tyx6Eb/purgecgetfile.txt
    |   otherrods         1 demoResc;compResc2;archiveResc2           54 2021-05-03.20:40 & purgecgetfile.txt
    |         generic    /var/lib/irods/archiveResc2Vault/home/otherrods/2021-05-04Z00:40:06--irods-testing-Tyx6Eb/purgecgetfile.txt
    |   otherrods         3 demoResc;compResc1;archiveResc1           54 2021-05-03.20:40 & purgecgetfile.txt
    |         generic    /var/lib/irods/archiveResc1Vault/home/otherrods/2021-05-04Z00:40:06--irods-testing-Tyx6Eb/purgecgetfile.txt
  stderr:
    | 
Output found

FAILED TESTING ASSERTION
...
```

It wants replica 0 to be gone, but I believe it just purged the cache copy on the hierarchy which was chosen for the get operation (demoResc;compResc1). So the test should be modified to look for the cache copy in the hierarchy that won the vote, right?