### PR TITLE
[#4331] Bumpers for data_object_finalize (master)

### DIFF
--- a/lib/api/include/data_object_finalize.h
+++ b/lib/api/include/data_object_finalize.h
@@ -18,13 +18,18 @@ extern "C" {
 /// desired modifications is required in the form of a JSON structure. Each replica can also
 /// have "file_modified" key which holds a set of key-value pairs for the file_modified plugin operation.
 ///
-/// The file_modified field is a boolean indicating whether the file_modified plugin operation
+/// The trigger_file_modified field is a boolean indicating whether the file_modified plugin operation
 /// should be called after the data object has been finalized.
+///
+/// irodsAdmin is a special keyword in iRODS to indicate that the operation requires elevated
+/// privileges. When present and set to true, the API will honor elevated privileges. If the user
+/// is not authorized to use elevated privileges, an error will be returned.
 /// \endparblock
 ///
 /// \p json_input must have the following JSON structure:
 /// \code{.js}
 /// {
+///     "irods_admin": <bool>,
 ///     "replicas": [
 ///         {
 ///             "before": {

--- a/plugins/api/src/atomic_apply_acl_operations.cpp
+++ b/plugins/api/src/atomic_apply_acl_operations.cpp
@@ -52,6 +52,7 @@ namespace
 {
     // clang-format off
     namespace fs    = irods::experimental::filesystem;
+    namespace ic    = irods::experimental::catalog;
 
     using log       = irods::experimental::log;
     using json      = nlohmann::json;
@@ -232,8 +233,7 @@ namespace
                                        " a.object_id = '{}'", _comm.clientUser.userName, _object_id);
 
         if (auto row = execute(_db_conn, query); row.next()) {
-            constexpr int access_own = 1200;
-            return row.get<int>(0) == access_own;
+            return static_cast<ic::access_type>(row.get<int>(0)) == ic::access_type::own;
         }
 
         return false;
@@ -379,8 +379,6 @@ namespace
 
     auto rs_atomic_apply_acl_operations(rsComm_t* _comm, bytesBuf_t* _input, bytesBuf_t** _output) -> int
     {
-        namespace ic = irods::experimental::catalog;
-
         try {
             if (!ic::connected_to_catalog_provider(*_comm)) {
                 log::api::trace("Redirecting request to catalog service provider ...");

--- a/plugins/api/src/atomic_apply_metadata_operations.cpp
+++ b/plugins/api/src/atomic_apply_metadata_operations.cpp
@@ -440,7 +440,7 @@ namespace
             return SYS_CONFIG_FILE_ERR;
         }
 
-        if (!ic::user_has_permission_to_modify_metadata(*_comm, db_conn, object_id, entity_type)) {
+        if (!ic::user_has_permission_to_modify_entity(*_comm, db_conn, object_id, entity_type)) {
             log::api::error("User not allowed to modify metadata [entity_name={}, entity_type={}, object_id={}]",
                             entity_name, input.at("entity_type").get<std::string>(), object_id);
             *_output = to_bytes_buffer(make_error_object(json{}, 0, "User not allowed to modify metadata").dump());

--- a/plugins/api/src/data_object_finalize.cpp
+++ b/plugins/api/src/data_object_finalize.cpp
@@ -103,6 +103,24 @@ namespace
         return _api->call_handler<BytesBuf*, BytesBuf**>(_comm, _input, _output);
     } // call_data_object_finalize
 
+    auto column_is_mutable(const std::string_view _c)
+    {
+        using immutable_columns_list_t = std::vector<const std::string_view>;
+        static const immutable_columns_list_t immutable_columns =
+        {
+            "data_id",
+            "coll_id",
+            "data_name"
+        };
+
+        const auto itr = std::find(
+            std::cbegin(immutable_columns),
+            std::cend(immutable_columns),
+            _c);
+
+        return std::cend(immutable_columns) == itr;
+    } // column_is_mutable
+
     auto validate_values(json& _obj) -> void
     {
         // clang-format off
@@ -125,6 +143,10 @@ namespace
         std::string sql{"update R_DATA_MAIN set"};
 
         for (auto&& c : cmap) {
+            if (!column_is_mutable(c.first)) {
+                continue;
+            }
+
             sql += fmt::format(" {} = ?,", c.first);
         }
         sql.pop_back();
@@ -149,6 +171,10 @@ namespace
         std::size_t index = 0;
         for (auto&& c : cmap) {
             const auto& key = c.first;
+
+            if (!column_is_mutable(key)) {
+                continue;
+            }
 
             const auto& bind_fcn = c.second;
             ic::bind_parameters bp{statement, index, _after, key, bind_values};
@@ -231,7 +257,7 @@ namespace
                 irods::log(LOG_DEBUG9, fmt::format("[{}:{}] - replica:[{}]", __FUNCTION__, __LINE__, replica.dump()));
 
                 if (replica.contains(FILE_MODIFIED_KW)) {
-                    const auto data_id = std::stoll(replica.at("after").at("data_id").get<std::string>());
+                    const auto data_id = std::stoll(replica.at("before").at("data_id").get<std::string>());
                     auto obj = irods::file_object_factory(_comm, data_id);
 
                     const auto leaf_resource_id = std::stoll(replica.at("after").at("resc_id").get<std::string>());
@@ -306,8 +332,8 @@ namespace
             ic::throw_if_catalog_provider_service_role_is_invalid();
         }
         catch (const irods::exception& e) {
-            std::string_view msg = e.what();
-            log::api::error(msg.data());
+            std::string_view msg = e.client_display_what();
+            irods::log(LOG_ERROR, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, msg));
             *_output = to_bytes_buffer(make_error_object(msg.data()).dump());
             return e.code();
         }
@@ -331,9 +357,25 @@ namespace
 
         json replicas;
         bool trigger_file_modified;
+        bool admin_operation = false;
 
         try {
+            if (input.contains("irods_admin") && input.at("irods_admin").get<bool>()) {
+                if (!irods::is_privileged_client(*_comm)) {
+                    const auto msg = "user is not authorized to use the admin keyword";
+
+                    *_output = to_bytes_buffer(make_error_object(msg).dump());
+
+                    irods::log(LOG_WARNING, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, msg));
+
+                    return CAT_INSUFFICIENT_PRIVILEGE_LEVEL;
+                }
+
+                admin_operation = true;
+            }
+
             replicas = input.at("replicas");
+
             trigger_file_modified = input.contains("trigger_file_modified") && input.at("trigger_file_modified").get<bool>();
         }
         catch (const json::type_error& e) {
@@ -345,8 +387,6 @@ namespace
             return SYS_INVALID_INPUT_PARAM;
         }
 
-        // TODO: check permissions on data object?
-
         nanodbc::connection db_conn;
 
         try {
@@ -355,6 +395,18 @@ namespace
         catch (const std::exception& e) {
             log::database::error(e.what());
             return SYS_CONFIG_FILE_ERR;
+        }
+
+        const auto data_id = std::stoll(replicas.front().at("before").at("data_id").get<std::string>());
+        const auto entity_type = ic::entity_type_map.at("data_object");
+        if (!admin_operation && !ic::user_has_permission_to_modify_entity(*_comm, db_conn, data_id, entity_type)) {
+            const auto msg = fmt::format("user not allowed to modify data object [data id=[{}]]", data_id);
+
+            irods::log(LOG_NOTICE, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, msg));
+
+            *_output = to_bytes_buffer(make_error_object(msg).dump());
+
+            return CAT_NO_ACCESS_PERMISSION;
         }
 
         try {
@@ -373,7 +425,7 @@ namespace
         }
         catch (const irods::exception& e) {
             log::database::error(e.what());
-            *_output = to_bytes_buffer(make_error_object(e.what()).dump());
+            *_output = to_bytes_buffer(make_error_object(e.client_display_what()).dump());
             return e.code();
         }
     } // rs_data_object_finalize

--- a/plugins/api/src/replica_close.cpp
+++ b/plugins/api/src/replica_close.cpp
@@ -29,15 +29,15 @@
 #include "irods_resource_backport.hpp"
 #include "irods_server_api_call.hpp"
 #include "json_serialization.hpp"
-#include "logical_locking.hpp"
 #include "replica_access_table.hpp"
 
 #define IRODS_FILESYSTEM_ENABLE_SERVER_SIDE_API
 #include "filesystem.hpp"
+
 #define IRODS_REPLICA_ENABLE_SERVER_SIDE_API
 #include "replica.hpp"
 
-#include "replica_state_table.hpp"
+#include "logical_locking.hpp"
 
 #include "fmt/format.h"
 #include "json.hpp"
@@ -178,11 +178,14 @@ namespace
 
         // Send an empty JSON structure if we do not want to trigger file_modified
         // as this is the way the RST interface determines whether it should trigger.
-        const auto file_modified = _send_notifications ? irods::to_json(&_l1desc.dataObjInp->condInput) : json{{}};
+        const auto cond_input = irods::experimental::make_key_value_proxy(_l1desc.dataObjInp->condInput);
+
+        const auto ctx = _send_notifications ? rst::publish::context{_replica, *cond_input.get()}
+                                             : rst::publish::context{_replica, cond_input.contains(ADMIN_KW)};
 
         // Publish to catalog and trigger file_modified as appropriate. The updates
         // made above will be reflected in the RST and stamped out to the catalog here.
-        const int ec = rst::publish_to_catalog(_comm, _replica.data_id(), _replica.replica_number(), file_modified);
+        const int ec = rst::publish::to_catalog(_comm, ctx);
 
         if (ec < 0) {
             irods::log(LOG_ERROR, fmt::format(

--- a/scripts/irods/test/test_iadmin.py
+++ b/scripts/irods/test/test_iadmin.py
@@ -983,71 +983,73 @@ class Test_Iadmin(resource_suite.ResourceBase, unittest.TestCase):
         self.admin.assert_icommand("iadmin addchildtoresc repl leaf_a")
         self.admin.assert_icommand("iadmin addchildtoresc repl leaf_b")
 
-        # =-=-=-=-=-=-=-
-        # place data into the resource
-        test_file = "rebalance_test_file"
-        lib.make_file(test_file, 100)
-        num_children = 3
-        for i in range(num_children):
-            self.admin.assert_icommand("iput -R repl %s foo%d" % (test_file, i))
-            self.user0.assert_icommand("iput -R repl %s bar%d" % (test_file, i))
+        try:
+            # =-=-=-=-=-=-=-
+            # place data into the resource
+            test_file = "rebalance_test_file"
+            lib.make_file(test_file, 100)
+            num_children = 3
+            for i in range(num_children):
+                self.admin.assert_icommand("iput -R repl %s foo%d" % (test_file, i))
+                self.user0.assert_icommand("iput -R repl %s bar%d" % (test_file, i))
 
-        # =-=-=-=-=-=-=-
-        # surgically trim repls so we can rebalance
-        self.admin.assert_icommand("itrim -N1 -n 0 foo1", 'STDOUT_SINGLELINE', "files trimmed")
-        self.user0.assert_icommand("itrim -N1 -n 0 bar0", 'STDOUT_SINGLELINE', "files trimmed")
+            # =-=-=-=-=-=-=-
+            # surgically trim repls so we can rebalance
+            self.admin.assert_icommand("itrim -N1 -n 0 foo1", 'STDOUT_SINGLELINE', "files trimmed")
+            self.user0.assert_icommand("itrim -N1 -n 0 bar0", 'STDOUT_SINGLELINE', "files trimmed")
 
-        # =-=-=-=-=-=-=-
-        # dirty up a foo10 repl to ensure that code path is tested also
-        self.admin.assert_icommand("iadmin modresc leaf_a status down")
-        test1_path = os.path.join(self.admin.local_session_dir, 'test1')
-        lib.make_file(test1_path, 1500, 'arbitrary')
-        self.user0.assert_icommand("iput -fR repl %s bar2" % (test1_path))
-        self.admin.assert_icommand("iadmin modresc leaf_a status up")
+            # =-=-=-=-=-=-=-
+            # dirty up a foo10 repl to ensure that code path is tested also
+            self.admin.assert_icommand("iadmin modresc leaf_a status down")
+            test1_path = os.path.join(self.admin.local_session_dir, 'test1')
+            lib.make_file(test1_path, 1500, 'arbitrary')
+            self.user0.assert_icommand("iput -fR repl %s bar2" % (test1_path))
+            self.admin.assert_icommand("iadmin modresc leaf_a status up")
 
-        # =-=-=-=-=-=-=-
-        # visualize our pruning and dirtying
-        self.admin.assert_icommand("ils -ALr /", 'STDOUT_SINGLELINE', self.admin.username)
+            # =-=-=-=-=-=-=-
+            # visualize our pruning and dirtying
+            self.admin.assert_icommand("ils -ALr /", 'STDOUT_SINGLELINE', self.admin.username)
 
-        # =-=-=-=-=-=-=-
-        # call rebalance function - the thing were actually testing... finally.
-        self.admin.assert_icommand("iadmin modresc repl rebalance")
+            # =-=-=-=-=-=-=-
+            # call rebalance function - the thing were actually testing... finally.
+            self.admin.assert_icommand("iadmin modresc repl rebalance")
 
-        # =-=-=-=-=-=-=-
-        # visualize our rebalance
-        self.admin.assert_icommand("ils -ALr /", 'STDOUT_SINGLELINE', self.admin.username)
+            # =-=-=-=-=-=-=-
+            # visualize our rebalance
+            self.admin.assert_icommand("ils -ALr /", 'STDOUT_SINGLELINE', self.admin.username)
 
-        # =-=-=-=-=-=-=-
-        # assert that all the appropriate repl numbers exist for all the children
-        self.admin.assert_icommand("ils -AL foo0", 'STDOUT_SINGLELINE', [" 0 ", " foo0"])
-        self.admin.assert_icommand("ils -AL foo0", 'STDOUT_SINGLELINE', [" 1 ", " foo0"])
+            # =-=-=-=-=-=-=-
+            # assert that all the appropriate repl numbers exist for all the children
+            self.admin.assert_icommand("ils -AL foo0", 'STDOUT_SINGLELINE', [" 0 ", " foo0"])
+            self.admin.assert_icommand("ils -AL foo0", 'STDOUT_SINGLELINE', [" 1 ", " foo0"])
 
-        self.admin.assert_icommand("ils -AL foo1", 'STDOUT_SINGLELINE', [" 1 ", " foo1"])
-        self.admin.assert_icommand("ils -AL foo1", 'STDOUT_SINGLELINE', [" 2 ", " foo1"])
+            self.admin.assert_icommand("ils -AL foo1", 'STDOUT_SINGLELINE', [" 1 ", " foo1"])
+            self.admin.assert_icommand("ils -AL foo1", 'STDOUT_SINGLELINE', [" 2 ", " foo1"])
 
-        self.admin.assert_icommand("ils -AL foo2", 'STDOUT_SINGLELINE', [" 0 ", " foo2"])
-        self.admin.assert_icommand("ils -AL foo2", 'STDOUT_SINGLELINE', [" 1 ", " foo2"])
+            self.admin.assert_icommand("ils -AL foo2", 'STDOUT_SINGLELINE', [" 0 ", " foo2"])
+            self.admin.assert_icommand("ils -AL foo2", 'STDOUT_SINGLELINE', [" 1 ", " foo2"])
 
-        self.user0.assert_icommand("ils -AL bar0", 'STDOUT_SINGLELINE', [" 1 ", " bar0"])
-        self.user0.assert_icommand("ils -AL bar0", 'STDOUT_SINGLELINE', [" 2 ", " bar0"])
+            self.user0.assert_icommand("ils -AL bar0", 'STDOUT_SINGLELINE', [" 1 ", " bar0"])
+            self.user0.assert_icommand("ils -AL bar0", 'STDOUT_SINGLELINE', [" 2 ", " bar0"])
 
-        self.user0.assert_icommand("ils -AL bar1", 'STDOUT_SINGLELINE', [" 0 ", " bar1"])
-        self.user0.assert_icommand("ils -AL bar1", 'STDOUT_SINGLELINE', [" 1 ", " bar1"])
+            self.user0.assert_icommand("ils -AL bar1", 'STDOUT_SINGLELINE', [" 0 ", " bar1"])
+            self.user0.assert_icommand("ils -AL bar1", 'STDOUT_SINGLELINE', [" 1 ", " bar1"])
 
-        self.user0.assert_icommand("ils -AL bar2", 'STDOUT_SINGLELINE', [" 0 ", " bar2"])
-        self.user0.assert_icommand("ils -AL bar2", 'STDOUT_SINGLELINE', [" 1 ", " bar2"])
+            self.user0.assert_icommand("ils -AL bar2", 'STDOUT_SINGLELINE', [" 0 ", " bar2"])
+            self.user0.assert_icommand("ils -AL bar2", 'STDOUT_SINGLELINE', [" 1 ", " bar2"])
 
-        # =-=-=-=-=-=-=-
-        # TEARDOWN
-        for i in range(num_children):
-            self.admin.assert_icommand("irm -f foo%d" % i)
-            self.user0.assert_icommand("irm -f bar%d" % i)
+        finally:
+            # =-=-=-=-=-=-=-
+            # TEARDOWN
+            for i in range(num_children):
+                self.admin.run_icommand("irm -f foo%d" % i)
+                self.user0.run_icommand("irm -f bar%d" % i)
 
-        self.admin.assert_icommand("iadmin rmchildfromresc repl leaf_b")
-        self.admin.assert_icommand("iadmin rmchildfromresc repl leaf_a")
-        self.admin.assert_icommand("iadmin rmresc leaf_b")
-        self.admin.assert_icommand("iadmin rmresc leaf_a")
-        self.admin.assert_icommand("iadmin rmresc repl")
+            self.admin.run_icommand("iadmin rmchildfromresc repl leaf_b")
+            self.admin.run_icommand("iadmin rmchildfromresc repl leaf_a")
+            self.admin.run_icommand("iadmin rmresc leaf_b")
+            self.admin.run_icommand("iadmin rmresc leaf_a")
+            self.admin.run_icommand("iadmin rmresc repl")
 
     def test_rebalance_for_child_with_substring_in_name(self):
         hostname = lib.get_hostname()

--- a/server/api/src/rsDataObjRename.cpp
+++ b/server/api/src/rsDataObjRename.cpp
@@ -36,11 +36,12 @@
 #include "irods_re_structs.hpp"
 #include "irods_logger.hpp"
 #include "key_value_proxy.hpp"
-#include "logical_locking.hpp"
 #include "scoped_privileged_client.hpp"
 
 #define IRODS_FILESYSTEM_ENABLE_SERVER_SIDE_API
 #include "filesystem.hpp"
+
+#include "logical_locking.hpp"
 
 #include <chrono>
 

--- a/server/api/src/rsDataObjUnlink.cpp
+++ b/server/api/src/rsDataObjUnlink.cpp
@@ -36,7 +36,6 @@
 #include "irods_hierarchy_parser.hpp"
 #include "irods_at_scope_exit.hpp"
 #include "irods_logger.hpp"
-#include "logical_locking.hpp"
 #include "scoped_privileged_client.hpp"
 
 #define IRODS_QUERY_ENABLE_SERVER_SIDE_API
@@ -47,6 +46,8 @@
 
 #define IRODS_REPLICA_ENABLE_SERVER_SIDE_API
 #include "data_object_proxy.hpp"
+
+#include "logical_locking.hpp"
 
 #include "boost/filesystem/path.hpp"
 #include "fmt/format.h"
@@ -384,7 +385,8 @@ int rsMvDataObjToTrash(
                 addKeyVal(&dataObjUnlinkInp->condInput, RESC_HIER_STR_KW, hier.c_str());
             }
             catch (const irods::exception& e) {
-                irods::log(PASS(irods::error(e)));
+                irods::log(LOG_NOTICE, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, e.client_display_what()));
+
                 // Continuation is intentional. See irods/irods#3154.
                 if(!getValByKey(&dataObjUnlinkInp->condInput, FORCE_FLAG_KW)) {
                     return e.code();

--- a/server/core/include/catalog_utilities.hpp
+++ b/server/core/include/catalog_utilities.hpp
@@ -116,21 +116,45 @@ namespace irods::experimental::catalog
         {"zone", entity_type::zone}
     };
 
-    /// \brief Determines whether the connected user can modify metadata on a given entity.
+    /// \brief Describes types of access in the iRODS permission model.
+    /// \since 4.2.9
+    enum class access_type
+    {
+        null                 = 1000,
+        execute              = 1010,
+        read_annotation      = 1020,
+        read_system_metadata = 1030,
+        read_metadata        = 1040,
+        read_object          = 1050,
+        write_annotation     = 1060,
+        create_metadata      = 1070,
+        modify_metadata      = 1080,
+        delete_metadata      = 1090,
+        administer_object    = 1100,
+        create_object        = 1110,
+        modify_object        = 1120,
+        delete_object        = 1130,
+        create_token         = 1140,
+        delete_token         = 1150,
+        curate               = 1160,
+        own                  = 1200
+    };
+
+    /// \brief Determines whether the connected user can modify a given entity.
     ///
     /// \param[in] _comm iRODS connection structure
     /// \param[in] _db_conn ODBC connection to the database
     /// \param[in] _object_id ID of the object in question in the catalog
     /// \param[in] _entity The type of entity that the object ID refers to
     ///
-    /// \retval true if user has permission to modify metadata
-    /// \retval false if user does not have permission to modify metadata
+    /// \retval true if user has permission to modify the entity
+    /// \retval false if user does not have permission to modify the entity
     ///
     /// \since 4.2.9
-    auto user_has_permission_to_modify_metadata(RsComm& _comm,
-                                                nanodbc::connection& _db_conn,
-                                                int _object_id,
-                                                const entity_type _entity) -> bool;
+    auto user_has_permission_to_modify_entity(RsComm& _comm,
+                                              nanodbc::connection& _db_conn,
+                                              int _object_id,
+                                              const entity_type _entity) -> bool;
 
     /// \throws irods::exception
     /// \since 4.2.9

--- a/server/core/include/finalize_utilities.hpp
+++ b/server/core/include/finalize_utilities.hpp
@@ -14,7 +14,7 @@ namespace irods
 {
     /// \brief Takes the ACLs included in the condInput and applies them to the objPath of _inp
     ///
-    /// \param[in/out] _comm
+    /// \param[in,out] _comm
     /// \param[in] _inp Supplies the objPath and condInput
     ///
     /// \since 4.2.9
@@ -22,7 +22,7 @@ namespace irods
 
     /// \brief Takes the metadata included in the condInput and applies them to the objPath of _inp
     ///
-    /// \param[in/out] _comm
+    /// \param[in,out] _comm
     /// \param[in] _inp Supplies the objPath and condInput
     ///
     /// \since 4.2.9
@@ -30,8 +30,8 @@ namespace irods
 
     /// \brief Calls _dataObjChksum with the REGISTER_CHKSUM_KW
     ///
-    /// \param[in/out] _comm
-    /// \param[in/out] _info Required for _dataObjChksum
+    /// \param[in,out] _comm
+    /// \param[in,out] _info Required for _dataObjChksum
     /// \param[in] _original_checksum
     ///
     /// \returns the computed checksum
@@ -43,8 +43,8 @@ namespace irods
 
     /// \brief Calls _dataObjChksum with the VERIFY_CHKSUM_KW
     ///
-    /// \param[in/out] _comm
-    /// \param[in/out] _info Required for _dataObjChksum
+    /// \param[in,out] _comm
+    /// \param[in,out] _info Required for _dataObjChksum
     /// \param[in] _original_checksum
     ///
     /// \returns empty string if calculated checksum does not match the original; else, the computed checksum
@@ -60,8 +60,8 @@ namespace irods
     /// the return value is likely the result of a resource which cannot stat its data in the
     /// expected manner. In this case, the result recorded by the plugin is "trusted".
     ///
-    /// \param[in/out] _comm
-    /// \param[in/out] _info
+    /// \param[in,out] _comm
+    /// \param[in,out] _info
     /// \parma[in] _verify_size Verify the recorded size against the size in the vault
     /// \param[in] _recorded_size Size to verify against
     ///
@@ -79,21 +79,10 @@ namespace irods
     /// \since 4.2.9
     auto duplicate_l1_descriptor(const l1desc& _src) -> l1desc;
 
-    /// \brief Marks the specified replica as stale in the catalog
-    ///
-    /// \param[in/out] _comm
-    /// \param[in] _l1desc
-    /// \param[in/out] _info Holds affected replica information
-    ///
-    /// \returns Status returned by rsModDataObjMeta
-    ///
-    /// \since 4.2.9
-    auto stale_replica(RsComm& _comm, const l1desc& _l1desc, DataObjInfo& _info) -> int;
-
     /// \brief Calls applyRule on the specified post-PEP name
     ///
-    /// \param[in/out] _comm
-    /// \param[in/out] _l1desc
+    /// \param[in,out] _comm
+    /// \param[in,out] _l1desc
     /// \param[in] _operation_status
     /// \param[in] _pep_name
     ///
@@ -107,7 +96,7 @@ namespace irods
 
     /// \brief Call rs_replica_close without touching the catalog
     ///
-    /// \param[in/out] _comm
+    /// \param[in,out] _comm
     /// \param[in] _fd l1 descriptor index
     /// \param[in] _preserve_replica_state_table Whether the RST entry should be preserved or erased
     ///

--- a/server/core/include/logical_locking.hpp
+++ b/server/core/include/logical_locking.hpp
@@ -1,7 +1,11 @@
 #ifndef IRODS_LOGICAL_LOCKING_HPP
 #define IRODS_LOGICAL_LOCKING_HPP
 
+#include "replica_state_table.hpp"
+
 #include <string_view>
+
+/// \file
 
 struct DataObjInfo;
 struct DataObjInp;
@@ -152,39 +156,16 @@ namespace irods::logical_locking
     /// \endparblock
     ///
     /// \param[in,out] _comm
-    /// \param[in] _data_id Data ID for object to lock
-    /// \param[in] _replica_number Target replica number
+    /// \param[in] _ctx Context for publishing an RST entry (see irods::replica_state_table::publish::context for details)
     /// \param[in] _lock_type Indicates the type of lock to set the replicas to, except the target replica
     ///
     /// \returns Error code on failure
     ///
     /// \since 4.2.9
     auto lock_and_publish(
-        RsComm&             _comm,
-        const std::uint64_t _data_id,
-        const int           _replica_number,
-        const lock_type     _lock_type) -> int;
-
-    /// \brief Lock data object using specified lock type, update RST, publish to catalog
-    ///
-    /// \parblock
-    /// Lock a data object which has no target replica. The main use of this function
-    /// would be to lock a data object on the creation of a new replica for said data object.
-    /// All replicas for the existing data object will be set to the appropriate status based
-    /// on the specified _lock_type.
-    /// \endparblock
-    ///
-    /// \param[in,out] _comm
-    /// \param[in] _data_id Data ID for object to lock
-    /// \param[in] _lock_type Indicates the type of lock to set the replicas to
-    ///
-    /// \returns Error code on failure
-    ///
-    /// \since 4.2.9
-    auto lock_before_create_and_publish(
-        RsComm&             _comm,
-        const std::uint64_t _data_id,
-        const lock_type     _lock_type) -> int;
+        RsComm&                      _comm,
+        const irods::replica_state_table::publish::context& _ctx,
+        const lock_type              _lock_type) -> int;
 
     /// \brief Unlock data object, update RST, publish to catalog
     ///
@@ -195,8 +176,7 @@ namespace irods::logical_locking
     /// \endparblock
     ///
     /// \param[in,out] _comm
-    /// \param[in] _data_id Data ID for object to unlock
-    /// \param[in] _replica_number Target replica number
+    /// \param[in] _ctx Context for publishing an RST entry (see irods::replica_state_table::publish::context for details)
     /// \param[in] _replica_status Desired replica status for the target replica
     /// \param[in] _other_replica_statuses The desired replica status for the sibling replicas
     ///
@@ -204,33 +184,10 @@ namespace irods::logical_locking
     ///
     /// \since 4.2.9
     auto unlock_and_publish(
-        RsComm&             _comm,
-        const std::uint64_t _data_id,
-        const int           _replica_number,
-        const int           _replica_status,
-        const int           _other_replica_statuses = restore_status) -> int;
-
-    /// \brief Unlock data object which has no target replica, update RST, publish to catalog
-    ///
-    /// \parblock
-    /// Unlock a data object which was locked without a target replica. The main use of this
-    /// function would be to recover from a failure in the creation of a new replica on an
-    /// existing data object which was locked for said creation of said replica. Due to the
-    /// failure, there would still not be a replica to target, so this is simply a counterpart
-    /// to the lock_before_create_and_publish interface.
-    /// \endparblock
-    ///
-    /// \param[in,out] _comm
-    /// \param[in] _data_id Data ID for object to unlock
-    /// \param[in] _replica_statuses The desired replica status for the sibling replicas
-    ///
-    /// \returns Error code on failure
-    ///
-    /// \since 4.2.9
-    auto unlock_before_create_and_publish(
-        RsComm&             _comm,
-        const std::uint64_t _data_id,
-        const int           _replica_statuses) -> int;
+        RsComm&                      _comm,
+        const irods::replica_state_table::publish::context& _ctx,
+        const int                    _replica_status,
+        const int                    _other_replica_statuses = restore_status) -> int;
 
     /// \brief Check to see if the data object will lock out some operation.
     ///

--- a/server/core/src/catalog_utilities.cpp
+++ b/server/core/src/catalog_utilities.cpp
@@ -51,10 +51,10 @@ namespace irods::experimental::catalog
         _bp.statement.bind(_bp.index, &value);
     } // bind_integer_to_statement
 
-    auto user_has_permission_to_modify_metadata(RsComm& _comm,
-                                                nanodbc::connection& _db_conn,
-                                                int _object_id,
-                                                const entity_type _entity_type) -> bool
+    auto user_has_permission_to_modify_entity(RsComm& _comm,
+                                              nanodbc::connection& _db_conn,
+                                              int _object_id,
+                                              const entity_type _entity_type) -> bool
     {
         using log = irods::experimental::log;
 
@@ -70,8 +70,7 @@ namespace irods::experimental::catalog
                                                " a.object_id = '{}'", _comm.clientUser.userName, _object_id);
 
                 if (auto row = execute(_db_conn, query); row.next()) {
-                    constexpr int access_modify_object = 1120;
-                    return row.get<int>(0) >= access_modify_object;
+                    return static_cast<access_type>(row.get<int>(0)) >= access_type::modify_object;
                 }
                 break;
             }
@@ -86,7 +85,7 @@ namespace irods::experimental::catalog
                 break;
         }
         return false;
-    } // user_has_permission_to_modify_metadata
+    } // user_has_permission_to_modify_entity
 
     auto throw_if_catalog_provider_service_role_is_invalid() -> void
     {


### PR DESCRIPTION
Adds 2 features to the data_object_finalize API plugin:

 1. Checks permissions of the authenticated user to update system
    metadata on the specified data object.

 2. There are now a few immutable columns in r_data_main when attempting
    to modify through this interface. These include the data_id,
    data_name, and coll_id. These are logical level information which
    should not be changed outside of a specific operation (e.g. rename).

---

CI tests running