### PR TITLE
[#5592] Added test for irepl (4-2-stable)

### DIFF
--- a/scripts/irods/lib.py
+++ b/scripts/irods/lib.py
@@ -682,3 +682,13 @@ def metadata_attr_with_value_exists(session, attr, value):
         '"select META_DATA_ATTR_VALUE where META_DATA_ATTR_NAME = \'{}\'"'.format(attr)])
     print(out)
     return value in out
+
+def create_ufs_resource(resource_name, user):
+    vault_name = resource_name + '_vault'
+    vault_directory = os.path.join(user.local_session_dir, vault_name)
+    vault = socket.gethostname() + ':' + vault_directory
+    user.assert_icommand(['iadmin', 'mkresc', resource_name, 'unixfilesystem', vault], 'STDOUT', [resource_name])
+
+def create_replication_resource(resource_name, user):
+    user.assert_icommand(['iadmin', 'mkresc', resource_name, 'replication'], 'STDOUT', [resource_name])
+

--- a/server/api/src/rsDataObjRepl.cpp
+++ b/server/api/src/rsDataObjRepl.cpp
@@ -144,6 +144,7 @@ namespace
             }
 
             _destination_replica.checksum(checksum_string);
+            rst::update(_destination_replica.data_id(), _destination_replica);
 
             if (_source_replica.checksum() != checksum_string) {
                 THROW(USER_CHKSUM_MISMATCH, fmt::format(


### PR DESCRIPTION
Do we want to erase the checksum if replication fails?

Right now, if a replication fails, the replica is marked as stale, but keeps the bad checksum.