### PR TITLE
Fixed nanodbc dependency in build hook (4-2-stable)

### DIFF
--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -33,7 +33,7 @@ def install_building_dependencies(externals_directory):
         'irods-externals-fmt6.1.2-1',
         'irods-externals-json3.7.3-0',
         'irods-externals-libarchive3.3.2-1',
-        'irods-externals-nanodbc2.13.0-0',
+        'irods-externals-nanodbc2.13.0-1',
         'irods-externals-zeromq4-14.1.6-0'
         ]
     if externals_directory is None or externals_directory == 'None':


### PR DESCRIPTION
This is required so that iRODS can be built in CI