### PR TITLE
[5545] send better error code when resource is in a hierarchy (4-2-stable)

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -4347,7 +4347,7 @@ irods::error db_del_resc_op(
                   "resource '%s' has a parent or child",
                   _resc_name );
         addRErrorMsg( &_ctx.comm()->rError, 0, errMsg );
-        return ERROR( CAT_RESOURCE_NOT_EMPTY, "resource not empty" );
+        return ERROR( CHILD_EXISTS, "resource has a parent or child" );
     }
 
     cllBindVars[cllBindVarCount++] = _resc_name;


### PR DESCRIPTION
helps to distinguish between resource not being empty