### PR TITLE
Various fixes for federation (master)

### DIFF
--- a/server/api/src/rsDataObjCopy.cpp
+++ b/server/api/src/rsDataObjCopy.cpp
@@ -125,41 +125,6 @@ int open_source_data_obj(rsComm_t *rsComm, dataObjInp_t& inp)
         inp.oprType = COPY_DEST;
         inp.openFlags = O_CREAT | O_WRONLY | O_TRUNC;
 
-        irods::file_object_ptr file_obj(new irods::file_object());
-        std::string hier{};
-        auto cond_input = irods::experimental::make_key_value_proxy(inp.condInput);
-
-        try {
-            if (!cond_input.contains(RESC_HIER_STR_KW)) {
-                std::tie(file_obj, hier) = irods::resolve_resource_hierarchy(irods::CREATE_OPERATION, rsComm, inp);
-                cond_input[RESC_HIER_STR_KW] = hier;
-            }
-            else {
-                hier = cond_input.at(RESC_HIER_STR_KW).value().data();
-                dataObjInfo_t* dataObjInfoHead{};
-                irods::error fac_err = irods::file_object_factory(rsComm, &inp, file_obj, &dataObjInfoHead);
-                if (!fac_err.ok()) {
-                    irods::log(fac_err);
-                }
-            }
-        }
-        catch (const irods::exception& e) {
-            irods::log(LOG_ERROR, fmt::format(
-                "[{}:{}] - [{}]",
-                __FUNCTION__, __LINE__, e.client_display_what()));
-
-            return e.code();
-        }
-
-        if (irods::hierarchy_has_replica(file_obj, hier) && !cond_input.contains(FORCE_FLAG_KW)) {
-            irods::log(LOG_ERROR, fmt::format(
-                "[{}:{}] - force flag required to overwrite data object for copy "
-                "[error_code=[{}], path=[{}], hierarchy=[{}]",
-                __FUNCTION__, __LINE__, inp.objPath, hier));
-
-            return OVERWRITE_WITHOUT_FORCE_FLAG;
-        }
-
         int destL1descInx = rsDataObjOpen(rsComm, &inp);
         if ( destL1descInx == CAT_UNKNOWN_COLLECTION ) {
             /* collection does not exist. make one */
@@ -193,7 +158,7 @@ int open_source_data_obj(rsComm_t *rsComm, dataObjInp_t& inp)
     {
         openedDataObjInp_t dataObjCloseInp{};
         dataObjCloseInp.l1descInx = _inx;
-        dataObjCloseInp.bytesWritten = L1desc[_inx].dataSize;
+        dataObjCloseInp.bytesWritten = L1desc[L1desc[_inx].srcL1descInx].dataObjInfo->dataSize;
 
         rodsLog(LOG_DEBUG8, "[%s:%d] - closing [%s]", __FUNCTION__, __LINE__, L1desc[_inx].dataObjInp->objPath);
 
@@ -259,7 +224,7 @@ int open_source_data_obj(rsComm_t *rsComm, dataObjInp_t& inp)
                 // These must be saved before the L1 descriptor is free'd.
                 *transStat = (transferStat_t*)malloc(sizeof(transferStat_t));
                 memset(*transStat, 0, sizeof(transferStat_t));
-                (*transStat)->bytesWritten = L1desc[destL1descInx].dataSize;
+                (*transStat)->bytesWritten = L1desc[srcL1descInx].dataObjInfo->dataSize;
                 (*transStat)->numThreads = L1desc[destL1descInx].dataObjInp->numThreads;
 
                 if (const int ec = close_destination_data_obj(rsComm, destL1descInx); ec < 0) {
@@ -306,6 +271,11 @@ int open_source_data_obj(rsComm_t *rsComm, dataObjInp_t& inp)
         L1desc[destL1descInx].srcL1descInx = srcL1descInx;
         L1desc[destL1descInx].dataSize = L1desc[srcL1descInx].dataObjInfo->dataSize;
         rstrcpy(L1desc[destL1descInx].dataObjInfo->dataType, L1desc[srcL1descInx].dataObjInfo->dataType, NAME_LEN);
+
+        // The input dataSize is used by legacy parallel transfer operations to determine
+        // the number of threads. Set this to the size of the source object so that the transfer
+        // can be set up successfully.
+        L1desc[destL1descInx].dataObjInp->dataSize = L1desc[srcL1descInx].dataObjInfo->dataSize;
 
         const int thread_count = getNumThreads(
             rsComm,

--- a/server/api/src/rsDataObjOpen.cpp
+++ b/server/api/src/rsDataObjOpen.cpp
@@ -1134,6 +1134,17 @@ int rsDataObjOpen(rsComm_t *rsComm, dataObjInp_t *dataObjInp)
     const auto data_object_exists = fs::server::exists(*rsComm, dataObjInp->objPath);
     const auto fd = rsDataObjOpen_impl(rsComm, dataObjInp);
 
+    // Do not update the collection mtime if the logical path refers to a remote
+    // zone. There is a known limitation in the iRODS protocol which does not allow
+    // for further communication over the server port with the remote server in
+    // parallel transfer situations once initiated. Further, if the remote zone
+    // cares about updating the mtime, the remote API endpoint called should have
+    // updated the collection mtime already, so it is unnecessary.
+    if (const auto zone_hint = fs::zone_name(fs::path{dataObjInp->objPath});
+        zone_hint && !isLocalZone(zone_hint->data())) {
+        return fd;
+    }
+
     // Update the parent collection's mtime.
     if (fd >= minimum_valid_file_descriptor && !data_object_exists) {
         const auto parent_path = fs::path{dataObjInp->objPath}.parent_path();

--- a/server/api/src/rsDataObjPut.cpp
+++ b/server/api/src/rsDataObjPut.cpp
@@ -675,6 +675,18 @@ int rsDataObjPut(rsComm_t* rsComm,
     namespace fs = ix::filesystem;
 
     const auto ec = rsDataObjPut_impl(rsComm, dataObjInp, dataObjInpBBuf, portalOprOut);
+
+    // Do not update the collection mtime if the logical path refers to a remote
+    // zone. There is a known limitation in the iRODS protocol which does not allow
+    // for further communication over the server port with the remote server in
+    // parallel transfer situations once initiated. Further, if the remote zone
+    // cares about updating the mtime, the remote API endpoint called should have
+    // updated the collection mtime already, so it is unnecessary.
+    if (const auto zone_hint = fs::zone_name(fs::path{dataObjInp->objPath});
+        zone_hint && !isLocalZone(zone_hint->data())) {
+        return ec;
+    }
+
     const auto parent_path = fs::path{dataObjInp->objPath}.parent_path();
 
     // Update the parent collection's mtime.

--- a/server/core/include/rodsConnect.h
+++ b/server/core/include/rodsConnect.h
@@ -153,7 +153,7 @@ int getRemoteZoneHost(rsComm_t *rsComm,
                       rodsServerHost_t **rodsServerHost,
                       char *remotZoneOpr);
 
-int isLocalZone(char *zoneHint);
+int isLocalZone(const char *zoneHint);
 
 int isSameZone(char *zoneHint1, char *zoneHint2);
 

--- a/server/core/src/objDesc.cpp
+++ b/server/core/src/objDesc.cpp
@@ -708,6 +708,7 @@ namespace irods
         l1desc.dataObjInp = static_cast<DataObjInp*>(std::malloc(sizeof(DataObjInp)));
         std::memset(l1desc.dataObjInp, 0, sizeof(DataObjInp));
         replDataObjInp(&_inp, l1desc.dataObjInp);
+        l1desc.dataObjInp->dataSize = dataSize;
 
         l1desc.dataObjInpReplFlag = 1;
         l1desc.dataObjInfo = replica.get();

--- a/server/core/src/rodsConnect.cpp
+++ b/server/core/src/rodsConnect.cpp
@@ -785,7 +785,7 @@ getAndConnRemoteZone( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
 }
 
 int
-isLocalZone( char *zoneHint ) {
+isLocalZone(const char *zoneHint ) {
     int status;
     rodsServerHost_t *icatServerHost = NULL;
 


### PR DESCRIPTION
Fixes several issues concerning federation (mostly parallel transfer related) which have occurred over time in master and 4-2-stable:
  - `icp` does not need to resolve the resource hierarchy for the destination replica as this can be done in `rsDataObjOpen`. This logic was here mainly to uphold the `OVERWRITE_WITHOUT_FORCE_FLAG` rules for `icp`, but this is being handled earlier in the function and the deleted logic was only checking for existing replicas anyway.
  - The `dataSize` parameter and `bytesWritten` are very touchy in `rsDataObjCopy` so I've put back a couple of these to more closely resemble how they were being set in the past. This mainly involves using the size of the data object for the source data object as the "expected" dataSize for the destination data object as well as the input dataSize for the destination data object and the bytesWritten for the `transStat`.
  - Prevent updating collection mtime in open and put when the path is not in the local zone because of the issue described in #5017 and also because it is unnecessary - the remote zone will take care of updating the collection mtime if it cares about that because it is part of the logic for these API endpoints.
  - You'll find the new test specifically for the linked issue at the bottom of `test_federation.py`. It uses an existing rule for dynamic PEPs which is exactly what I needed for the federation test, so that's why it is referring to the other issue number in the name of the rule text.

Federation test suite passed at the bench, but running through CI as well as the usual suite. CI tests are running.
