### PR TITLE
Implemented new library: scoped_permission (4-2-stable)

### DIFF
--- a/cmake/development_library.cmake
+++ b/cmake/development_library.cmake
@@ -546,6 +546,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/core/include/rsIcatOpr.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/rsLog.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/scoped_client_identity.hpp
+  ${CMAKE_SOURCE_DIR}/server/core/include/scoped_permission.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/scoped_privileged_client.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/server_utilities.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/specColl.hpp

--- a/lib/filesystem/include/filesystem/filesystem.hpp
+++ b/lib/filesystem/include/filesystem/filesystem.hpp
@@ -44,6 +44,9 @@ namespace irods::experimental::filesystem
         std::string units;
     };
 
+    /// A tag type used to instruct an operation to run in administrator mode.
+    inline struct admin_tag {} admin;
+
     namespace NAMESPACE_IMPL
     {
         // Operational functions
@@ -141,6 +144,47 @@ namespace irods::experimental::filesystem
         auto remove_all(rxComm& _comm, const path& _p, remove_options _opts = remove_options::none) -> std::uintmax_t;
 
         auto permissions(rxComm& _comm, const path& _p, const std::string& _user_or_group, perms _prms) -> void;
+
+        /// \brief Modifies the permissions of a collection or data object.
+        ///
+        /// \throws filesystem_error If the path is empty, exceeds the path limit, or does not
+        ///                          reference a collection or data object.
+        ///
+        /// \param[in] _admin         A tag which instructs the function to operate in administrator mode.
+        ///                           The client must be an administrator to use this function.
+        /// \param[in] _comm          The communication object.
+        /// \param[in] _p             The logical path to a collection or data object.
+        /// \param[in] _user_or_group The user or group for which the permission will apply to.
+        /// \param[in] _prms          The permission to set for \p _user_or_group.
+        ///
+        /// \since 4.2.11
+        auto permissions(admin_tag, rxComm& _comm, const path& _p, const std::string& _user_or_group, perms _prms) -> void;
+
+        /// \brief Modifies the inheritance option of a collection.
+        ///
+        /// \throws filesystem_error If the path is empty, exceeds the path limit, or does not
+        ///                          reference a collection.
+        ///
+        /// \param[in] _comm  The communication object.
+        /// \param[in] _p     The path to a collection.
+        /// \param[in] _value A boolean indicating whether inheritance should be enabled or not.
+        ///
+        /// \since 4.2.11
+        auto enable_inheritance(rxComm& _comm, const path& _p, bool _value) -> void;
+
+        /// \brief Modifies the inheritance option of a collection.
+        ///
+        /// \throws filesystem_error If the path is empty, exceeds the path limit, or does not
+        ///                          reference a collection.
+        ///
+        /// \param[in] _admin A tag which instructs the function to operate in administrator mode. The client
+        ///                   must be an administrator to use this function.
+        /// \param[in] _comm  The communication object.
+        /// \param[in] _p     The path to a collection.
+        /// \param[in] _value A boolean indicating whether inheritance should be enabled or not.
+        ///
+        /// \since 4.2.11
+        auto enable_inheritance(admin_tag _admin, rxComm& _comm, const path& _p, bool _value) -> void;
 
         auto rename(rxComm& _comm, const path& _from, const path& _to) -> void;
 

--- a/lib/filesystem/include/filesystem/object_status.hpp
+++ b/lib/filesystem/include/filesystem/object_status.hpp
@@ -33,6 +33,7 @@ namespace irods::experimental::filesystem
         explicit object_status(object_type _type, const std::vector<entity_permission>& _perms = {})
             : type_{_type}
             , perms_{_perms}
+            , inheritance_{}
         {
         }
 
@@ -48,17 +49,20 @@ namespace irods::experimental::filesystem
 
         auto type() const noexcept -> object_type { return type_; }
         auto permissions() const noexcept -> const std::vector<entity_permission>& { return perms_; }
+        auto is_inheritance_enabled() const noexcept -> bool { return inheritance_; }
 
         // Modifiers
 
-        auto type(object_type _ot) noexcept -> void    { type_ = _ot; }
+        auto type(object_type _ot) noexcept -> void { type_ = _ot; }
         auto permissions(const std::vector<entity_permission>& _perms) -> void { perms_ = _perms; }
+        auto inheritance(bool _value) noexcept -> void { inheritance_ = _value; }
 
         // clang-format on
 
     private:
         object_type type_;
         std::vector<entity_permission> perms_;
+        bool inheritance_;
     };
 } // namespace irods::experimental::filesystem
 

--- a/lib/filesystem/include/filesystem/permissions.hpp
+++ b/lib/filesystem/include/filesystem/permissions.hpp
@@ -10,9 +10,7 @@ namespace irods::experimental::filesystem
         null,
         read,
         write,
-        own,
-        inherit,
-        noinherit
+        own
     };
 
     struct entity_permission

--- a/lib/filesystem/src/filesystem.cpp
+++ b/lib/filesystem/src/filesystem.cpp
@@ -99,6 +99,7 @@ namespace irods::experimental::filesystem::NAMESPACE_IMPL
             long long ctime;
             long long mtime;
             std::vector<entity_permission> prms;
+            bool inheritance;
         };
 
         auto to_permission_enum(const std::string& _perm) -> perms
@@ -107,8 +108,6 @@ namespace irods::experimental::filesystem::NAMESPACE_IMPL
             if      (_perm == "read object")   { return perms::read; }
             else if (_perm == "modify object") { return perms::write; }
             else if (_perm == "own")           { return perms::own; }
-            else if (_perm == "inherit")       { return perms::inherit; }
-            else if (_perm == "noinherit")     { return perms::noinherit; }
             // clang-format on
 
             return perms::null;
@@ -173,6 +172,29 @@ namespace irods::experimental::filesystem::NAMESPACE_IMPL
             }
         }
 
+        auto get_inheritance(rxComm& _comm, const path& _p, int _object_type) -> bool
+        {
+            if (COLL_OBJ_T != _object_type) {
+                return false;
+            }
+
+            irods::experimental::query_builder qb;
+
+            if (const auto zone = zone_name(_p); zone) {
+                qb.zone_hint(*zone);
+            }
+
+            qb.type(irods::experimental::query_type::general);
+
+            const auto gql = fmt::format("select COLL_INHERITANCE where COLL_NAME = '{}'", _p.c_str());
+
+            for (const auto& row : qb.build(_comm, gql)) {
+                return std::atoi(row[0].data());
+            }
+
+            return false;
+        }
+
         auto stat(rxComm& _comm, const path& _p) -> stat
         {
             dataObjInp_t input{};
@@ -184,7 +206,7 @@ namespace irods::experimental::filesystem::NAMESPACE_IMPL
             s.error = rxObjStat(&_comm, &input, &output);
 
             if (s.error >= 0) {
-                irods::at_scope_exit<std::function<void()>> at_scope_exit{[output] {
+                irods::at_scope_exit at_scope_exit{[output] {
                     freeRodsObjStat(output);
                 }};
 
@@ -202,6 +224,7 @@ namespace irods::experimental::filesystem::NAMESPACE_IMPL
                 s.mode = static_cast<int>(output->dataMode);
                 s.owner_name = output->ownerName;
                 s.owner_zone = output->ownerZone;
+                s.inheritance = get_inheritance(_comm, _p, s.type);
 
                 set_permissions(_comm, _p, s);
             }
@@ -270,6 +293,100 @@ namespace irods::experimental::filesystem::NAMESPACE_IMPL
             }
 
             throw filesystem_error{"cannot remove: unknown object type", _p, make_error_code(CAT_NOT_A_DATAOBJ_AND_NOT_A_COLLECTION)};
+        }
+
+        auto set_permissions(bool _add_admin_flag,
+                             rxComm& _comm,
+                             const path& _p,
+                             const std::string& _user_or_group,
+                             perms _prms) -> void
+        {
+            detail::throw_if_path_length_exceeds_limit(_p);
+
+            char username[NAME_LEN]{};
+            char zone[NAME_LEN]{};
+
+            auto ec = parseUserName(_user_or_group.c_str(), username, zone);
+
+            if (ec != 0) {
+                throw filesystem_error{"cannot parse user/group name", _p, make_error_code(ec)};
+            }
+
+            modAccessControlInp_t input{};
+
+            input.userName = username;
+            input.zone = zone;
+
+            char path[MAX_NAME_LEN]{};
+            std::strncpy(path, _p.c_str(), std::strlen(_p.c_str()));
+            input.path = path;
+
+            char access[16]{};
+
+            if (_add_admin_flag) {
+                std::strcpy(access, "admin:");
+            }
+
+            switch (_prms) {
+                case perms::null:
+                    std::strncat(access, "null", 4);
+                    break;
+
+                case perms::read:
+                    std::strncat(access, "read", 4);
+                    break;
+
+                case perms::write:
+                    std::strncat(access, "write", 5);
+                    break;
+
+                case perms::own:
+                    std::strncat(access, "own", 3);
+                    break;
+            }
+
+            input.accessLevel = access;
+
+            ec = rxModAccessControl(&_comm, &input);
+
+            if (ec != 0) {
+                throw filesystem_error{"cannot set permissions", _p, make_error_code(ec)};
+            }
+        }
+
+        auto set_inheritance(bool _add_admin_flag, rxComm& _comm, const path& _p, bool _value) -> void
+        {
+            detail::throw_if_path_is_empty(_p);
+            detail::throw_if_path_length_exceeds_limit(_p);
+
+            if (!is_collection(_comm, _p)) {
+                throw filesystem_error{"existing path is not a collection", _p, make_error_code(NOT_A_COLLECTION)};
+            }
+
+            modAccessControlInp_t input{};
+
+            input.userName = "";
+            input.zone = "";
+
+            char path[MAX_NAME_LEN]{};
+            std::strncpy(path, _p.c_str(), std::strlen(_p.c_str()));
+            input.path = path;
+
+            char access[16]{};
+
+            if (_add_admin_flag) {
+                std::strcpy(access, "admin:");
+            }
+
+            std::strcat(access, _value ? "inherit" : "noinherit");
+
+            input.accessLevel = access;
+
+            const auto ec = rxModAccessControl(&_comm, &input);
+
+            if (ec != 0) {
+                throw filesystem_error{"cannot set inheritance", _p, make_error_code(ec)};
+            }
         }
 
         auto has_prefix(const path& _p, const path& _prefix) -> bool
@@ -799,61 +916,26 @@ namespace irods::experimental::filesystem::NAMESPACE_IMPL
 
     auto permissions(rxComm& _comm, const path& _p, const std::string& _user_or_group, perms _prms) -> void
     {
-        detail::throw_if_path_length_exceeds_limit(_p);
+        constexpr auto add_admin_flag = false;
+        set_permissions(add_admin_flag, _comm, _p, _user_or_group, _prms);
+    }
 
-        char username[NAME_LEN]{};
-        char zone[NAME_LEN]{};
+    auto permissions(admin_tag, rxComm& _comm, const path& _p, const std::string& _user_or_group, perms _prms) -> void
+    {
+        constexpr auto add_admin_flag = true;
+        set_permissions(add_admin_flag, _comm, _p, _user_or_group, _prms);
+    }
 
-        auto ec = parseUserName(_user_or_group.c_str(), username, zone);
+    auto enable_inheritance(rxComm& _comm, const path& _p, bool _value) -> void
+    {
+        constexpr auto add_admin_flag = false;
+        set_inheritance(add_admin_flag, _comm, _p, _value);
+    }
 
-        if (ec != 0) {
-            throw filesystem_error{"cannot parse user/group name", _p, make_error_code(ec)};
-        }
-
-        modAccessControlInp_t input{};
-
-        input.userName = username;
-        input.zone = zone;
-
-        char path[MAX_NAME_LEN]{};
-        std::strncpy(path, _p.c_str(), std::strlen(_p.c_str()));
-        input.path = path;
-
-        char access[10]{};
-
-        switch (_prms) {
-            case perms::null:
-                std::strncpy(access, "null", 4);
-                break;
-
-            case perms::read:
-                std::strncpy(access, "read", 4);
-                break;
-
-            case perms::write:
-                std::strncpy(access, "write", 5);
-                break;
-
-            case perms::own:
-                std::strncpy(access, "own", 3);
-                break;
-
-            case perms::inherit:
-                std::strncpy(access, "inherit", 7);
-                break;
-
-            case perms::noinherit:
-                std::strncpy(access, "noinherit", 9);
-                break;
-        }
-
-        input.accessLevel = access;
-
-        ec = rxModAccessControl(&_comm, &input);
-
-        if (ec != 0) {
-            throw filesystem_error{"cannot set permissions", _p, make_error_code(ec)};
-        }
+    auto enable_inheritance(admin_tag, rxComm& _comm, const path& _p, bool _value) -> void
+    {
+        constexpr auto add_admin_flag = true;
+        set_inheritance(add_admin_flag, _comm, _p, _value);
     }
 
     auto rename(rxComm& _comm, const path& _old_p, const path& _new_p) -> void
@@ -987,6 +1069,7 @@ namespace irods::experimental::filesystem::NAMESPACE_IMPL
         object_status status;
 
         status.permissions(s.prms);
+        status.inheritance(s.inheritance);
 
         // XXX This does not handle the case of object_type::unknown.
         // This type means a file exists, but the type is unknown.

--- a/server/core/include/scoped_permission.hpp
+++ b/server/core/include/scoped_permission.hpp
@@ -1,0 +1,89 @@
+#ifndef IRODS_SCOPED_PERMISSION_HPP
+#define IRODS_SCOPED_PERMISSION_HPP
+
+/// \file
+
+#include "rcConnect.h"
+#include "scoped_privileged_client.hpp"
+#include "rodsLog.h"
+
+#define IRODS_FILESYSTEM_ENABLE_SERVER_SIDE_API
+#include "filesystem.hpp"
+
+namespace irods::experimental
+{
+    /// This class provides a convenient RAII-style mechanism for setting permissions
+    /// on a collection or data object for the duration of a scoped block.
+    ///
+    /// Instances of this class are not copyable or moveable.
+    ///
+    /// \since 4.2.11
+    class scoped_permission
+    {
+    public:
+        /// Constructs a scoped_permission object and sets the requested permissions on the given
+        /// collection or data object to the client in RsComm::clientUser.
+        ///
+        /// \param[in] _comm The server communication object.
+        /// \param[in] _path A logical path representing a collection or data object.
+        /// \param[in] _perm The permissions to set on the collection or data object for the client.
+        ///
+        /// \exception irods::experimental::filesystem::filesystem_error
+        scoped_permission(RsComm& _comm, const filesystem::path& _path, filesystem::perms _perm)
+            : comm_{_comm}
+            , path_{_path}
+            , old_perm_{filesystem::perms::null}
+        {
+            namespace fs = filesystem;
+            
+            // Elevate privileges so that we can see the permissions.
+            scoped_privileged_client spc{comm_};
+
+            // Capture the client's current permissions if any.
+            const auto s = fs::server::status(comm_, path_);
+            for (auto&& entity : s.permissions()) {
+                if (entity.name == comm_.clientUser.userName &&
+                    entity.zone == comm_.clientUser.rodsZone)
+                {
+                    old_perm_ = entity.prms;
+                    break;
+                }
+            }
+
+            // Set the client's requested permissions on the collection or data object.
+            fs::server::permissions(fs::admin, comm_, path_, comm_.clientUser.userName, _perm);
+        }
+        
+        scoped_permission(const scoped_permission&) = delete;
+        auto operator=(const scoped_permission&) -> scoped_permission& = delete;
+        
+        /// Restores the permissions on the collection or data object to their original value.
+        ~scoped_permission()
+        {
+            namespace fs = filesystem;
+
+            // Elevate privileges in case the client did not set adequate permissions
+            // to restore them.
+            scoped_privileged_client spc{comm_};
+
+            try {
+                fs::server::permissions(fs::admin, comm_, path_, comm_.clientUser.userName, old_perm_);
+            }
+            catch (const fs::filesystem_error& e) {
+                rodsLog(LOG_ERROR, "%s: %s [error_code=%d]", __func__, e.what(), e.code().value());
+            }
+        }
+
+    private:
+        RsComm& comm_;
+        const filesystem::path path_;
+        filesystem::perms old_perm_;
+    }; // class scoped_permission
+} // namespace irods::experimental
+
+// Remove the macro so that it does not leak into the file that included it.
+// This keeps other headers from being affected by the presence of this macro.
+#undef IRODS_FILESYSTEM_ENABLE_SERVER_SIDE_API
+
+#endif // IRODS_SCOPED_PERMISSION_HPP
+

--- a/unit_tests/src/filesystem/test_filesystem.cpp
+++ b/unit_tests/src/filesystem/test_filesystem.cpp
@@ -349,6 +349,20 @@ TEST_CASE("filesystem")
         REQUIRE(fs::client::remove(conn, p, fs::remove_options::no_trash));
     }
 
+    SECTION("read/modify inheritance on a collection")
+    {
+        auto status = fs::client::status(conn, sandbox);
+        REQUIRE_FALSE(status.is_inheritance_enabled());
+
+        fs::client::enable_inheritance(conn, sandbox, true);
+        status = fs::client::status(conn, sandbox);
+        REQUIRE(status.is_inheritance_enabled());
+
+        fs::client::enable_inheritance(conn, sandbox, false);
+        status = fs::client::status(conn, sandbox);
+        REQUIRE_FALSE(status.is_inheritance_enabled());
+    }
+
     SECTION("collection iterators")
     {
         // Creates three data objects under the path "_collection".


### PR DESCRIPTION
Allows operations to temporarily grant permissions on a collection or data
object for the duration of a scoped block.