### PR TITLE
[5654] change default maximum threads to "default" (4-2-stable)

### DIFF
--- a/packaging/core.re.template
+++ b/packaging/core.re.template
@@ -273,7 +273,7 @@ acSetRescSchemeForRepl {msiSetDefaultResc("demoResc","null"); }
 # acSetNumThreads {msiSetNumThreads("16","4","default"); }
 # acSetNumThreads {msiSetNumThreads("default","16","default"); }
 # acSetNumThreads {ON($KVPairs.rescName == "macResc") {msiSetNumThreads("default","0","default"); } }
-acSetNumThreads {msiSetNumThreads("default","16","default"); }
+acSetNumThreads {msiSetNumThreads("default","default","default"); }
 # 10) acDataDeletePolicy - This rule set the policy for deleting data objects.
 #     This is the PreProcessing rule for delete.
 # Only one function can be called:

--- a/scripts/irods/test/settings.py
+++ b/scripts/irods/test/settings.py
@@ -20,7 +20,7 @@ class FEDERATION(object):
     TEST_FILE_SIZE = 4*1024*1024
     LARGE_FILE_SIZE = 64*1024*1024
     TEST_FILE_COUNT = 300
-    MAX_THREADS = 16
+    MAX_THREADS = 4
 
     # resource hierarchies
     REMOTE_PT_RESC_HIER = 'federation_remote_passthrough;federation_remote_unixfilesystem_leaf'

--- a/scripts/irods/test/test_federation.py
+++ b/scripts/irods/test/test_federation.py
@@ -160,9 +160,9 @@ class Test_ICommands(SessionsMixin, unittest.TestCase):
             **parameters)
 
         if filesize >= self.config['large_file_size']:
-            # put file in remote collection, ask for 6 threads
+            # put file in remote collection, ask for 4 threads
             test_session.assert_icommand(
-                "iput -v -N 6 {filepath} {remote_home_collection}/".format(**parameters), 'STDOUT_SINGLELINE', '6 thr')
+                "iput -v -N 4 {filepath} {remote_home_collection}/".format(**parameters), 'STDOUT_SINGLELINE', '4 thr')
         else:
             # put file in remote collection
             test_session.assert_icommand(
@@ -322,7 +322,7 @@ class Test_ICommands(SessionsMixin, unittest.TestCase):
 
         # for the next transfer we expect the number of threads
         # to be capped at max_threads or max_threads+1,
-        # e.g: we will look for '16 thr' or '17 thr' in stdout
+        # e.g: we will look for '4 thr' or '5 thr' in stdout
         parameters['max_threads_plus_one'] = parameters['max_threads'] + 1
         expected_output_regex = '[{max_threads}|{max_threads_plus_one}] thr'.format(
             **parameters)

--- a/scripts/irods/test/test_icp.py
+++ b/scripts/irods/test/test_icp.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import inspect
 import os
+import json
 import shutil
 import sys
 
@@ -13,6 +14,7 @@ import ustrings
 from .. import lib
 from . import session
 from .. import core_file
+from .. import paths
 from .. import test
 from .rule_texts_for_tests import rule_texts
 from ..configuration import IrodsConfig
@@ -73,6 +75,11 @@ class Test_Icp(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', '
                 self.alice.assert_icommand(['irm', '-f', dest_path])
                 self.alice.assert_icommand(['irm', '-f', another_dest_path])
 
+        server_config_filename = paths.server_config_path()
+        with open(server_config_filename) as f:
+            svr_cfg = json.load(f)
+            default_max_threads = svr_cfg['advanced_settings']['default_number_of_transfer_threads']
+
         default_buffer_size_in_bytes = 4 * (1024 ** 2)
         cases = [
             {
@@ -81,7 +88,7 @@ class Test_Icp(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', '
             },
             {
                 'size':     34603008,
-                'threads':  (34603008 / default_buffer_size_in_bytes) + 1
+                'threads':  min(default_max_threads, (34603008 / default_buffer_size_in_bytes) + 1)
             }
         ]
 

--- a/scripts/irods/test/test_iphymv.py
+++ b/scripts/irods/test/test_iphymv.py
@@ -7,6 +7,7 @@ if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
+import json
 import shutil
 import time
 
@@ -14,6 +15,7 @@ import replica_status_test
 from . import session
 from . import settings
 from .. import lib
+from .. import paths
 from .. import test
 from ..configuration import IrodsConfig
 from ..controller import IrodsController
@@ -316,6 +318,11 @@ class Test_iPhymv(ResourceBase, unittest.TestCase):
             finally:
                 self.user0.assert_icommand(['irm', '-f', dest_path])
 
+        server_config_filename = paths.server_config_path()
+        with open(server_config_filename) as f:
+            svr_cfg = json.load(f)
+            default_max_threads = svr_cfg['advanced_settings']['default_number_of_transfer_threads']
+
         default_buffer_size_in_bytes = 4 * (1024 ** 2)
         cases = [
             {
@@ -324,7 +331,7 @@ class Test_iPhymv(ResourceBase, unittest.TestCase):
             },
             {
                 'size':     34603008,
-                'threads':  (34603008 / default_buffer_size_in_bytes) + 1
+                'threads':  min(default_max_threads, (34603008 / default_buffer_size_in_bytes) + 1)
             }
         ]
 

--- a/scripts/irods/test/test_irepl.py
+++ b/scripts/irods/test/test_irepl.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import os
 import sys
+import json
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -415,6 +416,11 @@ class test_irepl_with_two_basic_ufs_resources(session.make_sessions_mixin([('oth
             finally:
                 user0.assert_icommand(['irm', '-f', dest_path])
 
+        server_config_filename = paths.server_config_path()
+        with open(server_config_filename) as f:
+            svr_cfg = json.load(f)
+            default_max_threads = svr_cfg['advanced_settings']['default_number_of_transfer_threads']
+
         default_buffer_size_in_bytes = 4 * (1024 ** 2)
         cases = [
             {
@@ -423,7 +429,7 @@ class test_irepl_with_two_basic_ufs_resources(session.make_sessions_mixin([('oth
             },
             {
                 'size':     34603008,
-                'threads':  (34603008 / default_buffer_size_in_bytes) + 1
+                'threads':  min(default_max_threads, (34603008 / default_buffer_size_in_bytes) + 1)
             }
         ]
 


### PR DESCRIPTION
shown to be enough to saturate a connection

defined in server_config.json as advanced_settings.default_number_of_transfer_threads
