### PR TITLE
[_XXXX] add DB plugin op for data_object_finalize (4-2-stable)

### DIFF
--- a/plugins/api/src/data_object_finalize.cpp
+++ b/plugins/api/src/data_object_finalize.cpp
@@ -421,6 +421,7 @@ namespace
             return SYS_INVALID_INPUT_PARAM;
         }
 
+#if 0
         // Establish connection with the database for use with nanodbc.
         // A connection with the database is already established via the
         // RsComm, but this allows us to atomically update the database
@@ -438,6 +439,7 @@ namespace
 
             return SYS_CONFIG_FILE_ERR;
         }
+#endif
 
         try {
             // This section perform permissions checks and update ticket information
@@ -491,13 +493,14 @@ namespace
         // Actually update the catalog with the information passed in. This is done
         // transactionally so that the update occurs atomically.
         try {
+#if 0
             const auto ec = ic::execute_transaction(db_conn, [&](auto& _trans) -> int
             {
                 set_data_object_state(db_conn, _trans, replicas);
                 return 0;
             });
-
-            if (ec < 0) {
+#endif
+            if (const auto ec = chl_data_object_finalize(*_comm, replicas.dump()); ec < 0) {
                 *_output = to_bytes_buffer(make_error_object("failed to update catalog").dump());
                 return ec;
             }
@@ -506,7 +509,7 @@ namespace
                 // If the update was successful and file modified is not supposed to be
                 // triggered, then we can return with success here.
                 *_output = to_bytes_buffer(make_error_object("", database_updated).dump());
-                return ec;
+                return 0;
             }
         }
         catch (const irods::exception& e) {

--- a/server/core/include/irods_database_constants.hpp
+++ b/server/core/include/irods_database_constants.hpp
@@ -112,6 +112,7 @@ namespace irods {
     const std::string DATABASE_OP_GET_REPL_LIST_FOR_LEAF_BUNDLES( "database_get_repl_list_for_leaf_bundles" );
     const std::string DATABASE_OP_CHECK_PERMISSION_TO_MODIFY_DATA_OBJECT{"database_check_permission_to_modify_data_object"};
     const std::string DATABASE_OP_UPDATE_TICKET_WRITE_BYTE_COUNT{"database_update_ticket_write_byte_count"};
+    const std::string DATABASE_OP_DATA_OBJECT_FINALIZE{"database_data_object_finalize"};
 }; // namespace irods
 
 #endif // __IRODS_DATABASE_CONSTANTS_HPP__

--- a/server/icat/include/icatHighLevelRoutines.hpp
+++ b/server/icat/include/icatHighLevelRoutines.hpp
@@ -271,4 +271,20 @@ auto chl_check_permission_to_modify_data_object(RsComm& _comm, const rodsLong_t 
 /// \since 4.2.9
 auto chl_update_ticket_write_byte_count(RsComm& _comm, const rodsLong_t _data_id, const rodsLong_t _bytes_written) -> int;
 
+/// \brief High-level wrapper for database operation which emulates data_object_finalize in the database plugin
+///
+/// \parblock
+/// This is the high-level wrapper for the database operation used by data_object_finalize to atomically
+/// update rows in R_DATA_MAIN for all replicas of a particular data object.
+/// \endparblock
+///
+/// \param[in,out] _comm iRODS comm structure
+/// \param[in] _replicas String holding a JSON array of replicas (see rc_data_object_finalize for details)
+///
+/// \returns Error code based on whether updating the catalog was successful
+/// \retval 0 Success
+///
+/// \since 4.2.9
+auto chl_data_object_finalize(RsComm& _comm, const std::string_view _replicas) -> int;
+
 #endif /* ICAT_HIGHLEVEL_ROUTINES_H */

--- a/server/icat/src/icatHighLevelRoutines.cpp
+++ b/server/icat/src/icatHighLevelRoutines.cpp
@@ -4772,3 +4772,24 @@ auto chl_update_ticket_write_byte_count(RsComm& _comm, const rodsLong_t _data_id
     return ret.code();
 } // chl_update_ticket_write_byte_count
 
+auto chl_data_object_finalize(RsComm& _comm, const std::string_view _replicas) -> int
+{
+    irods::database_object_ptr db_obj_ptr;
+    if (const auto ret = irods::database_factory(database_plugin_type, db_obj_ptr); !ret.ok()) {
+        irods::log(PASS(ret));
+        return ret.code();
+    }
+
+    irods::plugin_ptr db_plug_ptr;
+    if (const auto ret = db_obj_ptr->resolve(irods::DATABASE_INTERFACE, db_plug_ptr); !ret.ok()) {
+        irods::log(PASSMSG("failed to resolve database interface", ret));
+        return ret.code();
+    }
+
+    irods::first_class_object_ptr ptr = boost::dynamic_pointer_cast<irods::first_class_object>(db_obj_ptr);
+    irods::database_ptr           db = boost::dynamic_pointer_cast<irods::database>(db_plug_ptr);
+
+    const auto ret = db->call(&_comm, irods::DATABASE_OP_DATA_OBJECT_FINALIZE, ptr, _replicas);
+
+    return ret.code();
+} // chl_data_object_finalize


### PR DESCRIPTION
This adds a database plugin operation for use in the
data_object_finalize API plugin. This is meant to act as interchangeable
logic with the nanodbc-based database interactions which exists in the
API plugin today. This change is needed because of some possible bugs in
the implementation and/or in the nanodbc library itself. For more
details on the issue, see: https://github.com/nanodbc/nanodbc/issues/267

---

The relevant nanodbc code has been replaced by use of this database operation. Seems to work with both Postgres and Oracle.