### PR TITLE
[#5691] Relax usage of default resource for put (4-2-stable)

### DIFF
--- a/scripts/irods/test/test_ichksum.py
+++ b/scripts/irods/test/test_ichksum.py
@@ -210,6 +210,7 @@ class Test_Ichksum(resource_suite.ResourceBase, unittest.TestCase):
         self.admin.assert_icommand(['ichksum', '-K', '--no-compute', data_object])
         self.admin.assert_icommand(['ichksum', '-K', '--no-compute', '-n0', data_object])
 
+    @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, "Skip for topology testing from resource server")
     def test_ichksum_reports_when_replicas_do_not_share_identical_checksums__issue_5252(self):
         data_object = 'foo'
         self.admin.assert_icommand(['istream', 'write', data_object], input='some data')
@@ -379,6 +380,7 @@ C- {5}:
            data_object_3)
         self.assertTrue(re.match(pattern, out))
 
+    @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, "Skip for topology testing from resource server")
     def test_ichksum_honors_the_size_in_the_catalog_when_computing_checksums__issue_5401(self):
         data_object = os.path.join(self.admin.session_collection, 'foo')
         contents = 'the data'
@@ -410,6 +412,7 @@ C- {5}:
         do_test(0, '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
         do_test(3, 'uXdtfd9FnJrVsOHWrGHie++16Z/WJEZndgDXys71RNA=')
 
+    @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, "Skip for topology testing from resource server")
     def test_ichksum_detects_when_the_size_in_storage_is_less_than_the_size_in_catalog__issue_5401(self):
         data_object = 'issue_5401.txt'
 

--- a/scripts/irods/test/test_iphymv.py
+++ b/scripts/irods/test/test_iphymv.py
@@ -423,6 +423,7 @@ class test_iphymv_exit_codes(session.make_sessions_mixin([('otherrods', 'rods')]
         finally:
             IrodsController().start()
 
+    @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'Delete on resolution of #5690')
     def test_exit_code_for_authentication_failure(self):
         config = IrodsConfig()
 

--- a/scripts/irods/test/test_iput.py
+++ b/scripts/irods/test/test_iput.py
@@ -459,9 +459,10 @@ class Test_Iput(session.make_sessions_mixin(rodsadmins, rodsusers), unittest.Tes
 
                 assert_object_is_good()
 
+                # TODO: This overwrites some existing replica but will not emit an error. Might change in future.
                 # implictly target default resource, which has no replica
-                self.user.assert_icommand(['iput', '-f', local_file, logical_path], 'STDERR', 'HIERARCHY_ERROR')
-                assert_object_is_good()
+                #self.user.assert_icommand(['iput', '-f', local_file, logical_path], 'STDERR', 'HIERARCHY_ERROR')
+                #assert_object_is_good()
 
                 # target a specific resource which has no replica
                 self.user.assert_icommand(['iput', '-R', target_resc_2, '-f', local_file, logical_path], 'STDERR', 'HIERARCHY_ERROR')

--- a/scripts/irods/test/test_irepl.py
+++ b/scripts/irods/test/test_irepl.py
@@ -134,12 +134,14 @@ class Test_Irepl(session.make_sessions_mixin([('otherrods', 'rods')], [('alice',
 
             self.admin.run_icommand(['iadmin', 'rmresc', repl_resc])
 
+    @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'Skip for Topology Tests on Resource')
     def test_irepl_reports_checksum_mismatch_error_when_bytes_within_the_data_size_are_overwritten__issue_5592(self):
         # Passing "True" causes the test to trigger a checksum mismatch by overwriting a character
         # within a replica. The overwrite will not cause a mismatch in the size. Only the data within
         # the replica will change.
         self.do_test_for_issue_5592(trigger_checksum_mismatch_error=True)
 
+    @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'Skip for Topology Tests on Resource')
     def test_irepl_does_not_return_a_checksum_mismatch_error_after_appending_data_to_a_replica_out_of_band__issue_5592(self):
         # Passing "False" causes the test to append a character to a replica. This will not trigger
         # a checksum mismatch error because the API honors the data size in the catalog when calculating

--- a/scripts/irods/test/test_iticket.py
+++ b/scripts/irods/test/test_iticket.py
@@ -316,6 +316,7 @@ class Test_Iticket(SessionsMixin, unittest.TestCase):
         self.admin.assert_icommand(['iticket', 'create', 'read', collname_1, ticket])
         self.admin.assert_icommand(['ils', '-r', self.admin.session_collection + '/' + collname_1], 'STDOUT_SINGLELINE', filename_3)
         self.user.assert_icommand(['ils', '-r', self.admin.session_collection + '/' + collname_1, '-t', ticket], 'STDOUT_SINGLELINE', filename_3)
+        self.admin.assert_icommand(['iticket', 'delete', ticket])
 
     def test_ticket_create_ticket_with_string_as_number__issue_3553(self):
         filename = '3553_test_file'

--- a/scripts/irods/test/test_native_rule_engine_plugin.py
+++ b/scripts/irods/test/test_native_rule_engine_plugin.py
@@ -143,6 +143,7 @@ class Test_Native_Rule_Engine_Plugin(resource_suite.ResourceBase, unittest.TestC
                                                                                                'RULE_ENGINE_CONTINUE = 5000000'])
 
     @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Native only test when not in a topology')
+    @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'Do not run in topology on resource server')
     def test_peps_for_parallel_mode_transfers__4404(self):
 
         (fd, largefile) = tempfile.mkstemp()
@@ -188,6 +189,7 @@ class Test_Native_Rule_Engine_Plugin(resource_suite.ResourceBase, unittest.TestC
             self.admin.assert_icommand(['iadmin', 'rum'])
 
     @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Native only test when not in a topology')
+    @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'Do not run in topology on resource server')
     def test_dynamic_policy_enforcement_point_exception_for_plugins__4128(self):
         try:
             path = self.admin.get_vault_session_path('demoResc')
@@ -222,6 +224,7 @@ class Test_Native_Rule_Engine_Plugin(resource_suite.ResourceBase, unittest.TestC
             self.admin.assert_icommand(['iadmin', 'rum'])
 
     @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Native only test when not in a topology')
+    @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'Do not run in topology on resource server')
     def test_dynamic_policy_enforcement_point_exception_for_apis__4128(self):
         try:
             path = self.admin.get_vault_session_path('demoResc')

--- a/server/api/src/rsDataObjPhymv.cpp
+++ b/server/api/src/rsDataObjPhymv.cpp
@@ -583,6 +583,7 @@ namespace
         }
         L1desc[destination_l1descInx].srcL1descInx = source_l1descInx;
         L1desc[destination_l1descInx].dataSize = L1desc[source_l1descInx].dataObjInfo->dataSize;
+        L1desc[destination_l1descInx].dataObjInp->dataSize = L1desc[source_l1descInx].dataObjInfo->dataSize;
 
         const int thread_count = getNumThreads(
             &_comm,

--- a/server/api/src/rsDataObjPut.cpp
+++ b/server/api/src/rsDataObjPut.cpp
@@ -480,13 +480,11 @@ namespace
     {
         const auto cond_input = irods::experimental::make_key_value_proxy(_inp.condInput);
 
-        const auto destination_resource = cond_input.contains(DEST_RESC_NAME_KW) ? cond_input.at(DEST_RESC_NAME_KW).value()
-                                        : cond_input.contains(DEF_RESC_NAME_KW)  ? cond_input.at(DEF_RESC_NAME_KW).value()
-                                        : std::string_view{};
-
-        if (file_obj->replicas().empty() || !cond_input.contains(FORCE_FLAG_KW) || destination_resource.empty()) {
+        if (file_obj->replicas().empty() || !cond_input.contains(FORCE_FLAG_KW) || !cond_input.contains(DEST_RESC_NAME_KW)) {
             return;
         }
+
+        const auto destination_resource = cond_input.at(DEST_RESC_NAME_KW).value();
 
         const auto hier_match{
             [&destination_resource, &replicas = file_obj->replicas()]()

--- a/server/api/src/rsDataObjRepl.cpp
+++ b/server/api/src/rsDataObjRepl.cpp
@@ -510,6 +510,7 @@ namespace
 
         L1desc[destination_l1descInx].srcL1descInx = source_l1descInx;
         L1desc[destination_l1descInx].dataSize = source_data_obj_info.dataSize;
+        L1desc[destination_l1descInx].dataObjInp->dataSize = source_data_obj_info.dataSize;
 
         const int thread_count = getNumThreads(
             &_comm,

--- a/server/core/src/irods_resource_redirect.cpp
+++ b/server/core/src/irods_resource_redirect.cpp
@@ -354,8 +354,16 @@ namespace irods
 
             apply_policy_for_create_operation(_comm, _data_obj_inp, create_resc_name);
 
-            // If the replica exists on the target resource, use open/write
-            if (fac_err.ok() && hier_has_replica(create_resc_name, file_obj)) {
+            // If the data object exists, need to consider what operation is actually being done.
+            // In the case of a put or copy/rsync, which operates on the logical level, this should be
+            // treated as an overwrite because if any replica exists, we are considered to be
+            // overwriting the data object.. Otherwise, the operation is considering individual
+            // replicas and needs to see whether the hierarchy matching the provided keyword has a
+            // replica for this object.
+            const auto logical_operation = PUT_OPR == _data_obj_inp.oprType ||
+                                           COPY_DEST == _data_obj_inp.oprType ||
+                                           RSYNC_OPR == _data_obj_inp.oprType;
+            if (fac_err.ok() && (logical_operation || hier_has_replica(create_resc_name, file_obj))) {
                 oper = irods::WRITE_OPERATION;
             }
             else {


### PR DESCRIPTION
Matches 4.2.8 behavior. Topology tests still running, but passed in CI for timing, unit, core, and federation tests.