### PR TITLE
[#5723] rsDataObjGet sets output buffer size to zero for zero length data object (4-2-stable)

### DIFF
--- a/scripts/irods/test/test_iget.py
+++ b/scripts/irods/test/test_iget.py
@@ -71,3 +71,18 @@ class test_iget_general(session.make_sessions_mixin([('otherrods', 'rods')], [('
 
         do_test_iget_R_is_a_directive_not_a_preference__issue_4475(self, 1024)
         do_test_iget_R_is_a_directive_not_a_preference__issue_4475(self, 40 * 1024 * 1024)
+
+    def test_iget_correctly_handles_zero_length_file__issue_5723(self):
+        # Create a new empty data object.
+        data_object = 'foo'
+        self.user.assert_icommand(['itouch', data_object])
+        self.user.assert_icommand(['ils', '-l', data_object], 'STDOUT', [' 0 demoResc            0 '])
+
+        # Show that "iget" produces zero bytes.
+        self.user.assert_icommand(['iget', data_object, '-'])
+
+        # Show that "iget" produces a zero length file.
+        file_path = os.path.join(self.user.local_session_dir, 'foo')
+        self.user.assert_icommand(['iget', data_object, file_path])
+        self.assertEqual(0, os.path.getsize(file_path))
+

--- a/server/api/src/rsDataObjGet.cpp
+++ b/server/api/src/rsDataObjGet.cpp
@@ -82,6 +82,16 @@ namespace
                 __FUNCTION__, __LINE__, bytes_read,
                 replica.logical_path(), replica.hierarchy()));
         }
+        else if (0 == bytes_read) {
+            // Because clients may expect a buffer to always be returned, we set the
+            // length of the returned buffer to zero to indicate that it doesn't contain
+            // any valid data. A better solution is to not allocate anything and the clients
+            // use the bytes read as the indicator for how to move forward.
+            //
+            // This solution fixes this issue for clients that incorrectly use the buffer's
+            // size to determine if data was read.
+            _bbuf->len = 0;
+        }
 
         L1desc[_fd].oprStatus = bytes_read;
 


### PR DESCRIPTION
This solution fixes #5723 for `iget` and Jargon 4.3.2.2-SNAPSHOT.

I'm not aware of any other clients experiencing this issue.