### PR TITLE
[#5733] Only commit for tickets in check_permission_to_modify_data_object (master)

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -14699,13 +14699,26 @@ auto db_check_permission_to_modify_data_object_op(
                                       &icss);
 
     if (ec != 0) {
-        _rollback("check_permission_to_modify_data_object");
+        // Although the presence of a ticket is not a guarantee of a database update, it is
+        // the only case where a database update occurs as a result of calling cmlCheckDataObjId.
+        // Therefore, only rollback if there is ticket information present.
+        if (!std::string_view{mySessionTicket}.empty()) {
+            _rollback("check_permission_to_modify_data_object");
+        }
 
         const auto msg = fmt::format("user does not have permission to modify object with data id [{}]", _data_id);
 
         irods::log(LOG_NOTICE, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, msg));
 
         return ERROR(ec, msg);
+    }
+
+    // Although the presence of a ticket is not a guarantee of a database update, it is
+    // the only case where a database update occurs as a result of calling cmlCheckDataObjId.
+    // Therefore, return success if the ticket information is empty. Else, a commit may need
+    // to occur.
+    if (std::string_view{mySessionTicket}.empty()) {
+        return SUCCESS();
     }
 
     if (const auto commit_ec = cmlExecuteNoAnswerSql("commit", &icss); 0 != commit_ec) {

--- a/scripts/irods/test/test_quotas.py
+++ b/scripts/irods/test/test_quotas.py
@@ -65,7 +65,7 @@ class Test_Quotas(resource_suite.ResourceBase, unittest.TestCase):
                     cmd = 'irm -rf {0}'.format(filename_2) # clean up
                     self.admin.assert_icommand(cmd.split())
             time.sleep(2)  # remove once file hash fix is committed #2279
- 
+
     def test_iquota_empty__3048(self):
         cmd = 'iadmin suq' # no arguments
         self.admin.assert_icommand(cmd.split(), 'STDERR_SINGLELINE', 'ERROR: missing username parameter') # usage information
@@ -84,6 +84,9 @@ class Test_Quotas(resource_suite.ResourceBase, unittest.TestCase):
 
     def test_filter_out_groups_when_selecting_user__issue_3507(self):
         self.admin.assert_icommand(['igroupadmin', 'mkgroup', 'test_group_3507'])
-        # Attempt to set user quota passing in the name of a group; should fail
-        self.admin.assert_icommand(['iadmin', 'suq', 'test_group_3507', 'demoResc', '10000000'], 'STDERR_SINGLELINE', 'CAT_INVALID_USER')
 
+        try:
+            # Attempt to set user quota passing in the name of a group; should fail
+            self.admin.assert_icommand(['iadmin', 'suq', 'test_group_3507', 'demoResc', '10000000'], 'STDERR_SINGLELINE', 'CAT_INVALID_USER')
+        finally:
+            self.admin.assert_icommand(['iadmin', 'rmgroup', 'test_group_3507'])


### PR DESCRIPTION
This is not the complete solution for #5733, but does eliminate the bulk of the warning messages in the database logs. This will still result in a warning message when checking the permissions for an object being finalized via ticket access when no update has occurred for the ticket, but this is a much more niche case than every single call to finalize.

Tests running now
