### PR TITLE
[#5300] Server now creates PID file (4-2-stable)

### DIFF
--- a/server/core/src/rodsServer.cpp
+++ b/server/core/src/rodsServer.cpp
@@ -32,6 +32,8 @@
 #include <sys/un.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -222,7 +224,65 @@ namespace
             }
         }
         catch (...) {}
-    }
+    } // remove_leftover_rulebase_pid_files
+
+    int create_pid_file()
+    {
+        const auto pid_file = boost::filesystem::temp_directory_path() / "irods.pid";
+
+        // Open the PID file. If it does not exist, create it and give the owner
+        // permission to read and write to it.
+        const auto fd = open(pid_file.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+        if (fd == -1) {
+            rodsLog(LOG_ERROR, "Could not open PID file.");
+            return -1;
+        }
+
+        // Get the current open flags for the open file descriptor.
+        const auto flags = fcntl(fd, F_GETFD);
+        if (flags == -1) {
+            rodsLog(LOG_ERROR, "Could not retrieve open flags for PID file.");
+            return -1;
+        }
+
+        // Enable the FD_CLOEXEC option for the the open file descriptor.
+        // This option will cause successful calls to exec() to close the file descriptor.
+        // Keep in mind that record locks are NOT inherited by forked child processes.
+        if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1) {
+            rodsLog(LOG_ERROR, "Could not set FD_CLOEXEC on PID file.");
+            return -1;
+        }
+
+        struct flock input;
+        input.l_type = F_WRLCK;
+        input.l_whence = SEEK_SET;
+        input.l_start = 0;
+        input.l_len = 0;
+
+        // Try to acquire the write lock on the PID file. If we cannot get the lock,
+        // another instance of the application must already be running or something
+        // weird is going on.
+        if (fcntl(fd, F_SETLK, &input) == -1) {
+            if (EAGAIN == errno || EACCES == errno) {
+                rodsLog(LOG_ERROR, "Could not acquire write lock for PID file. Another instance "
+                                   "could be running already.");
+                return -1;
+            }
+        }
+        
+        if (ftruncate(fd, 0) == -1) {
+            rodsLog(LOG_ERROR, "Could not truncate PID file's contents.");
+            return -1;
+        }
+
+        const auto contents = fmt::format("{}\n", getpid());
+        if (write(fd, contents.data(), contents.size()) != static_cast<long>(contents.size())) {
+            rodsLog(LOG_ERROR, "Could not write PID to PID file.");
+            return -1;
+        }
+
+        return 0;
+    } // create_pid_file
 } // anonymous namespace
 
 static void set_agent_spawner_process_name(const InformationRequiredToSafelyRenameProcess& info) {
@@ -355,6 +415,11 @@ int main(int argc, char** argv)
         }
     }
 
+    const auto pid_file_fd = create_pid_file();
+    if (pid_file_fd == -1) {
+        return 1;
+    }
+
     rodsLog(LOG_NOTICE, "Initializing server ...");
 
     hnc::init("irods_hostname_cache", irods::get_hostname_cache_shared_memory_size());
@@ -420,17 +485,18 @@ int main(int argc, char** argv)
 
     agent_spawning_pid = fork();
 
+    // Agent factory process (child)
     if (agent_spawning_pid == 0) {
-        // Agent factory process (child)
+        close(pid_file_fd);
         ProcessType = AGENT_PT;
-        free( logDir );
-        return runIrodsAgentFactory( local_addr );
+        free(logDir);
+        return runIrodsAgentFactory(local_addr);
     }
     
     // Main iRODS server (parent)
     if (agent_spawning_pid < 0) {
-        rodsLog( LOG_ERROR, "fork() failed when attempting to create agent factory process" );
-        free( logDir );
+        rodsLog(LOG_ERROR, "fork() failed when attempting to create agent factory process");
+        free(logDir);
         return SYS_FORK_ERROR;
     }
 


### PR DESCRIPTION
This PR attempts to keep the irodsctl script from killing iRODS processes inside of a container by introducing a PID file.

With the PID file, the irodsctl script can confidently determine if a process is a descendant or not.