### PR TITLE
Implemented new library: scoped_permission (master)

### DIFF
--- a/cmake/development_library.cmake
+++ b/cmake/development_library.cmake
@@ -543,6 +543,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/core/include/rsIcatOpr.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/rsLog.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/scoped_client_identity.hpp
+  ${CMAKE_SOURCE_DIR}/server/core/include/scoped_permission.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/scoped_privileged_client.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/server_utilities.hpp
   ${CMAKE_SOURCE_DIR}/server/core/include/specColl.hpp

--- a/lib/filesystem/include/filesystem/filesystem.hpp
+++ b/lib/filesystem/include/filesystem/filesystem.hpp
@@ -52,6 +52,9 @@ namespace irods::experimental::filesystem
         std::string units;
     };
 
+    /// A tag type used to instruct an operation to run in administrator mode.
+    inline struct admin_tag {} admin;
+
     namespace NAMESPACE_IMPL
     {
         // Operational functions
@@ -151,6 +154,47 @@ namespace irods::experimental::filesystem
         auto remove_all(rxComm& _comm, const path& _p, extended_remove_options _opts) -> std::uintmax_t;
 
         auto permissions(rxComm& _comm, const path& _p, const std::string& _user_or_group, perms _prms) -> void;
+
+        /// \brief Modifies the permissions of a collection or data object.
+        ///
+        /// \throws filesystem_error If the path is empty, exceeds the path limit, or does not
+        ///                          reference a collection or data object.
+        ///
+        /// \param[in] _admin         A tag which instructs the function to operate in administrator mode.
+        ///                           The client must be an administrator to use this function.
+        /// \param[in] _comm          The communication object.
+        /// \param[in] _p             The logical path to a collection or data object.
+        /// \param[in] _user_or_group The user or group for which the permission will apply to.
+        /// \param[in] _prms          The permission to set for \p _user_or_group.
+        ///
+        /// \since 4.2.11
+        auto permissions(admin_tag, rxComm& _comm, const path& _p, const std::string& _user_or_group, perms _prms) -> void;
+
+        /// \brief Modifies the inheritance option of a collection.
+        ///
+        /// \throws filesystem_error If the path is empty, exceeds the path limit, or does not
+        ///                          reference a collection.
+        ///
+        /// \param[in] _comm  The communication object.
+        /// \param[in] _p     The path to a collection.
+        /// \param[in] _value A boolean indicating whether inheritance should be enabled or not.
+        ///
+        /// \since 4.2.11
+        auto enable_inheritance(rxComm& _comm, const path& _p, bool _value) -> void;
+
+        /// \brief Modifies the inheritance option of a collection.
+        ///
+        /// \throws filesystem_error If the path is empty, exceeds the path limit, or does not
+        ///                          reference a collection.
+        ///
+        /// \param[in] _admin A tag which instructs the function to operate in administrator mode. The client
+        ///                   must be an administrator to use this function.
+        /// \param[in] _comm  The communication object.
+        /// \param[in] _p     The path to a collection.
+        /// \param[in] _value A boolean indicating whether inheritance should be enabled or not.
+        ///
+        /// \since 4.2.11
+        auto enable_inheritance(admin_tag _admin, rxComm& _comm, const path& _p, bool _value) -> void;
 
         auto rename(rxComm& _comm, const path& _from, const path& _to) -> void;
 

--- a/lib/filesystem/include/filesystem/object_status.hpp
+++ b/lib/filesystem/include/filesystem/object_status.hpp
@@ -33,6 +33,7 @@ namespace irods::experimental::filesystem
         explicit object_status(object_type _type, const std::vector<entity_permission>& _perms = {})
             : type_{_type}
             , perms_{_perms}
+            , inheritance_{}
         {
         }
 
@@ -48,17 +49,20 @@ namespace irods::experimental::filesystem
 
         auto type() const noexcept -> object_type { return type_; }
         auto permissions() const noexcept -> const std::vector<entity_permission>& { return perms_; }
+        auto is_inheritance_enabled() const noexcept -> bool { return inheritance_; }
 
         // Modifiers
 
         auto type(object_type _ot) noexcept -> void { type_ = _ot; }
         auto permissions(const std::vector<entity_permission>& _perms) -> void { perms_ = _perms; }
+        auto inheritance(bool _value) noexcept -> void { inheritance_ = _value; }
 
         // clang-format on
 
     private:
         object_type type_;
         std::vector<entity_permission> perms_;
+        bool inheritance_;
     };
 } // namespace irods::experimental::filesystem
 

--- a/lib/filesystem/include/filesystem/permissions.hpp
+++ b/lib/filesystem/include/filesystem/permissions.hpp
@@ -10,9 +10,7 @@ namespace irods::experimental::filesystem
         null,
         read,
         write,
-        own,
-        inherit,
-        noinherit
+        own
     };
 
     struct entity_permission

--- a/server/core/include/scoped_permission.hpp
+++ b/server/core/include/scoped_permission.hpp
@@ -1,0 +1,89 @@
+#ifndef IRODS_SCOPED_PERMISSION_HPP
+#define IRODS_SCOPED_PERMISSION_HPP
+
+/// \file
+
+#include "rcConnect.h"
+#include "scoped_privileged_client.hpp"
+#include "rodsLog.h"
+
+#define IRODS_FILESYSTEM_ENABLE_SERVER_SIDE_API
+#include "filesystem.hpp"
+
+namespace irods::experimental
+{
+    /// This class provides a convenient RAII-style mechanism for setting permissions
+    /// on a collection or data object for the duration of a scoped block.
+    ///
+    /// Instances of this class are not copyable or moveable.
+    ///
+    /// \since 4.2.11
+    class scoped_permission
+    {
+    public:
+        /// Constructs a scoped_permission object and sets the requested permissions on the given
+        /// collection or data object to the client in RsComm::clientUser.
+        ///
+        /// \param[in] _comm The server communication object.
+        /// \param[in] _path A logical path representing a collection or data object.
+        /// \param[in] _perm The permissions to set on the collection or data object for the client.
+        ///
+        /// \exception irods::experimental::filesystem::filesystem_error
+        scoped_permission(RsComm& _comm, const filesystem::path& _path, filesystem::perms _perm)
+            : comm_{_comm}
+            , path_{_path}
+            , old_perm_{filesystem::perms::null}
+        {
+            namespace fs = filesystem;
+            
+            // Elevate privileges so that we can see the permissions.
+            scoped_privileged_client spc{comm_};
+
+            // Capture the client's current permissions if any.
+            const auto s = fs::server::status(comm_, path_);
+            for (auto&& entity : s.permissions()) {
+                if (entity.name == comm_.clientUser.userName &&
+                    entity.zone == comm_.clientUser.rodsZone)
+                {
+                    old_perm_ = entity.prms;
+                    break;
+                }
+            }
+
+            // Set the client's requested permissions on the collection or data object.
+            fs::server::permissions(fs::admin, comm_, path_, comm_.clientUser.userName, _perm);
+        }
+        
+        scoped_permission(const scoped_permission&) = delete;
+        auto operator=(const scoped_permission&) -> scoped_permission& = delete;
+        
+        /// Restores the permissions on the collection or data object to their original value.
+        ~scoped_permission()
+        {
+            namespace fs = filesystem;
+
+            // Elevate privileges in case the client did not set adequate permissions
+            // to restore them.
+            scoped_privileged_client spc{comm_};
+
+            try {
+                fs::server::permissions(fs::admin, comm_, path_, comm_.clientUser.userName, old_perm_);
+            }
+            catch (const fs::filesystem_error& e) {
+                rodsLog(LOG_ERROR, "%s: %s [error_code=%d]", __func__, e.what(), e.code().value());
+            }
+        }
+
+    private:
+        RsComm& comm_;
+        const filesystem::path path_;
+        filesystem::perms old_perm_;
+    }; // class scoped_permission
+} // namespace irods::experimental
+
+// Remove the macro so that it does not leak into the file that included it.
+// This keeps other headers from being affected by the presence of this macro.
+#undef IRODS_FILESYSTEM_ENABLE_SERVER_SIDE_API
+
+#endif // IRODS_SCOPED_PERMISSION_HPP
+

--- a/unit_tests/src/filesystem/test_filesystem.cpp
+++ b/unit_tests/src/filesystem/test_filesystem.cpp
@@ -360,6 +360,20 @@ TEST_CASE("filesystem")
         REQUIRE(fs::client::remove(conn, p, fs::remove_options::no_trash));
     }
 
+    SECTION("read/modify inheritance on a collection")
+    {
+        auto status = fs::client::status(conn, sandbox);
+        REQUIRE_FALSE(status.is_inheritance_enabled());
+
+        fs::client::enable_inheritance(conn, sandbox, true);
+        status = fs::client::status(conn, sandbox);
+        REQUIRE(status.is_inheritance_enabled());
+
+        fs::client::enable_inheritance(conn, sandbox, false);
+        status = fs::client::status(conn, sandbox);
+        REQUIRE_FALSE(status.is_inheritance_enabled());
+    }
+
     SECTION("collection iterators")
     {
         // Creates three data objects under the path "_collection".


### PR DESCRIPTION
Allows operations to temporarily grant permissions on a collection or data
object for the duration of a scoped block.