### PR TITLE
[#5602] Fix build for unit tests (master)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1210,7 +1210,7 @@ set(
 
 set(
   IRODS_SERVER_CORE_SOURCES
-  ${CMAKE_SOURCE_DIR}/server/core/src/irods_logger.cpp 
+  ${CMAKE_SOURCE_DIR}/server/core/src/irods_logger.cpp
   )
 
 add_library(

--- a/unit_tests/cmake/test_config/irods_data_object_modify_info.cmake
+++ b/unit_tests/cmake/test_config/irods_data_object_modify_info.cmake
@@ -11,10 +11,11 @@ set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
                             ${CMAKE_SOURCE_DIR}/server/core/include
                             ${CMAKE_SOURCE_DIR}/server/icat/include
                             ${CMAKE_SOURCE_DIR}/server/re/include
-                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
                             ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include
                             ${IRODS_EXTERNALS_FULLPATH_JSON}/include)
- 
+
 set(IRODS_TEST_LINK_LIBRARIES irods_common
                               irods_client
                               irods_plugin_dependencies

--- a/unit_tests/cmake/test_config/irods_linked_list_iterator.cmake
+++ b/unit_tests/cmake/test_config/irods_linked_list_iterator.cmake
@@ -9,10 +9,10 @@ set(IRODS_TEST_INCLUDE_PATH ${CMAKE_SOURCE_DIR}/lib/api/include
                             ${CMAKE_SOURCE_DIR}/server/core/include
                             ${CMAKE_SOURCE_DIR}/server/drivers/include
                             ${CMAKE_SOURCE_DIR}/server/re/include
-                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
                             ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
-                            ${IRODS_EXTERNALS_FULLPATH_JANSSON}/include)
- 
+                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
+
 set(IRODS_TEST_LINK_LIBRARIES irods_common
                               irods_server
                               ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so)

--- a/unit_tests/cmake/test_config/irods_packstruct.cmake
+++ b/unit_tests/cmake/test_config/irods_packstruct.cmake
@@ -7,7 +7,8 @@ set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
                             ${CMAKE_SOURCE_DIR}/lib/core/include
                             ${CMAKE_SOURCE_DIR}/lib/api/include
                             ${CMAKE_SOURCE_DIR}/server/core/include
+                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
                             ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
-                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include)
- 
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
+
 set(IRODS_TEST_LINK_LIBRARIES irods_common)


### PR DESCRIPTION
Unit tests were not building due to missing include dependency for the
fmt library which was introduced when the fmt library was added as a
dependency to irods_server_properties.hpp.