### PR TITLE
[related to #5786] Expose accessor for collection_entry::data_size_

### DIFF
--- a/lib/filesystem/include/filesystem/collection_entry.hpp
+++ b/lib/filesystem/include/filesystem/collection_entry.hpp
@@ -36,6 +36,7 @@ namespace irods::experimental::filesystem
         auto checksum() const noexcept -> const std::string&      { return checksum_; }
         auto owner() const noexcept -> const std::string&         { return owner_; }
         auto data_type() const noexcept -> const std::string&     { return data_type_; }
+        auto data_size() const noexcept -> std::uintmax_t         { return data_size_; }
 
         // Comparisons
 


### PR DESCRIPTION
Expose an accessor for the data_size_ member of the collection_entry (required to complete features in #5786)