### PR TITLE
[#4083] Install IrodsCXXCompiler CMake module and fix rsPhyPathReg.cpp includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1689,6 +1689,7 @@ install(
   ${CMAKE_SOURCE_DIR}/cmake/Modules/FindLibCXX.cmake
   ${CMAKE_SOURCE_DIR}/cmake/Modules/UseLibCXX.cmake
   ${CMAKE_SOURCE_DIR}/cmake/Modules/IrodsExternals.cmake
+  ${CMAKE_SOURCE_DIR}/cmake/Modules/IrodsCXXCompiler.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/irods/cmake/Modules
   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
   )

--- a/server/api/src/rsPhyPathReg.cpp
+++ b/server/api/src/rsPhyPathReg.cpp
@@ -1,6 +1,6 @@
 #include "rs_register_physical_path.hpp"
 
-#include <memory>
+#include <cstdlib>
 
 auto rsPhyPathReg(RsComm* _comm, DataObjInp* _inp) -> int
 {


### PR DESCRIPTION
In service of #4083

In libstdc++ 11, `#include <memory>` does not implicitly `#include <cstdlib>`, where `std::free( void* )` is found.
Also, I forgot to mark the `IrodsCXXCompiler` CMake module for installation.