### PR TITLE
Support SNI when connecting to remote irods server

### DIFF
--- a/lib/core/src/sslSockComm.cpp
+++ b/lib/core/src/sslSockComm.cpp
@@ -62,6 +62,16 @@ sslStart( rcComm_t *rcComm ) {
         return SSL_INIT_ERROR;
     }
 
+    status = SSL_set_tlsext_host_name( rcComm->ssl, rcComm->host );
+    if ( status != 1 ) {
+        sslLogError( "sslStart: error in SSL_set_tlsext_host_name" );
+        SSL_free( rcComm->ssl );
+        rcComm->ssl = NULL;
+        SSL_CTX_free( rcComm->ssl_ctx );
+        rcComm->ssl_ctx = NULL;
+        return SSL_INIT_ERROR;
+    }
+
     status = SSL_connect( rcComm->ssl );
     if ( status < 1 ) {
         sslLogError( "sslStart: error in SSL_connect" );

--- a/plugins/network/ssl/libssl.cpp
+++ b/plugins/network/ssl/libssl.cpp
@@ -685,8 +685,17 @@ irods::error ssl_client_start(
                 SSL_CTX_free( ctx );
             }
             else {
-                int status = SSL_connect( ssl );
-                std::string err_str = "error in SSL_connect";
+                int status = SSL_set_tlsext_host_name( ssl, ssl_obj->host().c_str() );
+                std::string err_str = "error in SSL_set_tlsext_host_name";
+                ssl_build_error_string( err_str );
+                if ( !( result = ASSERT_ERROR( status == 1, SSL_INIT_ERROR, err_str.c_str() ) ).ok() ) {
+                    SSL_free( ssl );
+                    SSL_CTX_free( ctx );
+                    return result;
+                }
+
+                status = SSL_connect( ssl );
+                err_str = "error in SSL_connect";
                 ssl_build_error_string( err_str );
                 if ( !( result = ASSERT_ERROR( status >= 1, SSL_HANDSHAKE_ERROR, err_str.c_str() ) ).ok() ) {
                     SSL_free( ssl );


### PR DESCRIPTION
Add SNI support to outgoing irods connections. This makes icommands and
irods behave as the python client and jargon applications such as
metalnx. It allows for advanced proxy setups.

Signed-off-by: Peter Verraedt <peter.verraedt@kuleuven.be>