### PR TITLE
Fix redirection logic and add hostname configuration to run_tests.py (master)

### DIFF
--- a/plugins/api/src/atomic_apply_acl_operations.cpp
+++ b/plugins/api/src/atomic_apply_acl_operations.cpp
@@ -32,7 +32,6 @@
 #include "rodsConnect.h"
 #include "rodsLog.h"
 #include "server_utilities.hpp"
-#include "irods_at_scope_exit.hpp"
 
 #define IRODS_QUERY_ENABLE_SERVER_SIDE_API
 #include "irods_query.hpp"
@@ -461,13 +460,12 @@ namespace
             if (!ic::connected_to_catalog_provider(*_comm)) {
                 log::api::trace("Redirecting request to catalog service provider ...");
 
-                auto host_info = ic::redirect_to_catalog_provider(*_comm);
-                irods::at_scope_exit close_conn{[&host_info] { rcDisconnect(host_info.conn); }};
+                auto* host_info = ic::redirect_to_catalog_provider(*_comm);
 
                 const std::string json_input(static_cast<const char*>(_input->buf), _input->len);
                 char* json_output = nullptr;
 
-                const auto ec = rc_atomic_apply_acl_operations(host_info.conn, json_input.data(), &json_output);
+                const auto ec = rc_atomic_apply_acl_operations(host_info->conn, json_input.data(), &json_output);
                 *_output = irods::to_bytes_buffer(json_output);
 
                 return ec;

--- a/plugins/api/src/atomic_apply_metadata_operations.cpp
+++ b/plugins/api/src/atomic_apply_metadata_operations.cpp
@@ -21,7 +21,6 @@
 
 #include "catalog.hpp"
 #include "catalog_utilities.hpp"
-#include "irods_at_scope_exit.hpp"
 #include "irods_get_full_path_for_config_file.hpp"
 #include "irods_get_l1desc.hpp"
 #include "irods_logger.hpp"
@@ -439,13 +438,12 @@ namespace
             if (!ic::connected_to_catalog_provider(*_comm)) {
                 log::api::trace("Redirecting request to catalog service provider ...");
 
-                auto host_info = ic::redirect_to_catalog_provider(*_comm);
-                irods::at_scope_exit close_conn{[&host_info] { rcDisconnect(host_info.conn); }};
+                auto* host_info = ic::redirect_to_catalog_provider(*_comm);
 
                 const std::string json_input(static_cast<const char*>(_input->buf), _input->len);
                 char* json_output = nullptr;
 
-                const auto ec = rc_atomic_apply_metadata_operations(host_info.conn, json_input.data(), &json_output);
+                const auto ec = rc_atomic_apply_metadata_operations(host_info->conn, json_input.data(), &json_output);
                 *_output = irods::to_bytes_buffer(json_output);
 
                 return ec;

--- a/plugins/api/src/data_object_finalize.cpp
+++ b/plugins/api/src/data_object_finalize.cpp
@@ -545,8 +545,7 @@ namespace
                 // to perform the file_modified logic here.
                 irods::log(LOG_DEBUG8, "Redirecting request to catalog service provider ...");
 
-                auto host_info = ic::redirect_to_catalog_provider(*_comm);
-                irods::at_scope_exit close_conn{[&host_info] { rcDisconnect(host_info.conn); }};
+                auto* host_info = ic::redirect_to_catalog_provider(*_comm);
 
                 // Explicitly set trigger_file_modified to false here. The file_modified logic should be
                 // executing on this machine, not the catalog service provider to which the connection is
@@ -555,7 +554,7 @@ namespace
 
                 char* json_output = nullptr;
 
-                const auto ec = rc_data_object_finalize(host_info.conn, input.dump().data(), &json_output);
+                const auto ec = rc_data_object_finalize(host_info->conn, input.dump().data(), &json_output);
                 *_output = irods::to_bytes_buffer(json_output);
                 if (ec < 0) {
                     return ec;

--- a/plugins/api/src/touch.cpp
+++ b/plugins/api/src/touch.cpp
@@ -23,7 +23,6 @@
 #include "irods_re_serialization.hpp"
 #include "irods_resource_manager.hpp"
 #include "irods_logger.hpp"
-#include "irods_at_scope_exit.hpp"
 
 #define IRODS_IO_TRANSPORT_ENABLE_SERVER_SIDE_API
 #include "transport/default_transport.hpp"
@@ -403,10 +402,9 @@ namespace
 
             if (!ic::connected_to_catalog_provider(*_comm)) {
                 log::api::trace("Redirecting request to catalog service provider ...");
-                auto host_info = ic::redirect_to_catalog_provider(*_comm);
-                irods::at_scope_exit close_conn{[&host_info] { rcDisconnect(host_info.conn); }};
+                auto* host_info = ic::redirect_to_catalog_provider(*_comm);
                 const std::string json_input(static_cast<const char*>(_bbuf_input->buf), _bbuf_input->len);
-                return rc_touch(host_info.conn, json_input.data());
+                return rc_touch(host_info->conn, json_input.data());
             }
 
             const auto json_input = parse_json(_bbuf_input);

--- a/scripts/irods/test/rule_texts_for_tests.py
+++ b/scripts/irods/test/rule_texts_for_tests.py
@@ -872,7 +872,7 @@ rule_texts['irods_rule_engine_plugin-python']['Test_Native_Rule_Engine_Plugin'] 
 rule_texts['irods_rule_engine_plugin-python']['Test_Native_Rule_Engine_Plugin']['test_remote_rule_execution'] = '''
 def main(rule_args, callback, rei):
     rule_code = "def main(rule_args, callback, rei):\\n    print('XXXX - PREP REMOTE EXEC TEST')"
-    callback.py_remote('icat.example.org', '', rule_code, '')
+    callback.py_remote('{}', '', rule_code, '')
 INPUT null
 OUTPUT ruleExecOut
 '''

--- a/scripts/irods/test/test_native_rule_engine_plugin.py
+++ b/scripts/irods/test/test_native_rule_engine_plugin.py
@@ -25,7 +25,7 @@ from ..controller import IrodsController
 def exec_icat_command(command):
     import paramiko
 
-    hostname = 'icat.example.org'
+    hostname = test.settings.ICAT_HOSTNAME
     port = 22
     username = 'irods'
     password = ''
@@ -282,7 +282,7 @@ class Test_Native_Rule_Engine_Plugin(resource_suite.ResourceBase, unittest.TestC
 
         # =-=-=-=-=-=-=-=-
         # run the remote rule to write to the log
-        rule_code = rule_texts[self.plugin_name][self.class_name][inspect.currentframe().f_code.co_name]
+        rule_code = rule_texts[self.plugin_name][self.class_name][inspect.currentframe().f_code.co_name].format(test.settings.ICAT_HOSTNAME)
         print('Executing code:\n'+rule_code)
         rule_file = 'test_remote_rule_execution.r'
         with open(rule_file, 'wt') as f:

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -46,14 +46,6 @@ def optparse_callback_use_ssl(*args, **kwargs):
 def optparse_callback_use_mungefs(*args, **kwargs):
     irods.test.settings.USE_MUNGEFS = True
 
-def optparse_callback_topology_test(option, opt_str, value, parser):
-    irods.test.settings.RUN_IN_TOPOLOGY = True
-    irods.test.settings.TOPOLOGY_FROM_RESOURCE_SERVER = value == 'resource'
-    irods.test.settings.HOSTNAME_1 = 'resource1.example.org'
-    irods.test.settings.HOSTNAME_2 = 'resource2.example.org'
-    irods.test.settings.HOSTNAME_3 = 'resource3.example.org'
-    irods.test.settings.ICAT_HOSTNAME = 'icat.example.org'
-
 def optparse_callback_federation(option, opt_str, value, parser):
     irods.test.settings.FEDERATION.REMOTE_IRODS_VERSION = tuple(map(int, value[0].split('.')))
     irods.test.settings.FEDERATION.REMOTE_ZONE = value[1]
@@ -160,13 +152,14 @@ if __name__ == '__main__':
     parser.add_option('--include_auth_tests', action='store_true')
     parser.add_option('--include_timing_tests', action='store_true')
     parser.add_option('--run_devtesty', action='store_true')
-    parser.add_option('--topology_test', type='choice', choices=['icat', 'resource'], action='callback', callback=optparse_callback_topology_test, metavar='<icat|resource>')
+    parser.add_option('--topology_test', type='choice', choices=['icat', 'resource'], metavar='<icat|resource>')
     parser.add_option('--catch_keyboard_interrupt', action='callback', callback=optparse_callback_catch_keyboard_interrupt)
     parser.add_option('--use_ssl', action='callback', callback=optparse_callback_use_ssl)
     parser.add_option('--use_mungefs', action='callback', callback=optparse_callback_use_mungefs)
     parser.add_option('--no_buffer', action='store_false', dest='buffer_test_output', default=True)
     parser.add_option('--xml_output', action='store_true', dest='xml_output', default=False)
     parser.add_option('--federation', type='str', nargs=3, action='callback', callback=optparse_callback_federation, metavar='<remote irods version, remote zone, remote host>')
+    parser.add_option('--hostnames', type='str', nargs=4, metavar='<ICAT_HOSTNAME HOSTNAME_1 HOSTNAME_2 HOSTNAME_3>')
     options, _ = parser.parse_args()
 
     if len(sys.argv) == 1:
@@ -181,6 +174,20 @@ if __name__ == '__main__':
         with open(univmss_testing, 'w') as f:
             f.write(univmss_contents)
         os.chmod(univmss_testing, 0o544)
+
+    if options.topology_test:
+        irods.test.settings.RUN_IN_TOPOLOGY = True
+        irods.test.settings.TOPOLOGY_FROM_RESOURCE_SERVER = options.topology_test == 'resource'
+        if options.hostnames:
+            irods.test.settings.ICAT_HOSTNAME = options.hostnames[0]
+            irods.test.settings.HOSTNAME_1 = options.hostnames[1]
+            irods.test.settings.HOSTNAME_2 = options.hostnames[2]
+            irods.test.settings.HOSTNAME_3 = options.hostnames[3]
+        else:
+            irods.test.settings.ICAT_HOSTNAME = 'icat.example.org'
+            irods.test.settings.HOSTNAME_1 = 'resource1.example.org'
+            irods.test.settings.HOSTNAME_2 = 'resource2.example.org'
+            irods.test.settings.HOSTNAME_3 = 'resource3.example.org'
 
     test_identifiers = []
     if options.run_specific_test:

--- a/server/api/src/rsRuleExecSubmit.cpp
+++ b/server/api/src/rsRuleExecSubmit.cpp
@@ -123,9 +123,9 @@ int rsRuleExecSubmit(RsComm* rsComm,
 
         kvp[EXEC_LOCALLY_KW] = "";
 
-        auto host_info = ic::redirect_to_catalog_provider(*rsComm);
+        auto* host_info = ic::redirect_to_catalog_provider(*rsComm);
 
-        return rcRuleExecSubmit(host_info.conn, ruleExecSubmitInp, ruleExecId);
+        return rcRuleExecSubmit(host_info->conn, ruleExecSubmitInp, ruleExecId);
     }
 
     if (const auto ec = _rsRuleExecSubmit(rsComm, ruleExecSubmitInp); ec < 0) {

--- a/server/core/include/catalog_utilities.hpp
+++ b/server/core/include/catalog_utilities.hpp
@@ -191,15 +191,17 @@ namespace irods::experimental::catalog
     ///
     /// If already connected to the catalog provider, simply returns the host information.
     ///
+    /// Note: The returned pointer is managed by a global list of servers to which this agent
+    /// is connected and so should not be free'd after use by the caller.
+    ///
     /// \param[in] _comm iRODS connection structure
     ///
     /// \throws irods::exception If fails to find or connect to the catalog provider host.
     ///
-    /// \retval true if catalog provider is remote
-    /// \retval false if catalog provider is local
+    /// \returns rodsServerHost* pointer to rodsServerHost which is managed by ServerHostHead
     ///
     /// \since 4.2.9
-    auto redirect_to_catalog_provider(RsComm& _comm) -> rodsServerHost;
+    auto redirect_to_catalog_provider(RsComm& _comm) -> rodsServerHost*;
 } // namespace irods::experimental::catalog
 
 #endif // #ifndef IRODS_CATALOG_UTILITIES_HPP

--- a/server/core/include/rodsConnect.h
+++ b/server/core/include/rodsConnect.h
@@ -1,6 +1,8 @@
 #ifndef RODS_CONNECT_H
 #define RODS_CONNECT_H
 
+/// \file
+
 #include "rodsDef.h"
 #include "rcConnect.h"
 
@@ -115,16 +117,45 @@ int getAndConnRcatHostNoLogin(rsComm_t *rsComm,
                               char *rcatZoneHint,
                               rodsServerHost_t **rodsServerHost);
 
+/// \brief Gets the Catalog Service Provider host information from `ZoneInfoHead`.
+///
+/// \parblock
+/// The information populated in `*rodsServerHost` will be a pointer to `masterServerHost` or
+/// `slaveServerHost` of the global `ZoneInfoHead` list. These linked lists are identical to the
+/// pointers in the global linked list of server information called `ServerHostHead`.
+///
+/// This function should be used for getting this pointer in particular because any connections
+/// made to the retrieved server will be reused from previous redirections, if applicable, and
+/// cleaned up automatically on agent teardown.
+/// \endparblock
 int getRcatHost(int rcatType,
                 const char *rcatZoneHint,
                 rodsServerHost_t **rodsServerHost);
 
 int disconnRcatHost(int rcatType, const char *rcatZoneHint);
 
+/// \brief Gets the Catalog Service Provider host from `ZoneInfoHead` and connects to it.
+///
+/// \parblock
+/// The information populated in `*rodsServerHost` will be a pointer to `masterServerHost` or
+/// `slaveServerHost` of the global `ZoneInfoHead` list. These linked lists are identical to the
+/// pointers in the global linked list of server information called `ServerHostHead`.
+///
+/// This function should be used for making any redirect connections to the Catalog Service
+/// Provider. Connections will be reused from previous redirections, if applicable, and cleaned
+/// up automatically on agent teardown.
+/// \endparblock
 int getAndDisconnRcatHost(int rcatType,
                           char *rcatZoneHint,
                           rodsServerHost_t **rodsServerHost);
 
+/// \brief Disconnects and cleans up all server-to-server connections made by this agent.
+///
+/// \parblock
+/// This function walks the list of connected iRODS servers in `ServerHostHead` and disconnects
+/// them. This is convenient at agent teardown to ensure that the agent is not leaving any open
+/// connections or leaking memory from the connection structures.
+/// \endparblock
 int disconnectAllSvrToSvrConn();
 
 int svrReconnect(rsComm_t *rsComm);

--- a/server/core/include/rsGlobalExtern.hpp
+++ b/server/core/include/rsGlobalExtern.hpp
@@ -1,11 +1,7 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-/* rsGlobalExtern.h - header file for global extern declaration for the server
- * modules
- */
-
 #ifndef RS_GLOBAL_EXTERN_HPP
 #define RS_GLOBAL_EXTERN_HPP
+
+/// \file
 
 #include "rods.h"
 #include "apiHandler.hpp"
@@ -16,10 +12,8 @@
 #include "authenticate.h"
 #include "openCollection.h"
 
-// =-=-=-=-=-=-=-
 #include "irods_resource_manager.hpp"
 
-// =-=-=-=-=-=-=-
 // externs to singleton plugin managers
 extern irods::resource_manager resc_mgr;
 
@@ -27,15 +21,45 @@ extern int LogFd;         		/* the log file descriptor */
 extern char *CurLogfileName;         	/* the path of the current logfile */
 extern char ProcLogDir[MAX_NAME_LEN];
 extern irods::api_entry_table RsApiTable;
-extern rodsServerHost_t *LocalServerHost;
-extern rodsServerHost_t *ServerHostHead;
-extern rodsServerHost_t *HostConfigHead;
-extern zoneInfo_t *ZoneInfoHead;
 extern int RescGrpInit;
-extern fileDesc_t FileDesc[NUM_FILE_DESC];
-extern l1desc_t L1desc[NUM_L1_DESC];
 extern specCollDesc_t SpecCollDesc[NUM_SPEC_COLL_DESC];
 extern std::vector<collHandle_t> CollHandle;;
+
+/// \brief Global table of L1 descriptors which contains information about open replicas.
+extern l1desc_t L1desc[NUM_L1_DESC];
+
+/// \brief Global table of file descriptors which contains information about open files.
+extern fileDesc_t FileDesc[NUM_FILE_DESC];
+
+/// \brief Global linked list of iRODS servers to which the agent has connected.
+///
+/// \parblock
+/// `LocalServerHost` is added as the head of this list in `initLocalServerHost()`.
+///
+/// Whenever a new connection is made to an iRODS server, its `rodsServerHost` information
+/// should be added to this list.
+///
+/// After the connection is no longer needed, it should be left in the list for reuse within
+/// the agent should a later redirection to the same server be needed later. All of the
+/// connections held open in this linked list will be connected on agent teardown via
+/// `cleanup()`.
+/// \endparblock
+extern rodsServerHost_t *ServerHostHead;
+
+/// \brief Global head of a linked list of connected iRODS servers, `ServerHostHead`.
+///
+/// \parblock
+/// This `rodsServerHost*` represents the local server and is always the head of the linked list
+/// of connected servers.
+/// \endparblock
+extern rodsServerHost_t *LocalServerHost;
+
+/// \brief Global linked list of zones. The head is always the local zone.
+///
+/// \p `queZone` is used to add zones to this list.
+extern zoneInfo_t *ZoneInfoHead;
+
+extern rodsServerHost_t *HostConfigHead;
 
 /* global Rule Engine File Initialization String */
 
@@ -53,10 +77,6 @@ extern int IcatConnState;
 
 extern specCollCache_t *SpecCollCacheHead;
 
-//int initRuleEngine( int processType, rsComm_t *svrComm, char *ruleSet, char *dvmSet, char* fnmSet );
-//int clearCoreRule();
-//int finalizeRuleEngine();
-
 extern char localSID[MAX_PASSWORD_LEN];
 extern irods::lookup_table <std::pair <std::string, std::string> > remote_SID_key_map; // remote zone SIDs and negotiation keys
 
@@ -72,5 +92,5 @@ extern gid_t ServiceGid;
 
 extern irodsStateFlag_t ReadWriteRuleState;
 
-#endif  /* RS_GLOBAL_EXTERN_H */
+#endif // RS_GLOBAL_EXTERN_HPP
 

--- a/server/core/src/catalog_utilities.cpp
+++ b/server/core/src/catalog_utilities.cpp
@@ -156,20 +156,16 @@ namespace irods::experimental::catalog
         return ::connected_to_catalog_provider(_comm, get_catalog_provider_host());
     } // connected_to_catalog_provider
 
-    auto redirect_to_catalog_provider(RsComm& _comm) -> rodsServerHost
+    auto redirect_to_catalog_provider(RsComm& _comm) -> rodsServerHost*
     {
-        rodsServerHost host = get_catalog_provider_host();
+        rodsServerHost* host = nullptr;
 
-        if (::connected_to_catalog_provider(_comm, host)) {
-            return host;
+        if (const int ec = getAndConnRcatHost(&_comm, MASTER_RCAT, nullptr, &host); ec < 0) {
+            THROW(ec, "failed to connect to catalog provider host");
         }
 
-        if (int ec = svrToSvrConnect(&_comm, &host); ec < 0) {
-            if (REMOTE_ICAT == host.rcatEnabled) {
-                ec = convZoneSockError(ec);
-            }
-
-            THROW(ec, fmt::format("svrToSvrConnect to {} failed", host.hostName->name));
+        if (!host) {
+            THROW(SYS_INVALID_SERVER_HOST, "failed to get catalog provider host");
         }
 
         return host;


### PR DESCRIPTION
Setting up CSCs now works and have confirmed that no disconnection error messages appear in the CSP log when a CSC-connected agent goes away (meaning, the connections are now cleaning up appropriately).