### PR TITLE
[#5863] Update mtime for creates/non-empty writes (master)

### DIFF
--- a/lib/core/include/stream_factory_utility.hpp
+++ b/lib/core/include/stream_factory_utility.hpp
@@ -159,7 +159,7 @@ namespace irods::experimental::io
     {
         using openmode = std::ios_base::openmode;
 
-        return [&_conn_pool, p = std::move(_logical_path), &_replica_id](openmode _mode, managed_dstream* _base)
+        return [&_conn_pool, p = std::move(_logical_path), repl_id = std::forward<ReplicaIdentifier>(_replica_id)](openmode _mode, managed_dstream* _base)
             -> managed_dstream
         {
             managed_dstream d{_conn_pool.get_connection()};
@@ -178,7 +178,7 @@ namespace irods::experimental::io
                               std::is_same_v<unqualified_type, io::root_resource_name>,
                               "Unsupported type for template parameter [ReplicaIdentifier].");
 
-                d.stream.open(*d.transport, p, _replica_id, _mode);
+                d.stream.open(*d.transport, p, repl_id, _mode);
             }
 
             d.rdbuf(d.stream.rdbuf());

--- a/plugins/api/src/replica_close.cpp
+++ b/plugins/api/src/replica_close.cpp
@@ -218,6 +218,7 @@ namespace
         if (CREATE_TYPE == _l1desc.openType) {
             repl.size(size_on_disk);
             repl.replica_status(GOOD_REPLICA);
+            repl.mtime(SET_TIME_TO_NOW_KW);
         }
         // If the size of the replica has changed since opening it, then update the size.
         else if (_l1desc.dataObjInfo->dataSize != size_on_disk) {
@@ -234,9 +235,9 @@ namespace
         }
         // If nothing has been written, the status is restored from the replica state table
         // so that the replica is not mistakenly marked as good when it is in fact stale.
+        // The mtime is also not updated so as to signal that nothing changed in the data.
         else {
             repl.replica_status(ill::get_original_replica_status(repl.data_id(), repl.replica_number()));
-            repl.mtime(SET_TIME_TO_NOW_KW);
         }
 
         // Update the RST with the changes made above to the replica.

--- a/server/api/src/rsDataObjClose.cpp
+++ b/server/api/src/rsDataObjClose.cpp
@@ -372,6 +372,7 @@ namespace
                 "[{}:{}] - created new replica, STALE sibling replicas [path=[{}], hier=[{}]]",
                 __FUNCTION__, __LINE__, r.logical_path(), r.hierarchy()));
             r.replica_status(GOOD_REPLICA);
+            r.mtime(SET_TIME_TO_NOW_KW);
         }
         else if (OPEN_FOR_WRITE_TYPE == l1desc.openType) {
             if (l1desc.bytesWritten > 0) {

--- a/server/api/src/rsDataObjOpen.cpp
+++ b/server/api/src/rsDataObjOpen.cpp
@@ -1200,7 +1200,7 @@ namespace
                 auto& l1desc = L1desc[l1descInx];
                 irods::log(LOG_DEBUG, fmt::format(
                     "[{}:{}] - opened replica "
-                    "[fd=[{}], path=[{}], hierarchy=[{}], replica_status=[{}], replica_token=[{}]] ",
+                    "[fd=[{}], path=[{}], hierarchy=[{}], replica_status=[{}], replica_token=[{}]] "
                     "[id=[{}], path=[{}], hierarchy=[{}], replica_status=[{}]]",
                     __FUNCTION__, __LINE__,
                     l1descInx,

--- a/server/api/src/rsDataObjPhymv.cpp
+++ b/server/api/src/rsDataObjPhymv.cpp
@@ -506,6 +506,10 @@ namespace
         const auto original_destination_replica_number = _destination_replica.replica_number();
 
         _destination_replica.replica_status(source_replica_original_status);
+
+        // Do not update the replica number, create time, or modify time because phymv was
+        // designed for a very specific use case and these system metadata are expected to
+        // remain unchanged from the source replica.
         _destination_replica.replica_number(source_replica_number);
         _destination_replica.ctime(_source_replica.ctime());
         _destination_replica.mtime(_source_replica.mtime());

--- a/server/api/src/rsDataObjPut.cpp
+++ b/server/api/src/rsDataObjPut.cpp
@@ -205,10 +205,14 @@ namespace
 
         cond_input[OPEN_TYPE_KW] = std::to_string(_l1desc.openType);
 
+        // Whether this put was an overwrite or a new data object, the mtime for the replica
+        // should be updated to reflect the time that it took to write the data and reflect
+        // the behavior seen in POSIX.
+        r.mtime(SET_TIME_TO_NOW_KW);
+
         // Set target replica to the state it should be
         if (OPEN_FOR_WRITE_TYPE == _l1desc.openType) {
             r.replica_status(GOOD_REPLICA);
-            r.mtime(SET_TIME_TO_NOW_KW);
 
             // stale other replicas because the truth has moved
             ill::unlock(r.data_id(), r.replica_number(), GOOD_REPLICA, STALE_REPLICA);

--- a/server/core/src/initServer.cpp
+++ b/server/core/src/initServer.cpp
@@ -94,11 +94,9 @@ namespace
             irods::log(LOG_ERROR, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, e.client_display_what()));
         }
 
-        if (OPEN_FOR_WRITE_TYPE == _l1desc.openType) {
-            // If the replica was opened for write and failed to close, we set the mtime
-            // because the status is going to change to stale due to failure to finalize.
-            r.mtime(SET_TIME_TO_NOW_KW);
-        }
+        // If the replica was opened for write or create and failed to close, we set the
+        // mtime because the status is going to change to stale due to failure to finalize.
+        r.mtime(SET_TIME_TO_NOW_KW);
 
         r.checksum("");
         r.replica_status(STALE_REPLICA);

--- a/unit_tests/src/test_logical_locking.cpp
+++ b/unit_tests/src/test_logical_locking.cpp
@@ -59,20 +59,6 @@ namespace
 
         REQUIRE(unit_test_utils::add_ufs_resource(comm, _name, "vault_for_"s + _name.data()));
     } // mkresc
-
-    auto close_replica(RcComm& _comm, const int _fd)
-    {
-        const auto close_input = nlohmann::json{
-            {"fd", _fd},
-            {"update_size", false},
-            {"update_status", false},
-            {"compute_checksum", false},
-            {"send_notifications", false},
-            {"preserve_replica_state_table", true}
-        }.dump();
-
-        return rc_replica_close(&_comm, close_input.data());
-    } // close_replica
 } // anonymous namespace
 
 TEST_CASE("open_and_close", "[write_lock]")
@@ -193,7 +179,7 @@ TEST_CASE("open_and_close", "[write_lock]")
             fail_cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
             const auto fd2 = rcDataObjOpen(&new_comm, &fail_open_inp);
             REQUIRE(fd2 > 2);
-            REQUIRE(close_replica(new_comm, fd2) >= 0);
+            REQUIRE(unit_test_utils::close_replica(new_comm, fd2) >= 0);
         }
 
         // open existing, currently locked replica
@@ -221,7 +207,7 @@ TEST_CASE("open_and_close", "[write_lock]")
             fail_cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
             const auto fd2 = rcDataObjOpen(&new_comm, &fail_open_inp);
             REQUIRE(fd2 > 2);
-            REQUIRE(close_replica(new_comm, fd2) >= 0);
+            REQUIRE(unit_test_utils::close_replica(new_comm, fd2) >= 0);
         }
 
         // open existing, currently locked replica
@@ -253,7 +239,7 @@ TEST_CASE("open_and_close", "[write_lock]")
             fail_cond_input[RESC_HIER_STR_KW] = opened_replica_resc;
             const auto fd2 = rcDataObjOpen(&new_comm, &fail_open_inp);
             REQUIRE(fd2 > 2);
-            REQUIRE(close_replica(new_comm, fd2) >= 0);
+            REQUIRE(unit_test_utils::close_replica(new_comm, fd2) >= 0);
         }
 
         // attempt overwriting existing, currently locked replica with new replica

--- a/unit_tests/src/test_rc_data_obj.cpp
+++ b/unit_tests/src/test_rc_data_obj.cpp
@@ -275,7 +275,7 @@ TEST_CASE("rc_data_obj_open")
 
             // ensure all system metadata were updated properly
             const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
-            CHECK(replica_info.mtime() == replica_info.ctime());
+            CHECK(replica_info.mtime() != replica_info.ctime());
             CHECK(0 == static_cast<unsigned long>(replica_info.size()));
             CHECK(STALE_REPLICA == replica_info.replica_status());
         }
@@ -286,6 +286,12 @@ TEST_CASE("rc_data_obj_open")
             RcComm& comm = static_cast<RcComm&>(conn);
 
             unit_test_utils::create_empty_replica(comm, target_object);
+
+            std::string original_mtime_for_replica_0;
+            {
+                const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
+                original_mtime_for_replica_0 = replica_info.mtime();
+            }
 
             std::this_thread::sleep_for(2s);
 
@@ -302,7 +308,7 @@ TEST_CASE("rc_data_obj_open")
 
             // ensure all system metadata were restored properly
             const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
-            CHECK(replica_info.mtime() == replica_info.ctime());
+            CHECK(replica_info.mtime() == original_mtime_for_replica_0);
             CHECK(0 == static_cast<unsigned long>(replica_info.size()));
             CHECK(GOOD_REPLICA == replica_info.replica_status());
         }
@@ -313,6 +319,12 @@ TEST_CASE("rc_data_obj_open")
             RcComm& comm = static_cast<RcComm&>(conn);
 
             unit_test_utils::create_empty_replica(comm, target_object);
+
+            std::string original_mtime_for_replica_0;
+            {
+                const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
+                original_mtime_for_replica_0 = replica_info.mtime();
+            }
 
             std::this_thread::sleep_for(2s);
 
@@ -329,7 +341,7 @@ TEST_CASE("rc_data_obj_open")
 
             // ensure all system metadata were updated properly
             const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
-            CHECK(replica_info.mtime() == replica_info.ctime());
+            CHECK(replica_info.mtime() == original_mtime_for_replica_0);
             CHECK(0 == static_cast<unsigned long>(replica_info.size()));
             CHECK(GOOD_REPLICA == replica_info.replica_status());
         }
@@ -340,6 +352,12 @@ TEST_CASE("rc_data_obj_open")
             RcComm& comm = static_cast<RcComm&>(conn);
 
             unit_test_utils::create_empty_replica(comm, target_object);
+
+            std::string original_mtime_for_replica_0;
+            {
+                const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
+                original_mtime_for_replica_0 = replica_info.mtime();
+            }
 
             std::this_thread::sleep_for(2s);
 
@@ -359,7 +377,7 @@ TEST_CASE("rc_data_obj_open")
 
             // ensure all system metadata were updated properly
             const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
-            CHECK(replica_info.mtime() == replica_info.ctime());
+            CHECK(replica_info.mtime() == original_mtime_for_replica_0);
             CHECK(0 == static_cast<unsigned long>(replica_info.size()));
             CHECK(GOOD_REPLICA == replica_info.replica_status());
         }
@@ -370,6 +388,12 @@ TEST_CASE("rc_data_obj_open")
             RcComm& comm = static_cast<RcComm&>(conn);
 
             unit_test_utils::create_empty_replica(comm, target_object);
+
+            std::string original_mtime_for_replica_0;
+            {
+                const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
+                original_mtime_for_replica_0 = replica_info.mtime();
+            }
 
             std::this_thread::sleep_for(2s);
 
@@ -409,7 +433,7 @@ TEST_CASE("rc_data_obj_open")
 
             // ensure all system metadata were updated properly
             const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
-            CHECK(replica_info.mtime() != replica_info.ctime());
+            CHECK(replica_info.mtime() != original_mtime_for_replica_0);
             CHECK(0 == static_cast<unsigned long>(replica_info.size()));
             CHECK(STALE_REPLICA == replica_info.replica_status());
         }
@@ -433,6 +457,9 @@ TEST_CASE("rc_data_obj_open")
                 unclosed_fd_pid = unit_test_utils::get_agent_pid(comm);
                 REQUIRE(unclosed_fd_pid > 0);
 
+                // sleep here to ensure that the mtime is updated on auto-close
+                std::this_thread::sleep_for(2s);
+
                 // disconnect without close
             }
 
@@ -444,14 +471,23 @@ TEST_CASE("rc_data_obj_open")
 
                 // ensure all system metadata were updated properly
                 const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
-                CHECK(replica_info.mtime() == replica_info.ctime());
+                CHECK(replica_info.mtime() != replica_info.ctime());
                 CHECK(0 == static_cast<unsigned long>(replica_info.size()));
                 CHECK(STALE_REPLICA == replica_info.replica_status());
             }
 
+            // sleep here to test that the mtime is NOT updated on close
+            std::this_thread::sleep_for(2s);
+
             // open for write, close
             irods::experimental::client_connection conn;
             RcComm& comm = static_cast<RcComm&>(conn);
+
+            std::string original_mtime_for_replica_0;
+            {
+                const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
+                original_mtime_for_replica_0 = replica_info.mtime();
+            }
 
             dataObjInp_t open_inp{};
             std::snprintf(open_inp.objPath, sizeof(open_inp.objPath), "%s", path_str.data());
@@ -466,7 +502,7 @@ TEST_CASE("rc_data_obj_open")
 
             // ensure all system metadata were updated properly
             const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
-            CHECK(replica_info.mtime() == replica_info.ctime());
+            CHECK(replica_info.mtime() == original_mtime_for_replica_0);
             CHECK(0 == static_cast<unsigned long>(replica_info.size()));
             CHECK(STALE_REPLICA == replica_info.replica_status());
         }
@@ -502,7 +538,7 @@ TEST_CASE("rc_data_obj_open")
 
             // ensure all system metadata were updated properly
             const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
-            CHECK(replica_info.mtime() == replica_info.ctime());
+            CHECK(replica_info.mtime() != replica_info.ctime());
             CHECK(contents.size() + 1 == static_cast<unsigned long>(replica_info.size()));
             CHECK(GOOD_REPLICA == replica_info.replica_status());
         }
@@ -532,7 +568,7 @@ TEST_CASE("rc_data_obj_open")
                 const auto bytes_written = rcDataObjWrite(&comm, &write_inp, &write_bbuf);
                 CHECK(write_bbuf.len == bytes_written);
 
-                // Sleep here to make sure that the mtime is not updated
+                // Sleep here to make sure that the mtime is updated
                 std::this_thread::sleep_for(2s);
 
                 unclosed_fd_pid = unit_test_utils::get_agent_pid(comm);
@@ -548,7 +584,7 @@ TEST_CASE("rc_data_obj_open")
             RcComm& comm = static_cast<RcComm&>(conn);
 
             const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
-            CHECK(replica_info.mtime() == replica_info.ctime());
+            CHECK(replica_info.mtime() != replica_info.ctime());
             CHECK(contents.size() + 1 == static_cast<unsigned long>(replica_info.size()));
             CHECK(STALE_REPLICA == replica_info.replica_status());
         }
@@ -562,6 +598,12 @@ TEST_CASE("rc_data_obj_open")
             unit_test_utils::create_empty_replica(comm, target_object, test_resc);
             REQUIRE(GOOD_REPLICA == replica::replica_status(comm, target_object, 0));
             REQUIRE(!replica::replica_exists(comm, target_object, 1));
+
+            std::string original_mtime_for_replica_0;
+            {
+                const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
+                original_mtime_for_replica_0 = replica_info.mtime();
+            }
 
             // Sleep to ensure that mtime updates when we write to it.
             std::this_thread::sleep_for(2s);
@@ -600,7 +642,7 @@ TEST_CASE("rc_data_obj_open")
 
             // Ensure all system metadata were updated properly
             const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
-            CHECK(replica_info.mtime() != replica_info.ctime());
+            CHECK(replica_info.mtime() != original_mtime_for_replica_0);
             CHECK(contents.size() + 1 == static_cast<unsigned long>(replica_info.size()));
         }
 
@@ -614,7 +656,13 @@ TEST_CASE("rc_data_obj_open")
             REQUIRE(GOOD_REPLICA == replica::replica_status(comm, target_object, 0));
             REQUIRE(!replica::replica_exists(comm, target_object, 1));
 
-            // Sleep to ensure that mtime correctly does not update when we create
+            std::string original_mtime_for_replica_0;
+            {
+                const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
+                original_mtime_for_replica_0 = replica_info.mtime();
+            }
+
+            // Sleep to ensure that mtime does not update when we create
             // the new replica.
             std::this_thread::sleep_for(2s);
 
@@ -648,7 +696,7 @@ TEST_CASE("rc_data_obj_open")
             // Ensure all system metadata were updated properly for the original replica.
             {
                 const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
-                CHECK(replica_info.mtime() == replica_info.ctime());
+                CHECK(replica_info.mtime() == original_mtime_for_replica_0);
                 CHECK(0 == static_cast<unsigned long>(replica_info.size()));
                 REQUIRE(STALE_REPLICA == replica::replica_status(comm, target_object, 0));
             }
@@ -656,7 +704,7 @@ TEST_CASE("rc_data_obj_open")
             // Ensure all system metadata were updated properly for the new replica.
             {
                 const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 1);
-                CHECK(replica_info.mtime() == replica_info.ctime());
+                CHECK(replica_info.mtime() != original_mtime_for_replica_0);
                 CHECK(contents.size() + 1 == static_cast<unsigned long>(replica_info.size()));
                 REQUIRE(GOOD_REPLICA == replica::replica_status(comm, target_object, 1));
             }
@@ -673,6 +721,18 @@ TEST_CASE("rc_data_obj_open")
             unit_test_utils::replicate_data_object(comm, path_str, DEFAULT_RESOURCE_HIERARCHY);
             REQUIRE(GOOD_REPLICA == replica::replica_status(comm, target_object, 0));
             REQUIRE(GOOD_REPLICA == replica::replica_status(comm, target_object, 1));
+
+            std::string original_mtime_for_replica_0;
+            {
+                const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
+                original_mtime_for_replica_0 = replica_info.mtime();
+            }
+
+            std::string original_mtime_for_replica_1;
+            {
+                const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 1);
+                original_mtime_for_replica_1 = replica_info.mtime();
+            }
 
             // Sleep here so that the mtime on the replica we open will be updated.
             std::this_thread::sleep_for(2s);
@@ -718,9 +778,7 @@ TEST_CASE("rc_data_obj_open")
                 CHECK(INTERMEDIATE_REPLICA == replica::replica_status(comm2, target_object, 0));
                 CHECK(WRITE_LOCKED == replica::replica_status(comm2, target_object, 1));
 
-                openedDataObjInp_t close_inp{};
-                close_inp.l1descInx = fd2;
-                REQUIRE(rcDataObjClose(&comm2, &close_inp) >= 0);
+                REQUIRE(unit_test_utils::close_replica(comm2, fd2) >= 0);
             }
 
             openedDataObjInp_t close_inp{};
@@ -732,14 +790,14 @@ TEST_CASE("rc_data_obj_open")
             // to what they were before opening.
             {
                 const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 0);
-                CHECK(replica_info.mtime() == replica_info.ctime());
+                CHECK(replica_info.mtime() == original_mtime_for_replica_0);
                 CHECK(0 == static_cast<unsigned long>(replica_info.size()));
                 CHECK(GOOD_REPLICA == replica_info.replica_status());
             }
 
             {
                 const auto [replica_info, replica_lm] = replica::make_replica_proxy(comm, target_object, 1);
-                CHECK(replica_info.mtime() == replica_info.ctime());
+                CHECK(replica_info.mtime() == original_mtime_for_replica_1);
                 CHECK(0 == static_cast<unsigned long>(replica_info.size()));
                 CHECK(GOOD_REPLICA == replica_info.replica_status());
             }

--- a/unit_tests/src/unit_test_utils.hpp
+++ b/unit_tests/src/unit_test_utils.hpp
@@ -22,6 +22,20 @@
 
 namespace unit_test_utils
 {
+    inline auto close_replica(RcComm& _comm, const int _fd) -> int
+    {
+        const auto close_input = nlohmann::json{
+            {"fd", _fd},
+            {"update_size", false},
+            {"update_status", false},
+            {"compute_checksum", false},
+            {"send_notifications", false},
+            {"preserve_replica_state_table", true}
+        }.dump();
+
+        return rc_replica_close(&_comm, close_input.data());
+    } // close_replica
+
     inline auto get_hostname() noexcept -> std::string
     {
         char hostname[256] {};


### PR DESCRIPTION
Historically, the mtime for a replica was only updated if it was opened
for write (that is, it must have already existed) and bytes were written
during the operation. This changes the logic such that any operation
that results in a create or a bytes-writing open-for-write will update
the mtime for the target replica. This means that the mtime and create
time for a new replica may not be equal.

___
CI tests running