### PR TITLE
[#5894] Remove cross-zone copy case in close (4-2-stable)

### DIFF
--- a/server/core/src/client_api_whitelist.cpp
+++ b/server/core/src/client_api_whitelist.cpp
@@ -110,7 +110,7 @@ namespace irods
                        GET_REMOTE_ZONE_RESC_AN,
                        DATA_OBJ_OPEN_AND_STAT_AN,
                        //L3_FILE_GET_SINGLE_BUF_AN,
-                       //L3_FILE_PUT_SINGLE_BUF_AN,
+                       L3_FILE_PUT_SINGLE_BUF_AN,
                        DATA_OBJ_CREATE_AND_STAT_AN,
                        DATA_OBJ_CLOSE_AN,
                        DATA_OBJ_LSEEK_AN,


### PR DESCRIPTION
The cross-zone copy operation in rsDataObjClose handles the legacy case
of copying a data object to a remote zone by registering it in the
catalog as part of finalizing the object. This is no longer needed in
4.2.9+ and in fact breaks federation for small file copies from a zone
running an iRODS server version before 4.2.9 to a remote zone running an
iRODS server version 4.2.9 or later.

The client API whitelist should also expose the L3 file single buffer
put API as it is used in the legacy rsDataObjCopy (4.2.8 and earlier)
and so is needed in order for federation to work.

---

Federation tests passed and confirmed that large and small copies of data objects over the federation boundary worked in both directions between a zone running 4.2.7 and a zone running the commit containing this change.