### PR TITLE
[5828] Add fmt irods-externals include dir to client_server_negotiation test

### DIFF
--- a/unit_tests/cmake/test_config/irods_client_server_negotiation.cmake
+++ b/unit_tests/cmake/test_config/irods_client_server_negotiation.cmake
@@ -6,7 +6,8 @@ set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
 set(IRODS_TEST_INCLUDE_PATH ${CMAKE_SOURCE_DIR}/lib/core/include
                             ${CMAKE_SOURCE_DIR}/lib/api/include
                             ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
-                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include)
+                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
 
 set(IRODS_TEST_LINK_LIBRARIES irods_client
                               ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so)


### PR DESCRIPTION
Found this while trying to track down a different issue