### PR TITLE
[#4231] Restore support for zone name param in admin API (master)

### DIFF
--- a/server/api/src/rsGeneralAdmin.cpp
+++ b/server/api/src/rsGeneralAdmin.cpp
@@ -677,7 +677,8 @@ _rsGeneralAdmin( rsComm_t *rsComm, generalAdminInp_t *generalAdminInp ) {
             return irods::create_user(*rsComm,
                                       generalAdminInp->arg2 ? generalAdminInp->arg2 : "",
                                       generalAdminInp->arg3 ? generalAdminInp->arg3 : "",
-                                      generalAdminInp->arg5 ? generalAdminInp->arg5 : "");
+                                      generalAdminInp->arg5 ? generalAdminInp->arg5 : "",
+                                      generalAdminInp->arg4 ? generalAdminInp->arg4 : "");
         }
         if ( strcmp( generalAdminInp->arg1, "dir" ) == 0 ) {
             memset( ( char* )&collInfo, 0, sizeof( collInfo ) );
@@ -1034,7 +1035,8 @@ _rsGeneralAdmin( rsComm_t *rsComm, generalAdminInp_t *generalAdminInp ) {
     if ( strcmp( generalAdminInp->arg0, "rm" ) == 0 ) {
         if ( strcmp( generalAdminInp->arg1, "user" ) == 0 ) {
             return irods::remove_user(*rsComm,
-                                      generalAdminInp->arg2 ? generalAdminInp->arg2 : "");
+                                      generalAdminInp->arg2 ? generalAdminInp->arg2 : "",
+                                      generalAdminInp->arg3 ? generalAdminInp->arg3 : "");
         }
         if ( strcmp( generalAdminInp->arg1, "dir" ) == 0 ) {
             memset( ( char* )&collInfo, 0, sizeof( collInfo ) );

--- a/server/api/src/rsUserAdmin.cpp
+++ b/server/api/src/rsUserAdmin.cpp
@@ -143,13 +143,15 @@ _rsUserAdmin( rsComm_t *rsComm, userAdminInp_t *userAdminInp ) {
     if ( strcmp( userAdminInp->arg0, "mkuser" ) == 0 ) {
         return irods::create_user(*rsComm,
                                   userAdminInp->arg1 ? userAdminInp->arg1 : "",
-                                  "rodsuser", "");
+                                  "rodsuser", "",
+                                  userAdminInp->arg3 ? userAdminInp->arg3 : "");
     }
     if ( strcmp( userAdminInp->arg0, "mkgroup" ) == 0 ) {
         return irods::create_user(*rsComm,
                                   userAdminInp->arg1 ? userAdminInp->arg1 : "",
                                   userAdminInp->arg2 ? userAdminInp->arg2 : "",
-                                  "");
+                                  "",
+                                  userAdminInp->arg3 ? userAdminInp->arg3 : "");
     }
 
     // =-=-=-=-=-=-=-

--- a/server/core/include/administration_utilities.hpp
+++ b/server/core/include/administration_utilities.hpp
@@ -9,15 +9,14 @@ namespace irods
 {
     /// \brief Create a user with the given name, type, and auth string
     ///
-    /// \parblock
-    /// If _user_name does not contain the zone name using the octothorpe delimiter, the
-    /// local zone will be used.
-    /// \endparblock
-    ///
     /// \param[in/out] _comm Server communication handle
-    /// \param[in] _user_name The name of the user to create (including zone name)
-    /// \param[in] _user_type The type of the user to create
-    /// \param[in] _auth_string The auth string for the user to create
+    /// \param[in] _user_name The name of the to-be-created user (including zone name)
+    /// \param[in] _user_type The type of the to-be-created user
+    /// \param[in] _auth_string The auth string for the to-be-created user
+    /// \param[in] _zone_name The zone name for the to-be-created user\parblock
+    /// If the _zone_name is not provided and the _user_name does not contain the zone name
+    /// using the octothorpe delimiter, the local zone will be used.
+    /// \endparblock
     ///
     /// \retval 0 Success
     /// \retval !0 Failure
@@ -26,18 +25,25 @@ namespace irods
     auto create_user(RsComm& _comm,
                      const std::string_view _user_name,
                      const std::string_view _user_type,
-                     const std::string_view _auth_string) -> int;
+                     const std::string_view _auth_string,
+                     const std::string_view _zone_name) -> int;
 
     /// \brief Remove a user with the given name
     ///
     /// \param[in/out] _comm Server communication handle
     /// \param[in] _user_name The name of the user to create (including zone name)
+    /// \param[in] _zone_name The zone name for the to-be-created user\parblock
+    /// If the _zone_name is not provided and the _user_name does not contain the zone name
+    /// using the octothorpe delimiter, the local zone will be used.
+    /// \endparblock
     ///
     /// \retval 0 Success
     /// \retval !0 Failure
     ///
     /// \since 4.2.11
-    auto remove_user(RsComm& _comm, const std::string_view _user_name) -> int;
+    auto remove_user(RsComm& _comm,
+                     const std::string_view _user_name,
+                     const std::string_view _zone_name) -> int;
 } // namespace irods
 
 #endif // IRODS_ADMINISTRATION_UTILITIES_HPP

--- a/server/core/src/administration_utilities.cpp
+++ b/server/core/src/administration_utilities.cpp
@@ -32,7 +32,8 @@ namespace irods
     auto create_user(RsComm& _comm,
                      const std::string_view _user_name,
                      const std::string_view _user_type,
-                     const std::string_view _auth_string) -> int
+                     const std::string_view _auth_string,
+                     const std::string_view _zone_name) -> int
     {
         if (!irods::user::type_is_valid(_user_type)) {
             return CAT_INVALID_USER_TYPE;
@@ -45,7 +46,24 @@ namespace irods
 
         const auto& [user_name, zone_name] = *user_and_zone_name;
 
-        if (_user_type == "rodsgroup" && !zone_name.empty() && zone_name != getLocalZoneName()) {
+        // If the zone name is provided both via argument in the admin API and in the username,
+        // they must match. The zone name is used in the user name to identify the home zone of
+        // each user.
+        if (!_zone_name.empty() && !zone_name.empty() && _zone_name != zone_name) {
+            return CAT_INVALID_ZONE;
+        }
+
+        const auto& local_zone_name = getLocalZoneName();
+
+        const auto user_zone_name_is_remote = !zone_name.empty() &&
+                                              zone_name != local_zone_name;
+
+        const auto arg_zone_name_is_remote = !_zone_name.empty() &&
+                                             _zone_name != local_zone_name;
+
+        // Remote groups are not allowed. If the provided zone name in either the
+        // administration API argument or the username is a remote zone, return an error.
+        if (_user_type == "rodsgroup" && (user_zone_name_is_remote || arg_zone_name_is_remote)) {
             constexpr auto err = SYS_NOT_ALLOWED;
             addRErrorMsg(&_comm.rError, err, "groups cannot be made for a remote zone");
             return err;
@@ -66,6 +84,12 @@ namespace irods
             std::strncpy(ui.userName, user_name.data(), sizeof(ui.userName));
         }
 
+        // The zone name is a parameter in both the General Admin and User Admin APIs, so copy
+        // the value into the rodsZone buffer if it was passed along.
+        if (!_zone_name.empty()) {
+            std::strncpy(ui.rodsZone, _zone_name.data(), sizeof(ui.rodsZone));
+        }
+
         ruleExecInfo_t rei{};
         rei.rsComm = &_comm;
         rei.uoio = &ui;
@@ -80,7 +104,9 @@ namespace irods
         return 0;
     } // create_user
 
-    auto remove_user(RsComm& _comm, const std::string_view _user_name) -> int
+    auto remove_user(RsComm& _comm,
+                     const std::string_view _user_name,
+                     const std::string_view _zone_name) -> int
     {
         const auto user_and_zone_name = irods::user::validate_name(_user_name);
         if (!user_and_zone_name) {
@@ -88,6 +114,13 @@ namespace irods
         }
 
         const auto& [user_name, zone_name] = *user_and_zone_name;
+
+        // If the zone name is provided both via argument in the admin API and in the username,
+        // they must match. The zone name is used in the user name to identify the home zone of
+        // each user.
+        if (!_zone_name.empty() && !zone_name.empty() && _zone_name != zone_name) {
+            return CAT_INVALID_ZONE;
+        }
 
         if (user_is_client_or_proxy_user(_comm, user_name, zone_name)) {
             constexpr auto err = SYS_NOT_ALLOWED;
@@ -110,7 +143,10 @@ namespace irods
         }
 
         userInfo_t uir = ui;
-        if (!zone_name.empty()) {
+        if (!_zone_name.empty()) {
+            std::strncpy(uir.rodsZone, _zone_name.data(), sizeof(ui.rodsZone));
+        }
+        else if (!zone_name.empty()) {
             std::strncpy(uir.rodsZone, zone_name.data(), sizeof(uir.rodsZone));
         }
 


### PR DESCRIPTION
The zone name can now be provided via argument in the GeneralAdmin API
as well as the UserAdmin API. This is done to support clients which
provide the argument. iadmin will provide the desired zone name through
the octothorpe-delimited method.

---

CI tests running. cherry-picked from work for #6015 