### PR TITLE
Undefined behavior / Memory Alignment / Boost.Container bug non-intrusive solution (main)

### DIFF
--- a/cmake/development_library.cmake
+++ b/cmake/development_library.cmake
@@ -23,6 +23,7 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/core/include/apiHandler.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/base64.h
   ${CMAKE_SOURCE_DIR}/lib/core/include/bunUtil.h
+  ${CMAKE_SOURCE_DIR}/lib/core/include/capped_memory_resource.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/chksumUtil.h
   ${CMAKE_SOURCE_DIR}/lib/core/include/client_connection.hpp
   ${CMAKE_SOURCE_DIR}/lib/core/include/connection_pool.hpp

--- a/lib/core/include/capped_memory_resource.hpp
+++ b/lib/core/include/capped_memory_resource.hpp
@@ -1,0 +1,92 @@
+#ifndef IRODS_CAPPED_MEMORY_RESOURCE_HPP
+#define IRODS_CAPPED_MEMORY_RESOURCE_HPP
+
+/// \file
+
+#include "boost/container/pmr/memory_resource.hpp"
+
+#include "fmt/format.h"
+
+#include <new>
+#include <stdexcept>
+
+/// A namespace containing components meant to be used with Boost.Container's PMR library.
+namespace irods::experimental::pmr
+{
+    /// A \p capped_memory_resource is a special purpose memory resource class that allows
+    /// applications to enforce a limit on the amount of memory that can be allocated via
+    /// global operator new and delete.
+    ///
+    /// \since 4.2.11
+    class capped_memory_resource
+        : public boost::container::pmr::memory_resource
+    {
+    public:
+        /// Constructs a \p capped_memory_resource with the given limit.
+        ///
+        /// \param[in] _max_size The maximum amount of bytes allowed to be allocated.
+        ///
+        /// \throws std::invalid_argument If any of the incoming constructor arguments do not
+        ///                               satisfy construction requirements.
+        ///
+        /// \since 4.2.11
+        explicit capped_memory_resource(std::int64_t _max_size)
+            : boost::container::pmr::memory_resource{}
+            , max_size_(_max_size)
+            , allocated_{}
+        {
+            if (_max_size <= 0) {
+                throw std::invalid_argument{
+                    fmt::format("capped_memory_resource: max size must be greater than zero [max_size={}].", _max_size)};
+            }
+        } // capped_memory_resource
+
+        capped_memory_resource(const capped_memory_resource&) = delete;
+        auto operator=(const capped_memory_resource&) -> capped_memory_resource& = delete;
+
+        ~capped_memory_resource() = default;
+
+        /// Returns the number of bytes used by the client.
+        ///
+        /// The value returned does not include memory used for tracking allocations.
+        ///
+        /// \return An unsigned integral type.
+        ///
+        /// \since 4.2.11
+        auto allocated() const noexcept -> std::size_t
+        {
+            return allocated_;
+        } // allocated
+
+    protected:
+        auto do_allocate(std::size_t _bytes, std::size_t _alignment) -> void* override
+        {
+            if (allocated_ + _bytes >= max_size_) {
+                throw std::bad_alloc{};
+            }
+
+            auto* p = ::operator new(_bytes, std::align_val_t{_alignment});
+            allocated_ += _bytes;
+
+            return p;
+        } // do_allocate
+
+        auto do_deallocate(void* _p, std::size_t _bytes, std::size_t _alignment) -> void override
+        {
+            ::operator delete(_p, std::align_val_t{_alignment});
+            allocated_ -= _bytes;
+        } // do_deallocate
+
+        auto do_is_equal(const boost::container::pmr::memory_resource&) const noexcept -> bool override
+        {
+            return true;
+        } // do_is_equal
+
+    private:
+        std::size_t max_size_;
+        std::size_t allocated_;
+    }; // capped_memory_resource
+} // namespace irods::experimental::pmr
+
+#endif // IRODS_CAPPED_MEMORY_RESOURCE_HPP
+

--- a/lib/core/include/fixed_buffer_resource.hpp
+++ b/lib/core/include/fixed_buffer_resource.hpp
@@ -3,17 +3,26 @@
 
 /// \file
 
-#include <boost/container/pmr/memory_resource.hpp>
+#include "boost/version.hpp"
 
-#include <fmt/format.h>
+#if BOOST_VERSION < 107200
+    // There is a known bug in Boost versions prior to v1.72.
+    // The bug appears when deallocating memory and results in UB due
+    // to memory alignment issues.
+    #error fixed_buffer_resource.hpp requires Boost v1.72!
+#endif // BOOST_VERSION < 107200
+
+#include "boost/container/pmr/memory_resource.hpp"
+
+#include "fmt/format.h"
 
 #include <cstddef>
 #include <cassert>
-#include <iterator>
-#include <algorithm>
-#include <type_traits>
+#include <memory>
 #include <ostream>
 #include <stdexcept>
+#include <tuple>
+#include <type_traits>
 
 /// A namespace containing components meant to be used with Boost.Container's PMR library.
 namespace irods::experimental::pmr
@@ -24,54 +33,58 @@ namespace irods::experimental::pmr
     ///
     /// This class implements a first-fit scheme and is NOT thread-safe.
     ///
-    /// \tparam ByteRep The memory representation for the underlying buffer. Must be \p char
-    ///                 or \p std::byte.
+    /// \tparam ByteRep The memory representation for the underlying buffer. Must be one of
+    ///                 the following:
+    /// - char
+    /// - unsigned char
+    /// - std::byte
     ///
-    /// \since 4.2.11
+    /// \since 4.3.0
     template <typename ByteRep>
     class fixed_buffer_resource
         : public boost::container::pmr::memory_resource
     {
     public:
-        static_assert(std::is_same_v<ByteRep, char> || std::is_same_v<ByteRep, std::byte>);
+        static_assert(std::is_same_v<ByteRep, char> ||
+                      std::is_same_v<ByteRep, unsigned char> ||
+                      std::is_same_v<ByteRep, std::byte>);
 
         /// Constructs a \p fixed_buffer_resource using the given buffer as the allocation
         /// source.
         ///
-        /// \param[in] _buffer                The buffer that will be used for allocations.
-        /// \param[in] _buffer_size           The size of the buffer in bytes.
-        /// \param[in] _initial_freelist_size The initial size of the freelist in terms of elements.
+        /// \param[in] _buffer      The buffer that will be used for allocations.
+        /// \param[in] _buffer_size The size of the buffer in bytes.
         ///
         /// \throws std::invalid_argument If any of the incoming constructor arguments do not
         ///                               satisfy construction requirements.
         ///
-        /// \since 4.2.11
-        fixed_buffer_resource(ByteRep* _buffer,
-                              std::int64_t _buffer_size,
-                              std::int64_t _initial_freelist_size)
+        /// \since 4.3.0
+        fixed_buffer_resource(ByteRep* _buffer, std::int64_t _buffer_size)
             : boost::container::pmr::memory_resource{}
             , buffer_{_buffer}
             , buffer_size_(_buffer_size)
             , allocated_{}
-            , overhead_{management_block_size}
             , headers_{}
-            , freelist_{}
         {
-            if (!_buffer || _buffer_size <= 0 || _initial_freelist_size <= 0) {
+            if (!_buffer || _buffer_size <= 0) {
                 const auto* msg_fmt = "fixed_buffer_resource: invalid constructor arguments "
-                                      "[buffer={}, size={}, freelist_size={}].";
-                const auto msg = fmt::format(msg_fmt, static_cast<void*>(_buffer), _buffer_size, _initial_freelist_size);
-                throw std::invalid_argument{msg};
+                                      "[buffer={}, size={}].";
+                throw std::invalid_argument{fmt::format(msg_fmt, fmt::ptr(_buffer), _buffer_size)};
             }
 
-            headers_ = reinterpret_cast<header*>(buffer_);
-            headers_->size = buffer_size_ - sizeof(header);
+            auto* header_storage = buffer_;
+            auto space_remaining = buffer_size_;
+
+            // Make sure the buffer is aligned for the header type.
+            if (!std::align(alignof(header), sizeof(header_storage), buffer_, space_remaining)) {
+                throw std::runtime_error{"fixed_buffer_resource: internal memory alignment error. "};
+            }
+
+            headers_ = new (header_storage) header;
+            headers_->size = space_remaining - sizeof(header);
             headers_->prev = nullptr;
             headers_->next = nullptr;
-            *address_of_used_flag(headers_) = false;
-
-            freelist_.reserve(_initial_freelist_size);
-            freelist_.push_back(headers_);
+            headers_->used = false;
         } // fixed_buffer_resource
 
         fixed_buffer_resource(const fixed_buffer_resource&) = delete;
@@ -79,44 +92,34 @@ namespace irods::experimental::pmr
 
         ~fixed_buffer_resource() = default;
 
-        /// Returns the number of bytes used by the client.
+        /// Returns the number of allocated bytes currently in use by the client.
         ///
         /// The value returned does not include memory used for tracking allocations.
         ///
         /// \return An unsigned integral type.
         ///
-        /// \since 4.2.11
+        /// \since 4.3.0
         auto allocated() const noexcept -> std::size_t
         {
             return allocated_;
         } // allocated
 
-        /// Returns the number of bytes used for tracking allocations.
-        ///
-        /// \return An unsigned integral type.
-        ///
-        /// \since 4.2.11
-        auto allocation_overhead() const noexcept -> std::size_t
-        {
-            return overhead_;
-        } // allocation_overhead
-
         /// Writes the state of the allocation table to the output stream.
         ///
-        /// \since 4.2.11
+        /// \since 4.3.0
         auto print(std::ostream& _os) const -> void
         {
             std::size_t i = 0;
 
             for (auto* h = headers_; h; h = h->next) {
-                _os << fmt::format("{:>3}. Header Info [{}]: {{previous={:14}, next={:14}, used={}, data_size={}, data={:14}}}\n",
+                _os << fmt::format("{:>3}. Header Info [{}]: {{previous={:14}, next={:14}, used={:>5}, data={:14}, data_size={}}}\n",
                                    i,
                                    fmt::ptr(h),
                                    fmt::ptr(h->prev),
                                    fmt::ptr(h->next),
-                                   is_data_in_use(h),
-                                   h->size,
-                                   fmt::ptr(address_of_data_segment(h)));
+                                   h->used,
+                                   fmt::ptr(address_of_data_segment(h)),
+                                   h->size);
                 ++i;
             }
         } // print
@@ -124,9 +127,8 @@ namespace irods::experimental::pmr
     protected:
         auto do_allocate(std::size_t _bytes, std::size_t _alignment) -> void* override
         {
-            for (auto* h : freelist_) {
+            for (auto* h = headers_; h; h = h->next) {
                 if (auto* p = allocate_block(_bytes, _alignment, h); p) {
-                    remove_header_from_freelist(h);
                     return p;
                 }
             }
@@ -136,15 +138,15 @@ namespace irods::experimental::pmr
 
         auto do_deallocate(void* _p, std::size_t _bytes, std::size_t _alignment) -> void override
         {
-            auto* h = reinterpret_cast<header*>(static_cast<ByteRep*>(_p) - management_block_size);
-            auto* used = address_of_used_flag(h);
+            static_cast<void>(_alignment); // Keep the compiler silent.
 
-            assert(*used);
+            void* data = *(static_cast<void**>(_p) - 1);
+            auto* h = reinterpret_cast<header*>(static_cast<ByteRep*>(data) - sizeof(header));
+
+            assert(h != nullptr);
             assert(h->size == _bytes);
 
-            *used = false;
-
-            freelist_.push_back(h);
+            h->used = false;
 
             coalesce_with_next_unused_block(h);
             coalesce_with_next_unused_block(h->prev);
@@ -158,75 +160,122 @@ namespace irods::experimental::pmr
         } // do_is_equal
 
     private:
-        // Metadata associated with a single data segment within the
+        // A type that holds management information for a single allocation within the
         // underlying memory buffer. All data segments will be preceded by a header.
+        //
+        // Memory layout for a single allocation:
+        //
+        //   +-------------------------------------------------------------------------+
+        //   |      header      |                    data segment                      |
+        //   +------------------+------------------------------------------------------+
+        //   | padding | header | padding | unaligned pointer | aligned pointer | data |
+        //   +------------------+------------------------------------------------------+
+        //
         struct header
         {
-            std::size_t size;   // Size of the memory block (excluding header).
+            std::size_t size;   // Size of the memory block (excluding all management info).
             header* prev;       // Pointer to the previous header block.
             header* next;       // Pointer to the next header block.
+            bool used;          // Indicates whether the memory is in use.
         }; // struct header
-
-        // The size of the header just before the data segment.
-        static constexpr std::size_t management_block_size = sizeof(header) + sizeof(bool);
-
-        auto address_of_used_flag(header* _h) const noexcept -> bool*
-        {
-            return static_cast<bool*>(static_cast<void*>(reinterpret_cast<ByteRep*>(_h) + sizeof(header)));
-        } // address_of_used_flag
 
         auto address_of_data_segment(header* _h) const noexcept -> ByteRep*
         {
-            return reinterpret_cast<ByteRep*>(_h) + management_block_size;
+            return reinterpret_cast<ByteRep*>(_h) + sizeof(header);
         } // address_of_data_segment
 
-        auto is_data_in_use(header* _h) const noexcept -> bool
+        auto aligned_pointer(std::size_t _bytes, std::size_t _alignment, header* _h)
+            -> std::tuple<void*, std::size_t>
         {
-            return *address_of_used_flag(_h);
-        } // is_data_in_use
+            // The unused memory is located right after the header.
+            void* data = address_of_data_segment(_h);
+
+            // Reserve space for the potentially unaligned pointer.
+            void* aligned_ptr = static_cast<ByteRep*>(data) + sizeof(void*);
+            auto space_remaining = _h->size - sizeof(void*);
+
+            // Aligning the pointer will use additional bytes if the pointer is not
+            // aligned to a proper address. If alignment fails or the block does not
+            // have enough space left after aligning the pointer, return immediately.
+            if (!std::align(_alignment, _bytes, aligned_ptr, space_remaining) || _bytes > space_remaining) {
+                return {nullptr, 0};
+            }
+
+            // Store the address of the original allocation directly before the
+            // aligned memory.
+            new (static_cast<ByteRep*>(aligned_ptr) - sizeof(void*)) void*{data};
+
+            return {aligned_ptr, space_remaining};
+        } // aligned_pointer
 
         auto allocate_block(std::size_t _bytes, std::size_t _alignment, header* _h) -> void*
         {
-            if (is_data_in_use(_h)) {
+            if (_h->used) {
                 return nullptr;
             }
 
             // Return the block if it matches the requested number of bytes.
             if (_bytes == _h->size) {
-                *address_of_used_flag(_h) = true;
-                allocated_ += _bytes;
-                return address_of_data_segment(_h);
-            }
+                auto* aligned_ptr = std::get<0>(aligned_pointer(_bytes, _alignment, _h));
 
-            // Split the data segment managed by this header if it is large enough
-            // to satisfy the allocation request and a new header block.
-            if (management_block_size + _bytes < _h->size) {
-                // The unused memory is located right after the header.
-                auto* data = address_of_data_segment(_h);
-
-#if 0
-                //
-                // This disabled block of code exists here as a reminder that this allocator
-                // implementation does not handle memory alignment requests. More understanding
-                // is needed before this can be addressed.
-                //
-
-                auto* aligned_data = std::align(_alignment, _bytes, data, _h->size);
-                
-                if (!aligned_data) {
+                if (!aligned_ptr) {
                     return nullptr;
                 }
-#endif
 
-                // Insert a new header after "_h"'s data segment.
+                _h->used = true;
+                allocated_ += _bytes;
+
+                return aligned_ptr;
+            }
+
+            // The following line can be interpreted as the following:
+            // - sizeof(void*)  : The number of bytes needed to store the unaligned pointer.
+            // - _bytes         : The number of bytes requested for allocation.
+            // - _alignment - 1 : The max number of bytes needed to achieve proper alignment.
+            //
+            // The sum of these values represents the amount of memory possibly needed to
+            // satisfy the allocation request.
+            const auto required_space = sizeof(void*) + _bytes + _alignment - 1;
+
+            // Split the data segment managed by this header if it is large enough
+            // to satisfy the allocation request.
+            if (required_space <= _h->size) {
+                auto [aligned_ptr, space_remaining] = aligned_pointer(_bytes, _alignment, _h);
+
+                if (!aligned_ptr) {
+                    return nullptr;
+                }
+
+                // Update the state to reflect the fact that "aligned_ptr" is valid
+                // and will be returned to the caller.
+                space_remaining -= _bytes;
+                allocated_ += _bytes;
+
+                // At this point, we have satisfied the request. However, we need to
+                // determine if we can split the segment so that the unused bytes can be
+                // used for other allocations.
+                //
+                // Return if there is not enough space left in the buffer to construct a
+                // new header and handle its alignment.
+                if (space_remaining <= sizeof(header) + alignof(header) - 1) {
+                    _h->size = _bytes;
+                    _h->used = true;
+                    return aligned_ptr;
+                }
+
+                void* aligned_header_storage = static_cast<ByteRep*>(aligned_ptr) + _bytes;
+
+                if (!std::align(alignof(header), sizeof(header), aligned_header_storage, space_remaining)) {
+                    return nullptr;
+                }
+
+                // Construct a new header after the memory managed by "_h".
                 // The new header manages unused memory.
-                auto* new_header = reinterpret_cast<header*>(data + _bytes);
-                new_header->size = _h->size - _bytes - management_block_size;
+                auto* new_header = new (aligned_header_storage) header;
+                new_header->size = space_remaining - sizeof(header);
                 new_header->prev = _h;
                 new_header->next = _h->next;
-                *address_of_used_flag(new_header) = false;
-
-                freelist_.push_back(new_header);
+                new_header->used = false;
 
                 // Update the allocation table links for the header just after the
                 // newly added header.
@@ -237,12 +286,9 @@ namespace irods::experimental::pmr
                 // Adjust the current header's size and mark it as used.
                 _h->size = _bytes;
                 _h->next = new_header;
-                *address_of_used_flag(_h) = true;
+                _h->used = true;
 
-                allocated_ += _bytes;
-                overhead_ += management_block_size;
-
-                return data;
+                return aligned_ptr;
             }
 
             return nullptr;
@@ -250,7 +296,7 @@ namespace irods::experimental::pmr
 
         auto coalesce_with_next_unused_block(header* _h) -> void
         {
-            if (!_h || is_data_in_use(_h)) {
+            if (!_h || _h->used) {
                 return;
             }
 
@@ -258,8 +304,8 @@ namespace irods::experimental::pmr
 
             // Coalesce the memory blocks if they are not in use by the client.
             // This means that "_h" will absorb the header at "_h->next".
-            if (header_to_remove && !is_data_in_use(header_to_remove)) {
-                _h->size += header_to_remove->size;
+            if (header_to_remove && !header_to_remove->used) {
+                _h->size = calculate_size_for_coalescing(_h, header_to_remove);
                 _h->next = header_to_remove->next;
 
                 // Make sure the links between the headers are updated appropriately.
@@ -267,27 +313,26 @@ namespace irods::experimental::pmr
                 if (auto* new_next_header = header_to_remove->next; new_next_header) {
                     new_next_header->prev = _h;
                 }
-
-                overhead_ -= management_block_size;
-                remove_header_from_freelist(header_to_remove);
             }
         } // coalesce_with_next_unused_block
 
-        auto remove_header_from_freelist(header* _h) -> void
+        auto calculate_size_for_coalescing(header* _h1, header* _h2) const noexcept -> std::size_t
         {
-            const auto end = std::end(freelist_);
+            auto* start = address_of_data_segment(_h1);
 
-            if (const auto iter = std::find(std::begin(freelist_), end, _h); iter != end) {
-                freelist_.erase(iter);
+            if (auto* header_after_h2 = _h2->next; header_after_h2) {
+                return reinterpret_cast<ByteRep*>(header_after_h2) - start;
             }
-        } // remove_header_from_freelist
+            
+            // At this point, we know "_h2" is the last header in the allocation table.
+            // Therefore, use the end of the underlying buffer.
+            return reinterpret_cast<ByteRep*>(buffer_) + buffer_size_ - start;
+        } // calculate_size_for_coalescing
 
-        ByteRep* buffer_;
+        void* buffer_;
         std::size_t buffer_size_;
         std::size_t allocated_;
-        std::size_t overhead_;
         header* headers_;
-        std::vector<header*> freelist_;
     }; // fixed_buffer_resource
 } // namespace irods::experimental::pmr
 

--- a/server/core/include/irods_delay_queue.hpp
+++ b/server/core/include/irods_delay_queue.hpp
@@ -32,8 +32,7 @@ namespace irods
             if (_pool_size_in_bytes > 0) {
                 buffer_.resize(_pool_size_in_bytes);
 
-                const std::size_t initial_freelist_size = 250; 
-                upstream_allocator_.reset(new ipmr::fixed_buffer_resource(buffer_.data(), buffer_.size(), initial_freelist_size));
+                upstream_allocator_.reset(new ipmr::fixed_buffer_resource(buffer_.data(), buffer_.size()));
                 allocator_.reset(new bpmr::unsynchronized_pool_resource{upstream_allocator_.get()});
 
                 queued_rules_.reset(new bpmr::vector<boost::container::pmr::string>{allocator_.get()});

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 # New tests should be added to this list.
 set(TEST_INCLUDE_LIST test_config/irods_atomic_apply_acl_operations
                       test_config/irods_atomic_apply_metadata_operations
+                      test_config/irods_capped_memory_resource
                       test_config/irods_client_connection
                       test_config/irods_client_server_negotiation
                       test_config/irods_connection_pool

--- a/unit_tests/cmake/test_config/irods_capped_memory_resource.cmake
+++ b/unit_tests/cmake/test_config/irods_capped_memory_resource.cmake
@@ -1,0 +1,13 @@
+set(IRODS_TEST_TARGET irods_capped_memory_resource)
+
+set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/src/test_capped_memory_resource.cpp)
+
+set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
+                            ${CMAKE_SOURCE_DIR}/lib/core/include
+                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
+                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
+ 
+set(IRODS_TEST_LINK_LIBRARIES ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_container.so
+                              ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)

--- a/unit_tests/src/test_capped_memory_resource.cpp
+++ b/unit_tests/src/test_capped_memory_resource.cpp
@@ -1,0 +1,61 @@
+#include "catch.hpp"
+
+#include "capped_memory_resource.hpp"
+
+#include "boost/container/pmr/vector.hpp"
+
+#include <cstddef>
+#include <stdexcept>
+
+namespace pmr = irods::experimental::pmr;
+
+TEST_CASE("capped_memory_resource allocation and deallocation")
+{
+    pmr::capped_memory_resource allocator{100};
+
+    // No bytes allocated yet.
+    CHECK(allocator.allocated() == 0);
+
+    // Show that allocations and deallocations are tracked correctly.
+    auto* p = allocator.allocate(10);
+    CHECK(allocator.allocated() == 10);
+
+    allocator.deallocate(p, 10);
+    CHECK(allocator.allocated() == 0);
+
+    // Show that the capped_memory_resource throws a std::bad_alloc exception
+    // when the memory cap will be exceeded.
+    CHECK_THROWS_AS([&allocator] { allocator.allocate(101); }(), std::bad_alloc);
+
+    // Show that the allocator's state is not corrupted following a
+    // std::bad_alloc exception.
+    CHECK(allocator.allocated() == 0);
+}
+
+TEST_CASE("capped_memory_resource throws on invalid cap")
+{
+    CHECK_THROWS_AS([] { pmr::capped_memory_resource{ 0}; }(), std::invalid_argument);
+    CHECK_THROWS_AS([] { pmr::capped_memory_resource{-1}; }(), std::invalid_argument);
+}
+
+TEST_CASE("capped_memory_resource works with pmr containers")
+{
+    pmr::capped_memory_resource allocator{64};
+
+    {
+        boost::container::pmr::vector<int> ints{&allocator};
+
+        ints.push_back(1);
+        ints.push_back(2);
+        ints.push_back(3);
+
+        CHECK_THROWS_AS([&ints] {
+            for (int i = 0; i < 100; ++i) {
+                ints.push_back(i + 4);
+            }
+        }(), std::bad_alloc);
+    }
+
+    CHECK(allocator.allocated() == 0);
+}
+

--- a/unit_tests/src/test_fixed_buffer_resource.cpp
+++ b/unit_tests/src/test_fixed_buffer_resource.cpp
@@ -1,8 +1,12 @@
+#include "boost/version.hpp"
+
+#if BOOST_VERSION >= 107200
+
 #include "catch.hpp"
 
 #include "fixed_buffer_resource.hpp"
 
-#include <boost/container/pmr/vector.hpp>
+#include "boost/container/pmr/vector.hpp"
 
 #include <cstddef>
 #include <sstream>
@@ -10,43 +14,28 @@
 
 namespace pmr = irods::experimental::pmr;
 
-TEST_CASE("fixed_buffer_resource")
+TEST_CASE("fixed_buffer_resource allocation and deallocation")
 {
-    std::byte buffer[1000];
-    pmr::fixed_buffer_resource mem_resc{buffer, sizeof(buffer), 100};
+    char buffer[100];
+    pmr::fixed_buffer_resource allocator{buffer, sizeof(buffer)};
 
-    {
-        boost::container::pmr::vector<int> ints{&mem_resc};
+    // No bytes allocated yet.
+    CHECK(allocator.allocated() == 0);
 
-        for (int i = 0; i < 20; ++i) {
-            ints.push_back(i);
-        }
+    // Show that allocations and deallocations are tracked correctly.
+    auto* p = allocator.allocate(10);
+    CHECK(allocator.allocated() == 10);
 
-        CHECK(mem_resc.allocated() > 0);
+    allocator.deallocate(p, 10);
+    CHECK(allocator.allocated() == 0);
 
-        // Show that the allocation table can be printed out.
-        std::ostringstream os;
-        CHECK_NOTHROW([&mem_resc, &os] { mem_resc.print(os); }());
+    // Show that the fixed_buffer_resource throws a std::bad_alloc exception
+    // when the underlying buffer is exhausted.
+    CHECK_THROWS_AS([&allocator] { allocator.allocate(101); }(), std::bad_alloc);
 
-        const auto alloc_table = os.str();
-        CHECK(alloc_table.find("  1. Header Info [") != std::string::npos);
-        CHECK(alloc_table.find("previous=") != std::string::npos);
-        CHECK(alloc_table.find("next=") != std::string::npos);
-        CHECK(alloc_table.find("used=") != std::string::npos);
-        CHECK(alloc_table.find("data_size=") != std::string::npos);
-        CHECK(alloc_table.find("data=") != std::string::npos);
-
-        // Show that the fixed_buffer_resource throws a std::bad_alloc exception
-        // when the memory is exhausted.
-        CHECK_THROWS_AS([&ints] {
-            for (int i = 0; i < 100000; ++i) {
-                ints.push_back(i);
-            }
-        }(), std::bad_alloc);
-    }
-
-    CHECK(mem_resc.allocated() == 0);
-    CHECK(mem_resc.allocation_overhead() == 25);
+    // Show that the allocator's state is not corrupted following a
+    // std::bad_alloc exception.
+    CHECK(allocator.allocated() == 0);
 }
 
 TEST_CASE("fixed_buffer_resource throws on invalid arguments")
@@ -54,7 +43,7 @@ TEST_CASE("fixed_buffer_resource throws on invalid arguments")
     SECTION("throws on invalid buffer")
     {
         CHECK_THROWS_AS(([] {
-            pmr::fixed_buffer_resource<char>{nullptr, 1, 1};
+            pmr::fixed_buffer_resource<char>{nullptr, 1};
         }()), std::invalid_argument);
     }
 
@@ -62,26 +51,51 @@ TEST_CASE("fixed_buffer_resource throws on invalid arguments")
     {
         CHECK_THROWS_AS(([] {
             char buffer;
-            pmr::fixed_buffer_resource<char>{&buffer, 0, 1};
+            pmr::fixed_buffer_resource<char>{&buffer, 0};
         }()), std::invalid_argument);
 
         CHECK_THROWS_AS(([] {
             char buffer;
-            pmr::fixed_buffer_resource<char>{&buffer, -1, 1};
-        }()), std::invalid_argument);
-    }
-
-    SECTION("throws on invalid freelist size")
-    {
-        CHECK_THROWS_AS(([] {
-            char buffer;
-            pmr::fixed_buffer_resource<char>{&buffer, 1, 0};
-        }()), std::invalid_argument);
-
-        CHECK_THROWS_AS(([] {
-            char buffer;
-            pmr::fixed_buffer_resource<char>{&buffer, 1, -1};
+            pmr::fixed_buffer_resource<char>{&buffer, -1};
         }()), std::invalid_argument);
     }
 }
+
+TEST_CASE("fixed_buffer_resource works with pmr containers")
+{
+    char buffer[64];
+    pmr::fixed_buffer_resource allocator{buffer, sizeof(buffer)};
+
+    {
+        boost::container::pmr::vector<int> ints{&allocator};
+
+        ints.push_back(1);
+        ints.push_back(2);
+        ints.push_back(3);
+
+        // Show that the allocation table can be printed out.
+        std::ostringstream os;
+        CHECK_NOTHROW([&allocator, &os] { allocator.print(os); }());
+
+        const auto alloc_table = os.str();
+        CHECK(alloc_table.find("  1. Header Info [") != std::string::npos);
+        CHECK(alloc_table.find("previous=") != std::string::npos);
+        CHECK(alloc_table.find("next=") != std::string::npos);
+        CHECK(alloc_table.find("used=") != std::string::npos);
+        CHECK(alloc_table.find("data=") != std::string::npos);
+        CHECK(alloc_table.find("data_size=") != std::string::npos);
+
+        // Show that the fixed_buffer_resource throws a std::bad_alloc exception
+        // when the memory is exhausted.
+        CHECK_THROWS_AS([&ints] {
+            for (int i = 0; i < 100; ++i) {
+                ints.push_back(i + 4);
+            }
+        }(), std::bad_alloc);
+    }
+
+    CHECK(allocator.allocated() == 0);
+}
+
+#endif // BOOST_VERSION >= 107200
 

--- a/unit_tests/unit_tests_list.json
+++ b/unit_tests/unit_tests_list.json
@@ -1,6 +1,7 @@
 [
     "irods_atomic_apply_acl_operations",
     "irods_atomic_apply_metadata_operations",
+    "irods_capped_memory_resource",
     "irods_client_connection",
     "irods_client_server_negotiation",
     "irods_connection_pool",
@@ -15,8 +16,8 @@
     "irods_get_file_descriptor_info",
     "irods_hierarchy_parser",
     "irods_hostname_cache",
-    "irods_key_value_proxy",
     "irods_json_apis_from_client",
+    "irods_key_value_proxy",
     "irods_lifetime_manager",
     "irods_linked_list_iterator",
     "irods_logical_locking",


### PR DESCRIPTION
A unit test for `capped_memory_resource` is in the works for this PR.

This PR resolves several issues with `fixed_buffer_resource` and Boost.Container. The changes are required for 4-2-stable as well. Once this PR is complete, the changes introduced here will be ported to 4-2-stable.