### PR TITLE
[6053] more graceful stop when server already stopped (4-2-stable)

### DIFF
--- a/packaging/irods
+++ b/packaging/irods
@@ -51,7 +51,7 @@ start)
 stop)
     su $SU_SHELL_OPTS $IRODS_SERVICE_ACCOUNT_NAME -c "$IRODS_CTL stop"
     if [ "$DETECTEDOS" = "RedHatCompatible" -o "$DETECTEDOS" = "SuSE" ] ; then
-        rm /var/lock/subsys/irods
+        rm -f /var/lock/subsys/irods
     fi
     ;;
 restart)


### PR DESCRIPTION
prevents a non-zero return value when the file does not exist