### PR TITLE
[#6089] Prevent checksums on archive replicas (4-2-stable)

### DIFF
--- a/plugins/resources/compound/libcompound.cpp
+++ b/plugins/resources/compound/libcompound.cpp
@@ -761,7 +761,7 @@ irods::error repl_object(
             file_obj->id(strtol(id_str, NULL, 10));
         }
 
-        //ret = resc->call<const char*>( _ctx.comm(), irods::RESOURCE_OP_SYNCTOARCH, file_obj, L1desc[source_l1descInx].dataObjInfo->filePath );
+        addKeyVal(&L1desc[destination_l1descInx].dataObjInfo->condInput, NO_COMPUTE_KW, "");
 
         // Sync to archive!
         int dst_create_path = 0;

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -1162,6 +1162,15 @@ class Test_Resource_CompoundWithMockarchive(ChunkyDevTest, ResourceSuite, unitte
         shutil.rmtree(irods_config.irods_directory + "/archiveRescVault", ignore_errors=True)
         shutil.rmtree(irods_config.irods_directory + "/cacheRescVault", ignore_errors=True)
 
+    def test_checksums_not_computed_for_archive__issue_6089(self):
+        filename = 'test_checksums_not_computed_for_archive__issue_6089'
+        filepath = lib.create_local_testfile(filename)
+        logical_path = os.path.join(self.admin.session_collection, filename)
+
+        self.admin.assert_icommand(['iput', '-K', filepath, logical_path])
+        self.assertNotEqual(0, len(lib.get_replica_checksum(self.admin, filename, 0)))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.admin, filename, 1)))
+
     def test_irm_specific_replica(self):
         self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', self.testfile)  # should be listed
         self.admin.assert_icommand("irepl -R " + self.testresc + " " + self.testfile)  # creates replica
@@ -1478,6 +1487,15 @@ class Test_Resource_CompoundWithUnivmss(ChunkyDevTest, ResourceSuite, unittest.T
         irods_config = IrodsConfig()
         shutil.rmtree(irods_config.irods_directory + "/archiveRescVault", ignore_errors=True)
         shutil.rmtree(irods_config.irods_directory + "/cacheRescVault", ignore_errors=True)
+
+    def test_checksums_not_computed_for_archive__issue_6089(self):
+        filename = 'test_checksums_not_computed_for_archive__issue_6089'
+        filepath = lib.create_local_testfile(filename)
+        logical_path = os.path.join(self.admin.session_collection, filename)
+
+        self.admin.assert_icommand(['iput', '-K', filepath, logical_path])
+        self.assertNotEqual(0, len(lib.get_replica_checksum(self.admin, filename, 0)))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.admin, filename, 1)))
 
     def test_irm_with_no_stage__2930(self):
         self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', self.testfile)  # should be listed
@@ -1808,6 +1826,15 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
         irods_config = IrodsConfig()
         shutil.rmtree(irods_config.irods_directory + "/archiveRescVault", ignore_errors=True)
         shutil.rmtree("rm -rf " + irods_config.irods_directory + "/cacheRescVault", ignore_errors=True)
+
+    def test_checksums_not_computed_for_archive__issue_6089(self):
+        filename = 'test_checksums_not_computed_for_archive__issue_6089'
+        filepath = lib.create_local_testfile(filename)
+        logical_path = os.path.join(self.admin.session_collection, filename)
+
+        self.admin.assert_icommand(['iput', '-K', filepath, logical_path])
+        self.assertNotEqual(0, len(lib.get_replica_checksum(self.admin, filename, 0)))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.admin, filename, 1)))
 
     @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "local filesystem check")
     def test_ichksum_no_file_modified_under_compound__4085(self):
@@ -2802,6 +2829,17 @@ class Test_Resource_ReplicationToTwoCompound(ChunkyDevTest, ResourceSuite, unitt
         shutil.rmtree(irods_config.irods_directory + "/archiveResc2Vault", ignore_errors=True)
         shutil.rmtree(irods_config.irods_directory + "/cacheResc2Vault", ignore_errors=True)
 
+    def test_checksums_not_computed_for_archive__issue_6089(self):
+        filename = 'test_checksums_not_computed_for_archive__issue_6089'
+        filepath = lib.create_local_testfile(filename)
+        logical_path = os.path.join(self.admin.session_collection, filename)
+
+        self.admin.assert_icommand(['iput', '-K', filepath, logical_path])
+        self.assertNotEqual(0, len(lib.get_replica_checksum(self.admin, filename, 0)))
+        self.assertNotEqual(0, len(lib.get_replica_checksum(self.admin, filename, 2)))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.admin, filename, 1)))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.admin, filename, 3)))
+
     def test_irm_specific_replica(self):
         self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', self.testfile)  # should be listed
         self.admin.assert_icommand("irepl -R " + self.testresc + " " + self.testfile)  # creates replica
@@ -3266,6 +3304,17 @@ class Test_Resource_ReplicationToTwoCompoundResourcesWithPreferArchive(ChunkyDev
         backupcorefilepath = core.filepath + "--" + self._testMethodName
         shutil.copy(backupcorefilepath, core.filepath)
         os.remove(backupcorefilepath)
+
+    def test_checksums_not_computed_for_archive__issue_6089(self):
+        filename = 'test_checksums_not_computed_for_archive__issue_6089'
+        filepath = lib.create_local_testfile(filename)
+        logical_path = os.path.join(self.admin.session_collection, filename)
+
+        self.admin.assert_icommand(['iput', '-K', filepath, logical_path])
+        self.assertNotEqual(0, len(lib.get_replica_checksum(self.admin, filename, 0)))
+        self.assertNotEqual(0, len(lib.get_replica_checksum(self.admin, filename, 2)))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.admin, filename, 1)))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.admin, filename, 3)))
 
     def test_irm_specific_replica(self):
         self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', self.testfile)  # should be listed

--- a/server/api/src/rsDataObjClose.cpp
+++ b/server/api/src/rsDataObjClose.cpp
@@ -132,6 +132,15 @@ namespace
                     __FUNCTION__, srcL1descInx));
             }
 
+            // If the user has requested that no checksum be computed for the destination
+            // replica, the checksum is cleared here and the checksum returned as an empty
+            // string. This is only applicable to the compound resource because replication
+            // API finalizes its own replicas now.
+            if (destination_replica.cond_input().contains(NO_COMPUTE_KW)) {
+                destination_replica.checksum("");
+                return {};
+            }
+
             auto source_replica = ir::replica_proxy_t{*L1desc[srcL1descInx].dataObjInfo};
             if (!source_replica.checksum().empty() && STALE_REPLICA != source_replica.replica_status()) {
                 destination_replica.cond_input()[ORIG_CHKSUM_KW] = source_replica.checksum();


### PR DESCRIPTION
CI tests passed