### PR TITLE
allow all access levels from icatDefines.h

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -10136,12 +10136,24 @@ irods::error db_mod_access_control_op(
         adminMode = 1;
     }
 
-    static const std::vector<char const *> allowed_access_levels { ACCESS_EXECUTE, ACCESS_READ_ANNOTATION, 
-        ACCESS_READ_SYSTEM_METADATA, ACCESS_READ_METADATA, ACCESS_READ_OBJECT, ACCESS_WRITE_ANNOTATION, 
-        ACCESS_CREATE_METADATA, ACCESS_MODIFY_METADATA, ACCESS_DELETE_METADATA, ACCESS_ADMINISTER_OBJECT, 
-        ACCESS_CREATE_OBJECT, ACCESS_MODIFY_OBJECT, ACCESS_DELETE_OBJECT, ACCESS_CREATE_TOKEN, 
-        ACCESS_DELETE_TOKEN, ACCESS_CURATE, ACCESS_OWN };
-    const char *myAccessLev = NULL;
+    static const std::vector<char const*> allowed_access_levels{ACCESS_EXECUTE,
+                                                                ACCESS_READ_ANNOTATION,
+                                                                ACCESS_READ_SYSTEM_METADATA,
+                                                                ACCESS_READ_METADATA,
+                                                                ACCESS_READ_OBJECT,
+                                                                ACCESS_WRITE_ANNOTATION,
+                                                                ACCESS_CREATE_METADATA,
+                                                                ACCESS_MODIFY_METADATA,
+                                                                ACCESS_DELETE_METADATA,
+                                                                ACCESS_ADMINISTER_OBJECT,
+                                                                ACCESS_CREATE_OBJECT,
+                                                                ACCESS_MODIFY_OBJECT,
+                                                                ACCESS_DELETE_OBJECT,
+                                                                ACCESS_CREATE_TOKEN,
+                                                                ACCESS_DELETE_TOKEN,
+                                                                ACCESS_CURATE,
+                                                                ACCESS_OWN};
+    const char* myAccessLev = NULL;
     int rmFlag = 0;
     int inheritFlag = 0;
     if ( strcmp( _access_level, AP_NULL ) == 0 ) {
@@ -10161,19 +10173,18 @@ irods::error db_mod_access_control_op(
         inheritFlag = 2;
     }
     else {
-        for ( char const *level: allowed_access_levels ) {
-            if ( !strcmp( _access_level, level ) ) {
+        for (char const* level : allowed_access_levels) {
+            if (!strcmp(_access_level, level)) {
                 myAccessLev = level;
                 break;
             }
         }
-        if ( myAccessLev == NULL ) {
+        if (myAccessLev == NULL) {
             char errMsg[105];
-            snprintf( errMsg, 100, "access level '%s' is invalid",
-                    _access_level );
-            addRErrorMsg( &_ctx.comm()->rError, 0, errMsg );
-            return ERROR( CAT_INVALID_ARGUMENT, errMsg );
-        }       
+            snprintf(errMsg, 100, "access level '%s' is invalid", _access_level);
+            addRErrorMsg(&_ctx.comm()->rError, 0, errMsg);
+            return ERROR(CAT_INVALID_ARGUMENT, errMsg);
+        }
     }
 
     if ( !icss.status ) {

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -10136,7 +10136,12 @@ irods::error db_mod_access_control_op(
         adminMode = 1;
     }
 
-    char *myAccessLev = NULL;
+    static const std::vector<char const *> allowed_access_levels { ACCESS_EXECUTE, ACCESS_READ_ANNOTATION, 
+        ACCESS_READ_SYSTEM_METADATA, ACCESS_READ_METADATA, ACCESS_READ_OBJECT, ACCESS_WRITE_ANNOTATION, 
+        ACCESS_CREATE_METADATA, ACCESS_MODIFY_METADATA, ACCESS_DELETE_METADATA, ACCESS_ADMINISTER_OBJECT, 
+        ACCESS_CREATE_OBJECT, ACCESS_MODIFY_OBJECT, ACCESS_DELETE_OBJECT, ACCESS_CREATE_TOKEN, 
+        ACCESS_DELETE_TOKEN, ACCESS_CURATE, ACCESS_OWN };
+    const char *myAccessLev = NULL;
     int rmFlag = 0;
     int inheritFlag = 0;
     if ( strcmp( _access_level, AP_NULL ) == 0 ) {
@@ -10149,9 +10154,6 @@ irods::error db_mod_access_control_op(
     else if ( strcmp( _access_level, AP_WRITE ) == 0 ) {
         myAccessLev = ACCESS_MODIFY_OBJECT;
     }
-    else if ( strcmp( _access_level, AP_OWN ) == 0 ) {
-        myAccessLev = ACCESS_OWN;
-    }
     else if ( strcmp( _access_level, ACCESS_INHERIT ) == 0 ) {
         inheritFlag = 1;
     }
@@ -10159,11 +10161,19 @@ irods::error db_mod_access_control_op(
         inheritFlag = 2;
     }
     else {
-        char errMsg[105];
-        snprintf( errMsg, 100, "access level '%s' is invalid",
-                  _access_level );
-        addRErrorMsg( &_ctx.comm()->rError, 0, errMsg );
-        return ERROR( CAT_INVALID_ARGUMENT, errMsg );
+        for ( char const *level: allowed_access_levels ) {
+            if ( !strcmp( _access_level, level ) ) {
+                myAccessLev = level;
+                break;
+            }
+        }
+        if ( myAccessLev == NULL ) {
+            char errMsg[105];
+            snprintf( errMsg, 100, "access level '%s' is invalid",
+                    _access_level );
+            addRErrorMsg( &_ctx.comm()->rError, 0, errMsg );
+            return ERROR( CAT_INVALID_ARGUMENT, errMsg );
+        }       
     }
 
     if ( !icss.status ) {

--- a/scripts/irods/lib.py
+++ b/scripts/irods/lib.py
@@ -662,3 +662,20 @@ def replica_exists(session, data_name, replica_number):
         .format(data_name, str(replica_number))])[0]
 
     return 'CAT_NO_ROWS_FOUND' not in out
+
+def iterfy(iterable):
+    """Will return an iterable, even if input is a single item
+
+    Args:
+        iterable : any type
+
+    Returns:
+        [ iterable ] if iterable is not iterable, otherwise just iterable.
+    """    
+    if isinstance(iterable, str):
+        iterable = [iterable]
+    try:
+        iter(iterable)
+    except TypeError:
+        iterable = [iterable]
+    return iterable

--- a/scripts/irods/test/test_ichmod.py
+++ b/scripts/irods/test/test_ichmod.py
@@ -60,15 +60,15 @@ class Test_ichmod(session.make_sessions_mixin([('otherrods', 'rods')], [('alice'
         # The access_specifier can be a string, or a list of strings
         # if aliases exist. All aliases will be tested
         access_specifiers = {
-            Access.NULL            : "null",        
-            Access.READ_METADATA   : "read metadata",    
-            Access.READ_OBJECT     : ["read object", "read"],
-            Access.CREATE_METADATA : "create metadata",
-            Access.MODIFY_METADATA : "modify metadata",
-            Access.DELETE_METADATA : "delete metadata", 
-            Access.CREATE_OBJECT   : "create object",
-            Access.MODIFY_OBJECT   : ["modify object", "write"],
-            Access.DELETE_OBJECT   : "delete object",
+            Access.NULL            : "null",
+            Access.READ_METADATA   : "read_metadata",
+            Access.READ_OBJECT     : ["read_object", "read"],
+            Access.CREATE_METADATA : "create_metadata",
+            Access.MODIFY_METADATA : "modify_metadata",
+            Access.DELETE_METADATA : "delete_metadata",
+            Access.CREATE_OBJECT   : "create_object",
+            Access.MODIFY_OBJECT   : ["modify_object", "write"],
+            Access.DELETE_OBJECT   : "delete_object",
             Access.OWN             : "own"
         }
 

--- a/scripts/irods/test/test_ichmod.py
+++ b/scripts/irods/test/test_ichmod.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from enum import Enum
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -27,6 +28,183 @@ class Test_ichmod(session.make_sessions_mixin([('otherrods', 'rods')], [('alice'
         lib.make_file(filepath, 1)
         self.admin.assert_icommand('iput ' + filepath + ' sub_dir1\\\\%/subdir2/')
         self.user.assert_icommand('iget ' + self.admin.session_collection + '/sub_dir1\\\\%/subdir2/file ' + os.path.join(self.user.local_session_dir, ''))
+
+    def test_ichmod_access_levels(self):
+        filename1 = 'test_ichmod_access_levels'
+        filename2 = 'test_access_levels_put_file'
+        local_file_path = os.path.join(self.admin.local_session_dir, filename1)
+        public_collection = os.path.join('/' + self.admin.zone_name, 'home', 'public')
+
+        test_object = os.path.join(public_collection, filename1)
+        test_collection_for_put = os.path.join(public_collection, 'test_ichmod_collection_put')
+        test_collection_for_access = os.path.join(public_collection, 'test_ichmod_collection_access')
+        test_collection_for_create = os.path.join(test_collection_for_put, 'new_collection')
+
+        user_file_path = os.path.join(self.user.local_session_dir, filename2)
+        user_iget_file = os.path.join(self.user.local_session_dir, filename1)
+
+        coll_access_path = os.path.join(test_collection_for_put, filename1)
+
+        class Access(Enum):
+            NULL            = 1
+            READ_METADATA   = 2
+            READ_OBJECT     = 3
+            CREATE_METADATA = 4
+            MODIFY_METADATA = 5
+            DELETE_METADATA = 6
+            CREATE_OBJECT   = 7
+            MODIFY_OBJECT   = 8
+            DELETE_OBJECT   = 9
+            OWN             = 10
+
+        # The access_specifier can be a string, or a list of strings
+        # if aliases exist. All aliases will be tested
+        access_specifiers = {
+            Access.NULL            : "null",        
+            Access.READ_METADATA   : "read metadata",    
+            Access.READ_OBJECT     : ["read object", "read"],
+            Access.CREATE_METADATA : "create metadata",
+            Access.MODIFY_METADATA : "modify metadata",
+            Access.DELETE_METADATA : "delete metadata", 
+            Access.CREATE_OBJECT   : "create object",
+            Access.MODIFY_OBJECT   : ["modify object", "write"],
+            Access.DELETE_OBJECT   : "delete object",
+            Access.OWN             : "own"
+        }
+
+        # Here the test commands we test with every access level are defined:
+        # 'cmd' is the command to run with assert_icommand
+        # the 'checks' list contains an access level range and the output of the command to match
+        # in the format (<min_level>, <max_level>, <arguments>)
+        # *arguments will be passed to the assert_icommands function
+        #
+        #
+        test_commands = {
+            # Test that iget needs READ OBJECT
+            'iget': {
+                'cmd': ['iget' , '-f', test_object, user_iget_file],
+                'checks': [
+                    (Access.NULL, Access.READ_METADATA,  ['STDERR', 'USER_INPUT_PATH_ERR']),
+                    (Access.READ_OBJECT, Access.OWN,   [])
+                ]
+            },
+            # Test that iput needs MODIFY_OBJECT on the collection
+            # NB why is CREATE OBJECT not enough?
+            'iput': {
+                'cmd': ['iput' , user_file_path, os.path.join(test_collection_for_put, filename2)],
+                'checks': [
+                    (Access.NULL, Access.CREATE_OBJECT, ['STDERR', 'CAT_NO_ACCESS_PERMISSION']),
+                    (Access.MODIFY_OBJECT, Access.OWN,  [])
+                ]
+            },
+            # Test that READ OBJECT is needed to read dataobject metadata
+            'imeta_dataobject_read': {
+                'cmd': ['imeta', 'ls', '-d', test_object],
+                'checks': [
+                    (Access.NULL, Access.READ_METADATA, ['STDERR', 'does not exist']),
+                    (Access.READ_OBJECT, Access.OWN, ['STDOUT', 'attribute: attr1'])
+                ]
+            },
+            # To modify metadata on an object, CREATE METADATA is required
+            'imeta_dataobject_modify': {
+                'cmd': ['imeta', 'set', '-d', test_object, 'attr1', 'new_value', 'and_new_unit'],
+                'checks': [
+                    (Access.NULL, Access.READ_OBJECT,  ['STDERR', 'CAT_NO_ACCESS_PERMISSION']),
+                    (Access.CREATE_METADATA, Access.OWN, [])
+                ]
+            },
+            # Test that DELETE METADATA is required to delete metadata from a dataobject
+            'imeta_dataobject_delete': {
+                'cmd': ['imeta', 'rm', '-d', test_object, 'remove', 'this', 'avu'],
+                'checks': [
+                    (Access.NULL, Access.MODIFY_METADATA, ['STDERR', 'CAT_NO_ACCESS_PERMISSION']),
+                    (Access.DELETE_METADATA, Access.OWN, [])
+                ]
+            },
+            # Test that READ OBJECT is needed to read collection metadata
+            'imeta_collection_read': {
+                'cmd': ['imeta', 'ls', '-C', test_collection_for_access],
+                'checks': [
+                    (Access.NULL, Access.READ_METADATA, ['STDERR', 'does not exist']),
+                    (Access.READ_OBJECT , Access.OWN, ['STDOUT', 'attribute: attr2'])
+                ]
+            },
+            # Test that CREATE METADATA is needed to modify dataobject metadata
+            'imeta_collection_modify': {
+                'cmd': ['imeta', 'set', '-C', test_collection_for_access, 'coll_attr', 'coll_value', 'new_coll_unit'],
+                'checks': [
+                    (Access.NULL, Access.READ_OBJECT , ['STDERR', 'CAT_NO_ACCESS_PERMISSION']),
+                    (Access.CREATE_METADATA, Access.OWN, [])
+                ]
+            },
+            # Test that DELETE METADATA is required to delete metadata from a collection
+            'imeta_collection_delete': {
+                'cmd': ['imeta', 'rm', '-C', test_collection_for_access, 'remove', 'this', 'coll_avu'],
+                'checks': [
+                    (Access.NULL, Access.MODIFY_METADATA, ['STDERR', 'CAT_NO_ACCESS_PERMISSION']),
+                    (Access.DELETE_METADATA, Access.OWN, [])
+                ]
+            },
+            # Test that OWN is required to delete a dataobject
+            'irm': {
+                'cmd': ['irm', test_object],
+                'checks': [
+                    (Access.NULL, Access.READ_METADATA, ['STDERR', 'does not exist']),
+                    (Access.READ_OBJECT , Access.DELETE_OBJECT, ['STDERR', 'CAT_NO_ACCESS_PERMISSION']),
+                    (Access.OWN, Access.OWN, [])
+                ]
+            },
+            # Test that you need READ OBJECT on a collection to delete a dataobject in that collection
+            'irm_coll_perms': {
+                'cmd': ['irm', coll_access_path],
+                'checks': [
+                    (Access.NULL, Access.READ_METADATA, ['STDERR', 'does not exist']),
+                    (Access.READ_OBJECT, Access.OWN, [])
+                ]
+            },
+            # Test that MODIFY_OBJECT is needed to create a sub collection
+            'imkdir': {
+                'cmd': ['imkdir', test_collection_for_create],
+                'checks': [
+                    (Access.NULL, Access.CREATE_OBJECT, ['STDERR', 'CAT_NO_ACCESS_PERMISSION']),
+                    (Access.MODIFY_OBJECT, Access.OWN, [])
+                ]
+            },
+            # Test for irmdir required permissions (DELETE_OBJECT)
+            'irmdir': {
+                'cmd': ['irmdir', test_collection_for_access],
+                'checks': [
+                    (Access.NULL, Access.READ_METADATA, ['STDOUT', 'does not exist']),
+                    (Access.READ_OBJECT, Access.MODIFY_OBJECT, ['STDOUT', 'rcRmColl failed with error']),
+                    (Access.DELETE_OBJECT, Access.OWN, [])
+                ]
+            }
+        }
+
+        lib.make_file(local_file_path, 1)
+        lib.make_file(user_file_path, 1)
+
+        for access_level in Access:
+            for access_level_alias in lib.iterfy(access_specifiers[access_level]):
+            # Set up some collections and dataobjects
+                self.admin.run_icommand(['ichmod', '-r', '-M', 'own', self.admin.username, public_collection])
+                self.admin.run_icommand(['irm','-rf', test_object, test_collection_for_put, test_collection_for_access])
+                self.admin.run_icommand(['iput', '-f', local_file_path, test_object])
+                self.admin.run_icommand(['imkdir', test_collection_for_put, test_collection_for_access])
+                self.admin.run_icommand(['ichmod', access_level_alias, self.user.username, test_object])
+                self.admin.run_icommand(['ichmod', access_level_alias, self.user.username, test_collection_for_put])
+                self.admin.run_icommand(['ichmod', access_level_alias, self.user.username, test_collection_for_access])
+                self.admin.run_icommand(['iput', '-f', local_file_path, coll_access_path])
+                self.admin.run_icommand(['ichmod', 'own', self.user.username, coll_access_path])
+                self.admin.run_icommand(['imeta', 'set', '-d', test_object, 'attr1', 'val1', 'unit1'])
+                self.admin.run_icommand(['imeta', 'set', '-d', test_object, 'remove', 'this', 'avu'])
+                self.admin.run_icommand(['imeta', 'set', '-C', test_collection_for_access, 'attr2', 'val2', 'unit2'])
+                self.admin.run_icommand(['imeta', 'set', '-C', test_collection_for_access, 'remove', 'this', 'coll_avu'])
+                for test_command, params in test_commands.items():
+                    for check in params.get('checks'):
+                        if access_level.value in range(check[0].value, check[1].value + 1):
+                            self.user.assert_icommand(params.get('cmd'), *check[2])
+
 
 
 class test_collection_acl_inheritance(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 'apass')]), unittest.TestCase):


### PR DESCRIPTION
This will allow all access permissions from icatDefines.h to be used when setting permissions. Since 'write' and 'read' are still valid as permission, this will be fully backward compatible.
I had some doubt about the spaces in access permission names, but it feels a bit silly to translate them all to new names without spaces. So I left them as they are.

This will work with all clients that depend on the irods api to check if a specified access permission is valid. Tested with ichmod, msiSetAcl, and the python-irodsclient.

Example usage: `ichmod "modify metadata" 'user1' /tempZone/data`

Resolves irods/irods#844