### PR TITLE
[_6169] updates for metaclass, test generation (4-2-stable)

### DIFF
--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -236,6 +236,7 @@ class Test_AllRules(with_metaclass(metaclass_unittest_test_case_generator.Metacl
                 "rulemsiSysReplDataObj",
                 "rulemsiNoChkFilePathPerm",
                 "rulemsiNoTrashCan",
+                "rulemsiSetRescSortScheme",
             ]
             for n in names_to_skip:
                 if n in rulefile:

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -6,6 +6,7 @@ import sys
 import getpass
 import tempfile
 import json
+from six import with_metaclass
 
 if sys.version_info >= (2, 7):
     import unittest
@@ -22,8 +23,10 @@ from . import resource_suite
 from . import session
 from .rule_texts_for_tests import rule_texts
 
-class Test_AllRules(resource_suite.ResourceBase, unittest.TestCase):
-    __metaclass__ = metaclass_unittest_test_case_generator.MetaclassUnittestTestCaseGenerator
+class Test_AllRules(with_metaclass(metaclass_unittest_test_case_generator.MetaclassUnittestTestCaseGenerator, # metaclass
+                                   resource_suite.ResourceBase, unittest.TestCase                             # base classes
+                                  )):
+
     class_name = 'Test_AllRules'
 
     global plugin_name
@@ -410,8 +413,8 @@ class Test_AllRules(resource_suite.ResourceBase, unittest.TestCase):
             def make_test(rulefile):
                 def test(self):
                     self.rods_session.assert_icommand("icd")
-                    self.rods_session.assert_icommand("irule -vF " + os.path.join(rulesdir, rulefile),
-                                                      'STDOUT_SINGLELINE', "completed successfully")
+                    self.rods_session.assert_icommand("irule -vF " + os.path.join(rulesdir, rulefile) + " -r " + plugin_name + "-instance"
+                                                     ,'STDOUT_SINGLELINE', "completed successfully")
                 return test
 
             yield 'test_' + rulefile.replace('.', '_'), make_test(rulefile)


### PR DESCRIPTION
Use the `six` module's portable metaclass syntax (instead of \_\_metaclass\_\_ which won't work starting in Python3). More importantly we use `-r` in irule invocations to guarantee a nonzero rule code causes the tests generated from rule file directories to return the appropriate pass / fail status to the testing framework. We target:
  - native plugin instance for the [icommands rulefiles](https://github.com/irods/irods_client_icommands/tree/4-2-stable/test/rules), and
  - Python  plugin instance for the   Python rule plugin [rule files](https://github.com/irods/irods_rule_engine_plugin_python/tree/4-2-stable/python_rules)