### PR TITLE
[#4260] Enforce valid hostname for remote rule execution (4-2-stable)

### DIFF
--- a/scripts/irods/test/rule_texts_for_tests.py
+++ b/scripts/irods/test/rule_texts_for_tests.py
@@ -667,6 +667,21 @@ test_remote_writeLine {{
 INPUT null
 OUTPUT ruleExecOut
 '''
+rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Remote_Exec']['test_remote_returns_appropriate_error_on_bad_hostname__issue_4260'] = '''
+test_remote_with_bad_hostname {{
+    # this will execute
+    msiAddKeyVal(*key_val_pair,"{metadata_attr}","{metadata_value_true}");
+    msiAssociateKeyValuePairsToObj(*key_val_pair,"{username}","-u");
+
+    # this block definitely should not execute
+    remote("{hostname}", "<ZONE>{zone}</ZONE>") {{
+        msiAddKeyVal(*key_val_pair,"{metadata_attr}","{metadata_value_false}");
+        msiAssociateKeyValuePairsToObj(*key_val_pair,"{username}","-u");
+    }}
+}}
+INPUT null
+OUTPUT ruleExecOut
+'''
 
 #===== Test_Delay_Queue =====
 rule_texts['irods_rule_engine_plugin-irods_rule_language']['Test_Delay_Queue'] = {}

--- a/server/api/src/rsExecMyRule.cpp
+++ b/server/api/src/rsExecMyRule.cpp
@@ -4,6 +4,8 @@
 #include "irods_re_plugin.hpp"
 #include "rsExecMyRule.hpp"
 
+#include <fmt/format.h>
+
 extern std::unique_ptr<struct irods::global_re_plugin_mgr> irods::re_plugin_globals;
 
 int rsExecMyRule(
@@ -46,6 +48,12 @@ int rsExecMyRule(
 
     rodsServerHost_t* rods_svr_host = nullptr;
     int remoteFlag = resolveHost( &_exec_inp->addr, &rods_svr_host );
+    if (remoteFlag < 0) {
+        const auto msg = fmt::format("Failed to resolve hostname: [{}]", _exec_inp->addr.hostAddr);
+        irods::log(LOG_ERROR, msg);
+        addRErrorMsg(&_comm->rError, remoteFlag, msg.data());
+        return remoteFlag;
+    }
 
     if ( remoteFlag == REMOTE_HOST ) {
         return remoteExecMyRule( _comm, _exec_inp,

--- a/server/core/src/rodsConnect.cpp
+++ b/server/core/src/rodsConnect.cpp
@@ -120,8 +120,18 @@ mkServerHost( char *myHostAddr, char *zoneName ) {
     tmpRodsServerHost->localFlag = UNKNOWN_HOST_LOC;
 
     status = queAddr( tmpRodsServerHost, myHostAddr );
+    if (status < 0) {
+        irods::log(ERROR(status, "queueAddr failed"));
+        free(tmpRodsServerHost);
+        return NULL;
+    }
 
     status = matchHostConfig( tmpRodsServerHost );
+    if (status < 0) {
+        irods::log(ERROR(status, "matchHostConfig failed"));
+        free(tmpRodsServerHost);
+        return NULL;
+    }
 
     status = getZoneInfo( zoneName,
                           ( zoneInfo_t ** )( static_cast< void * >( &tmpRodsServerHost->zoneInfo ) ) );


### PR DESCRIPTION
cherry-picked from work for #6243 

Test suite running now