### PR TITLE
Handling of federated groups

### DIFF
--- a/scripts/setup_irods.py
+++ b/scripts/setup_irods.py
@@ -207,11 +207,11 @@ def setup_service_account(irods_config, irods_user, irods_group):
 
     if irods_group not in [g.gr_name for g in grp.getgrall()]:
         l.info('Creating Service Group: %s', irods_group)
-        createGroup = irods.lib.execute_command_permissive(['groupadd', '-r', irods_group])
-        if createGroup[2] == 9:
+        out, err, returncode = irods.lib.execute_command_permissive(['groupadd', '-r', irods_group])
+        if returncode == 9:
             l.info('Existing non-local Group Detected: %s', irods_group)
-        elif createGroup[2] != 0:
-            raise IrodsError(createGroup[1])
+        elif returncode != 0:
+            raise IrodsError(err)
     else:
         l.info('Existing Group Detected: %s', irods_group)
 

--- a/scripts/setup_irods.py
+++ b/scripts/setup_irods.py
@@ -207,7 +207,11 @@ def setup_service_account(irods_config, irods_user, irods_group):
 
     if irods_group not in [g.gr_name for g in grp.getgrall()]:
         l.info('Creating Service Group: %s', irods_group)
-        irods.lib.execute_command(['groupadd', '-r', irods_group])
+        createGroup = irods.lib.execute_command_permissive(['groupadd', '-r', irods_group])
+        if createGroup[2] == 9:
+            l.info('Existing non-local Group Detected: %s', irods_group)
+        elif createGroup[2] != 0:
+            raise IrodsError(createGroup[1])
     else:
         l.info('Existing Group Detected: %s', irods_group)
 


### PR DESCRIPTION
I've only been able to partially test the code in its current form as I solved the problem with one change and then retrospectively fixed some issues in the script. I don't have multiple test environments to test with. 

The existing code had issues if the proposed irods service group was defined externally (to the /etc/group file) e.g. via Active Directory binding.

In the setup_service_account function, 'grp.getgrall()' was used to find all groups in /etc/group and if the new service account group did not appear, it would be created with a system call to 'groupadd -r <irods_group>'. If the group in question did indeed exist, but in an external authentication system, then it would throw an exception and terminate.

I've proposed a change that wraps the group creation command in an permissive execute and then checks the return value. It will report a warning if the group exists but is non-local and continue. It will also catch other errors and throw an exception with the exception message.

This relates to a conversation on google chat:
https://groups.google.com/g/irod-chat/c/7DaQzFMLGgY