### PR TITLE
[#3602] Timestamps in python log output are now displayed in UTC time (main)

### DIFF
--- a/lib/core/include/irods/irods_logger.tpp
+++ b/lib/core/include/irods/irods_logger.tpp
@@ -243,7 +243,7 @@ private:
         if (const auto ec = clock_gettime(CLOCK_REALTIME, &ts); ec != 0) {
             const auto now = clock_type::to_time_t(clock_type::now());
             std::stringstream utc_ss;
-            utc_ss << std::put_time(std::gmtime(&now), "%FT%T.000");
+            utc_ss << std::put_time(std::gmtime(&now), "%FT%T.000Z");
             return utc_ss.str();
         }
 
@@ -252,7 +252,7 @@ private:
         std::stringstream utc_ss;
         utc_ss << std::put_time(std::gmtime(&now), "%FT%T");
            
-        return fmt::format("{}.{:0>3}", utc_ss.str(), ts.tv_nsec / 1'000'000);
+        return fmt::format("{}.{:0>3}Z", utc_ss.str(), ts.tv_nsec / 1'000'000);
     }
 
     static constexpr const char* log_level_as_string() noexcept

--- a/scripts/irods/log.py
+++ b/scripts/irods/log.py
@@ -55,9 +55,8 @@ def register_tty_handler(stream, minlevel, maxlevel):
     logging.getLogger().addHandler(logging_handler)
 
 def register_file_handler(log_file_path, level=logging.DEBUG):
-    logging.Formatter.converter = time.gmtime
-
     logging_handler = logging.FileHandler(log_file_path)
-    logging_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)7s - %(filename)30s:%(lineno)4d - %(message)s'))
+    logging_handler.setFormatter(logging.Formatter('%(asctime)s.%(msecs)03dZ - %(levelname)7s - %(filename)30s:%(lineno)4d - %(message)s', '%Y-%m-%dT%H:%M:%S'))
+    logging_handler.formatter.converter = time.gmtime
     logging_handler.setLevel(logging.DEBUG)
     logging.getLogger().addHandler(logging_handler)


### PR DESCRIPTION
I'm not sure we actually need this, but we can discuss how important/useful this is here.

This needs to be ran through the test suite.