### PR TITLE
[#858] Fix up error handling in setup_service_account (main)

### DIFF
--- a/scripts/irods/lib.py
+++ b/scripts/irods/lib.py
@@ -43,6 +43,7 @@ execute_command_nonblocking = execute.execute_command_nonblocking
 execute_command_timeout = execute.execute_command_timeout
 execute_command_permissive = execute.execute_command_permissive
 execute_command = execute.execute_command
+check_command_return = execute.check_command_return
 
 def get_server_pid():
     try:

--- a/scripts/setup_irods.py
+++ b/scripts/setup_irods.py
@@ -207,11 +207,12 @@ def setup_service_account(irods_config, irods_user, irods_group):
 
     if irods_group not in [g.gr_name for g in grp.getgrall()]:
         l.info('Creating Service Group: %s', irods_group)
-        out, err, returncode = irods.lib.execute_command_permissive(['groupadd', '-r', irods_group])
+        cmd = ['groupadd', '-r', irods_group]
+        out, err, returncode = irods.lib.execute_command_permissive(cmd)
         if returncode == 9:
             l.info('Existing non-local Group Detected: %s', irods_group)
-        elif returncode != 0:
-            raise IrodsError(err)
+        else:
+            irods.lib.check_command_return(cmd, out, err, returncode, input=None)
     else:
         l.info('Existing Group Detected: %s', irods_group)
 


### PR DESCRIPTION
Instead of raising an IrodsError with the stderr contents, we should
handle the error case as we would with something that was executed using
execute_command. This provides more context for the error that occurred
for investigation for failures.

related to #6245 and #6280