### PR TITLE
[#3727] Fix auth objects resolving/loading plugins (main)

### DIFF
--- a/lib/core/src/irods_gsi_object.cpp
+++ b/lib/core/src/irods_gsi_object.cpp
@@ -29,22 +29,20 @@ namespace irods {
                 _interface.c_str()));
         }
 
-        auth_ptr auth;
-        if (const auto err = auth_mgr.resolve(AUTH_GSI_SCHEME, auth); !err.ok()) {
-            return PASSMSG("Failed to resolve the GSI auth plugin.", err);
+        const auto& type = irods::AUTH_GSI_SCHEME;
+
+        auth_ptr ap;
+        if (auto err = auth_mgr.resolve(type, ap); !err.ok()) {
+            // Attempt to load the plugin.
+            if (err = auth_mgr.init_from_type(ProcessType, type, type, type, std::string{}, ap); !err.ok()) {
+                return PASSMSG("Failed to load the GSI auth plugin.", err);
+            }
         }
 
-        // Attempt to load the plugin.
-        std::string unused;
-        const auto& type = AUTH_GSI_SCHEME;
-        if (const auto err = auth_mgr.init_from_type(ProcessType, type, type, type, unused, auth); !err.ok()) {
-            return PASSMSG("Failed to load the GSI auth plugin.", err);
-        }
-
-        _ptr = boost::dynamic_pointer_cast<plugin_base>(auth);
+        _ptr = boost::dynamic_pointer_cast<plugin_base>(ap);
 
         return SUCCESS();
-    }
+    } // gsi_auth_object::resolve
 
     bool gsi_auth_object::operator==(
         const gsi_auth_object& _rhs ) const {

--- a/lib/core/src/irods_krb_object.cpp
+++ b/lib/core/src/irods_krb_object.cpp
@@ -29,22 +29,20 @@ namespace irods {
                 _interface.c_str()));
         }
 
-        auth_ptr auth;
-        if (const auto err = auth_mgr.resolve(irods::AUTH_KRB_SCHEME, auth); !err.ok()) {
-            return PASSMSG("Failed to resolve the KRB auth plugin.", err);
-        }
-
-        // Attempt to load the plugin.
-        std::string unused;
         const auto& type = irods::AUTH_KRB_SCHEME;
-        if (const auto err = auth_mgr.init_from_type(ProcessType, type, type, type, unused, auth); !err.ok()) {
-            return PASSMSG("Failed to load the KRB auth plugin.", err);
+
+        auth_ptr ap;
+        if (auto err = auth_mgr.resolve(type, ap); !err.ok()) {
+            // Attempt to load the plugin.
+            if (err = auth_mgr.init_from_type(ProcessType, type, type, type, std::string{}, ap); !err.ok()) {
+                return PASSMSG("Failed to load the KRB auth plugin.", err);
+            }
         }
 
-        _ptr = boost::dynamic_pointer_cast<plugin_base>(auth);
+        _ptr = boost::dynamic_pointer_cast<plugin_base>(ap);
 
         return SUCCESS();
-    }
+    } // krb_auth_object::resolve
 
     bool krb_auth_object::operator==(
         const krb_auth_object& _rhs ) const {


### PR DESCRIPTION
In the event that an auth object fails to resolve an auth plugin
interface, it may be the case that the plugin hasn't been loaded yet.
The failure should indicate that an attempt to load the plugin should be
made before returning an error. On success, a resolved plugin interface
will be returned and the resolution will be considered successful.

Confirmed fix by hand for Kerberos. GSI has been nearly identical for all time so the fixes were applied there as well.