### PR TITLE
[#6320] for PREP, adapt test user for 6 tests, skip others ... (main)

### DIFF
--- a/scripts/irods/test/resource_suite.py
+++ b/scripts/irods/test/resource_suite.py
@@ -24,6 +24,7 @@ from ..configuration import IrodsConfig
 from ..controller import IrodsController
 from . import session
 
+plugin_name = IrodsConfig().default_rule_engine_plugin
 
 class ResourceBase(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 'apass'), ('bobby', 'bpass')])):
 
@@ -288,6 +289,8 @@ class ResourceSuite(ResourceBase):
     ###################
     # iput
     ###################
+
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only run for native rule language')
     @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing")
     def test_ssl_iput_with_rods_env(self):
         server_key_path = os.path.join(self.admin.local_session_dir, 'server.key')
@@ -347,6 +350,7 @@ class ResourceSuite(ResourceBase):
 
             IrodsController().restart(test_mode=True)
 
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only run for native rule language')
     @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing")
     def test_ssl_iput_small_and_large_files(self):
         # set up client and server side for ssl handshake

--- a/scripts/irods/test/rule_texts_for_tests.py
+++ b/scripts/irods/test/rule_texts_for_tests.py
@@ -1135,7 +1135,7 @@ def replicateMultiple(dest_list, callback, rei):
     callback.writeLine('serverLog', ' acPostProcForPut multiple replicate ' + obj_path + ' ' + filepath + ' -> ' + str(dest_list))
     for dest in dest_list:
         callback.writeLine('serverLog', 'acPostProcForPut replicate ' + obj_path + ' ' + filepath + ' -> ' + dest)
-        out_dict = callback.msiDataObjRepl(obj_path,"destRescName=' + dest '++++irodsAdmin='", 0);
+        out_dict = callback.msiDataObjRepl(obj_path,"destRescName=" + dest + "++++irodsAdmin=", 0);
         if not out_dict['code'] == 0:
             if out_dict['code'] == -808000:
                 callback.writeLine('serverLog', obj_path + ' cannot be found')

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -1360,6 +1360,8 @@ OUTPUT ruleExecOut
         self.admin.assert_icommand(['irule', '-r', rep_name, rule_text, 'null', 'ruleExecOut'])
 
 
+
+
 class Test_msiDataObjRepl_checksum_keywords(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 'apass')]), unittest.TestCase):
     global plugin_name
     plugin_name = IrodsConfig().default_rule_engine_plugin
@@ -1369,16 +1371,17 @@ class Test_msiDataObjRepl_checksum_keywords(session.make_sessions_mixin([('other
 
         self.admin = self.admin_sessions[0]
         self.user0 = self.user_sessions[0]
+        self.test_user = self.admin if 'python' in plugin_name else self.user0
 
         self.filename = 'Test_msiDataObjRepl_checksum_keywords'
-        self.logical_path = os.path.join(self.user0.session_collection, self.filename)
+        self.logical_path = os.path.join(self.test_user.session_collection, self.filename)
 
         self.target_resc = 'msiDataObjRepl_test_resource'
         lib.create_ufs_resource(self.target_resc, self.admin, hostname=test.settings.HOSTNAME_2)
 
 
     def tearDown(self):
-        self.user0.assert_icommand(['irm', '-f', self.logical_path])
+        self.test_user.assert_icommand(['irm', '-f', self.logical_path])
         lib.remove_resource(self.target_resc, self.admin)
 
         super(Test_msiDataObjRepl_checksum_keywords, self).tearDown()
@@ -1408,21 +1411,20 @@ OUTPUT ruleExecOut
 
     def do_checksum_keyword_test(self, checksum_source=False, expected_status=0, keywords=None):
         rep_instance = '-'.join([plugin_name, 'instance'])
-        rule_file = os.path.join(self.user0.local_session_dir, 'test_msiDataObjRepl_checksum_keywords.r')
+        rule_file = os.path.join(self.test_user.local_session_dir, 'test_msiDataObjRepl_checksum_keywords.r')
         rule_text = self.get_rule_text(keywords)
-
         with open(rule_file, 'wt') as f:
             print(rule_text, file=f, end='')
 
         try:
             if checksum_source:
-                self.user0.assert_icommand(['iput', '-K', rule_file, self.logical_path])
-                self.assertNotEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 0)))
+                self.test_user.assert_icommand(['iput', '-K', rule_file, self.logical_path])
+                self.assertNotEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 0)))
             else:
-                self.user0.assert_icommand(['iput', rule_file, self.logical_path])
-                self.assertEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 0)))
+                self.test_user.assert_icommand(['iput', rule_file, self.logical_path])
+                self.assertEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 0)))
 
-            return self.user0.run_icommand(['irule', '-r', rep_instance, '-F', rule_file]) # out, err, rc
+            return self.test_user.run_icommand(['irule', '-r', rep_instance, '-F', rule_file]) # out, err, rc
         finally:
             os.unlink(rule_file)
 
@@ -1434,8 +1436,8 @@ OUTPUT ruleExecOut
         self.assertEqual(0, len(err))
         self.assertEqual(0, ec)
 
-        self.assertEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 0)))
-        self.assertEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 1)))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 0)))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 1)))
 
 
     def test_chksum_true_forceChksum_none_verifyChksum_none__issue_5927(self):
@@ -1445,9 +1447,9 @@ OUTPUT ruleExecOut
         self.assertEqual(0, len(err))
         self.assertEqual(0, ec)
 
-        source_checksum = lib.get_replica_checksum(self.user0, self.filename, 0)
+        source_checksum = lib.get_replica_checksum(self.test_user, self.filename, 0)
         self.assertNotEqual(0, len(source_checksum))
-        self.assertEqual(source_checksum, lib.get_replica_checksum(self.user0, self.filename, 1))
+        self.assertEqual(source_checksum, lib.get_replica_checksum(self.test_user, self.filename, 1))
 
 
     def test_chksum_false_forceChksum_none_verifyChksum_0__issue_5927(self):
@@ -1459,8 +1461,8 @@ OUTPUT ruleExecOut
         self.assertEqual(0, len(err))
         self.assertEqual(0, ec)
 
-        self.assertEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 0)))
-        self.assertEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 1)))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 0)))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 1)))
 
 
     def test_chksum_true_forceChksum_none_verifyChksum_0__issue_5927(self):
@@ -1472,11 +1474,12 @@ OUTPUT ruleExecOut
         self.assertEqual(0, len(err))
         self.assertEqual(0, ec)
 
-        source_checksum = lib.get_replica_checksum(self.user0, self.filename, 0)
+        source_checksum = lib.get_replica_checksum(self.test_user, self.filename, 0)
         self.assertNotEqual(0, len(source_checksum))
-        self.assertEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 1)))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 1)))
 
 
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'checksum related errors in iRODS 4.3 under python RE plugin')
     def test_chksum_false_forceChksum_none_verifyChksum_1__issue_5927(self):
         keywords = ['verifyChksum=']
 
@@ -1486,11 +1489,12 @@ OUTPUT ruleExecOut
         self.assertIn('CAT_NO_CHECKSUM_FOR_REPLICA', err)
         self.assertNotEqual(0, ec)
 
-        self.assertEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 0)))
-        self.assertFalse(lib.replica_exists(self.user0, self.logical_path, 1))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 0)))
+        self.assertFalse(lib.replica_exists(self.test_user, self.logical_path, 1))
 
 
     def test_chksum_true_forceChksum_none_verifyChksum_1__issue_5927(self):
+
         keywords = ['verifyChksum=']
 
         out, err, ec = self.do_checksum_keyword_test(checksum_source=True, keywords=keywords)
@@ -1499,9 +1503,9 @@ OUTPUT ruleExecOut
         self.assertEqual(0, len(err))
         self.assertEqual(0, ec)
 
-        source_checksum = lib.get_replica_checksum(self.user0, self.filename, 0)
+        source_checksum = lib.get_replica_checksum(self.test_user, self.filename, 0)
         self.assertNotEqual(0, len(source_checksum))
-        self.assertEqual(source_checksum, lib.get_replica_checksum(self.user0, self.filename, 1))
+        self.assertEqual(source_checksum, lib.get_replica_checksum(self.test_user, self.filename, 1))
 
 
     def test_chksum_false_forceChksum_1_verifyChksum_none__issue_5927(self):
@@ -1513,10 +1517,11 @@ OUTPUT ruleExecOut
         self.assertEqual(0, len(err))
         self.assertEqual(0, ec)
 
-        self.assertEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 0)))
-        self.assertNotEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 1)))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 0)))
+        self.assertNotEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 1)))
 
 
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'checksum related errors in iRODS 4.3 under python RE plugin')
     def test_chksum_true_forceChksum_1_verifyChksum_none__issue_5927(self):
         keywords = ['forceChksum=']
 
@@ -1526,25 +1531,27 @@ OUTPUT ruleExecOut
         self.assertIn('SYS_NOT_ALLOWED', err)
         self.assertNotEqual(0, ec)
 
-        self.assertNotEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 0)))
-        self.assertFalse(lib.replica_exists(self.user0, self.logical_path, 1))
+        self.assertNotEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 0)))
+        self.assertFalse(lib.replica_exists(self.test_user, self.logical_path, 1))
 
 
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'checksum related errors in iRODS 4.3 under python RE plugin')
     def test_chksum_false_forceChksum_1_verifyChksum_0__issue_5927(self):
         keywords = ['forceChksum=', 'verifyChksum=0']
 
         out, err, ec = self.do_checksum_keyword_test(checksum_source=False, keywords=keywords)
 
-        self.user0.assert_icommand(['ils', '-l', self.logical_path], 'STDOUT', self.filename) # debug
+        self.test_user.assert_icommand(['ils', '-l', self.logical_path], 'STDOUT', self.filename) # debug
 
         self.assertIn('error when executing microservice', out)
         self.assertIn('USER_INCOMPATIBLE_PARAMS', err)
         self.assertNotEqual(0, ec)
 
-        self.assertEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 0)))
-        self.assertFalse(lib.replica_exists(self.user0, self.logical_path, 1))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 0)))
+        self.assertFalse(lib.replica_exists(self.test_user, self.logical_path, 1))
 
 
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'checksum related errors in iRODS 4.3 under python RE plugin')
     def test_chksum_true_forceChksum_1_verifyChksum_0__issue_5927(self):
         keywords = ['forceChksum=', 'verifyChksum=0']
 
@@ -1554,10 +1561,11 @@ OUTPUT ruleExecOut
         self.assertIn('USER_INCOMPATIBLE_PARAMS', err)
         self.assertNotEqual(0, ec)
 
-        self.assertNotEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 0)))
-        self.assertFalse(lib.replica_exists(self.user0, self.logical_path, 1))
+        self.assertNotEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 0)))
+        self.assertFalse(lib.replica_exists(self.test_user, self.logical_path, 1))
 
 
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'checksum related errors in iRODS 4.3 under python RE plugin')
     def test_chksum_false_forceChksum_1_verifyChksum_1__issue_5927(self):
         keywords = ['forceChksum=', 'verifyChksum=']
 
@@ -1567,10 +1575,11 @@ OUTPUT ruleExecOut
         self.assertIn('USER_INCOMPATIBLE_PARAMS', err)
         self.assertNotEqual(0, ec)
 
-        self.assertEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 0)))
-        self.assertFalse(lib.replica_exists(self.user0, self.logical_path, 1))
+        self.assertEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 0)))
+        self.assertFalse(lib.replica_exists(self.test_user, self.logical_path, 1))
 
 
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'checksum related errors in iRODS 4.3 under python RE plugin')
     def test_chksum_true_forceChksum_1_verifyChksum_1__issue_5927(self):
         keywords = ['forceChksum=', 'verifyChksum=']
 
@@ -1580,5 +1589,5 @@ OUTPUT ruleExecOut
         self.assertIn('USER_INCOMPATIBLE_PARAMS', err)
         self.assertNotEqual(0, ec)
 
-        self.assertNotEqual(0, len(lib.get_replica_checksum(self.user0, self.filename, 0)))
-        self.assertFalse(lib.replica_exists(self.user0, self.logical_path, 1))
+        self.assertNotEqual(0, len(lib.get_replica_checksum(self.test_user, self.filename, 0)))
+        self.assertFalse(lib.replica_exists(self.test_user, self.logical_path, 1))

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -783,6 +783,7 @@ OUTPUT ruleExecOut
             if os.path.exists(tar_file_name):
                 os.unlink(tar_file_name)
 
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only run for native rule language')
     @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing")
     def test_msiRenameCollection_does_rename_collections__issue_4597(self):
         # Create a collection, "col.a".
@@ -854,6 +855,7 @@ OUTPUT ruleExecOut'''
         self.admin.assert_icommand(['ils', src], 'STDOUT', [src])
         self.admin.assert_icommand(['ils', dst], 'STDOUT', [dst])
 
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only run for native rule language')
     def test_msiDataObjPhymv_to_resource_hierarchy__3234(self):
         source_resource = self.admin.default_resource
         passthrough_resource = 'phymv_pt'
@@ -1145,6 +1147,7 @@ OUTPUT ruleExecOut
         do_test('data_object')
         do_test('collection')
 
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only run for native rule language')
     def test_msi_touch__issue_4669(self):
         data_object = os.path.join(self.admin.session_collection, 'issue_4669')
 

--- a/scripts/irods/test/test_iqmod.py
+++ b/scripts/irods/test/test_iqmod.py
@@ -8,6 +8,9 @@ else:
 
 from . import session
 from .. import test
+from ..configuration import IrodsConfig
+
+plugin_name = IrodsConfig().default_rule_engine_plugin
 
 class Test_Iqmod(session.make_sessions_mixin([('otherrods', 'rods')], []), unittest.TestCase):
 
@@ -18,6 +21,7 @@ class Test_Iqmod(session.make_sessions_mixin([('otherrods', 'rods')], []), unitt
     def tearDown(self):
         super(Test_Iqmod, self).tearDown()
 
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only run for native rule language')
     @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing")
     def test_iqmod_does_not_accept_invalid_priority_levels__issue_2759(self):
         # Schedule a delay rule.

--- a/scripts/irods/test/test_misc.py
+++ b/scripts/irods/test/test_misc.py
@@ -137,6 +137,7 @@ class Test_Misc(session.make_sessions_mixin([('otherrods', 'rods')], []), unitte
         rule = 'msiCollCreate("{0}", 0, *ignored)'.format(collection + '/')
         self.admin.assert_icommand(['irule', '-r', rep, rule, 'null', 'ruleExecOut'], 'STDERR', ['-809000 CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME'])
 
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only run for native rule language')
     def test_trailing_slashes_generate_an_error_when_opening_data_objects__issue_3892(self):
         data_object = os.path.join(self.admin.session_collection, 'dobj_3892')
 


### PR DESCRIPTION
related to #5927 within class `irods.test.test_all_rules.Test_msiDataObjRepl_checksum_keywords`.

These tests are related to issue #5927 and are apparently failing for main branch whereas they are not failing for 4-2-stable (@alanking)