### PR TITLE
correct 'offset_limit_' subtest in test_query_objects

### DIFF
--- a/scripts/irods/test/test_prep_genquery_iterator.py
+++ b/scripts/irods/test/test_prep_genquery_iterator.py
@@ -228,14 +228,14 @@ class Test_Genquery_Iterator(resource_suite.ResourceBase, unittest.TestCase):
                 res_1=[row_format(r) for r in q]
                 row_count = q.total_rows()
                 res_2=[row_format(r) for r in q.copy(offset=row_count-1)]
-                callback.writeLine('stdout',repr( [len(x) for x in res_1,res_2] +\
+                callback.writeLine('stdout',repr( [len(x) for x in (res_1,res_2)] +\
                                                   [
                                                    (res_1 + res_2 ==
-                                                    [TestCollection+"/"+x for x in ["%04o"%y for y in 0,{max_count}]])
+                                                    [TestCollection+"/"+x for x in ["%04o"%y for y in (0,{max_count})]])
                                                   ] ))
                 '''),
             "offset_limit_",
-            lambda: True # lambda : output.replace(" ","").strip() == "[1,1,True]"
+            lambda : output.replace(" ","").strip() == "[1,1,True]"
         ), ( #----------------
             frame_rule('''\
                 q = Query(callback,


### PR DESCRIPTION
With this commit, in addition to the following one in
  https://github.com/irods/irods_rule_engine_plugin_python/pull/114:
  fix Query.copy: in python3, dict.items() no longer produces a list  79f471c

all tests in test_prep_genquery_iterator now pass on Py3 / iRODS 4.3