### PR TITLE
[#6232] Dequeue delay rules not found in catalog (main)

### DIFF
--- a/server/delay_server/src/irodsDelayServer.cpp
+++ b/server/delay_server/src/irodsDelayServer.cpp
@@ -142,39 +142,34 @@ namespace
     {
         std::vector<std::string> exec_info;
 
-        try {
-            // The database plugin implementation is not capable of fetching the r_rule_exec.exe_context
-            // column when it contains a large string. To get around this limitation, the delay server
-            // uses nanodbc directly. This solution assumes the delay server runs on an iRODS server that
-            // has access to the database credentials.
+        // The database plugin implementation is not capable of fetching the r_rule_exec.exe_context
+        // column when it contains a large string. To get around this limitation, the delay server
+        // uses nanodbc directly. This solution assumes the delay server runs on an iRODS server that
+        // has access to the database credentials.
 
-            namespace ic = irods::experimental::catalog;
+        namespace ic = irods::experimental::catalog;
 
-            auto [db_instance_name, db_conn] = ic::new_database_connection(/* read_server_config */ false);
+        auto [db_instance_name, db_conn] = ic::new_database_connection(/* read_server_config */ false);
 
-            nanodbc::statement stmt{db_conn};
-            nanodbc::prepare(stmt, "select rule_name, rei_file_path, user_name, exe_address, exe_time,"
-                                   " exe_frequency, priority, last_exe_time, exe_status, estimated_exe_time,"
-                                   " notification_addr, exe_context "
-                                   "from R_RULE_EXEC where rule_exec_id = ?");
+        nanodbc::statement stmt{db_conn};
+        nanodbc::prepare(stmt, "select rule_name, rei_file_path, user_name, exe_address, exe_time,"
+                               " exe_frequency, priority, last_exe_time, exe_status, estimated_exe_time,"
+                               " notification_addr, exe_context "
+                               "from R_RULE_EXEC where rule_exec_id = ?");
 
-            stmt.bind(0, rule_id.data());
+        stmt.bind(0, rule_id.data());
 
-            auto row = nanodbc::execute(stmt);
+        auto row = nanodbc::execute(stmt);
 
-            if (!row.next()) {
-                THROW(CAT_NO_ROWS_FOUND, fmt::format("Could not find row matching rule id [rule_id={}]", rule_id));
-            }
-
-            constexpr auto number_of_columns = 12;
-            exec_info.reserve(number_of_columns); 
-
-            for (int i = 0; i < number_of_columns; ++i) {
-                exec_info.push_back(row.get<std::string>(i, ""));
-            }
+        if (!row.next()) {
+            THROW(CAT_NO_ROWS_FOUND, fmt::format("Could not find row matching rule id [rule_id={}]", rule_id));
         }
-        catch (const std::exception& e) {
-            THROW(SYS_INTERNAL_ERR, e.what());
+
+        constexpr auto number_of_columns = 12;
+        exec_info.reserve(number_of_columns);
+
+        for (int i = 0; i < number_of_columns; ++i) {
+            exec_info.push_back(row.get<std::string>(i, ""));
         }
 
         namespace fs = boost::filesystem;
@@ -528,7 +523,29 @@ namespace
             rule_exec_submit_inp = fill_rule_exec_submit_inp(rule_id);
         }
         catch (const irods::exception& e) {
-            logger::delay_server::error(e.what());
+            if (delay_server_terminated) {
+                // Get out!
+                return;
+            }
+
+            if (CAT_NO_ROWS_FOUND == e.code()) {
+                // CAT_NO_ROWS_FOUND is returned in the event that the rule ID does not exist
+                // in the catalog. If this is the case, we assume that an executor has completed
+                // the rule since retrieving it in the main thread. Therefore, there is nothing
+                // to do and the rule can be safely removed from the queue.
+                logger::delay_server::info("dequeueing rule because rule ID [{}] no longer exists in the catalog", rule_id);
+                queue.dequeue_rule(std::string(rule_exec_submit_inp.ruleExecId));
+            }
+            else {
+                // Something serious happened - log it here.
+                logger::delay_server::error("[{}:{}] - [{}]", __func__, __LINE__, e.client_display_what());
+            }
+
+            return;
+        }
+        catch (const std::exception& e) {
+            logger::delay_server::error("[{}:{}] - [{}]", __func__, __LINE__, e.what());
+
             return;
         }
 
@@ -543,9 +560,12 @@ namespace
                                         rule_exec_submit_inp.ruleExecId, e.what());
         }
 
+        logger::delay_server::debug("rule [{}] complete", rule_exec_submit_inp.ruleExecId);
         if (!delay_server_terminated) {
+            logger::delay_server::debug("dequeueing rule [{}]", rule_exec_submit_inp.ruleExecId);
             queue.dequeue_rule(std::string(rule_exec_submit_inp.ruleExecId));
         }
+        logger::delay_server::debug("rule [{}] exists in queue: [{}]", rule_exec_submit_inp.ruleExecId, queue.contains_rule_id(rule_exec_submit_inp.ruleExecId));
     } // execute_rule
 
     auto make_delay_queue_query_processor(


### PR DESCRIPTION
When a rule in the queue is not found in the catalog for whatever
reason, it should be removed from the delay queue without doing any
additional work. This can happen due to a timing issue wherein the delay
server fetches work from the catalog that is currently being done and
then place it back on the queue after it has been removed. This is
normal and a side effect of the asynchronous producer-consumers model
employed by the delay server.

---

Tests cannot run yet due to changes in the setup script and upcoming changes to configuration files. I will confirm once these issues are resolved in the testing environment. Until then, this will be considered WIP.