### PR TITLE
[#6137] Renamed variables in irods_configuration_keywords.hpp (main)

### DIFF
--- a/lib/core/include/irods/authentication_plugin_framework.hpp
+++ b/lib/core/include/irods/authentication_plugin_framework.hpp
@@ -102,7 +102,7 @@ namespace irods::experimental
         auto err = irods::load_plugin<plugin_type>(
                         plugin,
                         name,
-                        irods::PLUGIN_TYPE_AUTHENTICATION,
+                        irods::KW_CFG_PLUGIN_TYPE_AUTHENTICATION,
                         name,
                         "empty_context");
         if(!err.ok()) {

--- a/lib/core/include/irods/irods_configuration_keywords.hpp
+++ b/lib/core/include/irods/irods_configuration_keywords.hpp
@@ -1,190 +1,185 @@
-#ifndef CONFIGURATION_KEYWORDS_HPP
-#define CONFIGURATION_KEYWORDS_HPP
-
-#include <string>
+#ifndef IRODS_CONFIGURATION_KEYWORDS_HPP
+#define IRODS_CONFIGURATION_KEYWORDS_HPP
 
 namespace irods
 {
     // server_config.json keywords
-    extern const std::string CFG_KERBEROS_NAME_KW;
-    extern const std::string CFG_KERBEROS_KEYTAB_KW;
-    extern const std::string CFG_PAM_PASSWORD_LENGTH_KW;
-    extern const std::string CFG_PAM_NO_EXTEND_KW;
-    extern const std::string CFG_PAM_PASSWORD_MIN_TIME_KW;
-    extern const std::string CFG_PAM_PASSWORD_MAX_TIME_KW;
+    extern const char* const KW_CFG_KERBEROS_NAME;
+    extern const char* const KW_CFG_KERBEROS_KEYTAB;
+    extern const char* const KW_CFG_PAM_PASSWORD_LENGTH;
+    extern const char* const KW_CFG_PAM_NO_EXTEND;
+    extern const char* const KW_CFG_PAM_PASSWORD_MIN_TIME;
+    extern const char* const KW_CFG_PAM_PASSWORD_MAX_TIME;
 
-    extern const std::string CFG_DB_HOST_KW;
-    extern const std::string CFG_DB_PORT_KW;
-    extern const std::string CFG_DB_NAME_KW;
-    extern const std::string CFG_DB_ODBC_DRIVER_KW;
-    extern const std::string CFG_DB_USERNAME_KW;
-    extern const std::string CFG_DB_PASSWORD_KW;
-    extern const std::string CFG_DB_SSLMODE_KW;
-    extern const std::string CFG_DB_SSLROOTCERT_KW;
-    extern const std::string CFG_DB_SSLCERT_KW;
-    extern const std::string CFG_DB_SSLKEY_KW;
-    extern const std::string CFG_ZONE_NAME_KW;
-    extern const std::string CFG_ZONE_KEY_KW;
-    extern const std::string CFG_NEGOTIATION_KEY_KW;
-    extern const std::string CFG_RE_RULEBASE_SET_KW;
-    extern const std::string CFG_RE_NAMESPACE_SET_KW;
-    extern const std::string CFG_NAMESPACE_KW;
-    extern const std::string CFG_RE_FUNCTION_NAME_MAPPING_SET_KW;
-    extern const std::string CFG_RE_DATA_VARIABLE_MAPPING_SET_KW;
-    extern const std::string CFG_RE_PEP_REGEX_SET_KW;
-    extern const std::string CFG_DEFAULT_DIR_MODE_KW;
-    extern const std::string CFG_DEFAULT_FILE_MODE_KW;
-    extern const std::string CFG_DEFAULT_HASH_SCHEME_KW;
-    extern const std::string CFG_MATCH_HASH_POLICY_KW;
-    extern const std::string CFG_FEDERATION_KW;
-    extern const std::string CFG_ENVIRONMENT_VARIABLES_KW;
-    extern const std::string CFG_ADVANCED_SETTINGS_KW;
+    extern const char* const KW_CFG_DB_HOST;
+    extern const char* const KW_CFG_DB_PORT;
+    extern const char* const KW_CFG_DB_NAME;
+    extern const char* const KW_CFG_DB_ODBC_DRIVER;
+    extern const char* const KW_CFG_DB_USERNAME;
+    extern const char* const KW_CFG_DB_PASSWORD;
+    extern const char* const KW_CFG_DB_SSLMODE;
+    extern const char* const KW_CFG_DB_SSLROOTCERT;
+    extern const char* const KW_CFG_DB_SSLCERT;
+    extern const char* const KW_CFG_DB_SSLKEY;
+    extern const char* const KW_CFG_ZONE_NAME;
+    extern const char* const KW_CFG_ZONE_KEY;
+    extern const char* const KW_CFG_NEGOTIATION_KEY;
+    extern const char* const KW_CFG_RE_RULEBASE_SET;
+    extern const char* const KW_CFG_RE_NAMESPACE_SET;
+    extern const char* const KW_CFG_NAMESPACE;
+    extern const char* const KW_CFG_RE_FUNCTION_NAME_MAPPING_SET;
+    extern const char* const KW_CFG_RE_DATA_VARIABLE_MAPPING_SET;
+    extern const char* const KW_CFG_RE_PEP_REGEX_SET;
+    extern const char* const KW_CFG_DEFAULT_DIR_MODE;
+    extern const char* const KW_CFG_DEFAULT_FILE_MODE;
+    extern const char* const KW_CFG_DEFAULT_HASH_SCHEME;
+    extern const char* const KW_CFG_MATCH_HASH_POLICY;
+    extern const char* const KW_CFG_FEDERATION;
+    extern const char* const KW_CFG_ENVIRONMENT_VARIABLES;
+    extern const char* const KW_CFG_ADVANCED_SETTINGS;
 
-    extern const std::string CFG_SERVER_PORT_RANGE_START_KW;
-    extern const std::string CFG_SERVER_PORT_RANGE_END_KW;
+    extern const char* const KW_CFG_SERVER_PORT_RANGE_START;
+    extern const char* const KW_CFG_SERVER_PORT_RANGE_END;
 
     // log_level
-    extern const std::string CFG_LOG_LEVEL_KW;
-    extern const std::string CFG_LOG_LEVEL_CATEGORY_LEGACY_KW;
-    extern const std::string CFG_LOG_LEVEL_CATEGORY_SERVER_KW;
-    extern const std::string CFG_LOG_LEVEL_CATEGORY_AGENT_FACTORY_KW;
-    extern const std::string CFG_LOG_LEVEL_CATEGORY_AGENT_KW;
-    extern const std::string CFG_LOG_LEVEL_CATEGORY_DELAY_SERVER_KW;
-    extern const std::string CFG_LOG_LEVEL_CATEGORY_RESOURCE_KW;
-    extern const std::string CFG_LOG_LEVEL_CATEGORY_DATABASE_KW;
-    extern const std::string CFG_LOG_LEVEL_CATEGORY_AUTHENTICATION_KW;
-    extern const std::string CFG_LOG_LEVEL_CATEGORY_API_KW;
-    extern const std::string CFG_LOG_LEVEL_CATEGORY_MICROSERVICE_KW;
-    extern const std::string CFG_LOG_LEVEL_CATEGORY_NETWORK_KW;
-    extern const std::string CFG_LOG_LEVEL_CATEGORY_RULE_ENGINE_KW;
+    extern const char* const KW_CFG_LOG_LEVEL;
+    extern const char* const KW_CFG_LOG_LEVEL_CATEGORY_LEGACY;
+    extern const char* const KW_CFG_LOG_LEVEL_CATEGORY_SERVER;
+    extern const char* const KW_CFG_LOG_LEVEL_CATEGORY_AGENT_FACTORY;
+    extern const char* const KW_CFG_LOG_LEVEL_CATEGORY_AGENT;
+    extern const char* const KW_CFG_LOG_LEVEL_CATEGORY_DELAY_SERVER;
+    extern const char* const KW_CFG_LOG_LEVEL_CATEGORY_RESOURCE;
+    extern const char* const KW_CFG_LOG_LEVEL_CATEGORY_DATABASE;
+    extern const char* const KW_CFG_LOG_LEVEL_CATEGORY_AUTHENTICATION;
+    extern const char* const KW_CFG_LOG_LEVEL_CATEGORY_API;
+    extern const char* const KW_CFG_LOG_LEVEL_CATEGORY_MICROSERVICE;
+    extern const char* const KW_CFG_LOG_LEVEL_CATEGORY_NETWORK;
+    extern const char* const KW_CFG_LOG_LEVEL_CATEGORY_RULE_ENGINE;
 
     // client_allow_list_policy
-    extern const std::string CFG_CLIENT_API_ALLOWLIST_POLICY_KW;
+    extern const char* const KW_CFG_CLIENT_API_ALLOWLIST_POLICY;
 
     // host_access_control
-    extern const std::string CFG_HOST_ACCESS_CONTROL_KW;
-    extern const std::string CFG_ACCESS_ENTRIES_KW;
-    extern const std::string CFG_USER_KW;
-    extern const std::string CFG_GROUP_KW;
-    extern const std::string CFG_MASK_KW;
+    extern const char* const KW_CFG_HOST_ACCESS_CONTROL;
+    extern const char* const KW_CFG_ACCESS_ENTRIES;
+    extern const char* const KW_CFG_USER;
+    extern const char* const KW_CFG_GROUP;
+    extern const char* const KW_CFG_MASK;
 
     // host_resolution
-    extern const std::string CFG_HOST_RESOLUTION_KW;
-    extern const std::string CFG_HOST_ENTRIES_KW;
-    extern const std::string CFG_ADDRESS_TYPE_KW;
-    extern const std::string CFG_ADDRESSES_KW;
-    extern const std::string CFG_ADDRESS_KW;
+    extern const char* const KW_CFG_HOST_RESOLUTION;
+    extern const char* const KW_CFG_HOST_ENTRIES;
+    extern const char* const KW_CFG_ADDRESS_TYPE;
+    extern const char* const KW_CFG_ADDRESSES;
+    extern const char* const KW_CFG_ADDRESS;
 
     // advanced settings
-    extern const std::string DELAY_RULE_EXECUTORS_KW;
-    extern const std::string CFG_MAX_SIZE_FOR_SINGLE_BUFFER;
-    extern const std::string CFG_DEF_NUMBER_TRANSFER_THREADS;
-    extern const std::string CFG_TRANS_CHUNK_SIZE_PARA_TRANS;
-    extern const std::string CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS;
-    extern const std::string CFG_DEF_TEMP_PASSWORD_LIFETIME;
-    extern const std::string CFG_MAX_TEMP_PASSWORD_LIFETIME;
-    extern const std::string CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS;
-    extern const std::string CFG_MAX_SIZE_OF_DELAY_QUEUE_IN_BYTES_KW;
-    extern const std::string CFG_STACKTRACE_FILE_PROCESSOR_SLEEP_TIME_IN_SECONDS_KW;
+    extern const char* const KW_CFG_DELAY_RULE_EXECUTORS;
+    extern const char* const KW_CFG_MAX_SIZE_FOR_SINGLE_BUFFER;
+    extern const char* const KW_CFG_DEF_NUMBER_TRANSFER_THREADS;
+    extern const char* const KW_CFG_TRANS_CHUNK_SIZE_PARA_TRANS;
+    extern const char* const KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS;
+    extern const char* const KW_CFG_DEF_TEMP_PASSWORD_LIFETIME;
+    extern const char* const KW_CFG_MAX_TEMP_PASSWORD_LIFETIME;
+    extern const char* const KW_CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS;
+    extern const char* const KW_CFG_MAX_SIZE_OF_DELAY_QUEUE_IN_BYTES;
+    extern const char* const KW_CFG_STACKTRACE_FILE_PROCESSOR_SLEEP_TIME_IN_SECONDS;
 
-    extern const std::string CFG_RE_CACHE_SALT_KW;
-    extern const std::string CFG_DELAY_SERVER_SLEEP_TIME_IN_SECONDS;
+    extern const char* const KW_CFG_RE_CACHE_SALT;
+    extern const char* const KW_CFG_DELAY_SERVER_SLEEP_TIME_IN_SECONDS;
 
-    extern const std::string CFG_DNS_CACHE_KW;
-    extern const std::string CFG_HOSTNAME_CACHE_KW;
+    extern const char* const KW_CFG_DNS_CACHE;
+    extern const char* const KW_CFG_HOSTNAME_CACHE;
 
-    extern const std::string CFG_SHARED_MEMORY_SIZE_IN_BYTES_KW;
-    extern const std::string CFG_EVICTION_AGE_IN_SECONDS_KW;
+    extern const char* const KW_CFG_SHARED_MEMORY_SIZE_IN_BYTES;
+    extern const char* const KW_CFG_EVICTION_AGE_IN_SECONDS;
 
     // service_account_environment.json keywords
-    extern const std::string CFG_IRODS_USER_NAME_KW;
-    extern const std::string CFG_IRODS_HOST_KW;
-    extern const std::string CFG_IRODS_PORT_KW;
-    extern const std::string CFG_IRODS_XMSG_HOST_KW;
-    extern const std::string CFG_IRODS_XMSG_PORT_KW;
-    extern const std::string CFG_IRODS_HOME_KW;
-    extern const std::string CFG_IRODS_CWD_KW;
-    extern const std::string CFG_IRODS_AUTHENTICATION_SCHEME_KW;
-    extern const std::string CFG_IRODS_DEFAULT_RESOURCE_KW;
-    extern const std::string CFG_IRODS_ZONE_KW;
-    extern const std::string CFG_IRODS_GSI_SERVER_DN_KW;
-    extern const std::string CFG_IRODS_LOG_LEVEL_KW;
-    extern const std::string CFG_IRODS_AUTHENTICATION_FILE_KW;
-    extern const std::string CFG_IRODS_DEBUG_KW;
-    extern const std::string CFG_IRODS_CLIENT_SERVER_POLICY_KW;
-    extern const std::string CFG_IRODS_CLIENT_SERVER_NEGOTIATION_KW;
-    extern const std::string CFG_IRODS_ENCRYPTION_KEY_SIZE_KW;
-    extern const std::string CFG_IRODS_ENCRYPTION_SALT_SIZE_KW;
-    extern const std::string CFG_IRODS_ENCRYPTION_NUM_HASH_ROUNDS_KW;
-    extern const std::string CFG_IRODS_ENCRYPTION_ALGORITHM_KW;
-    extern const std::string CFG_IRODS_DEFAULT_HASH_SCHEME_KW;
-    extern const std::string CFG_IRODS_MATCH_HASH_POLICY_KW;
+    extern const char* const KW_CFG_IRODS_USER_NAME;
+    extern const char* const KW_CFG_IRODS_HOST;
+    extern const char* const KW_CFG_IRODS_PORT;
+    extern const char* const KW_CFG_IRODS_HOME;
+    extern const char* const KW_CFG_IRODS_CWD;
+    extern const char* const KW_CFG_IRODS_AUTHENTICATION_SCHEME;
+    extern const char* const KW_CFG_IRODS_DEFAULT_RESOURCE;
+    extern const char* const KW_CFG_IRODS_ZONE;
+    extern const char* const KW_CFG_IRODS_GSI_SERVER_DN;
+    extern const char* const KW_CFG_IRODS_LOG_LEVEL;
+    extern const char* const KW_CFG_IRODS_AUTHENTICATION_FILE;
+    extern const char* const KW_CFG_IRODS_DEBUG;
+    extern const char* const KW_CFG_IRODS_CLIENT_SERVER_POLICY;
+    extern const char* const KW_CFG_IRODS_CLIENT_SERVER_NEGOTIATION;
+    extern const char* const KW_CFG_IRODS_ENCRYPTION_KEY_SIZE;
+    extern const char* const KW_CFG_IRODS_ENCRYPTION_SALT_SIZE;
+    extern const char* const KW_CFG_IRODS_ENCRYPTION_NUM_HASH_ROUNDS;
+    extern const char* const KW_CFG_IRODS_ENCRYPTION_ALGORITHM;
+    extern const char* const KW_CFG_IRODS_DEFAULT_HASH_SCHEME;
+    extern const char* const KW_CFG_IRODS_MATCH_HASH_POLICY;
 
-    extern const std::string CFG_IRODS_ENVIRONMENT_FILE_KW;
-    extern const std::string CFG_IRODS_SESSION_ENVIRONMENT_FILE_KW;
-    extern const std::string CFG_IRODS_SERVER_CONTROL_PLANE_PORT;
+    extern const char* const KW_CFG_IRODS_ENVIRONMENT_FILE;
+    extern const char* const KW_CFG_IRODS_SESSION_ENVIRONMENT_FILE;
+    extern const char* const KW_CFG_IRODS_SERVER_CONTROL_PLANE_PORT;
 
-    extern const std::string CFG_IRODS_SERVER_CONTROL_PLANE_KEY;
-    extern const std::string CFG_IRODS_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS_KW;
-    extern const std::string CFG_IRODS_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM_KW;
+    extern const char* const KW_CFG_IRODS_SERVER_CONTROL_PLANE_KEY;
+    extern const char* const KW_CFG_IRODS_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS;
+    extern const char* const KW_CFG_IRODS_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM;
 
     // irods environment advanced settings
-    extern const std::string CFG_IRODS_MAX_SIZE_FOR_SINGLE_BUFFER;
-    extern const std::string CFG_IRODS_DEF_NUMBER_TRANSFER_THREADS;
-    extern const std::string CFG_IRODS_MAX_NUMBER_TRANSFER_THREADS;
-    extern const std::string CFG_IRODS_TRANS_BUFFER_SIZE_FOR_PARA_TRANS;
-    extern const std::string CFG_IRODS_CONNECTION_POOL_REFRESH_TIME;
+    extern const char* const KW_CFG_IRODS_MAX_SIZE_FOR_SINGLE_BUFFER;
+    extern const char* const KW_CFG_IRODS_DEF_NUMBER_TRANSFER_THREADS;
+    extern const char* const KW_CFG_IRODS_MAX_NUMBER_TRANSFER_THREADS;
+    extern const char* const KW_CFG_IRODS_TRANS_BUFFER_SIZE_FOR_PARA_TRANS;
+    extern const char* const KW_CFG_IRODS_CONNECTION_POOL_REFRESH_TIME;
 
     // legacy ssl environment variables
-    extern const std::string CFG_IRODS_SSL_CA_CERTIFICATE_PATH;
-    extern const std::string CFG_IRODS_SSL_CA_CERTIFICATE_FILE;
-    extern const std::string CFG_IRODS_SSL_VERIFY_SERVER;
-    extern const std::string CFG_IRODS_SSL_CERTIFICATE_CHAIN_FILE;
-    extern const std::string CFG_IRODS_SSL_CERTIFICATE_KEY_FILE;
-    extern const std::string CFG_IRODS_SSL_DH_PARAMS_FILE;
+    extern const char* const KW_CFG_IRODS_SSL_CA_CERTIFICATE_PATH;
+    extern const char* const KW_CFG_IRODS_SSL_CA_CERTIFICATE_FILE;
+    extern const char* const KW_CFG_IRODS_SSL_VERIFY_SERVER;
+    extern const char* const KW_CFG_IRODS_SSL_CERTIFICATE_CHAIN_FILE;
+    extern const char* const KW_CFG_IRODS_SSL_CERTIFICATE_KEY_FILE;
+    extern const char* const KW_CFG_IRODS_SSL_DH_PARAMS_FILE;
 
     // irods environment values now included in server_config
-    extern const std::string CFG_ZONE_NAME;
-    extern const std::string CFG_ZONE_USER;
-    extern const std::string CFG_ZONE_PORT;
-    extern const std::string CFG_ZONE_AUTH_SCHEME;
+    extern const char* const KW_CFG_ZONE_USER;
+    extern const char* const KW_CFG_ZONE_PORT;
+    extern const char* const KW_CFG_ZONE_AUTH_SCHEME;
 
     // irods control plane values
-    extern const std::string CFG_SERVER_CONTROL_PLANE_PORT;
-    extern const std::string CFG_RULE_ENGINE_CONTROL_PLANE_PORT;
-    extern const std::string CFG_SERVER_CONTROL_PLANE_TIMEOUT;
-    extern const std::string CFG_SERVER_CONTROL_PLANE_KEY;
-    extern const std::string CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS_KW;
-    extern const std::string CFG_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM_KW;
+    extern const char* const KW_CFG_SERVER_CONTROL_PLANE_PORT;
+    extern const char* const KW_CFG_RULE_ENGINE_CONTROL_PLANE_PORT;
+    extern const char* const KW_CFG_SERVER_CONTROL_PLANE_TIMEOUT;
+    extern const char* const KW_CFG_SERVER_CONTROL_PLANE_KEY;
+    extern const char* const KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS;
+    extern const char* const KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM;
 
-    extern const std::string CFG_CATALOG_PROVIDER_HOSTS_KW;
-    extern const std::string CFG_CATALOG_SERVICE_ROLE;
-    extern const std::string CFG_SERVICE_ROLE_PROVIDER;
-    extern const std::string CFG_SERVICE_ROLE_CONSUMER;
-    extern const std::string CFG_SERVICE_ROLE_PROXY;
+    extern const char* const KW_CFG_CATALOG_PROVIDER_HOSTS;
+    extern const char* const KW_CFG_CATALOG_SERVICE_ROLE;
+    extern const char* const KW_CFG_SERVICE_ROLE_PROVIDER;
+    extern const char* const KW_CFG_SERVICE_ROLE_CONSUMER;
+    extern const char* const KW_CFG_SERVICE_ROLE_PROXY;
 
-    extern const std::string CFG_IRODS_PLUGINS_HOME_KW;
+    extern const char* const KW_CFG_IRODS_PLUGINS_HOME;
 
-    extern const std::string CFG_PLUGIN_CONFIGURATION_KW;
+    extern const char* const KW_CFG_PLUGIN_CONFIGURATION;
 
     // plugin types
-    extern const std::string PLUGIN_TYPE_API;
-    extern const std::string PLUGIN_TYPE_RULE_ENGINE;
-    extern const std::string PLUGIN_TYPE_AUTHENTICATION;
-    extern const std::string PLUGIN_TYPE_NETWORK;
-    extern const std::string PLUGIN_TYPE_DATABASE;
-    extern const std::string PLUGIN_TYPE_RESOURCE;
-    extern const std::string PLUGIN_TYPE_MICROSERVICE;
+    extern const char* const KW_CFG_PLUGIN_TYPE_API;
+    extern const char* const KW_CFG_PLUGIN_TYPE_RULE_ENGINE;
+    extern const char* const KW_CFG_PLUGIN_TYPE_AUTHENTICATION;
+    extern const char* const KW_CFG_PLUGIN_TYPE_NETWORK;
+    extern const char* const KW_CFG_PLUGIN_TYPE_DATABASE;
+    extern const char* const KW_CFG_PLUGIN_TYPE_RESOURCE;
+    extern const char* const KW_CFG_PLUGIN_TYPE_MICROSERVICE;
 
-    extern const std::string CFG_PLUGIN_SPECIFIC_CONFIGURATION_KW;
-    extern const std::string CFG_INSTANCE_NAME_KW;
-    extern const std::string CFG_PLUGIN_NAME_KW;
+    extern const char* const KW_CFG_PLUGIN_SPECIFIC_CONFIGURATION;
+    extern const char* const KW_CFG_INSTANCE_NAME;
+    extern const char* const KW_CFG_PLUGIN_NAME;
 
-    extern const std::string CFG_SHARED_MEMORY_INSTANCE_KW;
-    extern const std::string CFG_SHARED_MEMORY_MUTEX_KW;
+    extern const char* const KW_CFG_SHARED_MEMORY_INSTANCE;
+    extern const char* const KW_CFG_SHARED_MEMORY_MUTEX;
 
-    extern const std::string DEFAULT_RULE_ENGINE_PLUGIN_NAME_KW;
-    extern const std::string DEFAULT_RULE_ENGINE_INSTANCE_NAME_KW;
+    extern const char* const KW_CFG_DEFAULT_RULE_ENGINE_PLUGIN_NAME;
+    extern const char* const KW_CFG_DEFAULT_RULE_ENGINE_INSTANCE_NAME;
 } // namespace irods
 
-#endif // CONFIGURATION_KEYWORDS_HPP
+#endif // IRODS_CONFIGURATION_KEYWORDS_HPP

--- a/lib/core/include/irods/irods_server_properties.hpp
+++ b/lib/core/include/irods/irods_server_properties.hpp
@@ -196,7 +196,7 @@ namespace irods
     template< typename T >
     T get_advanced_setting( const std::string& _prop )
     {
-        return irods::get_server_property<T>(configuration_parser::key_path_t{CFG_ADVANCED_SETTINGS_KW, _prop});
+        return irods::get_server_property<T>(configuration_parser::key_path_t{KW_CFG_ADVANCED_SETTINGS, _prop});
     } // get_advanced_setting
 
     /// Returns the amount of shared memory that should be allocated for the DNS cache.

--- a/lib/core/src/apiHandler.cpp
+++ b/lib/core/src/apiHandler.cpp
@@ -107,7 +107,7 @@ namespace irods
         // =-=-=-=-=-=-=-
         // resolve plugin directory
         std::string plugin_home;
-        error ret = resolve_plugin_path( irods::PLUGIN_TYPE_API, plugin_home );
+        error ret = resolve_plugin_path( irods::KW_CFG_PLUGIN_TYPE_API, plugin_home );
         if ( !ret.ok() ) {
             return PASS( ret );
         }
@@ -150,7 +150,7 @@ namespace irods
                 error ret = load_plugin<api_entry>(
                                 entry,
                                 name,
-                                PLUGIN_TYPE_API,
+                                KW_CFG_PLUGIN_TYPE_API,
                                 "api_instance",
                                 "api_context");
                 if (ret.ok() && entry) {

--- a/lib/core/src/clientLogin.cpp
+++ b/lib/core/src/clientLogin.cpp
@@ -299,7 +299,7 @@ int clientLogin(
         else {
             // =-=-=-=-=-=-=-
             // check the environment variable first
-            char* auth_env_var = getenv( irods::to_env( irods::CFG_IRODS_AUTHENTICATION_SCHEME_KW ).c_str() );
+            char* auth_env_var = getenv( irods::to_env( irods::KW_CFG_IRODS_AUTHENTICATION_SCHEME ).c_str() );
             if ( !auth_env_var ) {
                 rodsEnv rods_env;
                 if ( getRodsEnv( &rods_env ) >= 0 ) {

--- a/lib/core/src/getRodsEnv.cpp
+++ b/lib/core/src/getRodsEnv.cpp
@@ -194,80 +194,80 @@ extern "C" {
             "native" );
 
         capture_string_property(
-            irods::CFG_IRODS_SESSION_ENVIRONMENT_FILE_KW,
+            irods::KW_CFG_IRODS_SESSION_ENVIRONMENT_FILE,
             configFileName );
 
         capture_string_property(
-            irods::CFG_IRODS_USER_NAME_KW,
+            irods::KW_CFG_IRODS_USER_NAME,
             _env->rodsUserName );
 
         capture_string_property(
-            irods::CFG_IRODS_HOST_KW,
+            irods::KW_CFG_IRODS_HOST,
             _env->rodsHost );
 
         capture_string_property(
-            irods::CFG_IRODS_HOME_KW,
+            irods::KW_CFG_IRODS_HOME,
             _env->rodsHome );
 
         capture_string_property(
-            irods::CFG_IRODS_CWD_KW,
+            irods::KW_CFG_IRODS_CWD,
             _env->rodsCwd );
 
         capture_string_property(
-            irods::CFG_IRODS_AUTHENTICATION_SCHEME_KW,
+            irods::KW_CFG_IRODS_AUTHENTICATION_SCHEME,
             _env->rodsAuthScheme );
 
         capture_integer_property(
-            irods::CFG_IRODS_PORT_KW,
+            irods::KW_CFG_IRODS_PORT,
             _env->rodsPort );
 
         capture_string_property(
-            irods::CFG_IRODS_DEFAULT_RESOURCE_KW,
+            irods::KW_CFG_IRODS_DEFAULT_RESOURCE,
             _env->rodsDefResource );
 
         capture_string_property(
-            irods::CFG_IRODS_ZONE_KW,
+            irods::KW_CFG_IRODS_ZONE,
             _env->rodsZone );
 
         capture_string_property(
-            irods::CFG_IRODS_CLIENT_SERVER_POLICY_KW,
+            irods::KW_CFG_IRODS_CLIENT_SERVER_POLICY,
             _env->rodsClientServerPolicy );
 
         capture_string_property(
-            irods::CFG_IRODS_CLIENT_SERVER_NEGOTIATION_KW,
+            irods::KW_CFG_IRODS_CLIENT_SERVER_NEGOTIATION,
             _env->rodsClientServerNegotiation );
 
         capture_integer_property(
-            irods::CFG_IRODS_ENCRYPTION_KEY_SIZE_KW,
+            irods::KW_CFG_IRODS_ENCRYPTION_KEY_SIZE,
             _env->rodsEncryptionKeySize );
 
         capture_integer_property(
-            irods::CFG_IRODS_ENCRYPTION_SALT_SIZE_KW,
+            irods::KW_CFG_IRODS_ENCRYPTION_SALT_SIZE,
             _env->rodsEncryptionSaltSize );
 
         capture_integer_property(
-            irods::CFG_IRODS_ENCRYPTION_NUM_HASH_ROUNDS_KW,
+            irods::KW_CFG_IRODS_ENCRYPTION_NUM_HASH_ROUNDS,
             _env->rodsEncryptionNumHashRounds );
 
         capture_string_property(
-            irods::CFG_IRODS_ENCRYPTION_ALGORITHM_KW,
+            irods::KW_CFG_IRODS_ENCRYPTION_ALGORITHM,
             _env->rodsEncryptionAlgorithm );
 
         capture_string_property(
-            irods::CFG_IRODS_DEFAULT_HASH_SCHEME_KW,
+            irods::KW_CFG_IRODS_DEFAULT_HASH_SCHEME,
             _env->rodsDefaultHashScheme );
 
         capture_string_property(
-            irods::CFG_IRODS_MATCH_HASH_POLICY_KW,
+            irods::KW_CFG_IRODS_MATCH_HASH_POLICY,
             _env->rodsMatchHashPolicy );
 
         capture_string_property(
-            irods::CFG_IRODS_DEBUG_KW,
+            irods::KW_CFG_IRODS_DEBUG,
             _env->rodsDebug );
 
         _env->rodsLogLevel = 0;
         int status = capture_integer_property(
-                         irods::CFG_IRODS_LOG_LEVEL_KW,
+                         irods::KW_CFG_IRODS_LOG_LEVEL,
                          _env->rodsLogLevel );
         if ( status == 0 && _env->rodsLogLevel > 0 ) {
             if( _env->rodsLogLevel < LOG_SYS_FATAL ) {
@@ -278,7 +278,7 @@ extern "C" {
 
         memset( _env->rodsAuthFile, 0, sizeof( _env->rodsAuthFile ) );
         status = capture_string_property(
-                     irods::CFG_IRODS_AUTHENTICATION_FILE_KW,
+                     irods::KW_CFG_IRODS_AUTHENTICATION_FILE,
                      _env->rodsAuthFile );
         if ( status == 0 ) {
             rstrcpy(
@@ -289,64 +289,64 @@ extern "C" {
 
         // legacy ssl environment variables
         capture_string_property(
-            irods::CFG_IRODS_SSL_CA_CERTIFICATE_PATH,
+            irods::KW_CFG_IRODS_SSL_CA_CERTIFICATE_PATH,
             _env->irodsSSLCACertificatePath );
 
         capture_string_property(
-            irods::CFG_IRODS_SSL_CA_CERTIFICATE_FILE,
+            irods::KW_CFG_IRODS_SSL_CA_CERTIFICATE_FILE,
             _env->irodsSSLCACertificateFile );
 
         capture_string_property(
-            irods::CFG_IRODS_SSL_VERIFY_SERVER,
+            irods::KW_CFG_IRODS_SSL_VERIFY_SERVER,
             _env->irodsSSLVerifyServer );
 
         capture_string_property(
-            irods::CFG_IRODS_SSL_CERTIFICATE_CHAIN_FILE,
+            irods::KW_CFG_IRODS_SSL_CERTIFICATE_CHAIN_FILE,
             _env->irodsSSLCertificateChainFile );
 
         capture_string_property(
-            irods::CFG_IRODS_SSL_CERTIFICATE_KEY_FILE,
+            irods::KW_CFG_IRODS_SSL_CERTIFICATE_KEY_FILE,
             _env->irodsSSLCertificateKeyFile );
 
         capture_string_property(
-            irods::CFG_IRODS_SSL_DH_PARAMS_FILE,
+            irods::KW_CFG_IRODS_SSL_DH_PARAMS_FILE,
             _env->irodsSSLDHParamsFile );
 
         // control plane variables
         capture_string_property(
-            irods::CFG_IRODS_SERVER_CONTROL_PLANE_KEY,
+            irods::KW_CFG_IRODS_SERVER_CONTROL_PLANE_KEY,
             _env->irodsCtrlPlaneKey );
 
         capture_integer_property(
-            irods::CFG_IRODS_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS_KW,
+            irods::KW_CFG_IRODS_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS,
             _env->irodsCtrlPlaneEncryptionNumHashRounds );
 
         capture_string_property(
-            irods::CFG_IRODS_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM_KW,
+            irods::KW_CFG_IRODS_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM,
             _env->irodsCtrlPlaneEncryptionAlgorithm );
 
         capture_integer_property(
-            irods::CFG_IRODS_SERVER_CONTROL_PLANE_PORT,
+            irods::KW_CFG_IRODS_SERVER_CONTROL_PLANE_PORT,
             _env->irodsCtrlPlanePort );
 
         capture_integer_property(
-            irods::CFG_IRODS_MAX_SIZE_FOR_SINGLE_BUFFER,
+            irods::KW_CFG_IRODS_MAX_SIZE_FOR_SINGLE_BUFFER,
             _env->irodsMaxSizeForSingleBuffer );
 
         capture_integer_property(
-            irods::CFG_IRODS_DEF_NUMBER_TRANSFER_THREADS,
+            irods::KW_CFG_IRODS_DEF_NUMBER_TRANSFER_THREADS,
             _env->irodsDefaultNumberTransferThreads );
 
         capture_integer_property(
-            irods::CFG_IRODS_TRANS_BUFFER_SIZE_FOR_PARA_TRANS,
+            irods::KW_CFG_IRODS_TRANS_BUFFER_SIZE_FOR_PARA_TRANS,
             _env->irodsTransBufferSizeForParaTrans );
 
         capture_integer_property(
-            irods::CFG_IRODS_CONNECTION_POOL_REFRESH_TIME,
+            irods::KW_CFG_IRODS_CONNECTION_POOL_REFRESH_TIME,
             _env->irodsConnectionPoolRefreshTime );
 
         capture_string_property(
-            irods::CFG_IRODS_PLUGINS_HOME_KW,
+            irods::KW_CFG_IRODS_PLUGINS_HOME,
             _env->irodsPluginHome );
 
         return 0;
@@ -468,88 +468,88 @@ extern "C" {
 
         }
 
-        std::string env_var = irods::CFG_IRODS_USER_NAME_KW;
+        std::string env_var = irods::KW_CFG_IRODS_USER_NAME;
         capture_string_env_var(
             env_var,
             _env->rodsUserName );
 
-        env_var = irods::CFG_IRODS_HOST_KW;
+        env_var = irods::KW_CFG_IRODS_HOST;
         capture_string_env_var(
             env_var,
             _env->rodsHost );
 
-        env_var = irods::CFG_IRODS_PORT_KW;
+        env_var = irods::KW_CFG_IRODS_PORT;
         capture_integer_env_var(
             env_var,
             _env->rodsPort );
 
-        env_var = irods::CFG_IRODS_HOME_KW;
+        env_var = irods::KW_CFG_IRODS_HOME;
         capture_string_env_var(
             env_var,
             _env->rodsHome );
 
-        env_var = irods::CFG_IRODS_CWD_KW;
+        env_var = irods::KW_CFG_IRODS_CWD;
         capture_string_env_var(
             env_var,
             _env->rodsCwd );
 
-        env_var = irods::CFG_IRODS_AUTHENTICATION_SCHEME_KW;
+        env_var = irods::KW_CFG_IRODS_AUTHENTICATION_SCHEME;
         capture_string_env_var(
             env_var,
             _env->rodsAuthScheme );
 
-        env_var = irods::CFG_IRODS_DEFAULT_RESOURCE_KW;
+        env_var = irods::KW_CFG_IRODS_DEFAULT_RESOURCE;
         capture_string_env_var(
             env_var,
             _env->rodsDefResource );
 
-        env_var = irods::CFG_IRODS_ZONE_KW;
+        env_var = irods::KW_CFG_IRODS_ZONE;
         capture_string_env_var(
             env_var,
             _env->rodsZone );
 
-        env_var = irods::CFG_IRODS_CLIENT_SERVER_POLICY_KW;
+        env_var = irods::KW_CFG_IRODS_CLIENT_SERVER_POLICY;
         capture_string_env_var(
             env_var,
             _env->rodsClientServerPolicy );
 
-        env_var = irods::CFG_IRODS_CLIENT_SERVER_NEGOTIATION_KW;
+        env_var = irods::KW_CFG_IRODS_CLIENT_SERVER_NEGOTIATION;
         capture_string_env_var(
             env_var,
             _env->rodsClientServerNegotiation );
 
-        env_var = irods::CFG_IRODS_ENCRYPTION_KEY_SIZE_KW;
+        env_var = irods::KW_CFG_IRODS_ENCRYPTION_KEY_SIZE;
         capture_integer_env_var(
             env_var,
             _env->rodsEncryptionKeySize );
 
-        env_var = irods::CFG_IRODS_ENCRYPTION_SALT_SIZE_KW;
+        env_var = irods::KW_CFG_IRODS_ENCRYPTION_SALT_SIZE;
         capture_integer_env_var(
             env_var,
             _env->rodsEncryptionSaltSize );
 
-        env_var = irods::CFG_IRODS_ENCRYPTION_NUM_HASH_ROUNDS_KW;
+        env_var = irods::KW_CFG_IRODS_ENCRYPTION_NUM_HASH_ROUNDS;
         capture_integer_env_var(
             env_var,
             _env->rodsEncryptionNumHashRounds );
 
-        env_var = irods::CFG_IRODS_ENCRYPTION_ALGORITHM_KW;
+        env_var = irods::KW_CFG_IRODS_ENCRYPTION_ALGORITHM;
         capture_string_env_var(
             env_var,
             _env->rodsEncryptionAlgorithm );
 
-        env_var = irods::CFG_IRODS_DEFAULT_HASH_SCHEME_KW;
+        env_var = irods::KW_CFG_IRODS_DEFAULT_HASH_SCHEME;
         capture_string_env_var(
             env_var,
             _env->rodsDefaultHashScheme );
 
-        env_var = irods::CFG_IRODS_MATCH_HASH_POLICY_KW;
+        env_var = irods::KW_CFG_IRODS_MATCH_HASH_POLICY;
         capture_string_env_var(
             env_var,
             _env->rodsMatchHashPolicy );
 
         _env->rodsLogLevel = 0;
-        env_var = irods::CFG_IRODS_LOG_LEVEL_KW;
+        env_var = irods::KW_CFG_IRODS_LOG_LEVEL;
         capture_integer_env_var(
             env_var,
             _env->rodsLogLevel );
@@ -562,7 +562,7 @@ extern "C" {
         }
 
         memset( _env->rodsAuthFile, 0, sizeof( _env->rodsAuthFile ) );
-        env_var = irods::CFG_IRODS_AUTHENTICATION_FILE_KW;
+        env_var = irods::KW_CFG_IRODS_AUTHENTICATION_FILE;
         capture_string_env_var(
             env_var,
             _env->rodsAuthFile );
@@ -571,57 +571,57 @@ extern "C" {
 
         }
 
-        env_var = irods::CFG_IRODS_DEBUG_KW;
+        env_var = irods::KW_CFG_IRODS_DEBUG;
         capture_string_env_var(
             env_var,
             _env->rodsDebug );
 
         // legacy ssl environment variables
-        env_var = irods::CFG_IRODS_SSL_CA_CERTIFICATE_PATH;
+        env_var = irods::KW_CFG_IRODS_SSL_CA_CERTIFICATE_PATH;
         capture_string_env_var(
             env_var,
             _env->irodsSSLCACertificatePath );
-        env_var = irods::CFG_IRODS_SSL_CA_CERTIFICATE_FILE;
+        env_var = irods::KW_CFG_IRODS_SSL_CA_CERTIFICATE_FILE;
         capture_string_env_var(
             env_var,
             _env->irodsSSLCACertificateFile );
-        env_var = irods::CFG_IRODS_SSL_VERIFY_SERVER;
+        env_var = irods::KW_CFG_IRODS_SSL_VERIFY_SERVER;
         capture_string_env_var(
             env_var,
             _env->irodsSSLVerifyServer );
-        env_var = irods::CFG_IRODS_SSL_VERIFY_SERVER;
+        env_var = irods::KW_CFG_IRODS_SSL_VERIFY_SERVER;
         capture_string_env_var(
             env_var,
             _env->irodsSSLVerifyServer );
-        env_var = irods::CFG_IRODS_SSL_CERTIFICATE_CHAIN_FILE;
+        env_var = irods::KW_CFG_IRODS_SSL_CERTIFICATE_CHAIN_FILE;
         capture_string_env_var(
             env_var,
             _env->irodsSSLCertificateChainFile );
-        env_var = irods::CFG_IRODS_SSL_CERTIFICATE_KEY_FILE;
+        env_var = irods::KW_CFG_IRODS_SSL_CERTIFICATE_KEY_FILE;
         capture_string_env_var(
             env_var,
             _env->irodsSSLCertificateKeyFile );
-        env_var = irods::CFG_IRODS_SSL_DH_PARAMS_FILE;
+        env_var = irods::KW_CFG_IRODS_SSL_DH_PARAMS_FILE;
         capture_string_env_var(
             env_var,
             _env->irodsSSLDHParamsFile );
 
-        env_var = irods::CFG_IRODS_MAX_SIZE_FOR_SINGLE_BUFFER;
+        env_var = irods::KW_CFG_IRODS_MAX_SIZE_FOR_SINGLE_BUFFER;
         capture_integer_env_var(
             env_var,
             _env->irodsMaxSizeForSingleBuffer );
 
-        env_var = irods::CFG_IRODS_DEF_NUMBER_TRANSFER_THREADS;
+        env_var = irods::KW_CFG_IRODS_DEF_NUMBER_TRANSFER_THREADS;
         capture_integer_env_var(
             env_var,
             _env->irodsDefaultNumberTransferThreads );
 
-        env_var = irods::CFG_IRODS_TRANS_BUFFER_SIZE_FOR_PARA_TRANS;
+        env_var = irods::KW_CFG_IRODS_TRANS_BUFFER_SIZE_FOR_PARA_TRANS;
         capture_integer_env_var(
             env_var,
             _env->irodsTransBufferSizeForParaTrans );
 
-        env_var = irods::CFG_IRODS_PLUGINS_HOME_KW;
+        env_var = irods::KW_CFG_IRODS_PLUGINS_HOME;
         capture_string_env_var(
             env_var,
             _env->irodsPluginHome );

--- a/lib/core/src/irods_auth_manager.cpp
+++ b/lib/core/src/irods_auth_manager.cpp
@@ -14,7 +14,7 @@ namespace
     {
         irods::auth* auth = nullptr;
 
-        constexpr auto& type = irods::PLUGIN_TYPE_AUTHENTICATION;
+        constexpr auto& type = irods::KW_CFG_PLUGIN_TYPE_AUTHENTICATION;
         if (const auto err = irods::load_plugin<irods::auth>(auth, _name, type, _instance, _context);
             !err.ok()) {
             return PASSMSG(fmt::format("Failed to load plugin: \"{}\".", _name), err);

--- a/lib/core/src/irods_client_negotiation.cpp
+++ b/lib/core/src/irods_client_negotiation.cpp
@@ -45,11 +45,11 @@ namespace irods
     {
         // search the federation map for the host name
         try {
-            for ( const auto& federation : irods::get_server_property<const nlohmann::json&>(irods::CFG_FEDERATION_KW) ) {
+            for ( const auto& federation : irods::get_server_property<const nlohmann::json&>(irods::KW_CFG_FEDERATION) ) {
                 try {
                     try {
-                        if (_host_name == federation.at(irods::CFG_CATALOG_PROVIDER_HOSTS_KW)[0].get<std::string>()) {
-                            return federation.at(irods::CFG_NEGOTIATION_KEY_KW).get<std::string>();
+                        if (_host_name == federation.at(irods::KW_CFG_CATALOG_PROVIDER_HOSTS)[0].get<std::string>()) {
+                            return federation.at(irods::KW_CFG_NEGOTIATION_KEY).get<std::string>();
                         }
                     } catch ( const nlohmann::json::exception& e) {
                         rodsLog(
@@ -76,7 +76,7 @@ namespace irods
         } catch ( const irods::exception& ) {}
 
         // if not, it must be in our zone
-        return irods::get_server_property<std::string>(CFG_NEGOTIATION_KEY_KW);
+        return irods::get_server_property<std::string>(KW_CFG_NEGOTIATION_KEY);
     } // determine_negotiation_key
 
     error sign_server_sid(const std::string& _zone_key,
@@ -334,7 +334,7 @@ namespace irods
             try {
                 boost::optional<std::string> zone_key;
                 try {
-                    zone_key.reset(irods::get_server_property<std::string>(irods::CFG_ZONE_KEY_KW));
+                    zone_key.reset(irods::get_server_property<std::string>(irods::KW_CFG_ZONE_KEY));
                 } catch (const irods::exception&) {
                     zone_key.reset(irods::get_server_property<std::string>(LOCAL_ZONE_SID_KW));
                 }

--- a/lib/core/src/irods_configuration_keywords.cpp
+++ b/lib/core/src/irods_configuration_keywords.cpp
@@ -3,182 +3,178 @@
 namespace irods
 {
     // server_config.json keywords
-    const std::string CFG_KERBEROS_NAME_KW( "kerberos_name" );
-    const std::string CFG_KERBEROS_KEYTAB_KW( "kerberos_keytab" );
-    const std::string CFG_PAM_PASSWORD_LENGTH_KW( "password_length" );
-    const std::string CFG_PAM_NO_EXTEND_KW( "no_extend" );
-    const std::string CFG_PAM_PASSWORD_MIN_TIME_KW( "password_min_time" );
-    const std::string CFG_PAM_PASSWORD_MAX_TIME_KW( "password_max_time" );
+    const char* const KW_CFG_KERBEROS_NAME{"kerberos_name"};
+    const char* const KW_CFG_KERBEROS_KEYTAB{"kerberos_keytab"};
+    const char* const KW_CFG_PAM_PASSWORD_LENGTH{"password_length"};
+    const char* const KW_CFG_PAM_NO_EXTEND{"no_extend"};
+    const char* const KW_CFG_PAM_PASSWORD_MIN_TIME{"password_min_time"};
+    const char* const KW_CFG_PAM_PASSWORD_MAX_TIME{"password_max_time"};
 
-    const std::string CFG_DB_HOST_KW("db_host");
-    const std::string CFG_DB_PORT_KW("db_port");
-    const std::string CFG_DB_NAME_KW("db_name");
-    const std::string CFG_DB_ODBC_DRIVER_KW("db_odbc_driver");
-    const std::string CFG_DB_USERNAME_KW( "db_username" );
-    const std::string CFG_DB_PASSWORD_KW( "db_password" );
-    const std::string CFG_DB_SSLMODE_KW( "db_sslmode" );
-    const std::string CFG_DB_SSLROOTCERT_KW( "db_sslrootcert" );
-    const std::string CFG_DB_SSLCERT_KW( "db_sslcert" );
-    const std::string CFG_DB_SSLKEY_KW( "db_sslkey" );
-    const std::string CFG_ZONE_NAME_KW( "zone_name" );
-    const std::string CFG_ZONE_KEY_KW( "zone_key" );
-    const std::string CFG_NEGOTIATION_KEY_KW( "negotiation_key" );
-    const std::string CFG_RE_RULEBASE_SET_KW( "re_rulebase_set" );
-    const std::string CFG_RE_NAMESPACE_SET_KW( "rule_engine_namespaces" );
-    const std::string CFG_NAMESPACE_KW( "namespace" );
-    const std::string CFG_RE_FUNCTION_NAME_MAPPING_SET_KW( "re_function_name_mapping_set" );
-    const std::string CFG_RE_DATA_VARIABLE_MAPPING_SET_KW( "re_data_variable_mapping_set" );
-    const std::string CFG_RE_PEP_REGEX_SET_KW( "regexes_for_supported_peps" );
-    const std::string CFG_DEFAULT_DIR_MODE_KW( "default_dir_mode" );
-    const std::string CFG_DEFAULT_FILE_MODE_KW( "default_file_mode" );
-    const std::string CFG_DEFAULT_HASH_SCHEME_KW( "default_hash_scheme" );
-    const std::string CFG_MATCH_HASH_POLICY_KW( "match_hash_policy" );
-    const std::string CFG_FEDERATION_KW( "federation" );
-    const std::string CFG_ENVIRONMENT_VARIABLES_KW( "environment_variables" );
-    const std::string CFG_ADVANCED_SETTINGS_KW( "advanced_settings" );
+    const char* const KW_CFG_DB_HOST{"db_host"};
+    const char* const KW_CFG_DB_PORT{"db_port"};
+    const char* const KW_CFG_DB_NAME{"db_name"};
+    const char* const KW_CFG_DB_ODBC_DRIVER{"db_odbc_driver"};
+    const char* const KW_CFG_DB_USERNAME{"db_username"};
+    const char* const KW_CFG_DB_PASSWORD{"db_password"};
+    const char* const KW_CFG_DB_SSLMODE{"db_sslmode"};
+    const char* const KW_CFG_DB_SSLROOTCERT{"db_sslrootcert"};
+    const char* const KW_CFG_DB_SSLCERT{"db_sslcert"};
+    const char* const KW_CFG_DB_SSLKEY{"db_sslkey"};
+    const char* const KW_CFG_ZONE_NAME{"zone_name"};
+    const char* const KW_CFG_ZONE_KEY{"zone_key"};
+    const char* const KW_CFG_NEGOTIATION_KEY{"negotiation_key"};
+    const char* const KW_CFG_RE_RULEBASE_SET{"re_rulebase_set"};
+    const char* const KW_CFG_RE_NAMESPACE_SET{"rule_engine_namespaces"};
+    const char* const KW_CFG_NAMESPACE{"namespace"};
+    const char* const KW_CFG_RE_FUNCTION_NAME_MAPPING_SET{"re_function_name_mapping_set"};
+    const char* const KW_CFG_RE_DATA_VARIABLE_MAPPING_SET{"re_data_variable_mapping_set"};
+    const char* const KW_CFG_RE_PEP_REGEX_SET{"regexes_for_supported_peps"};
+    const char* const KW_CFG_DEFAULT_DIR_MODE{"default_dir_mode"};
+    const char* const KW_CFG_DEFAULT_FILE_MODE{"default_file_mode"};
+    const char* const KW_CFG_DEFAULT_HASH_SCHEME{"default_hash_scheme"};
+    const char* const KW_CFG_MATCH_HASH_POLICY{"match_hash_policy"};
+    const char* const KW_CFG_FEDERATION{"federation"};
+    const char* const KW_CFG_ENVIRONMENT_VARIABLES{"environment_variables"};
+    const char* const KW_CFG_ADVANCED_SETTINGS{"advanced_settings"};
 
-    const std::string CFG_SERVER_PORT_RANGE_START_KW( "server_port_range_start" );
-    const std::string CFG_SERVER_PORT_RANGE_END_KW( "server_port_range_end" );
+    const char* const KW_CFG_SERVER_PORT_RANGE_START{"server_port_range_start"};
+    const char* const KW_CFG_SERVER_PORT_RANGE_END{"server_port_range_end"};
 
-    const std::string CFG_LOG_LEVEL_KW{"log_level"};
-    const std::string CFG_LOG_LEVEL_CATEGORY_LEGACY_KW{"legacy"};
-    const std::string CFG_LOG_LEVEL_CATEGORY_SERVER_KW{"server"};
-    const std::string CFG_LOG_LEVEL_CATEGORY_AGENT_FACTORY_KW{"agent_factory"};
-    const std::string CFG_LOG_LEVEL_CATEGORY_AGENT_KW{"agent"};
-    const std::string CFG_LOG_LEVEL_CATEGORY_DELAY_SERVER_KW{"delay_server"};
-    const std::string CFG_LOG_LEVEL_CATEGORY_RESOURCE_KW{"resource"};
-    const std::string CFG_LOG_LEVEL_CATEGORY_DATABASE_KW{"database"};
-    const std::string CFG_LOG_LEVEL_CATEGORY_AUTHENTICATION_KW{"authentication"};
-    const std::string CFG_LOG_LEVEL_CATEGORY_API_KW{"api"};
-    const std::string CFG_LOG_LEVEL_CATEGORY_MICROSERVICE_KW{"microservice"};
-    const std::string CFG_LOG_LEVEL_CATEGORY_NETWORK_KW{"network"};
-    const std::string CFG_LOG_LEVEL_CATEGORY_RULE_ENGINE_KW{"rule_engine"};
+    const char* const KW_CFG_LOG_LEVEL{"log_level"};
+    const char* const KW_CFG_LOG_LEVEL_CATEGORY_LEGACY{"legacy"};
+    const char* const KW_CFG_LOG_LEVEL_CATEGORY_SERVER{"server"};
+    const char* const KW_CFG_LOG_LEVEL_CATEGORY_AGENT_FACTORY{"agent_factory"};
+    const char* const KW_CFG_LOG_LEVEL_CATEGORY_AGENT{"agent"};
+    const char* const KW_CFG_LOG_LEVEL_CATEGORY_DELAY_SERVER{"delay_server"};
+    const char* const KW_CFG_LOG_LEVEL_CATEGORY_RESOURCE{"resource"};
+    const char* const KW_CFG_LOG_LEVEL_CATEGORY_DATABASE{"database"};
+    const char* const KW_CFG_LOG_LEVEL_CATEGORY_AUTHENTICATION{"authentication"};
+    const char* const KW_CFG_LOG_LEVEL_CATEGORY_API{"api"};
+    const char* const KW_CFG_LOG_LEVEL_CATEGORY_MICROSERVICE{"microservice"};
+    const char* const KW_CFG_LOG_LEVEL_CATEGORY_NETWORK{"network"};
+    const char* const KW_CFG_LOG_LEVEL_CATEGORY_RULE_ENGINE{"rule_engine"};
 
-    const std::string CFG_CLIENT_API_ALLOWLIST_POLICY_KW("client_api_allowlist_policy");
+    const char* const KW_CFG_CLIENT_API_ALLOWLIST_POLICY{"client_api_allowlist_policy"};
 
-    const std::string CFG_HOST_ACCESS_CONTROL_KW("host_access_control");
-    const std::string CFG_ACCESS_ENTRIES_KW("access_entries");
-    const std::string CFG_USER_KW("user");
-    const std::string CFG_GROUP_KW("group");
-    const std::string CFG_MASK_KW("mask");
+    const char* const KW_CFG_HOST_ACCESS_CONTROL{"host_access_control"};
+    const char* const KW_CFG_ACCESS_ENTRIES{"access_entries"};
+    const char* const KW_CFG_USER{"user"};
+    const char* const KW_CFG_GROUP{"group"};
+    const char* const KW_CFG_MASK{"mask"};
 
-    const std::string CFG_HOST_RESOLUTION_KW("host_resolution");
-    const std::string CFG_HOST_ENTRIES_KW("host_entries");
-    const std::string CFG_ADDRESS_TYPE_KW("address_type");
-    const std::string CFG_ADDRESSES_KW("addresses");
-    const std::string CFG_ADDRESS_KW("address");
+    const char* const KW_CFG_HOST_RESOLUTION{"host_resolution"};
+    const char* const KW_CFG_HOST_ENTRIES{"host_entries"};
+    const char* const KW_CFG_ADDRESS_TYPE{"address_type"};
+    const char* const KW_CFG_ADDRESSES{"addresses"};
+    const char* const KW_CFG_ADDRESS{"address"};
 
     // advanced settings
-    const std::string DELAY_RULE_EXECUTORS_KW("delay_rule_executors");
-    const std::string CFG_MAX_SIZE_FOR_SINGLE_BUFFER( "maximum_size_for_single_buffer_in_megabytes" );
-    const std::string CFG_DEF_NUMBER_TRANSFER_THREADS( "default_number_of_transfer_threads" );
-    const std::string CFG_TRANS_CHUNK_SIZE_PARA_TRANS( "transfer_chunk_size_for_parallel_transfer_in_megabytes" );
-    const std::string CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS( "transfer_buffer_size_for_parallel_transfer_in_megabytes" );
-    const std::string CFG_DEF_TEMP_PASSWORD_LIFETIME( "default_temporary_password_lifetime_in_seconds" );
-    const std::string CFG_MAX_TEMP_PASSWORD_LIFETIME( "maximum_temporary_password_lifetime_in_seconds" );
-    const std::string CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS( "number_of_concurrent_delay_rule_executors" );
-    const std::string CFG_MAX_SIZE_OF_DELAY_QUEUE_IN_BYTES_KW("maximum_size_of_delay_queue_in_bytes");
-    const std::string CFG_STACKTRACE_FILE_PROCESSOR_SLEEP_TIME_IN_SECONDS_KW("stacktrace_file_processor_sleep_time_in_seconds");
+    const char* const KW_CFG_DELAY_RULE_EXECUTORS{"delay_rule_executors"};
+    const char* const KW_CFG_MAX_SIZE_FOR_SINGLE_BUFFER{"maximum_size_for_single_buffer_in_megabytes"};
+    const char* const KW_CFG_DEF_NUMBER_TRANSFER_THREADS{"default_number_of_transfer_threads"};
+    const char* const KW_CFG_TRANS_CHUNK_SIZE_PARA_TRANS{"transfer_chunk_size_for_parallel_transfer_in_megabytes"};
+    const char* const KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS{"transfer_buffer_size_for_parallel_transfer_in_megabytes"};
+    const char* const KW_CFG_DEF_TEMP_PASSWORD_LIFETIME{"default_temporary_password_lifetime_in_seconds"};
+    const char* const KW_CFG_MAX_TEMP_PASSWORD_LIFETIME{"maximum_temporary_password_lifetime_in_seconds"};
+    const char* const KW_CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS{"number_of_concurrent_delay_rule_executors"};
+    const char* const KW_CFG_MAX_SIZE_OF_DELAY_QUEUE_IN_BYTES{"maximum_size_of_delay_queue_in_bytes"};
+    const char* const KW_CFG_STACKTRACE_FILE_PROCESSOR_SLEEP_TIME_IN_SECONDS{"stacktrace_file_processor_sleep_time_in_seconds"};
 
-    const std::string CFG_RE_CACHE_SALT_KW("reCacheSalt");
-    const std::string CFG_DELAY_SERVER_SLEEP_TIME_IN_SECONDS( "delay_server_sleep_time_in_seconds");
+    const char* const KW_CFG_RE_CACHE_SALT{"reCacheSalt"};
+    const char* const KW_CFG_DELAY_SERVER_SLEEP_TIME_IN_SECONDS{"delay_server_sleep_time_in_seconds"};
 
-    const std::string CFG_DNS_CACHE_KW("dns_cache");
-    const std::string CFG_HOSTNAME_CACHE_KW("hostname_cache");
+    const char* const KW_CFG_DNS_CACHE{"dns_cache"};
+    const char* const KW_CFG_HOSTNAME_CACHE{"hostname_cache"};
 
-    const std::string CFG_SHARED_MEMORY_SIZE_IN_BYTES_KW("shared_memory_size_in_bytes");
-    const std::string CFG_EVICTION_AGE_IN_SECONDS_KW("eviction_age_in_seconds");
+    const char* const KW_CFG_SHARED_MEMORY_SIZE_IN_BYTES{"shared_memory_size_in_bytes"};
+    const char* const KW_CFG_EVICTION_AGE_IN_SECONDS{"eviction_age_in_seconds"};
 
     // service_account_environment.json keywords
-    const std::string CFG_IRODS_USER_NAME_KW( "irods_user_name" );
-    const std::string CFG_IRODS_HOST_KW( "irods_host" );
-    const std::string CFG_IRODS_PORT_KW( "irods_port" );
-    const std::string CFG_IRODS_XMSG_HOST_KW( "xmsg_host" );
-    const std::string CFG_IRODS_XMSG_PORT_KW( "xmsg_port" );
-    const std::string CFG_IRODS_HOME_KW( "irods_home" );
-    const std::string CFG_IRODS_CWD_KW( "irods_cwd" );
-    const std::string CFG_IRODS_AUTHENTICATION_SCHEME_KW( "irods_authentication_scheme" );
-    const std::string CFG_IRODS_DEFAULT_RESOURCE_KW( "irods_default_resource" );
-    const std::string CFG_IRODS_ZONE_KW( "irods_zone_name" );
-    const std::string CFG_IRODS_GSI_SERVER_DN_KW( "irods_gsi_server_dn" );
-    const std::string CFG_IRODS_LOG_LEVEL_KW( "irods_log_level" );
-    const std::string CFG_IRODS_AUTHENTICATION_FILE_KW( "irods_authentication_file" );
-    const std::string CFG_IRODS_DEBUG_KW( "irods_debug" );
-    const std::string CFG_IRODS_CLIENT_SERVER_POLICY_KW( "irods_client_server_policy" );
-    const std::string CFG_IRODS_CLIENT_SERVER_NEGOTIATION_KW( "irods_client_server_negotiation" );
-    const std::string CFG_IRODS_ENCRYPTION_KEY_SIZE_KW( "irods_encryption_key_size" );
-    const std::string CFG_IRODS_ENCRYPTION_SALT_SIZE_KW( "irods_encryption_salt_size" );
-    const std::string CFG_IRODS_ENCRYPTION_NUM_HASH_ROUNDS_KW( "irods_encryption_num_hash_rounds" );
-    const std::string CFG_IRODS_ENCRYPTION_ALGORITHM_KW( "irods_encryption_algorithm" );
-    const std::string CFG_IRODS_DEFAULT_HASH_SCHEME_KW( "irods_default_hash_scheme" );
-    const std::string CFG_IRODS_MATCH_HASH_POLICY_KW( "irods_match_hash_policy" );
+    const char* const KW_CFG_IRODS_USER_NAME{"irods_user_name"};
+    const char* const KW_CFG_IRODS_HOST{"irods_host"};
+    const char* const KW_CFG_IRODS_PORT{"irods_port"};
+    const char* const KW_CFG_IRODS_HOME{"irods_home"};
+    const char* const KW_CFG_IRODS_CWD{"irods_cwd"};
+    const char* const KW_CFG_IRODS_AUTHENTICATION_SCHEME{"irods_authentication_scheme"};
+    const char* const KW_CFG_IRODS_DEFAULT_RESOURCE{"irods_default_resource"};
+    const char* const KW_CFG_IRODS_ZONE{"irods_zone_name"};
+    const char* const KW_CFG_IRODS_GSI_SERVER_DN{"irods_gsi_server_dn"};
+    const char* const KW_CFG_IRODS_LOG_LEVEL{"irods_log_level"};
+    const char* const KW_CFG_IRODS_AUTHENTICATION_FILE{"irods_authentication_file"};
+    const char* const KW_CFG_IRODS_DEBUG{"irods_debug"};
+    const char* const KW_CFG_IRODS_CLIENT_SERVER_POLICY{"irods_client_server_policy"};
+    const char* const KW_CFG_IRODS_CLIENT_SERVER_NEGOTIATION{"irods_client_server_negotiation"};
+    const char* const KW_CFG_IRODS_ENCRYPTION_KEY_SIZE{"irods_encryption_key_size"};
+    const char* const KW_CFG_IRODS_ENCRYPTION_SALT_SIZE{"irods_encryption_salt_size"};
+    const char* const KW_CFG_IRODS_ENCRYPTION_NUM_HASH_ROUNDS{"irods_encryption_num_hash_rounds"};
+    const char* const KW_CFG_IRODS_ENCRYPTION_ALGORITHM{"irods_encryption_algorithm"};
+    const char* const KW_CFG_IRODS_DEFAULT_HASH_SCHEME{"irods_default_hash_scheme"};
+    const char* const KW_CFG_IRODS_MATCH_HASH_POLICY{"irods_match_hash_policy"};
 
-    const std::string CFG_IRODS_ENVIRONMENT_FILE_KW( "irods_environment_file" );
-    const std::string CFG_IRODS_SESSION_ENVIRONMENT_FILE_KW( "irods_session_environment_file" );
-    const std::string CFG_IRODS_SERVER_CONTROL_PLANE_PORT( "irods_server_control_plane_port" );
+    const char* const KW_CFG_IRODS_ENVIRONMENT_FILE{"irods_environment_file"};
+    const char* const KW_CFG_IRODS_SESSION_ENVIRONMENT_FILE{"irods_session_environment_file"};
+    const char* const KW_CFG_IRODS_SERVER_CONTROL_PLANE_PORT{"irods_server_control_plane_port"};
 
-    const std::string CFG_IRODS_SERVER_CONTROL_PLANE_KEY( "irods_server_control_plane_key" );
-    const std::string CFG_IRODS_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS_KW( "irods_server_control_plane_encryption_num_hash_rounds" );
-    const std::string CFG_IRODS_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM_KW( "irods_server_control_plane_encryption_algorithm" );
+    const char* const KW_CFG_IRODS_SERVER_CONTROL_PLANE_KEY{"irods_server_control_plane_key"};
+    const char* const KW_CFG_IRODS_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS{"irods_server_control_plane_encryption_num_hash_rounds"};
+    const char* const KW_CFG_IRODS_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM{"irods_server_control_plane_encryption_algorithm"};
 
     // irods environment advanced settings
-    const std::string CFG_IRODS_MAX_SIZE_FOR_SINGLE_BUFFER( "irods_maximum_size_for_single_buffer_in_megabytes" );
-    const std::string CFG_IRODS_DEF_NUMBER_TRANSFER_THREADS( "irods_default_number_of_transfer_threads" );
-    const std::string CFG_IRODS_MAX_NUMBER_TRANSFER_THREADS( "irods_maximum_number_of_transfer_threads" );
-    const std::string CFG_IRODS_TRANS_BUFFER_SIZE_FOR_PARA_TRANS( "irods_transfer_buffer_size_for_parallel_transfer_in_megabytes" );
-    const std::string CFG_IRODS_CONNECTION_POOL_REFRESH_TIME( "irods_connection_pool_refresh_time_in_seconds");
+    const char* const KW_CFG_IRODS_MAX_SIZE_FOR_SINGLE_BUFFER{"irods_maximum_size_for_single_buffer_in_megabytes"};
+    const char* const KW_CFG_IRODS_DEF_NUMBER_TRANSFER_THREADS{"irods_default_number_of_transfer_threads"};
+    const char* const KW_CFG_IRODS_MAX_NUMBER_TRANSFER_THREADS{"irods_maximum_number_of_transfer_threads"};
+    const char* const KW_CFG_IRODS_TRANS_BUFFER_SIZE_FOR_PARA_TRANS{"irods_transfer_buffer_size_for_parallel_transfer_in_megabytes"};
+    const char* const KW_CFG_IRODS_CONNECTION_POOL_REFRESH_TIME{"irods_connection_pool_refresh_time_in_seconds"};
 
     // legacy ssl environment variables
-    const std::string CFG_IRODS_SSL_CA_CERTIFICATE_PATH( "irods_ssl_ca_certificate_path" );
-    const std::string CFG_IRODS_SSL_CA_CERTIFICATE_FILE( "irods_ssl_ca_certificate_file" );
-    const std::string CFG_IRODS_SSL_VERIFY_SERVER( "irods_ssl_verify_server" );
-    const std::string CFG_IRODS_SSL_CERTIFICATE_CHAIN_FILE( "irods_ssl_certificate_chain_file" );
-    const std::string CFG_IRODS_SSL_CERTIFICATE_KEY_FILE( "irods_ssl_certificate_key_file" );
-    const std::string CFG_IRODS_SSL_DH_PARAMS_FILE( "irods_ssl_dh_params_file" );
+    const char* const KW_CFG_IRODS_SSL_CA_CERTIFICATE_PATH{"irods_ssl_ca_certificate_path"};
+    const char* const KW_CFG_IRODS_SSL_CA_CERTIFICATE_FILE{"irods_ssl_ca_certificate_file"};
+    const char* const KW_CFG_IRODS_SSL_VERIFY_SERVER{"irods_ssl_verify_server"};
+    const char* const KW_CFG_IRODS_SSL_CERTIFICATE_CHAIN_FILE{"irods_ssl_certificate_chain_file"};
+    const char* const KW_CFG_IRODS_SSL_CERTIFICATE_KEY_FILE{"irods_ssl_certificate_key_file"};
+    const char* const KW_CFG_IRODS_SSL_DH_PARAMS_FILE{"irods_ssl_dh_params_file"};
 
     // irods environment values now included in server_config
-    const std::string CFG_ZONE_NAME( "zone_name" );
-    const std::string CFG_ZONE_USER( "zone_user" );
-    const std::string CFG_ZONE_PORT( "zone_port" );
-    const std::string CFG_ZONE_AUTH_SCHEME( "zone_auth_scheme" );
-    const std::string CFG_XMSG_PORT( "xmsg_port" );
+    const char* const KW_CFG_ZONE_USER{"zone_user"};
+    const char* const KW_CFG_ZONE_PORT{"zone_port"};
+    const char* const KW_CFG_ZONE_AUTH_SCHEME{"zone_auth_scheme"};
 
     // irods control plane values
-    const std::string CFG_SERVER_CONTROL_PLANE_PORT( "server_control_plane_port" );
-    const std::string CFG_RULE_ENGINE_CONTROL_PLANE_PORT( "rule_engine_control_plane_port" );
-    const std::string CFG_SERVER_CONTROL_PLANE_TIMEOUT( "server_control_plane_timeout_milliseconds" );
+    const char* const KW_CFG_SERVER_CONTROL_PLANE_PORT{"server_control_plane_port"};
+    const char* const KW_CFG_RULE_ENGINE_CONTROL_PLANE_PORT{"rule_engine_control_plane_port"};
+    const char* const KW_CFG_SERVER_CONTROL_PLANE_TIMEOUT{"server_control_plane_timeout_milliseconds"};
 
-    const std::string CFG_SERVER_CONTROL_PLANE_KEY( "server_control_plane_key" );
-    const std::string CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS_KW( "server_control_plane_encryption_num_hash_rounds" );
-    const std::string CFG_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM_KW( "server_control_plane_encryption_algorithm" );
+    const char* const KW_CFG_SERVER_CONTROL_PLANE_KEY{"server_control_plane_key"};
+    const char* const KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS{"server_control_plane_encryption_num_hash_rounds"};
+    const char* const KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM{"server_control_plane_encryption_algorithm"};
 
-    const std::string CFG_CATALOG_PROVIDER_HOSTS_KW("catalog_provider_hosts");
-    const std::string CFG_CATALOG_SERVICE_ROLE("catalog_service_role");
-    const std::string CFG_SERVICE_ROLE_PROVIDER("provider");
-    const std::string CFG_SERVICE_ROLE_CONSUMER("consumer");
-    const std::string CFG_SERVICE_ROLE_PROXY("proxy");
+    const char* const KW_CFG_CATALOG_PROVIDER_HOSTS{"catalog_provider_hosts"};
+    const char* const KW_CFG_CATALOG_SERVICE_ROLE{"catalog_service_role"};
+    const char* const KW_CFG_SERVICE_ROLE_PROVIDER{"provider"};
+    const char* const KW_CFG_SERVICE_ROLE_CONSUMER{"consumer"};
+    const char* const KW_CFG_SERVICE_ROLE_PROXY{"proxy"};
 
-    const std::string CFG_IRODS_PLUGINS_HOME_KW( "irods_plugins_home" );
+    const char* const KW_CFG_IRODS_PLUGINS_HOME{"irods_plugins_home"};
 
-    const std::string CFG_PLUGIN_CONFIGURATION_KW("plugin_configuration");
+    const char* const KW_CFG_PLUGIN_CONFIGURATION{"plugin_configuration"};
 
     // plugin types
-    const std::string PLUGIN_TYPE_API( "api" );
-    const std::string PLUGIN_TYPE_RULE_ENGINE( "rule_engines" );
-    const std::string PLUGIN_TYPE_AUTHENTICATION( "auth" );
-    const std::string PLUGIN_TYPE_NETWORK( "network" );
-    const std::string PLUGIN_TYPE_DATABASE( "database" );
-    const std::string PLUGIN_TYPE_RESOURCE( "resources" );
-    const std::string PLUGIN_TYPE_MICROSERVICE( "microservices" );
+    const char* const KW_CFG_PLUGIN_TYPE_API{"api"};
+    const char* const KW_CFG_PLUGIN_TYPE_RULE_ENGINE{"rule_engines"};
+    const char* const KW_CFG_PLUGIN_TYPE_AUTHENTICATION{"auth"};
+    const char* const KW_CFG_PLUGIN_TYPE_NETWORK{"network"};
+    const char* const KW_CFG_PLUGIN_TYPE_DATABASE{"database"};
+    const char* const KW_CFG_PLUGIN_TYPE_RESOURCE{"resources"};
+    const char* const KW_CFG_PLUGIN_TYPE_MICROSERVICE{"microservices"};
 
-    const std::string CFG_PLUGIN_SPECIFIC_CONFIGURATION_KW("plugin_specific_configuration");
-    const std::string CFG_INSTANCE_NAME_KW("instance_name");
-    const std::string CFG_PLUGIN_NAME_KW("plugin_name");
+    const char* const KW_CFG_PLUGIN_SPECIFIC_CONFIGURATION{"plugin_specific_configuration"};
+    const char* const KW_CFG_INSTANCE_NAME{"instance_name"};
+    const char* const KW_CFG_PLUGIN_NAME{"plugin_name"};
 
-    const std::string CFG_SHARED_MEMORY_INSTANCE_KW("shared_memory_instance");
-    const std::string CFG_SHARED_MEMORY_MUTEX_KW("shared_memory_mutex");
+    const char* const KW_CFG_SHARED_MEMORY_INSTANCE{"shared_memory_instance"};
+    const char* const KW_CFG_SHARED_MEMORY_MUTEX{"shared_memory_mutex"};
 
-    const std::string DEFAULT_RULE_ENGINE_PLUGIN_NAME_KW("re-irods");
-    const std::string DEFAULT_RULE_ENGINE_INSTANCE_NAME_KW("default_rule_engine_instance");
+    const char* const KW_CFG_DEFAULT_RULE_ENGINE_PLUGIN_NAME{"re-irods"};
+    const char* const KW_CFG_DEFAULT_RULE_ENGINE_INSTANCE_NAME{"default_rule_engine_instance"};
 } // namespace irods
 

--- a/lib/core/src/irods_environment_properties.cpp
+++ b/lib/core/src/irods_environment_properties.cpp
@@ -22,7 +22,7 @@ namespace irods {
         // capture parent process id for use in creation of 'session'
         // file which contains the cwd for a given session.  this cwd
         // is only updated by the icd command which writes a new irods
-        // CFG_IRODS_CWD_KW to the session dir which repaves the existing
+        // KW_CFG_IRODS_CWD to the session dir which repaves the existing
         // one in the original irodsEnv file.
         std::stringstream ppid_str; ppid_str << getppid();
 
@@ -36,7 +36,7 @@ namespace irods {
             return ERROR(-1, "failed to get irods home directory");
         }
         std::string json_session_file = json_file;
-        std::string env_var = to_env( CFG_IRODS_ENVIRONMENT_FILE_KW );
+        std::string env_var = to_env( KW_CFG_IRODS_ENVIRONMENT_FILE );
         char* irods_env = getenv(env_var.c_str());
         if ( irods_env && strlen( irods_env ) > 0 ) {
             json_file = irods_env;
@@ -93,13 +93,13 @@ namespace irods {
 
         try {
             capture_json( json_file );
-            config_props_.set< std::string >( CFG_IRODS_ENVIRONMENT_FILE_KW, json_file );
+            config_props_.set< std::string >( KW_CFG_IRODS_ENVIRONMENT_FILE, json_file );
             try {
                 capture_json( json_session_file );
             } catch ( const irods::exception& e ) {
                 // debug - irods::log( PASS( ret ) );
             }
-            config_props_.set< std::string >( CFG_IRODS_SESSION_ENVIRONMENT_FILE_KW, json_session_file );
+            config_props_.set< std::string >( KW_CFG_IRODS_SESSION_ENVIRONMENT_FILE, json_session_file );
             return;
         } catch ( const irods::exception& e ) {
             irods::log(e);

--- a/lib/core/src/irods_logger.cpp
+++ b/lib/core/src/irods_logger.cpp
@@ -170,7 +170,7 @@ namespace irods::experimental
     auto log::get_level_from_config(const std::string& _category) -> log::level
     {
         try {
-            const auto& log_level = irods::get_server_property<const nlohmann::json&>(irods::CFG_LOG_LEVEL_KW);
+            const auto& log_level = irods::get_server_property<const nlohmann::json&>(irods::KW_CFG_LOG_LEVEL);
             return to_level(log_level.at(_category).get_ref<const std::string&>());
         }
         catch (const std::exception&) {

--- a/lib/core/src/irods_network_manager.cpp
+++ b/lib/core/src/irods_network_manager.cpp
@@ -63,7 +63,7 @@ namespace irods {
         error ret = load_plugin< network >(
                         net,
                         _plugin_name,
-                        PLUGIN_TYPE_NETWORK,
+                        KW_CFG_PLUGIN_TYPE_NETWORK,
                         _inst_name,
                         _context );
         if ( ret.ok() && net ) {

--- a/lib/core/src/irods_server_properties.cpp
+++ b/lib/core/src/irods_server_properties.cpp
@@ -238,7 +238,7 @@ namespace irods
     auto get_dns_cache_shared_memory_size() noexcept -> int
     {
         try {
-            const auto wrapped = get_advanced_setting<nlohmann::json>(CFG_DNS_CACHE_KW).at(CFG_SHARED_MEMORY_SIZE_IN_BYTES_KW);
+            const auto wrapped = get_advanced_setting<nlohmann::json>(KW_CFG_DNS_CACHE).at(KW_CFG_SHARED_MEMORY_SIZE_IN_BYTES);
             const auto bytes   = wrapped.get<int>();
 
             if (bytes > 0) {
@@ -249,7 +249,7 @@ namespace irods
         }
         catch (...) {
             rodsLog(LOG_DEBUG, "Could not read server configuration property [%s.%s.%s].",
-                    CFG_ADVANCED_SETTINGS_KW.data(), CFG_DNS_CACHE_KW.data(), CFG_SHARED_MEMORY_SIZE_IN_BYTES_KW.data());
+                    KW_CFG_ADVANCED_SETTINGS, KW_CFG_DNS_CACHE, KW_CFG_SHARED_MEMORY_SIZE_IN_BYTES);
         }
 
         rodsLog(LOG_DEBUG, "Returning default shared memory size for DNS cache [default=5000000].");
@@ -260,7 +260,7 @@ namespace irods
     int get_dns_cache_eviction_age() noexcept
     {
         try {
-            const auto wrapped = get_advanced_setting<nlohmann::json>(CFG_DNS_CACHE_KW).at(CFG_EVICTION_AGE_IN_SECONDS_KW);
+            const auto wrapped = get_advanced_setting<nlohmann::json>(KW_CFG_DNS_CACHE).at(KW_CFG_EVICTION_AGE_IN_SECONDS);
             const auto seconds = wrapped.get<int>();
 
             if (seconds >= 0) {
@@ -271,7 +271,7 @@ namespace irods
         }
         catch (...) {
             rodsLog(LOG_DEBUG, "Could not read server configuration property [%s.%s.%s].",
-                    CFG_ADVANCED_SETTINGS_KW.data(), CFG_DNS_CACHE_KW.data(), CFG_EVICTION_AGE_IN_SECONDS_KW.data());
+                    KW_CFG_ADVANCED_SETTINGS, KW_CFG_DNS_CACHE, KW_CFG_EVICTION_AGE_IN_SECONDS);
         }
 
         rodsLog(LOG_DEBUG, "Returning default eviction age for DNS cache [default=3600].");
@@ -282,7 +282,7 @@ namespace irods
     auto get_hostname_cache_shared_memory_size() noexcept -> int
     {
         try {
-            const auto wrapped = get_advanced_setting<nlohmann::json>(CFG_HOSTNAME_CACHE_KW).at(CFG_SHARED_MEMORY_SIZE_IN_BYTES_KW);
+            const auto wrapped = get_advanced_setting<nlohmann::json>(KW_CFG_HOSTNAME_CACHE).at(KW_CFG_SHARED_MEMORY_SIZE_IN_BYTES);
             const auto bytes   = wrapped.get<int>();
 
             if (bytes > 0) {
@@ -293,7 +293,7 @@ namespace irods
         }
         catch (...) {
             rodsLog(LOG_DEBUG, "Could not read server configuration property [%s.%s.%s].",
-                    CFG_ADVANCED_SETTINGS_KW.data(), CFG_HOSTNAME_CACHE_KW.data(), CFG_SHARED_MEMORY_SIZE_IN_BYTES_KW.data());
+                    KW_CFG_ADVANCED_SETTINGS, KW_CFG_HOSTNAME_CACHE, KW_CFG_SHARED_MEMORY_SIZE_IN_BYTES);
         }
 
         rodsLog(LOG_DEBUG, "Returning default shared memory size for Hostname cache [default=2500000].");
@@ -304,7 +304,7 @@ namespace irods
     int get_hostname_cache_eviction_age() noexcept
     {
         try {
-            const auto wrapped = get_advanced_setting<nlohmann::json>(CFG_HOSTNAME_CACHE_KW).at(CFG_EVICTION_AGE_IN_SECONDS_KW);
+            const auto wrapped = get_advanced_setting<nlohmann::json>(KW_CFG_HOSTNAME_CACHE).at(KW_CFG_EVICTION_AGE_IN_SECONDS);
             const auto seconds = wrapped.get<int>();
 
             if (seconds >= 0) {
@@ -315,7 +315,7 @@ namespace irods
         }
         catch (...) {
             rodsLog(LOG_DEBUG, "Could not read server configuration property [%s.%s.%s].",
-                    CFG_ADVANCED_SETTINGS_KW.data(), CFG_HOSTNAME_CACHE_KW.data(), CFG_EVICTION_AGE_IN_SECONDS_KW.data());
+                    KW_CFG_ADVANCED_SETTINGS, KW_CFG_HOSTNAME_CACHE, KW_CFG_EVICTION_AGE_IN_SECONDS);
         }
 
         rodsLog(LOG_DEBUG, "Returning default eviction age for Hostname cache [default=3600].");

--- a/lib/core/src/rcMisc.cpp
+++ b/lib/core/src/rcMisc.cpp
@@ -4641,13 +4641,13 @@ auto resolve_hostname(const std::string_view _hostname, hostname_resolution_sche
 {
     using json = nlohmann::json;
 
-    const auto& host_resolution = irods::get_server_property<const json&>(irods::CFG_HOST_RESOLUTION_KW);
-    const auto& host_entries = host_resolution.at(irods::CFG_HOST_ENTRIES_KW);
+    const auto& host_resolution = irods::get_server_property<const json&>(irods::KW_CFG_HOST_RESOLUTION);
+    const auto& host_entries = host_resolution.at(irods::KW_CFG_HOST_ENTRIES);
     const auto end = std::end(host_entries);
 
     // Find the addresses object that contains the address, "_hostname".
     const auto iter = std::find_if(std::begin(host_entries), end, [_hostname](const json& _entry) {
-        const auto& addresses = _entry.at(irods::CFG_ADDRESSES_KW);
+        const auto& addresses = _entry.at(irods::KW_CFG_ADDRESSES);
         const auto end = std::end(addresses);
         return end != std::find_if(std::begin(addresses), end, [_hostname](const json& _address) {
             return _hostname == _address.get_ref<const std::string&>();
@@ -4664,12 +4664,12 @@ auto resolve_hostname(const std::string_view _hostname, hostname_resolution_sche
 
     switch (_scheme) {
         case hostname_resolution_scheme::match_preferred: {
-            const auto& addresses = iter->at(irods::CFG_ADDRESSES_KW);
+            const auto& addresses = iter->at(irods::KW_CFG_ADDRESSES);
             return addresses.front().get<std::string>();
         }
 
         case hostname_resolution_scheme::match_longest: {
-            const auto& addresses = iter->at(irods::CFG_ADDRESSES_KW);
+            const auto& addresses = iter->at(irods::KW_CFG_ADDRESSES);
             const std::string* longest{};
 
             for (auto&& address : addresses) {

--- a/lib/core/src/sockComm.cpp
+++ b/lib/core/src/sockComm.cpp
@@ -318,7 +318,7 @@ sockOpenForInConn( rsComm_t *rsComm, int *portNum, char **addr, int proto ) {
 
     boost::optional<int> svr_port_range_start_wrapper;
     try {
-        svr_port_range_start_wrapper.reset(irods::get_server_property<const int>(irods::CFG_SERVER_PORT_RANGE_START_KW));
+        svr_port_range_start_wrapper.reset(irods::get_server_property<const int>(irods::KW_CFG_SERVER_PORT_RANGE_START));
     } catch ( const irods::exception& ) {}
     if ( *portNum <= 0 && svr_port_range_start_wrapper ) {
         int svr_port_range_start = *svr_port_range_start_wrapper;
@@ -330,7 +330,7 @@ sockOpenForInConn( rsComm_t *rsComm, int *portNum, char **addr, int proto ) {
 
         int svr_port_range_end;
         try {
-            svr_port_range_end = irods::get_server_property<const int>(irods::CFG_SERVER_PORT_RANGE_END_KW);
+            svr_port_range_end = irods::get_server_property<const int>(irods::KW_CFG_SERVER_PORT_RANGE_END);
             if ( svr_port_range_end < svr_port_range_start ) {
                 rodsLog( LOG_ERROR,
                          "sockOpenForInConn: PortRangeStart %d > PortRangeEnd %d",

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -1895,11 +1895,11 @@ irods::error db_open_op(
     // =-=-=-=-=-=-=-
     // cache db creds
     try {
-        const auto db_plugin_map = irods::get_server_property<nlohmann::json>(std::vector<std::string>{irods::CFG_PLUGIN_CONFIGURATION_KW, irods::PLUGIN_TYPE_DATABASE});
+        const auto db_plugin_map = irods::get_server_property<nlohmann::json>(std::vector<std::string>{irods::KW_CFG_PLUGIN_CONFIGURATION, irods::KW_CFG_PLUGIN_TYPE_DATABASE});
         const auto db_type   = db_plugin_map.items().begin().key();
         const auto db_plugin = db_plugin_map.items().begin().value();
-        snprintf(icss.databaseUsername, DB_USERNAME_LEN, "%s", db_plugin.at(irods::CFG_DB_USERNAME_KW).get<std::string>().c_str());
-        snprintf(icss.databasePassword, DB_PASSWORD_LEN, "%s", db_plugin.at(irods::CFG_DB_PASSWORD_KW).get<std::string>().c_str());
+        snprintf(icss.databaseUsername, DB_USERNAME_LEN, "%s", db_plugin.at(irods::KW_CFG_DB_USERNAME).get<std::string>().c_str());
+        snprintf(icss.databasePassword, DB_PASSWORD_LEN, "%s", db_plugin.at(irods::KW_CFG_DB_PASSWORD).get<std::string>().c_str());
         snprintf(icss.database_plugin_type, DB_TYPENAME_LEN, "%s", db_type.c_str());
     } catch ( const irods::exception& e ) {
         return irods::error(e);
@@ -1931,10 +1931,10 @@ irods::error db_open_op(
     // =-=-=-=-=-=-=-
     // set pam properties
     try {
-        irods_pam_auth_no_extend = irods::get_server_property<const bool>(std::vector<std::string>{irods::PLUGIN_TYPE_AUTHENTICATION, irods::AUTH_PAM_SCHEME, irods::CFG_PAM_NO_EXTEND_KW});
-        irods_pam_password_len = irods::get_server_property<const size_t>(std::vector<std::string>{irods::PLUGIN_TYPE_AUTHENTICATION, irods::AUTH_PAM_SCHEME, irods::CFG_PAM_PASSWORD_LENGTH_KW});
-        snprintf(irods_pam_password_min_time, NAME_LEN, "%s", irods::get_server_property<const std::string>(std::vector<std::string>{irods::PLUGIN_TYPE_AUTHENTICATION, irods::AUTH_PAM_SCHEME, irods::CFG_PAM_PASSWORD_MIN_TIME_KW}).c_str());
-        snprintf(irods_pam_password_max_time, NAME_LEN, "%s", irods::get_server_property<const std::string>(std::vector<std::string>{irods::PLUGIN_TYPE_AUTHENTICATION, irods::AUTH_PAM_SCHEME, irods::CFG_PAM_PASSWORD_MAX_TIME_KW}).c_str());
+        irods_pam_auth_no_extend = irods::get_server_property<const bool>(std::vector<std::string>{irods::KW_CFG_PLUGIN_TYPE_AUTHENTICATION, irods::AUTH_PAM_SCHEME, irods::KW_CFG_PAM_NO_EXTEND});
+        irods_pam_password_len = irods::get_server_property<const size_t>(std::vector<std::string>{irods::KW_CFG_PLUGIN_TYPE_AUTHENTICATION, irods::AUTH_PAM_SCHEME, irods::KW_CFG_PAM_PASSWORD_LENGTH});
+        snprintf(irods_pam_password_min_time, NAME_LEN, "%s", irods::get_server_property<const std::string>(std::vector<std::string>{irods::KW_CFG_PLUGIN_TYPE_AUTHENTICATION, irods::AUTH_PAM_SCHEME, irods::KW_CFG_PAM_PASSWORD_MIN_TIME}).c_str());
+        snprintf(irods_pam_password_max_time, NAME_LEN, "%s", irods::get_server_property<const std::string>(std::vector<std::string>{irods::KW_CFG_PLUGIN_TYPE_AUTHENTICATION, irods::AUTH_PAM_SCHEME, irods::KW_CFG_PAM_PASSWORD_MAX_TIME}).c_str());
     } catch ( const irods::exception& e ) {
         rodsLog(LOG_DEBUG, "[%s:%d] PAM property not found", __FUNCTION__, __LINE__);
         return CODE( status );
@@ -6607,7 +6607,7 @@ irods::error db_check_auth_op(
 
     int temp_password_max_time;
     try {
-        temp_password_max_time = irods::get_advanced_setting<const int>(irods::CFG_MAX_TEMP_PASSWORD_LIFETIME);
+        temp_password_max_time = irods::get_advanced_setting<const int>(irods::KW_CFG_MAX_TEMP_PASSWORD_LIFETIME);
     } catch ( const irods::exception& e ) {
         return irods::error(e);
     }
@@ -6615,7 +6615,7 @@ irods::error db_check_auth_op(
     if ( expireTime < temp_password_max_time ) {
         int temp_password_time;
         try {
-            temp_password_time = irods::get_advanced_setting<const int>(irods::CFG_DEF_TEMP_PASSWORD_LIFETIME);
+            temp_password_time = irods::get_advanced_setting<const int>(irods::KW_CFG_DEF_TEMP_PASSWORD_LIFETIME);
         } catch ( const irods::exception& e ) {
             return irods::error(e);
         }
@@ -6810,7 +6810,7 @@ irods::error db_make_temp_pw_op(
 
     int temp_password_time;
     try {
-        temp_password_time = irods::get_advanced_setting<const int>(irods::CFG_DEF_TEMP_PASSWORD_LIFETIME);
+        temp_password_time = irods::get_advanced_setting<const int>(irods::KW_CFG_DEF_TEMP_PASSWORD_LIFETIME);
     } catch ( const irods::exception& e ) {
         return irods::error(e);
     }
@@ -6979,7 +6979,7 @@ irods::error db_make_limited_pw_op(
 
     int temp_password_time;
     try {
-        temp_password_time = irods::get_advanced_setting<const int>(irods::CFG_DEF_TEMP_PASSWORD_LIFETIME);
+        temp_password_time = irods::get_advanced_setting<const int>(irods::KW_CFG_DEF_TEMP_PASSWORD_LIFETIME);
     } catch ( const irods::exception& e ) {
         return irods::error(e);
     }

--- a/plugins/experimental/include/irods/private/parallel_filesystem_operation.hpp
+++ b/plugins/experimental/include/irods/private/parallel_filesystem_operation.hpp
@@ -38,7 +38,7 @@ namespace irods::experimental::api {
 
                     { std::ifstream f{path}; f >> cfg; }
 
-                    auto psc = cfg.at(irods::CFG_PLUGIN_CONFIGURATION_KW);
+                    auto psc = cfg.at(irods::KW_CFG_PLUGIN_CONFIGURATION);
 
                     if(psc.contains("api") && psc.at("api").contains(instance_name_)) {
                         auto in = psc.at("api").at(instance_name_);

--- a/plugins/resources/src/mockarchive.cpp
+++ b/plugins/resources/src/mockarchive.cpp
@@ -341,7 +341,7 @@ mockArchiveCopyPlugin(
 
     size_t trans_buff_size;
     try {
-        trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
+        trans_buff_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
     } catch ( const irods::exception& e ) {
         irods::log(e);
         return e.code();

--- a/plugins/resources/src/nonblocking.cpp
+++ b/plugins/resources/src/nonblocking.cpp
@@ -992,7 +992,7 @@ non_blockingFileCopyPlugin( int         mode,
         else {
             size_t trans_buff_size;
             try {
-                trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
+                trans_buff_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
             } catch ( const irods::exception& e ) {
                 close( outFd );
                 close( inFd );

--- a/plugins/resources/src/unixfilesystem.cpp
+++ b/plugins/resources/src/unixfilesystem.cpp
@@ -136,7 +136,7 @@ static irods::error unix_file_copy(
 
     size_t trans_buff_size;
     try {
-        trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
+        trans_buff_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
     }
     catch ( const irods::exception& e ) {
         return irods::error(e);

--- a/plugins/rule_engines/irods_rule_language/src/irods_rule_language.cpp
+++ b/plugins/rule_engines/irods_rule_language/src/irods_rule_language.cpp
@@ -124,19 +124,19 @@ irods::error start(irods::default_re_ctx&, const std::string& _instance_name)
     local_instance_name = _instance_name;
 
     try {
-        const auto& re_plugin_arr = irods::get_server_property<const nlohmann::json&>(irods::CFG_PLUGIN_CONFIGURATION_KW)
-            .at(irods::PLUGIN_TYPE_RULE_ENGINE);
+        const auto& re_plugin_arr = irods::get_server_property<const nlohmann::json&>(irods::KW_CFG_PLUGIN_CONFIGURATION)
+            .at(irods::KW_CFG_PLUGIN_TYPE_RULE_ENGINE);
 
         for (const auto& plugin_config : re_plugin_arr) {
-            const auto& inst_name = plugin_config.at(irods::CFG_INSTANCE_NAME_KW).get_ref<const std::string&>();
+            const auto& inst_name = plugin_config.at(irods::KW_CFG_INSTANCE_NAME).get_ref<const std::string&>();
 
             if (inst_name == _instance_name) {
-                const auto& shmem_value = plugin_config.at(irods::CFG_SHARED_MEMORY_INSTANCE_KW).get_ref<const std::string&>();
-                const auto& plugin_spec_cfg = plugin_config.at(irods::CFG_PLUGIN_SPECIFIC_CONFIGURATION_KW);
+                const auto& shmem_value = plugin_config.at(irods::KW_CFG_SHARED_MEMORY_INSTANCE).get_ref<const std::string&>();
+                const auto& plugin_spec_cfg = plugin_config.at(irods::KW_CFG_PLUGIN_SPECIFIC_CONFIGURATION);
 
-                const std::string core_re  = get_string_array_from_array(plugin_spec_cfg.at(irods::CFG_RE_RULEBASE_SET_KW));
-                const std::string core_fnm = get_string_array_from_array(plugin_spec_cfg.at(irods::CFG_RE_FUNCTION_NAME_MAPPING_SET_KW));
-                const std::string core_dvm = get_string_array_from_array(plugin_spec_cfg.at(irods::CFG_RE_DATA_VARIABLE_MAPPING_SET_KW));
+                const std::string core_re  = get_string_array_from_array(plugin_spec_cfg.at(irods::KW_CFG_RE_RULEBASE_SET));
+                const std::string core_fnm = get_string_array_from_array(plugin_spec_cfg.at(irods::KW_CFG_RE_FUNCTION_NAME_MAPPING_SET));
+                const std::string core_dvm = get_string_array_from_array(plugin_spec_cfg.at(irods::KW_CFG_RE_DATA_VARIABLE_MAPPING_SET));
 
                 if (const int ec = initRuleEngine(shmem_value.c_str(), nullptr, core_re.c_str(), core_dvm.c_str(), core_fnm.c_str()); ec < 0) {
                     return ERROR(ec, "Failed to initialize native rule engine");
@@ -145,8 +145,8 @@ irods::error start(irods::default_re_ctx&, const std::string& _instance_name)
                 // index locally defined microservices
                 initialize_microservice_table();
 
-                if (plugin_spec_cfg.count(irods::CFG_RE_PEP_REGEX_SET_KW) > 0) {
-                    register_regexes_from_array(plugin_spec_cfg.at(irods::CFG_RE_PEP_REGEX_SET_KW), _instance_name);
+                if (plugin_spec_cfg.count(irods::KW_CFG_RE_PEP_REGEX_SET) > 0) {
+                    register_regexes_from_array(plugin_spec_cfg.at(irods::KW_CFG_RE_PEP_REGEX_SET), _instance_name);
                 }
                 else {
                     RuleExistsHelper::Instance()->registerRuleRegex(STATIC_PEP_RULE_REGEX);

--- a/plugins/rule_engines/src/passthrough.cpp
+++ b/plugins/rule_engines/src/passthrough.cpp
@@ -74,12 +74,12 @@ namespace
 
         try {
             // Iterate over the list of rule engine plugins until the Passthrough REP is found.
-            for (const auto& re : config.at(irods::CFG_PLUGIN_CONFIGURATION_KW).at(irods::PLUGIN_TYPE_RULE_ENGINE)) {
-                if (_instance_name == re.at(irods::CFG_INSTANCE_NAME_KW).get<std::string>()) {
+            for (const auto& re : config.at(irods::KW_CFG_PLUGIN_CONFIGURATION).at(irods::KW_CFG_PLUGIN_TYPE_RULE_ENGINE)) {
+                if (_instance_name == re.at(irods::KW_CFG_INSTANCE_NAME).get<std::string>()) {
                     // Fill the "pep_configs" plugin variable with objects containing the values
                     // defined in the "return_codes_for_peps" configuration. Each object in the list
                     // will contain a regular expression and a code.
-                    for (const auto& e : re.at(irods::CFG_PLUGIN_SPECIFIC_CONFIGURATION_KW).at("return_codes_for_peps")) {
+                    for (const auto& e : re.at(irods::KW_CFG_PLUGIN_SPECIFIC_CONFIGURATION).at("return_codes_for_peps")) {
                         pep_configs[_instance_name].push_back({std::regex{e.at("regex").get<std::string>()}, e.at("code").get<int>()});
                     }
 

--- a/server/api/src/rsAuthCheck.cpp
+++ b/server/api/src/rsAuthCheck.cpp
@@ -29,7 +29,7 @@ int rsAuthCheck(
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         int status;
         int privLevel;
         int clientPrivLevel;
@@ -132,7 +132,7 @@ int rsAuthCheck(
         }
 
         return status;
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         /* this may be a gateway to the rcat host */
         rodsServerHost_t *rodsServerHost;
         int status;

--- a/server/api/src/rsBulkDataObjReg.cpp
+++ b/server/api/src/rsBulkDataObjReg.cpp
@@ -45,10 +45,10 @@ rsBulkDataObjReg( rsComm_t *rsComm, genQueryOut_t *bulkDataObjRegInp,
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsBulkDataObjReg( rsComm, bulkDataObjRegInp,
                                         bulkDataObjRegOut );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(
@@ -79,7 +79,7 @@ int _rsBulkDataObjReg(
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         sqlResult_t *objPath, *dataType, *dataSize, *rescName, *rescID, *filePath,
                     *dataMode, *oprType, *replNum, *chksum;
         char *tmpObjPath, *tmpDataType, *tmpDataSize, *tmpRescName, *tmpRescID, *tmpFilePath,
@@ -254,7 +254,7 @@ int _rsBulkDataObjReg(
         }
 
         return status;
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         return SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(

--- a/server/api/src/rsChkObjPermAndStat.cpp
+++ b/server/api/src/rsChkObjPermAndStat.cpp
@@ -41,9 +41,9 @@ rsChkObjPermAndStat( rsComm_t *rsComm,
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsChkObjPermAndStat( rsComm, chkObjPermAndStatInp );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(
@@ -71,7 +71,7 @@ _rsChkObjPermAndStat( rsComm_t *rsComm,
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         int status;
 
         if ( ( chkObjPermAndStatInp->flags & CHK_COLL_FOR_BUNDLE_OPR ) != 0 ) {
@@ -84,7 +84,7 @@ _rsChkObjPermAndStat( rsComm_t *rsComm,
             return SYS_OPR_FLAG_NOT_SUPPORT;
         }
         return status;
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         return SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(
@@ -105,7 +105,7 @@ chkCollForBundleOpr( rsComm_t *rsComm,
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         int status;
         collInp_t openCollInp;
         collEnt_t *collEnt = NULL;
@@ -282,7 +282,7 @@ chkCollForBundleOpr( rsComm_t *rsComm,
         }
         rsCloseCollection(rsComm, &handleInx);
         return 0;
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         return SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(

--- a/server/api/src/rsClientHints.cpp
+++ b/server/api/src/rsClientHints.cpp
@@ -57,13 +57,13 @@ irods::error get_hash_and_policy(
     }
 
     try {
-        _hash = irods::get_server_property<const std::string>(irods::CFG_DEFAULT_HASH_SCHEME_KW);
+        _hash = irods::get_server_property<const std::string>(irods::KW_CFG_DEFAULT_HASH_SCHEME);
     } catch ( const irods::exception& ) {
         _hash = "SHA256";
     }
 
     try {
-        _policy = irods::get_server_property<const std::string>(irods::CFG_MATCH_HASH_POLICY_KW);
+        _policy = irods::get_server_property<const std::string>(irods::KW_CFG_MATCH_HASH_POLICY);
     } catch ( const irods::exception& ) {
         _policy = "compatible";
     }

--- a/server/api/src/rsCollCreate.cpp
+++ b/server/api/src/rsCollCreate.cpp
@@ -123,7 +123,7 @@ namespace
                 return ret.code();
             }
 
-            if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+            if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
                 /* for STRUCT_FILE_COLL to make a directory in the structFile, the
                  * COLLECTION_TYPE_KW must be set */
 
@@ -169,7 +169,7 @@ namespace
                                  collCreateInp->collName, status );
                     }
                 }
-            } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+            } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
                 status = SYS_NO_RCAT_SERVER_ERR;
             } else {
                 rodsLog(

--- a/server/api/src/rsDataObjGet.cpp
+++ b/server/api/src/rsDataObjGet.cpp
@@ -284,7 +284,7 @@ int rsDataObjGet(
 
     try {
         const auto replica_size = L1desc[fd].dataObjInfo->dataSize;
-        if (const auto single_buffer_size = irods::get_advanced_setting<const int>(irods::CFG_MAX_SIZE_FOR_SINGLE_BUFFER) * 1024 * 1024;
+        if (const auto single_buffer_size = irods::get_advanced_setting<const int>(irods::KW_CFG_MAX_SIZE_FOR_SINGLE_BUFFER) * 1024 * 1024;
             replica_size <= single_buffer_size && UNKNOWN_FILE_SZ != replica_size)
         {
             dataObjOutBBuf->buf = std::malloc(single_buffer_size);

--- a/server/api/src/rsDataObjLock.cpp
+++ b/server/api/src/rsDataObjLock.cpp
@@ -102,7 +102,7 @@ rsDataObjLock( rsComm_t *rsComm, dataObjInp_t *dataObjInp ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         int cmd, type;
         if (const int status = getLockCmdAndType(dataObjInp->condInput, &cmd, &type);
             status < 0) {
@@ -110,7 +110,7 @@ rsDataObjLock( rsComm_t *rsComm, dataObjInp_t *dataObjInp ) {
         }
         return fsDataObjLock( dataObjInp->objPath, cmd, type );
     }
-    else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         return SYS_NO_RCAT_SERVER_ERR;
     }
     else {
@@ -157,7 +157,7 @@ rsDataObjUnlock( rsComm_t *rsComm, dataObjInp_t *dataObjInp ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         char * fd_string = getValByKey( &dataObjInp->condInput, LOCK_FD_KW );
         if (!fd_string) {
             int status = SYS_LOCK_TYPE_INP_ERR;
@@ -167,7 +167,7 @@ rsDataObjUnlock( rsComm_t *rsComm, dataObjInp_t *dataObjInp ) {
         }
         return fsDataObjUnlock( F_SETLK, F_UNLCK, atoi( fd_string ) );
     }
-    else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         return SYS_NO_RCAT_SERVER_ERR;
     }
     else {

--- a/server/api/src/rsDataObjRename.cpp
+++ b/server/api/src/rsDataObjRename.cpp
@@ -64,10 +64,10 @@ namespace
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             return SYS_NO_ICAT_SERVER_ERR;
         }
-        else if( irods::CFG_SERVICE_ROLE_PROVIDER != svc_role ) {
+        else if( irods::KW_CFG_SERVICE_ROLE_PROVIDER != svc_role ) {
             rodsLog(LOG_ERROR, "%s: role not supported [%s]",
                     __FUNCTION__, svc_role.c_str() );
             return SYS_SERVICE_ROLE_NOT_SUPPORTED;
@@ -412,9 +412,9 @@ namespace
                 return ret.code();
             }
 
-            if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+            if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
                 status = _rsDataObjRename( rsComm, dataObjRenameInp );
-            } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+            } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
                 status = SYS_NO_RCAT_SERVER_ERR;
             } else {
                 rodsLog(

--- a/server/api/src/rsDataObjRepl.cpp
+++ b/server/api/src/rsDataObjRepl.cpp
@@ -861,7 +861,7 @@ namespace
     {
         int trans_buff_size;
         try {
-            trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
+            trans_buff_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
         } catch ( const irods::exception& e ) {
             irods::log(e);
             return e.code();

--- a/server/api/src/rsEndTransaction.cpp
+++ b/server/api/src/rsEndTransaction.cpp
@@ -28,9 +28,9 @@ rsEndTransaction( rsComm_t *rsComm, endTransactionInp_t *endTransactionInp ) {
             irods::log(PASS(ret));
             return ret.code();
         }
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsEndTransaction( rsComm, endTransactionInp );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsExecMyRule.cpp
+++ b/server/api/src/rsExecMyRule.cpp
@@ -64,7 +64,7 @@ int rsExecMyRule(
 
     char* inst_name_str = getValByKey(
                               &_exec_inp->condInput,
-                              irods::CFG_INSTANCE_NAME_KW.c_str() );
+                              irods::KW_CFG_INSTANCE_NAME);
     std::string inst_name;
     if( inst_name_str ) {
         inst_name = inst_name_str;

--- a/server/api/src/rsFileChksum.cpp
+++ b/server/api/src/rsFileChksum.cpp
@@ -106,7 +106,7 @@ int fileChksum(rsComm_t* rsComm,
     // capture server hashing settings
     std::string hash_scheme( irods::MD5_NAME );
     try {
-        hash_scheme = irods::get_server_property<const std::string>(irods::CFG_DEFAULT_HASH_SCHEME_KW);
+        hash_scheme = irods::get_server_property<const std::string>(irods::KW_CFG_DEFAULT_HASH_SCHEME);
     } catch ( const irods::exception& ) {}
 
     // make sure the read parameter is lowercased
@@ -118,7 +118,7 @@ int fileChksum(rsComm_t* rsComm,
 
     std::string hash_policy;
     try {
-        hash_policy = irods::get_server_property<const std::string>(irods::CFG_MATCH_HASH_POLICY_KW);
+        hash_policy = irods::get_server_property<const std::string>(irods::KW_CFG_MATCH_HASH_POLICY);
     } catch ( const irods::exception& ) {}
 
     // =-=-=-=-=-=-=-
@@ -271,7 +271,7 @@ int file_checksum(RsComm* _comm,
     // Capture server hashing settings.
     std::string hash_scheme = irods::MD5_NAME;
     try {
-        hash_scheme = irods::get_server_property<const std::string>(irods::CFG_DEFAULT_HASH_SCHEME_KW);
+        hash_scheme = irods::get_server_property<const std::string>(irods::KW_CFG_DEFAULT_HASH_SCHEME);
     }
     catch (const irods::exception&) {}
 
@@ -280,7 +280,7 @@ int file_checksum(RsComm* _comm,
 
     std::string_view hash_policy;
     try {
-        hash_policy = irods::get_server_property<const std::string>(irods::CFG_MATCH_HASH_POLICY_KW);
+        hash_policy = irods::get_server_property<const std::string>(irods::KW_CFG_MATCH_HASH_POLICY);
     }
     catch (const irods::exception&) {}
 

--- a/server/api/src/rsGenQuery.cpp
+++ b/server/api/src/rsGenQuery.cpp
@@ -675,9 +675,9 @@ rsGenQuery( rsComm_t *rsComm, genQueryInp_t *genQueryInp,
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsGenQuery( rsComm, genQueryInp, genQueryOut );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             rodsLog( LOG_NOTICE,
                      "rsGenQuery error. RCAT is not configured on this host" );
             return SYS_NO_RCAT_SERVER_ERR;

--- a/server/api/src/rsGeneralAdmin.cpp
+++ b/server/api/src/rsGeneralAdmin.cpp
@@ -267,9 +267,9 @@ rsGeneralAdmin( rsComm_t *rsComm, generalAdminInp_t *generalAdminInp ) {
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsGeneralAdmin( rsComm, generalAdminInp );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(
@@ -577,7 +577,7 @@ _addResource(
     // =-=-=-=-=-=-=-
     // resolve plugin directory
     std::string plugin_home;
-    irods::error ret = irods::resolve_plugin_path( irods::PLUGIN_TYPE_RESOURCE, plugin_home );
+    irods::error ret = irods::resolve_plugin_path( irods::KW_CFG_PLUGIN_TYPE_RESOURCE, plugin_home );
     if ( !ret.ok() ) {
         irods::log( PASS( ret ) );
         return ret.code();
@@ -625,7 +625,7 @@ _listRescTypes( rsComm_t* _rsComm ) {
     // =-=-=-=-=-=-=-
     // resolve plugin directory
     std::string plugin_home;
-    irods::error ret = irods::resolve_plugin_path( irods::PLUGIN_TYPE_RESOURCE, plugin_home );
+    irods::error ret = irods::resolve_plugin_path( irods::KW_CFG_PLUGIN_TYPE_RESOURCE, plugin_home );
     if ( !ret.ok() ) {
         irods::log( PASS( ret ) );
         return ret.code();

--- a/server/api/src/rsGeneralRowInsert.cpp
+++ b/server/api/src/rsGeneralRowInsert.cpp
@@ -28,9 +28,9 @@ rsGeneralRowInsert( rsComm_t *rsComm, generalRowInsertInp_t *generalRowInsertInp
             irods::log(PASS(ret));
             return ret.code();
         }
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsGeneralRowInsert( rsComm, generalRowInsertInp );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsGeneralRowPurge.cpp
+++ b/server/api/src/rsGeneralRowPurge.cpp
@@ -24,9 +24,9 @@ rsGeneralRowPurge( rsComm_t *rsComm, generalRowPurgeInp_t *generalRowPurgeInp ) 
     if ( rodsServerHost->localFlag == LOCAL_HOST ) {
 
         std::string svc_role;
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsGeneralRowPurge( rsComm, generalRowPurgeInp );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsGeneralUpdate.cpp
+++ b/server/api/src/rsGeneralUpdate.cpp
@@ -29,9 +29,9 @@ rsGeneralUpdate( rsComm_t *rsComm, generalUpdateInp_t *generalUpdateInp ) {
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsGeneralUpdate( generalUpdateInp );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsGetHierarchyForResc.cpp
+++ b/server/api/src/rsGetHierarchyForResc.cpp
@@ -24,7 +24,7 @@ int _rsGetHierarchyForResc(
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         // =-=-=-=-=-=-=-
         // allocate the outgoing structure
         ( *_out ) = ( getHierarchyForRescOut_t* )malloc( sizeof( getHierarchyForRescOut_t ) );
@@ -44,7 +44,7 @@ int _rsGetHierarchyForResc(
         snprintf( ( *_out )->resc_hier_, MAX_NAME_LEN, "%s", hier.c_str() );
 
         return status;
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         return SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(
@@ -93,9 +93,9 @@ int rsGetHierarchyForResc(
             irods::log(PASS(ret));
             return ret.code();
         }
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsGetHierarchyForResc( _inp, _out );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsGetLimitedPassword.cpp
+++ b/server/api/src/rsGetLimitedPassword.cpp
@@ -30,12 +30,12 @@ rsGetLimitedPassword( rsComm_t *rsComm,
             irods::log(PASS(ret));
             return ret.code();
         }
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsGetLimitedPassword(
                          rsComm,
                          getLimitedPasswordInp,
                          getLimitedPasswordOut );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsGetMiscSvrInfo.cpp
+++ b/server/api/src/rsGetMiscSvrInfo.cpp
@@ -32,9 +32,9 @@ rsGetMiscSvrInfo( rsComm_t *rsComm, miscSvrInfo_t **outSvrInfo ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         myOutSvrInfo->serverType = RCAT_ENABLED;
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         myOutSvrInfo->serverType = RCAT_NOT_ENABLED;
     } else {
         rodsLog(
@@ -47,7 +47,7 @@ rsGetMiscSvrInfo( rsComm_t *rsComm, miscSvrInfo_t **outSvrInfo ) {
     rstrcpy( myOutSvrInfo->relVersion, RODS_REL_VERSION, NAME_LEN );
     rstrcpy( myOutSvrInfo->apiVersion, RODS_API_VERSION, NAME_LEN );
 
-    const auto& zone_name = irods::get_server_property<const std::string>(irods::CFG_ZONE_NAME);
+    const auto& zone_name = irods::get_server_property<const std::string>(irods::KW_CFG_ZONE_NAME);
     if ( !ret.ok() ) {
         irods::log( PASS( ret ) );
         return ret.code();

--- a/server/api/src/rsGetTempPassword.cpp
+++ b/server/api/src/rsGetTempPassword.cpp
@@ -29,9 +29,9 @@ rsGetTempPassword( rsComm_t *rsComm,
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
              status = _rsGetTempPassword( rsComm, getTempPasswordOut );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsGetTempPasswordForOther.cpp
+++ b/server/api/src/rsGetTempPasswordForOther.cpp
@@ -31,12 +31,12 @@ rsGetTempPasswordForOther( rsComm_t *rsComm,
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsGetTempPasswordForOther(
                          rsComm,
                          getTempPasswordForOtherInp,
                          getTempPasswordForOtherOut );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsIESClientHints.cpp
+++ b/server/api/src/rsIESClientHints.cpp
@@ -36,10 +36,10 @@ int rsIESClientHints( rsComm_t* _comm, bytesBuf_t** _bbuf )
             return ret.code();
         }
 
-        if ( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if ( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsIESClientHints( _comm, _bbuf );
         }
-        else if ( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        else if ( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         }
         else {

--- a/server/api/src/rsModAVUMetadata.cpp
+++ b/server/api/src/rsModAVUMetadata.cpp
@@ -63,9 +63,9 @@ rsModAVUMetadata( rsComm_t *rsComm, modAVUMetadataInp_t *modAVUMetadataInp ) {
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsModAVUMetadata( rsComm, modAVUMetadataInp );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsModAccessControl.cpp
+++ b/server/api/src/rsModAccessControl.cpp
@@ -41,9 +41,9 @@ rsModAccessControl( rsComm_t *rsComm, modAccessControlInp_t *modAccessControlInp
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsModAccessControl( rsComm, &newModAccessControlInp );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsModColl.cpp
+++ b/server/api/src/rsModColl.cpp
@@ -31,9 +31,9 @@ rsModColl( rsComm_t *rsComm, collInp_t *modCollInp ) {
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsModColl( rsComm, modCollInp );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(
@@ -59,7 +59,7 @@ _rsModColl( rsComm_t *rsComm, collInp_t *modCollInp ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         int status;
         collInfo_t collInfo;
         char *tmpStr;
@@ -134,7 +134,7 @@ _rsModColl( rsComm_t *rsComm, collInp_t *modCollInp ) {
         }
 
         return status;
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         return SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(

--- a/server/api/src/rsModDataObjMeta.cpp
+++ b/server/api/src/rsModDataObjMeta.cpp
@@ -46,9 +46,9 @@ rsModDataObjMeta( rsComm_t *rsComm, modDataObjMeta_t *modDataObjMetaInp ) {
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsModDataObjMeta( rsComm, modDataObjMetaInp );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(
@@ -88,7 +88,7 @@ _rsModDataObjMeta( rsComm_t *rsComm, modDataObjMeta_t *modDataObjMetaInp ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         int status = 0;
         dataObjInfo_t *dataObjInfo;
         keyValPair_t *regParam;
@@ -191,7 +191,7 @@ _rsModDataObjMeta( rsComm_t *rsComm, modDataObjMeta_t *modDataObjMetaInp ) {
         /**  June 1 2009 for pre-post processing rule hooks **/
 
         return status;
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         return SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(

--- a/server/api/src/rsObjStat.cpp
+++ b/server/api/src/rsObjStat.cpp
@@ -54,9 +54,9 @@ int rsObjStat(rsComm_t *rsComm,
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsObjStat( rsComm, dataObjInp, rodsObjStatOut );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsPamAuthRequest.cpp
+++ b/server/api/src/rsPamAuthRequest.cpp
@@ -38,12 +38,12 @@ rsPamAuthRequest( rsComm_t *rsComm, pamAuthRequestInp_t *pamAuthRequestInp,
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsPamAuthRequest(
                          rsComm,
                          pamAuthRequestInp,
                          pamAuthRequestOut );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsRegColl.cpp
+++ b/server/api/src/rsRegColl.cpp
@@ -51,9 +51,9 @@ rsRegColl( rsComm_t *rsComm, collInp_t *regCollInp ) {
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsRegColl( rsComm, regCollInp );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(
@@ -80,7 +80,7 @@ _rsRegColl( rsComm_t *rsComm, collInp_t *collCreateInp ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         int status;
         collInfo_t collInfo;
         char *tmpStr;
@@ -102,7 +102,7 @@ _rsRegColl( rsComm_t *rsComm, collInp_t *collCreateInp ) {
         status = chlRegColl( rsComm, &collInfo );
         clearKeyVal( &collInfo.condInput );
         return status;
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         return SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(

--- a/server/api/src/rsRegDataObj.cpp
+++ b/server/api/src/rsRegDataObj.cpp
@@ -35,7 +35,7 @@ rsRegDataObj( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsRegDataObj( rsComm, dataObjInfo );
             if ( status >= 0 ) {
                 *outDataObjInfo = ( dataObjInfo_t * ) malloc( sizeof( dataObjInfo_t ) );
@@ -43,7 +43,7 @@ rsRegDataObj( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
                 //**outDataObjInfo = *dataObjInfo;
                 memcpy( *outDataObjInfo, dataObjInfo, sizeof( dataObjInfo_t ) );
             }
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(
@@ -69,7 +69,7 @@ _rsRegDataObj( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         int status;
         irods::error ret;
         status = chlRegDataObj( rsComm, dataObjInfo );
@@ -102,7 +102,7 @@ _rsRegDataObj( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo ) {
             }
         }
         return status;
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         return SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(
@@ -140,9 +140,9 @@ svrRegDataObj( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo ) {
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsRegDataObj( rsComm, dataObjInfo );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsRegReplica.cpp
+++ b/server/api/src/rsRegReplica.cpp
@@ -252,11 +252,11 @@ int rsRegReplica(rsComm_t *rsComm, regReplica_t *regReplicaInp)
         return ret.code();
     }
 
-    if (irods::CFG_SERVICE_ROLE_CONSUMER == svc_role) {
+    if (irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role) {
         return SYS_NO_RCAT_SERVER_ERR;
     }
 
-    if (irods::CFG_SERVICE_ROLE_PROVIDER != svc_role) {
+    if (irods::KW_CFG_SERVICE_ROLE_PROVIDER != svc_role) {
         rodsLog(LOG_ERROR, "role not supported [%s]", svc_role.c_str());
         return SYS_SERVICE_ROLE_NOT_SUPPORTED;
     }

--- a/server/api/src/rsRmColl.cpp
+++ b/server/api/src/rsRmColl.cpp
@@ -501,7 +501,7 @@ svrUnregColl( rsComm_t *rsComm, collInp_t *rmCollInp ) {
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             collInfo_t collInfo{};
             rstrcpy( collInfo.collName, rmCollInp->collName, MAX_NAME_LEN );
             if (getValByKey(&rmCollInp->condInput, ADMIN_RMTRASH_KW) ||
@@ -514,7 +514,7 @@ svrUnregColl( rsComm_t *rsComm, collInp_t *rmCollInp ) {
             else {
                 status = chlDelColl( rsComm, &collInfo );
             }
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsRuleExecDel.cpp
+++ b/server/api/src/rsRuleExecDel.cpp
@@ -70,7 +70,7 @@ namespace
             }
         }
 
-        if (irods::CFG_SERVICE_ROLE_PROVIDER == svc_role) {
+        if (irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role) {
             // Unregister rule (i.e. remove the entry from the catalog).
             const auto ec = chlDelRuleExec(rsComm, ruleExecDelInp->ruleExecId);
 
@@ -82,7 +82,7 @@ namespace
             return ec;
         }
 
-        if (irods::CFG_SERVICE_ROLE_CONSUMER == svc_role) {
+        if (irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role) {
             rodsLog(LOG_ERROR, "_rsRuleExecDel: chlDelRuleExec must be invoked on the catalog provider host");
             return SYS_NO_RCAT_SERVER_ERR;
         }
@@ -117,10 +117,10 @@ int rsRuleExecDel( rsComm_t *rsComm, ruleExecDelInp_t *ruleExecDelInp )
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsRuleExecDel( rsComm, ruleExecDelInp );
         }
-        else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             rodsLog( LOG_NOTICE, "rsRuleExecDel error. ICAT is not configured on this host" );
             return SYS_NO_RCAT_SERVER_ERR;
         }

--- a/server/api/src/rsRuleExecMod.cpp
+++ b/server/api/src/rsRuleExecMod.cpp
@@ -25,10 +25,10 @@ int rsRuleExecMod(RsComm* _rsComm, RuleExecModifyInput* _ruleExecModInp)
             return ret.code();
         }
 
-        if (irods::CFG_SERVICE_ROLE_PROVIDER == svc_role) {
+        if (irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role) {
             status = _rsRuleExecMod(_rsComm, _ruleExecModInp);
         }
-        else if (irods::CFG_SERVICE_ROLE_CONSUMER == svc_role) {
+        else if (irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role) {
             status = SYS_NO_RCAT_SERVER_ERR;
         }
         else {

--- a/server/api/src/rsRuleExecSubmit.cpp
+++ b/server/api/src/rsRuleExecSubmit.cpp
@@ -80,7 +80,7 @@ namespace
             return err.code();
         }
 
-        if (irods::CFG_SERVICE_ROLE_PROVIDER == svc_role) {
+        if (irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role) {
             const auto status = chlRegRuleExec(rsComm, ruleExecSubmitInp);
 
             if (status < 0) {
@@ -90,7 +90,7 @@ namespace
             return status;
         }
 
-        if (irods::CFG_SERVICE_ROLE_CONSUMER == svc_role) {
+        if (irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role) {
             rodsLog(LOG_ERROR, "_rsRuleExecSubmit error. ICAT is not configured on this host");
             return SYS_NO_ICAT_SERVER_ERR;
         }

--- a/server/api/src/rsSimpleQuery.cpp
+++ b/server/api/src/rsSimpleQuery.cpp
@@ -29,9 +29,9 @@ rsSimpleQuery( rsComm_t *rsComm, simpleQueryInp_t *simpleQueryInp,
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsSimpleQuery( rsComm, simpleQueryInp, simpleQueryOut );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsSpecificQuery.cpp
+++ b/server/api/src/rsSpecificQuery.cpp
@@ -36,9 +36,9 @@ rsSpecificQuery( rsComm_t *rsComm, specificQueryInp_t *specificQueryInp,
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsSpecificQuery( rsComm, specificQueryInp, genQueryOut );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             rodsLog( LOG_NOTICE,
                      "rsSpecificQuery error. RCAT is not configured on this host" );
             return SYS_NO_RCAT_SERVER_ERR;

--- a/server/api/src/rsTicketAdmin.cpp
+++ b/server/api/src/rsTicketAdmin.cpp
@@ -24,10 +24,10 @@ int rsTicketAdmin(rsComm_t* rsComm, ticketAdminInp_t* ticketAdminInp)
             return ret.code();
         }
 
-        if (irods::CFG_SERVICE_ROLE_PROVIDER == svc_role) {
+        if (irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role) {
             status = _rsTicketAdmin(rsComm, ticketAdminInp);
         }
-        else if (irods::CFG_SERVICE_ROLE_CONSUMER == svc_role) {
+        else if (irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role) {
             status = SYS_NO_RCAT_SERVER_ERR;
         }
         else {

--- a/server/api/src/rsUnregDataObj.cpp
+++ b/server/api/src/rsUnregDataObj.cpp
@@ -34,9 +34,9 @@ rsUnregDataObj( rsComm_t *rsComm, unregDataObj_t *unregDataObjInp ) {
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsUnregDataObj( rsComm, unregDataObjInp );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(
@@ -63,7 +63,7 @@ _rsUnregDataObj( rsComm_t *rsComm, unregDataObj_t *unregDataObjInp ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         dataObjInfo_t *dataObjInfo;
         keyValPair_t *condInput;
         int status;
@@ -104,7 +104,7 @@ _rsUnregDataObj( rsComm_t *rsComm, unregDataObj_t *unregDataObjInp ) {
             }
         }
         return status;
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         return SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(

--- a/server/api/src/rsUserAdmin.cpp
+++ b/server/api/src/rsUserAdmin.cpp
@@ -25,9 +25,9 @@ rsUserAdmin( rsComm_t *rsComm, userAdminInp_t *userAdminInp ) {
             return ret.code();
         }
 
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsUserAdmin( rsComm, userAdminInp );
-        } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         } else {
             rodsLog(

--- a/server/api/src/rsZoneReport.cpp
+++ b/server/api/src/rsZoneReport.cpp
@@ -37,10 +37,10 @@ int rsZoneReport( rsComm_t* _comm, bytesBuf_t** _bbuf ) {
             return ret.code();
         }
 
-        if ( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if ( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             status = _rsZoneReport( _comm, _bbuf );
         }
-        else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+        else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
             status = SYS_NO_RCAT_SERVER_ERR;
         }
         else {

--- a/server/core/src/catalog.cpp
+++ b/server/core/src/catalog.cpp
@@ -24,12 +24,12 @@ namespace
                                std::string& _db_username,
                                std::string& _db_password) -> void
     {
-        const auto& db_plugin_config = _server_config.at(irods::CFG_PLUGIN_CONFIGURATION_KW).at(irods::PLUGIN_TYPE_DATABASE);
+        const auto& db_plugin_config = _server_config.at(irods::KW_CFG_PLUGIN_CONFIGURATION).at(irods::KW_CFG_PLUGIN_TYPE_DATABASE);
         const auto& db_instance = db_plugin_config.front();
 
         _db_instance_name = std::begin(db_plugin_config).key();
-        _db_username = db_instance.at(irods::CFG_DB_USERNAME_KW).get<std::string>();
-        _db_password = db_instance.at(irods::CFG_DB_PASSWORD_KW).get<std::string>();
+        _db_username = db_instance.at(irods::KW_CFG_DB_USERNAME).get<std::string>();
+        _db_password = db_instance.at(irods::KW_CFG_DB_PASSWORD).get<std::string>();
     }
 } // anonymous namespace
 

--- a/server/core/src/catalog_utilities.cpp
+++ b/server/core/src/catalog_utilities.cpp
@@ -185,11 +185,11 @@ namespace irods::experimental::catalog
             THROW(err.code(), "Failed to retrieve service role");
         }
 
-        if (irods::CFG_SERVICE_ROLE_CONSUMER == role) {
+        if (irods::KW_CFG_SERVICE_ROLE_CONSUMER == role) {
             THROW(SYS_NO_ICAT_SERVER_ERR, "Remote catalog provider not found");
         }
 
-        if (irods::CFG_SERVICE_ROLE_PROVIDER != role) {
+        if (irods::KW_CFG_SERVICE_ROLE_PROVIDER != role) {
             THROW(SYS_SERVICE_ROLE_NOT_SUPPORTED, fmt::format("Role not supported [role => {}]", role));
         }
     } // throw_if_service_role_is_invalid

--- a/server/core/src/client_api_allowlist.cpp
+++ b/server/core/src/client_api_allowlist.cpp
@@ -200,12 +200,12 @@ namespace irods
 
         const auto& config = irods::server_properties::instance().map();
 
-        if (const auto iter = config.find(irods::CFG_CLIENT_API_ALLOWLIST_POLICY_KW); iter != std::end(config)) {
+        if (const auto iter = config.find(irods::KW_CFG_CLIENT_API_ALLOWLIST_POLICY); iter != std::end(config)) {
             return iter->get_ref<const std::string&>() == "enforce";
         }
 
         logger::api::trace("Could not retrieve [{}] from configuration. Using default value of \"enforce\".",
-                           irods::CFG_CLIENT_API_ALLOWLIST_POLICY_KW);
+                           irods::KW_CFG_CLIENT_API_ALLOWLIST_POLICY);
 
         return true;
     }

--- a/server/core/src/initServer.cpp
+++ b/server/core/src/initServer.cpp
@@ -172,8 +172,8 @@ int initServerInfo(int processType, rsComm_t* rsComm)
     int status = 0;
 
     try {
-        const auto& zone_name = irods::get_server_property<const std::string>(irods::CFG_ZONE_NAME);
-        const auto zone_port = irods::get_server_property<const int>( irods::CFG_ZONE_PORT);
+        const auto& zone_name = irods::get_server_property<const std::string>(irods::KW_CFG_ZONE_NAME);
+        const auto zone_port = irods::get_server_property<const int>( irods::KW_CFG_ZONE_PORT);
 
         /* queue the local zone */
         status = queueZone(zone_name.c_str(), zone_port, nullptr, nullptr);
@@ -218,7 +218,7 @@ int initServerInfo(int processType, rsComm_t* rsComm)
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         status = connectRcat();
         if ( status < 0 ) {
             rodsLog(
@@ -306,13 +306,13 @@ int initRcatServerHostByFile()
 {
     std::string prop_str;
     try {
-        snprintf( KerberosName, sizeof( KerberosName ), "%s", irods::get_server_property<const std::string>(irods::CFG_KERBEROS_NAME_KW).c_str());
+        snprintf( KerberosName, sizeof( KerberosName ), "%s", irods::get_server_property<const std::string>(irods::KW_CFG_KERBEROS_NAME).c_str());
     }
     catch (const irods::exception& e) {}
 
     try {
         rodsHostAddr_t addr{};
-        const auto& catalog_provider_hosts = irods::get_server_property<const nlohmann::json&>(irods::CFG_CATALOG_PROVIDER_HOSTS_KW);
+        const auto& catalog_provider_hosts = irods::get_server_property<const nlohmann::json&>(irods::KW_CFG_CATALOG_PROVIDER_HOSTS);
         snprintf(addr.hostAddr, sizeof(addr.hostAddr), "%s", catalog_provider_hosts[0].get_ref<const std::string&>().c_str());
 
         rodsServerHost_t* tmp_host{};
@@ -335,7 +335,7 @@ int initRcatServerHostByFile()
     // slave icat host
 
     try {
-        snprintf( localSID, sizeof( localSID ), "%s", irods::get_server_property<const std::string>(irods::CFG_ZONE_KEY_KW).c_str() );
+        snprintf( localSID, sizeof( localSID ), "%s", irods::get_server_property<const std::string>(irods::KW_CFG_ZONE_KEY).c_str() );
     } catch ( const irods::exception& e ) {
         try {
             snprintf( localSID, sizeof( localSID ), "%s", irods::get_server_property<const std::string>(LOCAL_ZONE_SID_KW).c_str() );
@@ -347,12 +347,12 @@ int initRcatServerHostByFile()
 
     // try for new federation config
     try {
-        for (const auto& federation : irods::get_server_property<const nlohmann::json&>(irods::CFG_FEDERATION_KW)) {
+        for (const auto& federation : irods::get_server_property<const nlohmann::json&>(irods::KW_CFG_FEDERATION)) {
             try {
                 try {
-                    const auto& fed_zone_key             = federation.at(irods::CFG_ZONE_KEY_KW).get_ref<const std::string&>();
-                    const auto& fed_zone_name            = federation.at(irods::CFG_ZONE_NAME_KW).get_ref<const std::string&>();
-                    const auto& fed_zone_negotiation_key = federation.at(irods::CFG_NEGOTIATION_KEY_KW).get_ref<const std::string&>();
+                    const auto& fed_zone_key             = federation.at(irods::KW_CFG_ZONE_KEY).get_ref<const std::string&>();
+                    const auto& fed_zone_name            = federation.at(irods::KW_CFG_ZONE_NAME).get_ref<const std::string&>();
+                    const auto& fed_zone_negotiation_key = federation.at(irods::KW_CFG_NEGOTIATION_KEY).get_ref<const std::string&>();
 
                     // store in remote_SID_key_map
                     remote_SID_key_map[fed_zone_name] = std::make_pair(fed_zone_key, fed_zone_negotiation_key);
@@ -387,7 +387,7 @@ int initRcatServerHostByFile()
                     std::string fed_zone_key = rem_sid.substr(pos + 1);
                     // use our negotiation key for the old configuration
                     try {
-                        const auto& neg_key = irods::get_server_property<const std::string>(irods::CFG_NEGOTIATION_KEY_KW);
+                        const auto& neg_key = irods::get_server_property<const std::string>(irods::KW_CFG_NEGOTIATION_KEY);
                         remote_SID_key_map[fed_zone_name] = std::make_pair(fed_zone_key, neg_key);
                     }
                     catch (const irods::exception& e) {
@@ -420,7 +420,7 @@ initZone( rsComm_t *rsComm ) {
 
     boost::optional<std::string> zone_name;
     try {
-        zone_name.reset(irods::get_server_property<std::string>(irods::CFG_ZONE_NAME));
+        zone_name.reset(irods::get_server_property<std::string>(irods::KW_CFG_ZONE_NAME));
     } catch ( const irods::exception& e ) {
         irods::log( irods::error(e) );
         return e.code();
@@ -657,7 +657,7 @@ cleanup() {
         disconnectAllSvrToSvrConn();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         disconnectRcat();
     }
 
@@ -685,15 +685,15 @@ signalExit( int ) {
 int initHostConfigByFile()
 {
     try {
-        const auto& hosts_config = irods::get_server_property<const nlohmann::json&>(irods::CFG_HOST_RESOLUTION_KW);
-        const auto& host_entries = hosts_config.at(irods::CFG_HOST_ENTRIES_KW); // An array.
+        const auto& hosts_config = irods::get_server_property<const nlohmann::json&>(irods::KW_CFG_HOST_RESOLUTION);
+        const auto& host_entries = hosts_config.at(irods::KW_CFG_HOST_ENTRIES); // An array.
 
         for (auto&& entry : host_entries) {
             try {
                 auto* svr_host = static_cast<rodsServerHost_t*>(std::malloc(sizeof(rodsServerHost_t)));
                 std::memset(svr_host, 0, sizeof(rodsServerHost_t));
 
-                const auto& address_type = entry.at(irods::CFG_ADDRESS_TYPE_KW).get_ref<const std::string&>();
+                const auto& address_type = entry.at(irods::KW_CFG_ADDRESS_TYPE).get_ref<const std::string&>();
 
                 if (address_type == "remote") {
                     svr_host->localFlag = REMOTE_HOST;
@@ -713,7 +713,7 @@ int initHostConfigByFile()
                     rodsLog(LOG_ERROR, "queueRodsServerHost failed");
                 }
 
-                for (auto&& address : entry.at(irods::CFG_ADDRESSES_KW)) {
+                for (auto&& address : entry.at(irods::KW_CFG_ADDRESSES)) {
                     try {
                         if (queueHostName(svr_host, address.get_ref<const std::string&>().data(), 0) < 0) {
                             rodsLog(LOG_ERROR, "queueHostName failed");
@@ -753,9 +753,9 @@ initRsComm( rsComm_t *rsComm ) {
     }
 
     try {
-        const auto& zone_name = irods::get_server_property<const std::string>(irods::CFG_ZONE_NAME);
-        const auto& zone_user = irods::get_server_property<const std::string>(irods::CFG_ZONE_USER);
-        const auto& zone_auth_scheme = irods::get_server_property<const std::string>(irods::CFG_ZONE_AUTH_SCHEME);
+        const auto& zone_name = irods::get_server_property<const std::string>(irods::KW_CFG_ZONE_NAME);
+        const auto& zone_user = irods::get_server_property<const std::string>(irods::KW_CFG_ZONE_USER);
+        const auto& zone_auth_scheme = irods::get_server_property<const std::string>(irods::KW_CFG_ZONE_AUTH_SCHEME);
 
         /* fill in the proxyUser info from server_config. clientUser
          * has to come from the rei */
@@ -1042,8 +1042,8 @@ chkAllowedUser( const char *userName, const char *rodsZone ) {
 int
 setRsCommFromRodsEnv( rsComm_t *rsComm ) {
     try {
-        const auto& zone_name = irods::get_server_property<const std::string>(irods::CFG_ZONE_NAME);
-        const auto& zone_user = irods::get_server_property<const std::string>(irods::CFG_ZONE_USER);
+        const auto& zone_name = irods::get_server_property<const std::string>(irods::KW_CFG_ZONE_NAME);
+        const auto& zone_user = irods::get_server_property<const std::string>(irods::KW_CFG_ZONE_USER);
 
         rstrcpy( rsComm->proxyUser.userName,  zone_user.c_str(), NAME_LEN );
         rstrcpy( rsComm->clientUser.userName, zone_user.c_str(), NAME_LEN );

--- a/server/core/src/irods_database_manager.cpp
+++ b/server/core/src/irods_database_manager.cpp
@@ -65,7 +65,7 @@ namespace irods {
         error ret = load_plugin< database >(
                         db,
                         _plugin_name,
-                        PLUGIN_TYPE_DATABASE,
+                        KW_CFG_PLUGIN_TYPE_DATABASE,
                         _inst_name,
                         _context );
         if ( ret.ok() && db ) {

--- a/server/core/src/irods_report_plugins_in_json.cpp
+++ b/server/core/src/irods_report_plugins_in_json.cpp
@@ -43,7 +43,7 @@ namespace irods {
     {
         _plugins = json::array();
 
-        error ret = add_plugin_type_to_json_array( PLUGIN_TYPE_RESOURCE, "resource", _plugins );
+        error ret = add_plugin_type_to_json_array( KW_CFG_PLUGIN_TYPE_RESOURCE, "resource", _plugins );
         if ( !ret.ok() ) {
             return PASS( ret );
         }
@@ -55,29 +55,29 @@ namespace irods {
             return PASS( ret );
         }
 
-        if( CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
-            ret = add_plugin_type_to_json_array( PLUGIN_TYPE_DATABASE, "database", _plugins );
+        if( KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+            ret = add_plugin_type_to_json_array( KW_CFG_PLUGIN_TYPE_DATABASE, "database", _plugins );
             if ( !ret.ok() ) {
                 return PASS( ret );
             }
         }
 
-        ret = add_plugin_type_to_json_array( PLUGIN_TYPE_AUTHENTICATION, "authentication", _plugins );
+        ret = add_plugin_type_to_json_array( KW_CFG_PLUGIN_TYPE_AUTHENTICATION, "authentication", _plugins );
         if ( !ret.ok() ) {
             return PASS( ret );
         }
 
-        ret = add_plugin_type_to_json_array( PLUGIN_TYPE_NETWORK, "network", _plugins );
+        ret = add_plugin_type_to_json_array( KW_CFG_PLUGIN_TYPE_NETWORK, "network", _plugins );
         if ( !ret.ok() ) {
             return PASS( ret );
         }
 
-        ret = add_plugin_type_to_json_array( PLUGIN_TYPE_API, "api", _plugins );
+        ret = add_plugin_type_to_json_array( KW_CFG_PLUGIN_TYPE_API, "api", _plugins );
         if ( !ret.ok() ) {
             return PASS( ret );
         }
 
-        ret = add_plugin_type_to_json_array( PLUGIN_TYPE_MICROSERVICE, "microservice", _plugins );
+        ret = add_plugin_type_to_json_array( KW_CFG_PLUGIN_TYPE_MICROSERVICE, "microservice", _plugins );
         if ( !ret.ok() ) {
             return PASS( ret );
         }

--- a/server/core/src/irods_resource_manager.cpp
+++ b/server/core/src/irods_resource_manager.cpp
@@ -113,7 +113,7 @@ namespace irods
         error ret = load_plugin< resource >(
                         resc,
                         _plugin_name,
-                        PLUGIN_TYPE_RESOURCE,
+                        KW_CFG_PLUGIN_TYPE_RESOURCE,
                         _inst_name,
                         _context );
         if ( ret.ok() && resc ) {

--- a/server/core/src/irods_server_negotiation.cpp
+++ b/server/core/src/irods_server_negotiation.cpp
@@ -23,14 +23,14 @@ namespace irods
 
         // Check local zone keys for a match with the sent zone key.
         try {
-            const auto& neg_key = irods::get_server_property<const std::string>(CFG_NEGOTIATION_KEY_KW);
+            const auto& neg_key = irods::get_server_property<const std::string>(KW_CFG_NEGOTIATION_KEY);
             if (!negotiation_key_is_valid(neg_key)) {
                 irods::log(LOG_WARNING, fmt::format(
                     "[{}:{}] - negotiation_key in server_config is invalid",
                     __func__, __LINE__));
             }
 
-            const auto& zone_key = irods::get_server_property<const std::string>(CFG_ZONE_KEY_KW);
+            const auto& zone_key = irods::get_server_property<const std::string>(KW_CFG_ZONE_KEY);
 
             std::string signed_zone_key;
             if (const auto err = sign_server_sid(zone_key, neg_key, signed_zone_key); !err.ok()) {

--- a/server/core/src/miscServerFunct.cpp
+++ b/server/core/src/miscServerFunct.cpp
@@ -189,8 +189,8 @@ setupSrvPortalForParaOpr( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
     else {
         int port_range_count;
         try {
-            const auto svr_port_range_start = irods::get_server_property<const int>(irods::CFG_SERVER_PORT_RANGE_START_KW);
-            const auto svr_port_range_end = irods::get_server_property<const int>(irods::CFG_SERVER_PORT_RANGE_END_KW);
+            const auto svr_port_range_start = irods::get_server_property<const int>(irods::KW_CFG_SERVER_PORT_RANGE_START);
+            const auto svr_port_range_end = irods::get_server_property<const int>(irods::KW_CFG_SERVER_PORT_RANGE_END);
             port_range_count = svr_port_range_end - svr_port_range_start + 1;
         } catch ( irods::exception& e ) {
             return e.code();
@@ -680,7 +680,7 @@ partialDataPut( portalTransferInp_t *myInput ) {
 
     int chunk_size;
     try {
-        chunk_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_CHUNK_SIZE_PARA_TRANS) * 1024 * 1024;
+        chunk_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_CHUNK_SIZE_PARA_TRANS) * 1024 * 1024;
     } catch ( const irods::exception& e ) {
         irods::log(e);
         return;
@@ -688,7 +688,7 @@ partialDataPut( portalTransferInp_t *myInput ) {
 
     int trans_buff_size = 0;
     try {
-        trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
+        trans_buff_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
     } catch ( const irods::exception& e ) {
         irods::log(e);
         return;
@@ -906,7 +906,7 @@ void partialDataGet(
 
     int trans_buff_size = 0;
     try {
-        trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
+        trans_buff_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
     } catch ( const irods::exception& e ) {
         irods::log(e);
         return;
@@ -919,7 +919,7 @@ void partialDataGet(
 
     int chunk_size;
     try {
-        chunk_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_CHUNK_SIZE_PARA_TRANS) * 1024 * 1024;
+        chunk_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_CHUNK_SIZE_PARA_TRANS) * 1024 * 1024;
     } catch ( const irods::exception& e ) {
         irods::log(e);
         return;
@@ -1134,7 +1134,7 @@ remToLocPartialCopy( portalTransferInp_t *myInput ) {
 
     int trans_buff_size;
     try {
-        trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
+        trans_buff_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
     } catch ( const irods::exception& e ) {
         irods::log(e);
         return;
@@ -1671,7 +1671,7 @@ sameHostPartialCopy( portalTransferInp_t *myInput ) {
 
     int trans_buff_size;
     try {
-        trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
+        trans_buff_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
     } catch ( const irods::exception& e ) {
         irods::log(e);
         return;
@@ -1787,7 +1787,7 @@ void locToRemPartialCopy(portalTransferInp_t *myInput)
 
     int trans_buff_size;
     try {
-        trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
+        trans_buff_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
     } catch ( const irods::exception& e ) {
         irods::log(e);
         return;
@@ -2528,7 +2528,7 @@ singleRemToLocCopy( rsComm_t *rsComm, dataCopyInp_t *dataCopyInp ) {
 
     int trans_buff_size;
     try {
-        trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
+        trans_buff_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
     } catch ( const irods::exception& e ) {
         irods::log(e);
         return e.code();
@@ -2592,7 +2592,7 @@ singleLocToRemCopy( rsComm_t *rsComm, dataCopyInp_t *dataCopyInp ) {
 
     int trans_buff_size;
     try {
-        trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
+        trans_buff_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS) * 1024 * 1024;
     } catch ( const irods::exception& e ) {
         irods::log(e);
         return e.code();
@@ -2949,7 +2949,7 @@ checkModArgType( const char *arg ) {
 irods::error setRECacheSaltFromEnv() {
     // Should only ever set the cache salt once
     try {
-        const auto& existing_name = irods::get_server_property<const std::string>( irods::CFG_RE_CACHE_SALT_KW);
+        const auto& existing_name = irods::get_server_property<const std::string>( irods::KW_CFG_RE_CACHE_SALT);
         rodsLog( LOG_NOTICE, "setRECacheSaltFromEnv: mutex name already set [%s]", existing_name.c_str() );
         return SUCCESS();
     } catch ( const irods::exception& ) {
@@ -2960,7 +2960,7 @@ irods::error setRECacheSaltFromEnv() {
         }
 
         try {
-            irods::set_server_property<std::string>( irods::CFG_RE_CACHE_SALT_KW, p_mutex_salt );
+            irods::set_server_property<std::string>( irods::KW_CFG_RE_CACHE_SALT, p_mutex_salt );
         } catch ( const irods::exception& e ) {
             rodsLog( LOG_ERROR, "setRECacheSaltFromEnv: failed to set server_properties" );
             return irods::error(e);
@@ -3082,7 +3082,7 @@ irods::error get_catalog_service_role(
     std::string& _role ) {
 
     try {
-        _role = irods::get_server_property<std::string>(irods::CFG_CATALOG_SERVICE_ROLE);
+        _role = irods::get_server_property<std::string>(irods::KW_CFG_CATALOG_SERVICE_ROLE);
     } catch ( const irods::exception& e ) {
         return irods::error(e);
     }
@@ -3094,7 +3094,7 @@ irods::error get_catalog_service_role(
 irods::error get_default_rule_plugin_instance(std::string& _instance_name)
 {
     try {
-        _instance_name = irods::get_server_property<const nlohmann::json&>(std::vector<std::string>{irods::CFG_PLUGIN_CONFIGURATION_KW, irods::PLUGIN_TYPE_RULE_ENGINE})[0].at(irods::CFG_INSTANCE_NAME_KW).get<std::string>();
+        _instance_name = irods::get_server_property<const nlohmann::json&>(std::vector<std::string>{irods::KW_CFG_PLUGIN_CONFIGURATION, irods::KW_CFG_PLUGIN_TYPE_RULE_ENGINE})[0].at(irods::KW_CFG_INSTANCE_NAME).get<std::string>();
     }
     catch (const irods::exception& e) {
         return irods::error(e);
@@ -3112,9 +3112,9 @@ irods::error get_default_rule_plugin_instance(std::string& _instance_name)
 irods::error list_rule_plugin_instances(std::vector<std::string>& _instance_names)
 {
     try {
-        const auto& rule_engines = irods::get_server_property<const nlohmann::json&>(std::vector<std::string>{irods::CFG_PLUGIN_CONFIGURATION_KW, irods::PLUGIN_TYPE_RULE_ENGINE});
+        const auto& rule_engines = irods::get_server_property<const nlohmann::json&>(std::vector<std::string>{irods::KW_CFG_PLUGIN_CONFIGURATION, irods::KW_CFG_PLUGIN_TYPE_RULE_ENGINE});
         for (const auto& el : rule_engines) {
-            _instance_names.push_back(el.at(irods::CFG_INSTANCE_NAME_KW).get_ref<const std::string&>());
+            _instance_names.push_back(el.at(irods::KW_CFG_INSTANCE_NAME).get_ref<const std::string&>());
         }
     }
     catch (const irods::exception& e) {

--- a/server/core/src/physPath.cpp
+++ b/server/core/src/physPath.cpp
@@ -1146,7 +1146,7 @@ int
 getDefFileMode() {
     std::stringstream ss;
     try {
-        ss << std::oct << irods::get_server_property<const std::string>(irods::CFG_DEFAULT_FILE_MODE_KW);
+        ss << std::oct << irods::get_server_property<const std::string>(irods::KW_CFG_DEFAULT_FILE_MODE);
     } catch ( const irods::exception& e ) {
         return DEFAULT_FILE_MODE;
     }
@@ -1159,7 +1159,7 @@ int
 getDefDirMode() {
     std::stringstream ss;
     try {
-        ss << std::oct << irods::get_server_property<const std::string>(irods::CFG_DEFAULT_DIR_MODE_KW);
+        ss << std::oct << irods::get_server_property<const std::string>(irods::KW_CFG_DEFAULT_DIR_MODE);
     } catch ( const irods::exception& e ) {
         return DEFAULT_DIR_MODE;
     }

--- a/server/core/src/rodsAgent.cpp
+++ b/server/core/src/rodsAgent.cpp
@@ -202,7 +202,7 @@ runIrodsAgentFactory( sockaddr_un agent_addr ) {
     using log = irods::experimental::log;
 
     irods::server_properties::instance().capture();
-    log::agent_factory::set_level(log::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_AGENT_FACTORY_KW));
+    log::agent_factory::set_level(log::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_AGENT_FACTORY));
 
     // Attach the error stack object to the logger and release it once this function returns.
     log::set_server_type("agent_factory");
@@ -387,23 +387,23 @@ runIrodsAgentFactory( sockaddr_un agent_addr ) {
 
                     // Update the eviction age for DNS cache entries.
                     irods::set_server_property(
-                        key_path_t{irods::CFG_ADVANCED_SETTINGS_KW, irods::CFG_DNS_CACHE_KW, irods::CFG_EVICTION_AGE_IN_SECONDS_KW},
+                        key_path_t{irods::KW_CFG_ADVANCED_SETTINGS, irods::KW_CFG_DNS_CACHE, irods::KW_CFG_EVICTION_AGE_IN_SECONDS},
                         irods::get_dns_cache_eviction_age());
 
                     // Update the eviction age for hostname cache entries.
                     irods::set_server_property(
-                        key_path_t{irods::CFG_ADVANCED_SETTINGS_KW, irods::CFG_HOSTNAME_CACHE_KW, irods::CFG_EVICTION_AGE_IN_SECONDS_KW},
+                        key_path_t{irods::KW_CFG_ADVANCED_SETTINGS, irods::KW_CFG_HOSTNAME_CACHE, irods::KW_CFG_EVICTION_AGE_IN_SECONDS},
                         irods::get_hostname_cache_eviction_age());
 
-                    log::agent::set_level(log::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_AGENT_KW));
-                    log::legacy::set_level(log::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_LEGACY_KW));
-                    log::resource::set_level(log::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_RESOURCE_KW));
-                    log::database::set_level(log::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_DATABASE_KW));
-                    log::authentication::set_level(log::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_AUTHENTICATION_KW));
-                    log::api::set_level(log::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_API_KW));
-                    log::microservice::set_level(log::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_MICROSERVICE_KW));
-                    log::network::set_level(log::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_NETWORK_KW));
-                    log::rule_engine::set_level(log::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_RULE_ENGINE_KW));
+                    log::agent::set_level(log::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_AGENT));
+                    log::legacy::set_level(log::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_LEGACY));
+                    log::resource::set_level(log::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_RESOURCE));
+                    log::database::set_level(log::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_DATABASE));
+                    log::authentication::set_level(log::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_AUTHENTICATION));
+                    log::api::set_level(log::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_API));
+                    log::microservice::set_level(log::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_MICROSERVICE));
+                    log::network::set_level(log::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_NETWORK));
+                    log::rule_engine::set_level(log::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_RULE_ENGINE));
 
                     log::agent::trace("Agent started.");
 
@@ -505,7 +505,7 @@ runIrodsAgentFactory( sockaddr_un agent_addr ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         if ( strstr( rsComm.myEnv.rodsDebug, "CAT" ) != NULL ) {
             chlDebug( rsComm.myEnv.rodsDebug );
         }

--- a/server/delay_server/src/irodsDelayServer.cpp
+++ b/server/delay_server/src/irodsDelayServer.cpp
@@ -66,9 +66,9 @@ namespace
     {
         logger::init(write_to_stdout, enable_test_mode);
 
-        logger::server::set_level(logger::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_SERVER_KW));
-        logger::legacy::set_level(logger::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_LEGACY_KW));
-        logger::delay_server::set_level(logger::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_DELAY_SERVER_KW));
+        logger::server::set_level(logger::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_SERVER));
+        logger::legacy::set_level(logger::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_LEGACY));
+        logger::delay_server::set_level(logger::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_DELAY_SERVER));
 
         logger::set_server_type("delay_server");
 
@@ -81,12 +81,12 @@ namespace
     {
         const auto& config = irods::server_properties::instance().map();
 
-        const auto advanced_settings = config.find(irods::CFG_ADVANCED_SETTINGS_KW);
+        const auto advanced_settings = config.find(irods::KW_CFG_ADVANCED_SETTINGS);
         if (advanced_settings == std::end(config)) {
             return std::nullopt;
         }
 
-        const auto executors = advanced_settings->find(irods::DELAY_RULE_EXECUTORS_KW);
+        const auto executors = advanced_settings->find(irods::KW_CFG_DELAY_RULE_EXECUTORS);
         if (executors == std::end(*advanced_settings)) {
             return std::nullopt;
         }
@@ -665,12 +665,12 @@ int main(int argc, char** argv)
 
     const auto sleep_time = [] {
         try {
-            return irods::get_advanced_setting<const int>(irods::CFG_DELAY_SERVER_SLEEP_TIME_IN_SECONDS);
+            return irods::get_advanced_setting<const int>(irods::KW_CFG_DELAY_SERVER_SLEEP_TIME_IN_SECONDS);
         }
         catch (...) {
             logger::delay_server::warn("Could not retrieve [{}] from advanced settings configuration. "
                                        "Using default value of {}.",
-                                       irods::CFG_DELAY_SERVER_SLEEP_TIME_IN_SECONDS,
+                                       irods::KW_CFG_DELAY_SERVER_SLEEP_TIME_IN_SECONDS,
                                        irods::default_delay_server_sleep_time_in_seconds);
         }
 
@@ -700,12 +700,12 @@ int main(int argc, char** argv)
 
     const auto number_of_concurrent_executors = [] {
         try {
-            return irods::get_advanced_setting<const int>(irods::CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS);
+            return irods::get_advanced_setting<const int>(irods::KW_CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS);
         }
         catch (...) {
             logger::delay_server::warn("Could not retrieve [{}] from advanced settings configuration. "
                                        "Using default value of {}.",
-                                       irods::CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS,
+                                       irods::KW_CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS,
                                        irods::default_number_of_concurrent_delay_executors);
         }
 
@@ -716,7 +716,7 @@ int main(int argc, char** argv)
 
     const auto queue_size_in_bytes = []() -> int {
         try {
-            const auto bytes = irods::get_advanced_setting<int>(irods::CFG_MAX_SIZE_OF_DELAY_QUEUE_IN_BYTES_KW);
+            const auto bytes = irods::get_advanced_setting<int>(irods::KW_CFG_MAX_SIZE_OF_DELAY_QUEUE_IN_BYTES);
 
             if (bytes > 0) {
                 return bytes;
@@ -725,7 +725,7 @@ int main(int argc, char** argv)
         catch (...) {
             logger::delay_server::warn("Could not retrieve [{}] from advanced settings configuration. "
                                        "Delay server will use as much memory as necessary.",
-                                       irods::CFG_MAX_SIZE_OF_DELAY_QUEUE_IN_BYTES_KW);
+                                       irods::KW_CFG_MAX_SIZE_OF_DELAY_QUEUE_IN_BYTES);
         }
 
         return 0;

--- a/server/icat/src/icatHighLevelRoutines.cpp
+++ b/server/icat/src/icatHighLevelRoutines.cpp
@@ -91,7 +91,7 @@ int chlOpen() {
     // =-=-=-=-=-=-=-
     // cache the database type for subsequent calls
     try {
-        const auto& database_plugin_map = irods::get_server_property<const nlohmann::json&>(std::vector<std::string>{irods::CFG_PLUGIN_CONFIGURATION_KW, irods::PLUGIN_TYPE_DATABASE});
+        const auto& database_plugin_map = irods::get_server_property<const nlohmann::json&>(std::vector<std::string>{irods::KW_CFG_PLUGIN_CONFIGURATION, irods::KW_CFG_PLUGIN_TYPE_DATABASE});
         if ( database_plugin_map.size() != 1 ) {
             rodsLog( LOG_ERROR, "Database plugin map must contain exactly one plugin object" );
             return SYS_INVALID_INPUT_PARAM;

--- a/server/main_server/src/main_server_control_plane.cpp
+++ b/server/main_server/src/main_server_control_plane.cpp
@@ -73,11 +73,11 @@ namespace irods
         buffer_crypt::array_t shared_secret;
         try {
             const auto& config = server_properties::instance().map();
-            time_out = config.at(CFG_SERVER_CONTROL_PLANE_TIMEOUT).get<int>();
+            time_out = config.at(KW_CFG_SERVER_CONTROL_PLANE_TIMEOUT).get<int>();
             port = config.at(_port_keyword).get<int>();
-            num_hash_rounds = config.at(CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS_KW).get<int>();
-            encryption_algorithm.reset(config.at(CFG_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM_KW).get_ref<const std::string&>());
-            const auto& key = config.at(CFG_SERVER_CONTROL_PLANE_KEY).get_ref<const std::string&>();
+            num_hash_rounds = config.at(KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS).get<int>();
+            encryption_algorithm.reset(config.at(KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM).get_ref<const std::string&>());
+            const auto& key = config.at(KW_CFG_SERVER_CONTROL_PLANE_KEY).get_ref<const std::string&>();
             shared_secret.assign(key.begin(), key.end());
         }
         catch (const nlohmann::json::exception& e) {
@@ -214,7 +214,7 @@ namespace irods
 
         int sleep_time_out_milli_sec = 0;
         try {
-            sleep_time_out_milli_sec = get_server_property<int>(CFG_SERVER_CONTROL_PLANE_TIMEOUT);
+            sleep_time_out_milli_sec = get_server_property<int>(KW_CFG_SERVER_CONTROL_PLANE_TIMEOUT);
         }
         catch (const irods::exception& e) {
             return irods::error(e);
@@ -438,7 +438,7 @@ namespace irods
         op_map_[SERVER_CONTROL_RESUME] = operation_resume;
         op_map_[SERVER_CONTROL_STATUS] = operation_status;
         op_map_[SERVER_CONTROL_PING]   = operation_ping;
-        if (_prop == CFG_RULE_ENGINE_CONTROL_PLANE_PORT) {
+        if (_prop == KW_CFG_RULE_ENGINE_CONTROL_PLANE_PORT) {
             op_map_[SERVER_CONTROL_SHUTDOWN] = rule_engine_operation_shutdown;
         }
         else {
@@ -451,7 +451,7 @@ namespace irods
         local_server_hostname_ = my_env.rodsHost;
 
         // get the provider's hostname host for ordering
-        provider_hostname_ = server_properties::instance().map().at(CFG_CATALOG_PROVIDER_HOSTS_KW)[0].get_ref<const std::string&>();
+        provider_hostname_ = server_properties::instance().map().at(KW_CFG_CATALOG_PROVIDER_HOSTS)[0].get_ref<const std::string&>();
 
         // repave provider_hostname_ as we do not want to process 'localhost'
         if ("localhost" == provider_hostname_) {
@@ -556,9 +556,9 @@ namespace irods
         try {
             const auto& config = server_properties::instance().map();
             port = config.at(port_prop_).get<int>();
-            num_hash_rounds = config.at(CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS_KW).get<int>();
-            encryption_algorithm.reset(config.at(CFG_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM_KW).get_ref<const std::string&>());
-            const auto& key = config.at(CFG_SERVER_CONTROL_PLANE_KEY).get_ref<const std::string&>();
+            num_hash_rounds = config.at(KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS).get<int>();
+            encryption_algorithm.reset(config.at(KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM).get_ref<const std::string&>());
+            const auto& key = config.at(KW_CFG_SERVER_CONTROL_PLANE_KEY).get_ref<const std::string&>();
             shared_secret.assign(key.begin(), key.end());
         }
         catch (const nlohmann::json::exception& e) {
@@ -729,7 +729,7 @@ namespace irods
             ret = forward_command(
                       _cmd_name,
                       provider_hostname_,
-                      CFG_SERVER_CONTROL_PLANE_PORT,
+                      KW_CFG_SERVER_CONTROL_PLANE_PORT,
                       _wait_option,
                       _wait_seconds,
                       _output);
@@ -743,7 +743,7 @@ namespace irods
             ret = forward_command(
                       _cmd_name,
                       local_server_hostname_,
-                      CFG_SERVER_CONTROL_PLANE_PORT,
+                      KW_CFG_SERVER_CONTROL_PLANE_PORT,
                       _wait_option,
                       _wait_seconds,
                       _output );
@@ -776,7 +776,7 @@ namespace irods
             ret = forward_command(
                       _cmd_name,
                       local_server_hostname_,
-                      CFG_SERVER_CONTROL_PLANE_PORT,
+                      KW_CFG_SERVER_CONTROL_PLANE_PORT,
                       _wait_option,
                       _wait_seconds,
                       _output );
@@ -787,7 +787,7 @@ namespace irods
             ret = forward_command(
                       _cmd_name,
                       provider_hostname_,
-                      CFG_SERVER_CONTROL_PLANE_PORT,
+                      KW_CFG_SERVER_CONTROL_PLANE_PORT,
                       _wait_option,
                       _wait_seconds,
                       _output );
@@ -968,9 +968,9 @@ namespace irods
         buffer_crypt::array_t shared_secret;
         try {
             const auto& config = server_properties::instance().map();
-            num_hash_rounds = config.at(CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS_KW).get<int>();
-            encryption_algorithm.reset(config.at(CFG_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM_KW).get_ref<const std::string&>());
-            const auto& key = config.at(CFG_SERVER_CONTROL_PLANE_KEY).get_ref<const std::string&>();
+            num_hash_rounds = config.at(KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS).get<int>();
+            encryption_algorithm.reset(config.at(KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM).get_ref<const std::string&>());
+            const auto& key = config.at(KW_CFG_SERVER_CONTROL_PLANE_KEY).get_ref<const std::string&>();
             shared_secret.assign(key.begin(), key.end());
         }
         catch (const nlohmann::json::exception& e) {

--- a/server/main_server/src/rodsServer.cpp
+++ b/server/main_server/src/rodsServer.cpp
@@ -133,7 +133,7 @@ namespace
     {
         // Should only ever set the cache salt once.
         try {
-            const auto& existing_salt = irods::get_server_property<const std::string>(irods::CFG_RE_CACHE_SALT_KW);
+            const auto& existing_salt = irods::get_server_property<const std::string>(irods::KW_CFG_RE_CACHE_SALT);
             rodsLog(LOG_ERROR, "createAndSetRECacheSalt: salt already set [%s]", existing_salt.c_str());
             return ERROR(SYS_ALREADY_INITIALIZED, "createAndSetRECacheSalt: cache salt already set");
         }
@@ -155,7 +155,7 @@ namespace
             const auto cache_salt = fmt::format("pid{}_{}", static_cast<std::intmax_t>(getpid()), cache_salt_random);
 
             try {
-                irods::set_server_property<std::string>(irods::CFG_RE_CACHE_SALT_KW, cache_salt);
+                irods::set_server_property<std::string>(irods::KW_CFG_RE_CACHE_SALT, cache_salt);
             }
             catch (const nlohmann::json::exception& e) {
                 rodsLog(LOG_ERROR, "createAndSetRECacheSalt: failed to set server_properties");
@@ -191,7 +191,7 @@ namespace
 
     bool instantiate_shared_memory_for_plugin(const nlohmann::json& _plugin_object)
     {
-        const auto itr = _plugin_object.find(irods::CFG_SHARED_MEMORY_INSTANCE_KW);
+        const auto itr = _plugin_object.find(irods::KW_CFG_SHARED_MEMORY_INSTANCE);
 
         if (_plugin_object.end() != itr) {
             const auto& mem_name = itr->get_ref<const std::string&>();
@@ -208,7 +208,7 @@ namespace
         try {
             const auto& config = irods::server_properties::instance().map();
 
-            for (const auto& item : config.at(irods::CFG_PLUGIN_CONFIGURATION_KW).items()) {
+            for (const auto& item : config.at(irods::KW_CFG_PLUGIN_CONFIGURATION).items()) {
                 for (const auto& plugin : item.value().items()) {
                     instantiate_shared_memory_for_plugin(plugin.value());
                 }
@@ -226,7 +226,7 @@ namespace
 
     bool uninstantiate_shared_memory_for_plugin(const nlohmann::json& _plugin_object)
     {
-        const auto itr = _plugin_object.find(irods::CFG_SHARED_MEMORY_INSTANCE_KW);
+        const auto itr = _plugin_object.find(irods::KW_CFG_SHARED_MEMORY_INSTANCE);
 
         if (_plugin_object.end() != itr) {
             const auto& mem_name = itr->get_ref<const std::string&>();
@@ -243,7 +243,7 @@ namespace
         try {
             const auto& config = irods::server_properties::instance().map();
 
-            for (const auto& item : config.at(irods::CFG_PLUGIN_CONFIGURATION_KW).items()) {
+            for (const auto& item : config.at(irods::KW_CFG_PLUGIN_CONFIGURATION).items()) {
                 for (const auto& plugin : item.value().items()) {
                     uninstantiate_shared_memory_for_plugin(plugin.value());
                 }
@@ -263,7 +263,7 @@ namespace
     {
         ix::log::init(_write_to_stdout, _enable_test_mode);
         irods::server_properties::instance().capture();
-        ix::log::server::set_level(ix::log::get_level_from_config(irods::CFG_LOG_LEVEL_CATEGORY_SERVER_KW));
+        ix::log::server::set_level(ix::log::get_level_from_config(irods::KW_CFG_LOG_LEVEL_CATEGORY_SERVER));
         ix::log::set_server_type("server");
 
         if (char hostname[HOST_NAME_MAX]{}; gethostname(hostname, sizeof(hostname)) == 0) {
@@ -296,20 +296,20 @@ namespace
             }
 
             // Find the NREP.
-            const auto& plugin_config = config.at(irods::CFG_PLUGIN_CONFIGURATION_KW);
-            const auto& rule_engines = plugin_config.at(irods::PLUGIN_TYPE_RULE_ENGINE);
+            const auto& plugin_config = config.at(irods::KW_CFG_PLUGIN_CONFIGURATION);
+            const auto& rule_engines = plugin_config.at(irods::KW_CFG_PLUGIN_TYPE_RULE_ENGINE);
 
             const auto end = std::end(rule_engines);
             const auto nrep = std::find_if(std::begin(rule_engines), end, [](const nlohmann::json& _object) {
-                return _object.at(irods::CFG_PLUGIN_NAME_KW).get<std::string>() == "irods_rule_engine_plugin-irods_rule_language";
+                return _object.at(irods::KW_CFG_PLUGIN_NAME).get<std::string>() == "irods_rule_engine_plugin-irods_rule_language";
             });
             if (nrep == end) {
                 return;
             }
 
             // Get the rulebase set.
-            const auto& plugin_specific_config = nrep->at(irods::CFG_PLUGIN_SPECIFIC_CONFIGURATION_KW);
-            const auto& rulebase_set = plugin_specific_config.at(irods::CFG_RE_RULEBASE_SET_KW);
+            const auto& plugin_specific_config = nrep->at(irods::KW_CFG_PLUGIN_SPECIFIC_CONFIGURATION);
+            const auto& rulebase_set = plugin_specific_config.at(irods::KW_CFG_RE_RULEBASE_SET);
 
             // Iterate over the list of rulebases and remove the leftover PID files.
             for (const auto& rb : rulebase_set) {
@@ -348,10 +348,10 @@ namespace
     {
         try {
             const auto adv_settings = irods::server_properties::instance().map()
-                .at(irods::CFG_ADVANCED_SETTINGS_KW);
+                .at(irods::KW_CFG_ADVANCED_SETTINGS);
 
             const auto iter = adv_settings
-                .find(irods::CFG_STACKTRACE_FILE_PROCESSOR_SLEEP_TIME_IN_SECONDS_KW);
+                .find(irods::KW_CFG_STACKTRACE_FILE_PROCESSOR_SLEEP_TIME_IN_SECONDS);
 
             if (iter != std::end(adv_settings)) {
                 if (const auto seconds = iter->get<int>(); seconds > 0) {
@@ -688,7 +688,7 @@ namespace
                 return;
             }
 
-            const auto is_provider = (irods::CFG_SERVICE_ROLE_PROVIDER == service_role);
+            const auto is_provider = (irods::KW_CFG_SERVICE_ROLE_PROVIDER == service_role);
 
             irods::at_scope_exit disconnect_from_database{[is_provider] {
                 if (is_provider) {
@@ -937,12 +937,12 @@ int main(int argc, char** argv)
 
     // Set the default value for evicting DNS cache entries.
     irods::set_server_property(
-        key_path_t{irods::CFG_ADVANCED_SETTINGS_KW, irods::CFG_DNS_CACHE_KW, irods::CFG_EVICTION_AGE_IN_SECONDS_KW},
+        key_path_t{irods::KW_CFG_ADVANCED_SETTINGS, irods::KW_CFG_DNS_CACHE, irods::KW_CFG_EVICTION_AGE_IN_SECONDS},
         irods::get_dns_cache_eviction_age());
 
     // Set the default value for evicting hostname cache entries.
     irods::set_server_property(
-        key_path_t{irods::CFG_ADVANCED_SETTINGS_KW, irods::CFG_HOSTNAME_CACHE_KW, irods::CFG_EVICTION_AGE_IN_SECONDS_KW},
+        key_path_t{irods::KW_CFG_ADVANCED_SETTINGS, irods::KW_CFG_HOSTNAME_CACHE, irods::KW_CFG_EVICTION_AGE_IN_SECONDS},
         irods::get_hostname_cache_eviction_age());
 
     setup_signal_handlers();
@@ -1112,7 +1112,7 @@ int serverMain(const bool enable_test_mode = false, const bool write_to_stdout =
 
     try {
         // Launch the control plane.
-        irods::server_control_plane ctrl_plane(irods::CFG_SERVER_CONTROL_PLANE_PORT, is_control_plane_accepting_requests);
+        irods::server_control_plane ctrl_plane(irods::KW_CFG_SERVER_CONTROL_PLANE_PORT, is_control_plane_accepting_requests);
 
         status = startProcConnReqThreads();
         if (status < 0) {
@@ -1120,7 +1120,7 @@ int serverMain(const bool enable_test_mode = false, const bool write_to_stdout =
             return status;
         }
 
-        if (irods::CFG_SERVICE_ROLE_PROVIDER == svc_role) {
+        if (irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role) {
             try {
                 PurgeLockFileThread = new boost::thread(purgeLockFileWorkerTask);
             }
@@ -1221,7 +1221,7 @@ int serverMain(const bool enable_test_mode = false, const bool write_to_stdout =
             addConnReqToQueue(&svrComm, newSock);
         }
 
-        if (irods::CFG_SERVICE_ROLE_PROVIDER == svc_role) {
+        if (irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role) {
             try {
                 PurgeLockFileThread->join();
             }
@@ -1493,7 +1493,7 @@ int execAgent(int newSock, startupPack_t* startupPack)
     }
 
     status = sendEnvironmentVarStrToSocket(SP_RE_CACHE_SALT,
-                                           irods::get_server_property<const std::string>(irods::CFG_RE_CACHE_SALT_KW).c_str(),
+                                           irods::get_server_property<const std::string>(irods::KW_CFG_RE_CACHE_SALT).c_str(),
                                            tmp_socket);
     if (status < 0) {
         rodsLog(LOG_ERROR, "Failed to send SP_RE_CACHE_SALT to agent");
@@ -1752,7 +1752,7 @@ int initServer(rsComm_t* svrComm)
 
 
     if (LOCAL_HOST == rodsServerHost->localFlag) {
-        if (irods::CFG_SERVICE_ROLE_PROVIDER == svc_role) {
+        if (irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role) {
             disconnectRcat();
         }
     }
@@ -1761,7 +1761,7 @@ int initServer(rsComm_t* svrComm)
         rodsServerHost->conn = nullptr;
     }
 
-    if (irods::CFG_SERVICE_ROLE_PROVIDER == svc_role) {
+    if (irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role) {
         purgeLockFileDir(0);
     }
 
@@ -1857,7 +1857,7 @@ int initServerMain(rsComm_t *svrComm,
 
     int zone_port;
     try {
-        zone_port = irods::get_server_property<const int>(irods::CFG_ZONE_PORT);
+        zone_port = irods::get_server_property<const int>(irods::KW_CFG_ZONE_PORT);
     }
     catch (const irods::exception& e) {
         irods::log(irods::error(e));

--- a/server/re/include/irods/irods_re_plugin.hpp
+++ b/server/re/include/irods/irods_re_plugin.hpp
@@ -853,7 +853,7 @@ namespace irods {
     struct global_re_plugin_mgr {
         microservice_manager<default_ms_ctx> global_ms_mgr;
         std::vector<re_pack_inp<default_re_ctx> > global_re_packs = init_global_re_packs();
-        rule_engine_plugin_manager<default_re_ctx> global_re_plugin_mgr = rule_engine_plugin_manager<default_re_ctx>(PLUGIN_TYPE_RULE_ENGINE);
+        rule_engine_plugin_manager<default_re_ctx> global_re_plugin_mgr = rule_engine_plugin_manager<default_re_ctx>(KW_CFG_PLUGIN_TYPE_RULE_ENGINE);
         rule_engine_manager<default_re_ctx, default_ms_ctx> global_re_mgr = rule_engine_manager<default_re_ctx, default_ms_ctx>(global_re_plugin_mgr, global_re_packs, global_ms_mgr);
     };
 

--- a/server/re/src/icatAdminMS.cpp
+++ b/server/re/src/icatAdminMS.cpp
@@ -60,9 +60,9 @@ int msiCreateUser( ruleExecInfo_t *rei ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         i =  chlRegUserRE( rei->rsComm, rei->uoio );
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         i =  SYS_NO_ICAT_SERVER_ERR;
     } else {
         rodsLog(
@@ -130,9 +130,9 @@ int msiCreateCollByAdmin( msParam_t* xparColl, msParam_t* xchildName, ruleExecIn
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         i =  chlRegCollByAdmin( rei->rsComm, &collInfo );
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         i =  SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(
@@ -201,9 +201,9 @@ int msiDeleteCollByAdmin( msParam_t* xparColl, msParam_t* xchildName, ruleExecIn
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         i = chlDelCollByAdmin( rei->rsComm, &collInfo );
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         i = SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(
@@ -264,9 +264,9 @@ msiDeleteUser( ruleExecInfo_t *rei ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         i =  chlDelUserRE( rei->rsComm, rei->uoio );
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         i = SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(
@@ -321,14 +321,14 @@ msiAddUserToGroup( msParam_t *msParam, ruleExecInfo_t *rei ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         if ( strncmp( rei->uoio->userType, "rodsgroup", 9 ) == 0 ) {
             return 0;
         }
         groupName = ( char * ) msParam->inOutStruct;
         i =  chlModGroup( rei->rsComm, groupName, "add", rei->uoio->userName,
                           rei->uoio->rodsZone );
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         i = SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(
@@ -384,14 +384,14 @@ msiRenameLocalZone( msParam_t* oldName, msParam_t* newName, ruleExecInfo_t *rei 
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         char *oldNameStr;
         char *newNameStr;
 
         oldNameStr = ( char * ) oldName->inOutStruct;
         newNameStr = ( char * ) newName->inOutStruct;
         status = chlRenameLocalZone( rei->rsComm, oldNameStr, newNameStr );
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         status = SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(
@@ -447,7 +447,7 @@ int msiRenameCollection(msParam_t* oldName, msParam_t* newName, ruleExecInfo_t *
 
     using log = irods::experimental::log;
 
-    if (irods::CFG_SERVICE_ROLE_PROVIDER == svc_role) {
+    if (irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role) {
         namespace fs = irods::experimental::filesystem;
 
         const fs::path src_path = static_cast<const char*>(oldName->inOutStruct);
@@ -476,7 +476,7 @@ int msiRenameCollection(msParam_t* oldName, msParam_t* newName, ruleExecInfo_t *
         }
     }
 
-    if (irods::CFG_SERVICE_ROLE_CONSUMER == svc_role) {
+    if (irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role) {
         return SYS_NO_RCAT_SERVER_ERR;
     }
 
@@ -508,7 +508,7 @@ int msiRenameLocalZoneCollection(msParam_t* _new_zone_name, ruleExecInfo_t* _rei
         return ret.code();
     }
 
-    if (irods::CFG_SERVICE_ROLE_PROVIDER == svc_role) {
+    if (irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role) {
         namespace fs = irods::experimental::filesystem;
 
         const fs::path root = "/";
@@ -543,7 +543,7 @@ int msiRenameLocalZoneCollection(msParam_t* _new_zone_name, ruleExecInfo_t* _rei
         }
     }
 
-    if (irods::CFG_SERVICE_ROLE_CONSUMER == svc_role) {
+    if (irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role) {
         return SYS_NO_RCAT_SERVER_ERR;
     }
 
@@ -603,14 +603,14 @@ msiAclPolicy( msParam_t* msParam, ruleExecInfo_t* ) {
     inputArg = ( char * ) msParam->inOutStruct;
     if ( inputArg != NULL ) {
         if ( strncmp( inputArg, "STRICT", 6 ) == 0 ) {
-            if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+            if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
                 chlGenQueryAccessControlSetup( NULL, NULL, NULL, 0, 2 );
                 strict = "on";
             }
         }
     }
     else {
-        if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+        if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
             chlGenQueryAccessControlSetup( NULL, NULL, NULL, 0, 0 );
         }
     }

--- a/server/re/src/icatGeneralMS.cpp
+++ b/server/re/src/icatGeneralMS.cpp
@@ -99,7 +99,7 @@ msiQuota( ruleExecInfo_t *rei ) {
         return ret.code();
     }
 
-    if (irods::CFG_SERVICE_ROLE_PROVIDER != svc_role) {
+    if (irods::KW_CFG_SERVICE_ROLE_PROVIDER != svc_role) {
         return SYS_NO_RCAT_SERVER_ERR;
     }
     rodsLog( LOG_NOTICE, "msiQuota/chlCalcUsageAndQuota called\n" );
@@ -355,9 +355,9 @@ msiCommit( ruleExecInfo_t *rei ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         status = chlCommit( rei->rsComm );
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         status =  SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(
@@ -411,9 +411,9 @@ msiRollback( ruleExecInfo_t *rei ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         status = chlRollback( rei->rsComm );
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         status =  SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(
@@ -594,10 +594,10 @@ msiDeleteUnusedAVUs( ruleExecInfo_t *rei ) {
         return ret.code();
     }
 
-    if( irods::CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
+    if( irods::KW_CFG_SERVICE_ROLE_PROVIDER == svc_role ) {
         rodsLog( LOG_NOTICE, "msiDeleteUnusedAVUs/chlDelUnusedAVUs called\n" );
         status = chlDelUnusedAVUs( rei->rsComm );
-    } else if( irods::CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
+    } else if( irods::KW_CFG_SERVICE_ROLE_CONSUMER == svc_role ) {
         status =  SYS_NO_RCAT_SERVER_ERR;
     } else {
         rodsLog(

--- a/server/re/src/irods_ms_plugin.cpp
+++ b/server/re/src/irods_ms_plugin.cpp
@@ -244,7 +244,7 @@ namespace irods {
         error load_err = load_plugin< ms_table_entry >(
                              entry,
                              _ms,
-                             PLUGIN_TYPE_MICROSERVICE,
+                             KW_CFG_PLUGIN_TYPE_MICROSERVICE,
                              "msvc", "ctx" );
         if ( load_err.ok() && entry ) {
             _table[ _ms ] = entry;

--- a/server/re/src/irods_re_namespaceshelper.cpp
+++ b/server/re/src/irods_re_namespaceshelper.cpp
@@ -7,7 +7,7 @@ NamespacesHelper* NamespacesHelper::Instance() {
     if (!_instance) {
         _instance = new NamespacesHelper;
 
-        const auto& re_namespace_set = irods::get_server_property<const nlohmann::json&>(irods::CFG_RE_NAMESPACE_SET_KW);
+        const auto& re_namespace_set = irods::get_server_property<const nlohmann::json&>(irods::KW_CFG_RE_NAMESPACE_SET);
         for ( const auto& el : re_namespace_set ) {
             namespaces.push_back(el.get_ref<const std::string&>());
         }

--- a/server/re/src/irods_re_plugin.cpp
+++ b/server/re/src/irods_re_plugin.cpp
@@ -30,7 +30,7 @@ namespace irods{
     unpack::unpack(std::list<boost::any> &_l) : l_(_l) {};
 
     std::vector<re_pack_inp<default_re_ctx>> init_global_re_packs() {
-        const auto& re_plugin_configs = irods::get_server_property<const nlohmann::json&>(std::vector<std::string>{irods::CFG_PLUGIN_CONFIGURATION_KW, irods::PLUGIN_TYPE_RULE_ENGINE});
+        const auto& re_plugin_configs = irods::get_server_property<const nlohmann::json&>(std::vector<std::string>{irods::KW_CFG_PLUGIN_CONFIGURATION, irods::KW_CFG_PLUGIN_TYPE_RULE_ENGINE});
         std::vector<re_pack_inp<default_re_ctx>> ret;
 
         for (const auto& map : re_plugin_configs) {

--- a/server/re/src/locks.cpp
+++ b/server/re/src/locks.cpp
@@ -90,7 +90,7 @@ void resetMutex(const char* _inst_name) {
 
 irods::error getMutexName( const char* _inst_name, std::string &mutex_name ) {
     try {
-        const auto& mutex_name_salt = irods::get_server_property<const std::string>(irods::CFG_RE_CACHE_SALT_KW);
+        const auto& mutex_name_salt = irods::get_server_property<const std::string>(irods::KW_CFG_RE_CACHE_SALT);
         mutex_name = "irods_re_cache_mutex_";
         mutex_name += _inst_name;
         mutex_name += "_";

--- a/server/re/src/nre.systemMS.cpp
+++ b/server/re/src/nre.systemMS.cpp
@@ -890,7 +890,7 @@ int
 msiBytesBufToStr( msParam_t* buf_msp, msParam_t* str_msp, ruleExecInfo_t* ) {
     int single_buff_sz;
     try {
-        single_buff_sz = irods::get_advanced_setting<const int>(irods::CFG_MAX_SIZE_FOR_SINGLE_BUFFER) * 1024 * 1024;
+        single_buff_sz = irods::get_advanced_setting<const int>(irods::KW_CFG_MAX_SIZE_FOR_SINGLE_BUFFER) * 1024 * 1024;
     } catch ( const irods::exception& e ) {
         irods::log(e);
         return e.code();
@@ -986,7 +986,7 @@ msiListEnabledMS(
     // =-=-=-=-=-=-=-
     // scan plugin directory for additional plugins
     std::string plugin_home;
-    irods::error ret = irods::resolve_plugin_path( irods::PLUGIN_TYPE_MICROSERVICE, plugin_home );
+    irods::error ret = irods::resolve_plugin_path( irods::KW_CFG_PLUGIN_TYPE_MICROSERVICE, plugin_home );
     if ( !ret.ok() ) {
         free( results );
         irods::log( PASS( ret ) );

--- a/server/re/src/reIn2p3SysRule.cpp
+++ b/server/re/src/reIn2p3SysRule.cpp
@@ -325,16 +325,16 @@ int checkHostAccessControl(const std::string& _user_name,
     std::vector<std::string> group_list;
     boost::split(group_list, _groups_name, boost::is_any_of("\t "), boost::token_compress_on);
 
-    const auto& host_access_control = irods::get_server_property<const nlohmann::json&>(irods::CFG_HOST_ACCESS_CONTROL_KW);
-    const auto& access_entries = host_access_control.at(irods::CFG_ACCESS_ENTRIES_KW);
+    const auto& host_access_control = irods::get_server_property<const nlohmann::json&>(irods::KW_CFG_HOST_ACCESS_CONTROL);
+    const auto& access_entries = host_access_control.at(irods::KW_CFG_ACCESS_ENTRIES);
 
     try {
         for (const auto& access_entry : access_entries) {
             try {
-                const auto& user = access_entry.at(irods::CFG_USER_KW).get_ref<const std::string&>();
-                const auto& group = access_entry.at(irods::CFG_GROUP_KW).get_ref<const std::string&>();
-                const auto& addy = access_entry.at(irods::CFG_ADDRESS_KW).get_ref<const std::string&>();
-                const auto& mask = access_entry.at(irods::CFG_MASK_KW).get_ref<const std::string&>();
+                const auto& user = access_entry.at(irods::KW_CFG_USER).get_ref<const std::string&>();
+                const auto& group = access_entry.at(irods::KW_CFG_GROUP).get_ref<const std::string&>();
+                const auto& addy = access_entry.at(irods::KW_CFG_ADDRESS).get_ref<const std::string&>();
+                const auto& mask = access_entry.at(irods::KW_CFG_MASK).get_ref<const std::string&>();
 
                 boost::system::error_code error_code;
                 const auto address_entry = ip::make_address_v4(addy, error_code);

--- a/server/re/src/reSysDataObjOpr.cpp
+++ b/server/re/src/reSysDataObjOpr.cpp
@@ -666,7 +666,7 @@ msiSetNumThreads( msParam_t *xsizePerThrInMbStr, msParam_t *xmaxNumThrStr,
 
     int def_num_thr = 0;
     try {
-        def_num_thr = irods::get_advanced_setting<const int>(irods::CFG_DEF_NUMBER_TRANSFER_THREADS);
+        def_num_thr = irods::get_advanced_setting<const int>(irods::KW_CFG_DEF_NUMBER_TRANSFER_THREADS);
     } catch ( const irods::exception& e ) {
         irods::log(e);
         return e.code();
@@ -684,7 +684,7 @@ msiSetNumThreads( msParam_t *xsizePerThrInMbStr, msParam_t *xmaxNumThrStr,
 
     int size_per_tran_thr = 0;
     try {
-        size_per_tran_thr = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS);
+        size_per_tran_thr = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS);
     } catch ( const irods::exception& e ) {
         irods::log(e);
         return e.code();
@@ -742,7 +742,7 @@ msiSetNumThreads( msParam_t *xsizePerThrInMbStr, msParam_t *xmaxNumThrStr,
 
         int trans_buff_size = 0;
         try {
-            trans_buff_size = irods::get_advanced_setting<const int>(irods::CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS);
+            trans_buff_size = irods::get_advanced_setting<const int>(irods::KW_CFG_TRANS_BUFFER_SIZE_FOR_PARA_TRANS);
         } catch ( const irods::exception& e ) {
             irods::log(e);
             return e.code();
@@ -1322,14 +1322,14 @@ msiSetReServerNumProc(msParam_t* xnumProc, ruleExecInfo_t* rei)
         int number_of_concurrent_executors = -1;
 
         try {
-            number_of_concurrent_executors = irods::get_advanced_setting<const int>(irods::CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS);
+            number_of_concurrent_executors = irods::get_advanced_setting<const int>(irods::KW_CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS);
         }
         catch (...) {
             number_of_concurrent_executors = irods::default_number_of_concurrent_delay_executors;
 
             using log = irods::experimental::log::server;
             log::warn("Could not retrieve [{}] from advanced settings configuration. Using default value of {}.",
-                      irods::CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS,
+                      irods::KW_CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS,
                       number_of_concurrent_executors);
         }
 

--- a/server/re/src/sharedmemory.cpp
+++ b/server/re/src/sharedmemory.cpp
@@ -96,7 +96,7 @@ unsigned char *prepareNonServerSharedMemory( const std::string& _key ) {
 
 irods::error getSharedMemoryName( const std::string& _key, std::string &shared_memory_name ) {
     try {
-        const auto& shared_memory_name_salt = irods::get_server_property<const std::string>(irods::CFG_RE_CACHE_SALT_KW);
+        const auto& shared_memory_name_salt = irods::get_server_property<const std::string>(irods::KW_CFG_RE_CACHE_SALT);
         shared_memory_name = "irods_re_cache_shared_memory_" + _key + "_" + shared_memory_name_salt;
     } catch ( const irods::exception& e ) {
         rodsLog( LOG_ERROR, "getSharedMemoryName: failed to retrieve re cache salt from server_properties\n%s", e.what() );

--- a/unit_tests/src/test_server_properties.cpp
+++ b/unit_tests/src/test_server_properties.cpp
@@ -10,22 +10,22 @@ TEST_CASE("server_properties", "[exceptions]")
 {
     SECTION("exceptions include key string")
     {
-        CHECK_THROWS(irods::get_server_property<std::string>(irods::PLUGIN_TYPE_DATABASE),
-                     fmt::format("key does not exist [{}].", irods::PLUGIN_TYPE_DATABASE));
+        CHECK_THROWS(irods::get_server_property<std::string>(irods::KW_CFG_PLUGIN_TYPE_DATABASE),
+                     fmt::format("key does not exist [{}].", irods::KW_CFG_PLUGIN_TYPE_DATABASE));
     }
 
     SECTION("exceptions include key path as string")
     {
         const irods::configuration_parser::key_path_t key_path{
-            irods::CFG_PLUGIN_CONFIGURATION_KW,
-            irods::PLUGIN_TYPE_DATABASE,
-            irods::CFG_DB_PASSWORD_KW
+            irods::KW_CFG_PLUGIN_CONFIGURATION,
+            irods::KW_CFG_PLUGIN_TYPE_DATABASE,
+            irods::KW_CFG_DB_PASSWORD
         };
 
         CHECK_THROWS(irods::get_server_property<std::string>(key_path),
                      fmt::format("path does not exist [{}.{}.{}].",
-                                 irods::CFG_PLUGIN_CONFIGURATION_KW,
-                                 irods::PLUGIN_TYPE_DATABASE,
-                                 irods::CFG_DB_PASSWORD_KW));
+                                 irods::KW_CFG_PLUGIN_CONFIGURATION,
+                                 irods::KW_CFG_PLUGIN_TYPE_DATABASE,
+                                 irods::KW_CFG_DB_PASSWORD));
     }
 }

--- a/unit_tests/src/unit_test_utils.hpp
+++ b/unit_tests/src/unit_test_utils.hpp
@@ -144,7 +144,7 @@ namespace unit_test_utils
         MsParamArray *out_array = nullptr;
         const auto clear_ms_param_array = irods::at_scope_exit{[&out_array] { clearMsParamArray(out_array, true); }};
 
-        cond_input[irods::CFG_INSTANCE_NAME_KW] = "irods_rule_engine_plugin-irods_rule_language-instance";
+        cond_input[irods::KW_CFG_INSTANCE_NAME] = "irods_rule_engine_plugin-irods_rule_language-instance";
 
         const auto out_var = std::string{"*pid"};
         const auto rule_text = fmt::format("msi_get_agent_pid({});", out_var);


### PR DESCRIPTION
- Should `KW_` be used instead of `KW_CFG_`?
- Do all variables defined in irods_configuration_keywords.hpp reference a config option?

Notice that the data type for these variables has changed from `std::string` to `const char* const`. `std::string_view` would work, but it required adjusting internal APIs and function call invocations. Either way, `const char* const` provides a lot of flexibility and doesn't break existing APIs.