### PR TITLE
[#6334] Python2-syntax compat. for RPM byte-compile on centos7

### DIFF
--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -6,6 +6,7 @@ import sys
 import getpass
 import tempfile
 import json
+import six
 
 if sys.version_info >= (2, 7):
     import unittest
@@ -22,8 +23,8 @@ from . import resource_suite
 from . import session
 from .rule_texts_for_tests import rule_texts
 
-class Test_AllRules(resource_suite.ResourceBase, unittest.TestCase,
-                    metaclass = metaclass_unittest_test_case_generator.MetaclassUnittestTestCaseGenerator):
+@six.add_metaclass(metaclass_unittest_test_case_generator.MetaclassUnittestTestCaseGenerator)
+class Test_AllRules(resource_suite.ResourceBase, unittest.TestCase):
 
     class_name = 'Test_AllRules'
 

--- a/scripts/irods/test/test_icommands_file_operations.py
+++ b/scripts/irods/test/test_icommands_file_operations.py
@@ -54,13 +54,14 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
                 with tempfile.NamedTemporaryFile(prefix='test_re_serialization__prep_13') as f:
                     lib.make_file(f.name, 80, contents='arbitrary')
                     self.admin.assert_icommand(['iput', f.name])
+            time.sleep(5)
             occur = lib.count_occurrences_of_regexp_in_log( paths.server_log_path(),
-                                                            (r'^.*writeLine: inString =\s*(\S+)=(\S*).*$',re.M),
+                                                            (r'writeLine: inString =\s*(\S+)=(\S*)',re.M),
                                                             start_index=initial_size_of_server_log)
             self.assertTrue(3 == len(occur))
-            self.assertTrue(occur[0].group(1) == 'physical_path'   and occur[0].group(2).startswith(os.path.sep))
-            self.assertTrue(occur[1].group(1) == 'logical_path'    and occur[1].group(2).startswith('/'))
-            self.assertTrue(occur[2].group(1) == 'proxy_user_name' and occur[2].group(2) == self.admin.username)
+            self.assertTrue(occur[0].group(1) == b'physical_path'   and occur[0].group(2).decode('utf-8').startswith(os.path.sep))
+            self.assertTrue(occur[1].group(1) == b'logical_path'    and occur[1].group(2).startswith(b'/'))
+            self.assertTrue(occur[2].group(1) == b'proxy_user_name' and occur[2].group(2).decode('utf-8') == self.admin.username)
         finally:
             IrodsController().restart()
 
@@ -75,11 +76,12 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
                 with tempfile.NamedTemporaryFile(prefix='test_re_serialization__prep_55') as f:
                     lib.make_file(f.name, 80, contents='arbitrary')
                     self.admin.assert_icommand(['iput', f.name])
+            time.sleep(5)
             occur = lib.count_occurrences_of_regexp_in_log( paths.server_log_path(),
-                                                            (r'^.*writeLine: inString =\s*(\S+)=(\S*).*$',re.M),
+                                                            (r'writeLine: inString =\s*(\S+)=(\S*)',re.M),
                                                             start_index=initial_size_of_server_log)
             self.assertTrue(1 == len(occur))
-            self.assertTrue(occur[0].group(1) == 'user_rods_zone' and occur[0].group(2) == self.admin.zone_name)
+            self.assertTrue(occur[0].group(1) == b'user_rods_zone' and occur[0].group(2).decode('utf-8') == self.admin.zone_name)
         finally:
             IrodsController().restart()
 

--- a/scripts/irods/test/test_isysmeta.py
+++ b/scripts/irods/test/test_isysmeta.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import datetime
 import os
 import time


### PR DESCRIPTION
lack of Python2 compatibility (for metaclass and print function) were causing RPM bytecompiling to trip over some test related scripts.