### PR TITLE
Add legacy PAM plugin with new authentication plugin framework (main)

### DIFF
--- a/lib/core/include/irods/authentication_plugin_framework.hpp
+++ b/lib/core/include/irods/authentication_plugin_framework.hpp
@@ -1,64 +1,64 @@
 #ifndef IRODS_AUTHENTICATION_PLUGIN_FRAMEWORK_HPP
 #define IRODS_AUTHENTICATION_PLUGIN_FRAMEWORK_HPP
 
-#include "irods/authCheck.h"
-#include "irods/authPluginRequest.h"
-#include "irods/authRequest.h"
-#include "irods/authResponse.h"
 #include "irods/authenticate.h"
+#include "irods/getRodsEnv.h"
 #include "irods/irods_auth_constants.hpp"
-#include "irods/irods_auth_factory.hpp"
-#include "irods/irods_auth_manager.hpp"
-#include "irods/irods_auth_plugin.hpp"
-#include "irods/irods_kvp_string_parser.hpp"
-#include "irods/irods_native_auth_object.hpp"
-#include "irods/irods_stacktrace.hpp"
-#include "irods/miscServerFunct.hpp"
-#include "irods/msParam.h"
+#include "irods/irods_exception.hpp"
+#include "irods/irods_load_plugin.hpp"
+#include "irods/irods_plugin_base.hpp"
 #include "irods/rcConnect.h"
-#include "irods/rodsDef.h"
-
-#ifdef RODS_SERVER
-#include "irods/rsAuthCheck.hpp"
-#include "irods/rsAuthRequest.hpp"
-#endif // RODS_SERVER
+#include "irods/rodsErrorTable.h"
+#include "irods/version.hpp"
 
 #include <boost/any.hpp>
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
-#include <openssl/md5.h>
-
-#include <termios.h>
-#include <unistd.h>
-#include <iostream>
-#include <sstream>
+#include <functional>
 #include <string>
+#include <string_view>
+#include <vector>
+
+/// \file
 
 using json = nlohmann::json;
 
-namespace irods::experimental
+namespace irods::experimental::auth
 {
-    namespace auth
-    {
-        static const std::string flow_complete{"authentication_flow_complete"};
+    static const char* const flow_complete{"authentication_flow_complete"};
+    static const char* const next_operation{"next_operation"};
 
-        static const std::string next_operation{"next_operation"};
-    }
-
+    /// \brief Base class for authentication plugin implementations.
+    ///
+    /// \since 4.3.0
     class authentication_base : public irods::plugin_base
     {
     public:
         #define OPERATION(C, F) std::function<json(C&, const json&)>([&](C& c, const json& j) -> json {return F(c, j);})
 
+        /// \brief Constructor for the authentication plugin base class.
+        ///
+        /// \since 4.3.0
         authentication_base()
             : plugin_base{"authentication_framework_plugin", "empty_context_string"}
         {
-            add_operation(AUTH_CLIENT_START, OPERATION(rcComm_t, auth_client_start));
+            add_operation(AUTH_CLIENT_START, OPERATION(RcComm, auth_client_start));
         } // ctor
 
-        virtual json auth_client_start(rcComm_t& comm, const json& req) = 0;
+        /// Pure virtual method which all authentication plugins must implement.
+        ///
+        /// \since 4.3.0
+        virtual json auth_client_start(RcComm& _comm, const json& req) = 0;
 
+        /// \brief Add the operation captured in \p f to the plugin's operation map at key \p n.
+        ///
+        /// \param[in] n Key with which the operation will be discovered in the operation map.
+        /// \param[in] f Function object which implements the operation being added.
+        ///
+        /// \throws irods::exception If \p n is empty or already exists in the operation map.
+        ///
+        /// \since 4.3.0
         template<typename RxComm>
         void add_operation(const std::string& n, std::function<json(RxComm&, const json&)> f)
         {
@@ -66,18 +66,28 @@ namespace irods::experimental
                 THROW(SYS_INVALID_INPUT_PARAM, fmt::format("operation name is empty [{}]", n));
             }
 
-            if(operations_.find(n) != operations_.end()) {
+            if (operations_.has_entry(n)) {
                 THROW(SYS_INTERNAL_ERR, fmt::format("operation already exists [{}]", n));
             }
 
             operations_[n] = f;
         } // add_operation
 
+        /// \brief Invoke the operation at key \p n.
+        ///
+        /// param[in/out] _comm iRODS communication object.
+        /// param[in] n Key associated with the operation being invoked.
+        /// param[in] req JSON payload including the data for the operation.
+        ///
+        /// \throws irods::exception If there is no key \p n in the operations map.
+        ///
+        /// \returns JSON object representing the result of the operation.
+        ///
+        /// \since 4.3.0
         template<typename RxComm>
-        json call(RxComm& comm, const std::string& n, const json& req)
+        json call(RxComm& _comm, const std::string& n, const json& req)
         {
-            auto itr = operations_.find(n);
-            if(itr == operations_.end()) {
+            if (!operations_.has_entry(n)) {
                 THROW(SYS_INVALID_INPUT_PARAM,
                       fmt::format("call operation :: missing operation[{}]", n));
             }
@@ -85,26 +95,35 @@ namespace irods::experimental
             using fcn_t = std::function<json(RxComm&, const json&)>;
             auto op = boost::any_cast<fcn_t&>(operations_[n]);
 
-            return op(comm, req);
+            return op(_comm, req);
         } // call
     }; // class authentication_base
 
-    auto resolve_authentication_plugin(const std::string& scheme, const std::string& type)
+    /// \brief Resolve the authentication plugin with \p _scheme of \p _type "client" or "server".
+    ///
+    /// \param[in] _scheme The authentication scheme whose plugin is being loaded.
+    /// \param[in] _type A string which indicates the type of the plugin ("client" or "server").
+    ///
+    /// \throws irods::exception If loading the plugin is unsuccessful.
+    ///
+    /// \returns The authentication plugin object (descendant of \p authentication_base).
+    ///
+    /// \since 4.3.0
+    auto resolve_authentication_plugin(const std::string& _scheme, const std::string& _type)
     {
-        using plugin_type = irods::experimental::authentication_base;
+        using plugin_type = authentication_base;
 
-        std::string lower = scheme;
-        std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+        std::string scheme = _scheme;
+        std::transform(scheme.begin(), scheme.end(), scheme.begin(), ::tolower);
 
-        const std::string name = fmt::format("irods_auth_plugin-{}_{}", lower, type);
+        const std::string name = fmt::format("irods_auth_plugin-{}_{}", scheme, _type);
 
         plugin_type* plugin{};
-        auto err = irods::load_plugin<plugin_type>(
-                        plugin,
-                        name,
-                        irods::KW_CFG_PLUGIN_TYPE_AUTHENTICATION,
-                        name,
-                        "empty_context");
+        auto err = irods::load_plugin<plugin_type>(plugin,
+                                                   name,
+                                                   irods::KW_CFG_PLUGIN_TYPE_AUTHENTICATION,
+                                                   name,
+                                                   "empty_context");
         if(!err.ok()) {
             THROW(err.code(), err.result());
         }
@@ -112,12 +131,33 @@ namespace irods::experimental
         return plugin;
     } // resolve_authentication_plugin
 
-    void authenticate_client(rcComm_t& comm, const rodsEnv& env)
+    /// \brief Authenticate the client indicated by \p _comm with scheme \p _env.
+    ///
+    /// \parblock
+    /// Starting with the operation indicated by \p irods::AUTH_CLIENT_START in the operation
+    /// map of the authentication plugin, this function loops until the response from an
+    /// invoked operation in the plugin returns a "next_operation" of \p auth::flow_complete.
+    /// At that time, \p _comm.loggedIn should be set to 1 (or anything other than 0) and the
+    /// client is considered authenticated.
+    ///
+    /// This function acts as the interface to the authentication plugins much like
+    /// \p clientLogin was the interface for the legacy authentication plugins.
+    /// \endparblock
+    ///
+    /// \param[in/out] _comm iRODS communication object.
+    /// \param[in] _env Environment object from which the authentication scheme is retrieved.
+    /// \param[in] _ctx JSON object which includes information for the authentication plugin.
+    ///
+    /// \throws irods::exception \parblock
+    /// - If the authentication plugin cannot be resolved
+    /// - If an operation fails to set "next_operation" to a non-empty string in its response
+    /// - If the flow is completed with \p !_comm.loggedIn
+    /// \endparblock
+    ///
+    /// \since 4.3.0
+    void authenticate_client(RcComm& _comm, const RodsEnvironment& _env, const json& _ctx)
     {
-        // example native authentication scheme: irods-authentication_plugin-native
-        std::string scheme{env.rodsAuthScheme};
-
-        // TODO:: make some decisions about auth scheme?
+        std::string scheme = _env.rodsAuthScheme;
 
         auto auth = resolve_authentication_plugin(scheme, "client");
 
@@ -128,21 +168,25 @@ namespace irods::experimental
         req["scheme"] = scheme;
         req[auth::next_operation] = *next_operation;
 
-        while (true) {
-            resp = auth->call(comm, *next_operation, req);
+        for (const auto& [k, v] : _ctx.items()) {
+            req[k] = v;
+        }
 
-            if(comm.loggedIn) {
+        while (true) {
+            resp = auth->call(_comm, *next_operation, req);
+
+            if (_comm.loggedIn) {
                 break;
             }
 
-            if(!resp.contains(auth::next_operation)) {
+            if (!resp.contains(auth::next_operation)) {
                 THROW(SYS_INVALID_INPUT_PARAM, fmt::format(
                       "authentication request missing [{}] parameter",
                       auth::next_operation));
             }
 
             next_operation = resp.at(auth::next_operation).get_ptr<std::string*>();
-            if(next_operation->empty() || auth::flow_complete == *next_operation) {
+            if (next_operation->empty() || auth::flow_complete == *next_operation) {
                 THROW(CAT_INVALID_AUTHENTICATION,
                       "authentication flow completed without success");
             }
@@ -150,6 +194,88 @@ namespace irods::experimental
             req = resp;
         }
     } // authenticate_client
-} // namespace irods::experimental
+
+    /// \brief Return true if server version is too old for authentication plugin framework.
+    ///
+    /// \param[in] _comm The comm object from which version information is derived.
+    ///
+    /// \retval true If server version is less than 4.3.0
+    /// \retval false If server version is greater than or equal to 4.3.0
+    ///
+    /// \since 4.3.0
+    auto use_legacy_authentication(const RcComm& _comm) -> bool
+    {
+        static constexpr auto minimum_version_for_auth_plugin_framework = irods::version{4, 3, 0};
+
+        const auto server_version = irods::to_version(_comm.svrVersion->relVersion);
+        if (!server_version) {
+            THROW(VERSION_EMPTY_IN_STRUCT_ERR, fmt::format(
+                  "Failed to get version from server [{}]\n",
+                  _comm.svrVersion->relVersion));
+        }
+
+        return *server_version < minimum_version_for_auth_plugin_framework;
+    } // use_legacy_authentication
+
+    /// \brief Convenience function for invoking the authentication API endpoint.
+    ///
+    /// \param[in/out] _comm
+    /// \param[in] _msg JSON-based request message to send to the server.\parblock
+    ///
+    /// Depending on the step in the authentication flow for the given plugin, certain keys
+    /// must be present in order for the request to be processed.
+    /// \endparblock
+    ///
+    /// \throws irods::exception If the API request returns with a non-zero code
+    ///
+    /// \return JSON response from the server which may be built upon for the next request
+    ///
+    /// \since 4.3.0
+    auto request(rcComm_t& _comm, const json& _msg)
+    {
+        constexpr int authentication_api_number = 110000;
+
+        auto str = _msg.dump();
+
+        bytesBuf_t inp;
+        inp.buf = static_cast<void*>(const_cast<char*>(str.c_str()));
+        inp.len = str.size();
+
+        bytesBuf_t* resp{};
+        auto ec = procApiRequest(&_comm,
+                                 authentication_api_number,
+                                 static_cast<void*>(&inp),
+                                 nullptr,
+                                 reinterpret_cast<void**>(&resp),
+                                 nullptr);
+
+        if (ec < 0) {
+            THROW(ec, "failed to perform request");
+        }
+
+        return json::parse(static_cast<char*>(resp->buf),
+                           static_cast<char*>(resp->buf) + resp->len);
+    } // request
+
+    /// \brief Throw if request message is missing a required key
+    ///
+    /// \param[in] _msg JSON structure in which \p _required_keys must be found
+    /// \param[in] _required_keys Vector of keys which must be found in \p _msg
+    ///
+    /// \throw irods::exception On first key in \p _required_keys not contained in \p _msg
+    ///
+    /// \since 4.3.0
+    inline auto throw_if_request_message_is_missing_key(
+        const json& _msg,
+        const std::vector<std::string_view>& _required_keys) -> void
+    {
+        for (const auto& k : _required_keys) {
+            if (!_msg.contains(k.data())) {
+                THROW(SYS_INVALID_INPUT_PARAM, fmt::format(
+                      "missing [{}] in request", __func__, __LINE__, k));
+            }
+        }
+    } // throw_if_request_message_is_missing_key
+} // namespace irods::experimental::auth
 
 #endif // IRODS_AUTHENTICATION_PLUGIN_FRAMEWORK_HPP

--- a/lib/core/src/obf.cpp
+++ b/lib/core/src/obf.cpp
@@ -165,7 +165,9 @@ obfGetPw( char *pw ) {
     int i;
     int envVal;
 
-    strcpy( pw, "" );
+    if (pw) {
+        strcpy( pw, "" );
+    }
 
     envVal = obfiGetEnvKey();
 
@@ -199,7 +201,10 @@ obfGetPw( char *pw ) {
     if ( obfDebug ) {
         printf( "out:%s\n", myPwD );
     }
-    strcpy( pw, myPwD );
+
+    if (pw) {
+        strcpy( pw, myPwD );
+    }
 
     return 0;
 }

--- a/plugins/auth/CMakeLists.txt
+++ b/plugins/auth/CMakeLists.txt
@@ -9,6 +9,7 @@ add_dependencies(all-plugins_no_database all-plugins-auth)
 set(
   IRODS_AUTH_PLUGINS
   native
+  pam
 )
 
 foreach(plugin IN LISTS IRODS_AUTH_PLUGINS)

--- a/plugins/auth/src/pam.cpp
+++ b/plugins/auth/src/pam.cpp
@@ -1,0 +1,341 @@
+#include "irods/authentication_plugin_framework.hpp"
+
+#define USE_SSL 1
+#include "irods/sslSockComm.h"
+
+#include "irods/icatHighLevelRoutines.hpp"
+#include "irods/irods_at_scope_exit.hpp"
+#include "irods/irods_auth_constants.hpp"
+#include "irods/irods_client_server_negotiation.hpp"
+#include "irods/irods_logger.hpp"
+#include "irods/irods_pam_auth_object.hpp"
+#include "irods/rcConnect.h"
+
+#include <boost/lexical_cast.hpp>
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <string>
+#include <termios.h>
+#include <unistd.h>
+
+namespace
+{
+    namespace irods_auth = irods::experimental::auth;
+    using json = nlohmann::json;
+
+    auto get_password_from_client_stdin() -> std::string
+    {
+        struct termios tty;
+        tcgetattr(STDIN_FILENO, &tty);
+        tcflag_t oldflag = tty.c_lflag;
+        tty.c_lflag &= ~ECHO;
+        int error = tcsetattr(STDIN_FILENO, TCSANOW, &tty);
+        int errsv = errno;
+
+        if (error) {
+            printf("WARNING: Error %d disabling echo mode. Password will be displayed in plaintext.", errsv);
+        }
+        printf("Enter your current PAM password:");
+        std::string password;
+        getline(std::cin, password);
+        char new_password[MAX_PASSWORD_LEN + 2]{};
+        strncpy(new_password, password.c_str(), MAX_PASSWORD_LEN);
+        printf("\n");
+        tty.c_lflag = oldflag;
+        if (tcsetattr(STDIN_FILENO, TCSANOW, &tty)) {
+            printf( "Error reinstating echo mode." );
+        }
+
+        return new_password;
+    } // get_password_from_client_stdin
+
+#ifdef RODS_SERVER
+    auto run_pam_auth_check(const std::string& _username, const std::string& _password) -> void
+    {
+        // TODO why do we need a separate executable?
+#ifndef PAM_AUTH_CHECK_PROG
+#define PAM_AUTH_CHECK_PROG  "./irodsPamAuthCheck"
+#endif
+
+        // pipe between parent and child processes to which the password will be written
+        // Do not attempt to close the pipe at any ol' scope exit. Rather, only close the pipe
+        // when we are done with it or if an early exit occurs.
+        int p2cp[2]{};
+        if (pipe(p2cp) < 0) {
+            THROW(SYS_PIPE_ERROR, "failed to open pipe");
+        }
+
+        int pid = fork();
+        if (pid == -1) {
+            close(p2cp[1]);
+            THROW(SYS_FORK_ERROR, "failed to fork process");
+        }
+
+        // parent process
+        if (pid) {
+            if (write(p2cp[1], _password.c_str(), _password.size()) == -1) {
+                int errsv = errno;
+                irods::log(ERROR(errsv, "Error writing from parent to child."));
+            }
+            close(p2cp[1]);
+
+            int ec = 0;
+            waitpid(pid, &ec, 0);
+
+            // anything other than 0 indicates that an error occurred.
+            if (0 == ec) {
+                return;
+            }
+
+            // what is 256?
+            if (256 == ec) {
+                THROW(PAM_AUTH_PASSWORD_FAILED, "pam auth check failed");
+            }
+
+            THROW(ec, "pam auth check failed");
+        }
+
+        // child process
+        if (dup2(p2cp[0], STDIN_FILENO) == -1) {
+            int errsv = errno;
+            irods::log(ERROR(errsv, "Error duplicating the file descriptor."));
+        }
+        close(p2cp[1]);
+
+        // From the docs...
+        //
+        // The exec() functions only return if an error has occurred.
+        // The return value is -1, and errno is set to indicate the error.
+        //
+        // The list of arguments must be terminated by a NULL pointer, and, since these are
+        // variadic functions, this pointer must be cast (char *) NULL.
+        execl(PAM_AUTH_CHECK_PROG, PAM_AUTH_CHECK_PROG, _username.c_str(), (char*)NULL);
+
+        THROW(SYS_FORK_ERROR, fmt::format("execl failed [errno:{}]", errno));
+    } // run_pam_auth_check
+#endif // #ifdef RODS_SERVER
+} // anonymous namespace
+
+namespace irods
+{
+    class pam_authentication : public irods_auth::authentication_base {
+    private:
+        static constexpr char* perform_native_auth = "perform_native_auth";
+
+    public:
+        pam_authentication()
+        {
+            add_operation(AUTH_CLIENT_AUTH_REQUEST,  OPERATION(rcComm_t, pam_auth_client_request));
+            add_operation(perform_native_auth,       OPERATION(rcComm_t, pam_auth_client_perform_native_auth));
+#ifdef RODS_SERVER
+            add_operation(AUTH_AGENT_AUTH_REQUEST,   OPERATION(rsComm_t, pam_auth_agent_request));
+#endif
+        } // ctor
+
+    private:
+        json auth_client_start(rcComm_t& comm, const json& req)
+        {
+            json resp{req};
+            resp["user_name"] = comm.proxyUser.userName;
+            resp["zone_name"] = comm.proxyUser.rodsZone;
+
+            // This is used for CLI argument-passed passwords, which is a very, very bad idea.
+            const auto v = req.find(irods::AUTH_PASSWORD_KEY);
+            const bool password_provided_in_request = req.end() != v;
+            const bool provided_password_is_empty = password_provided_in_request &&
+                                                    v->get_ref<const std::string&>().empty();
+
+            if (!password_provided_in_request || provided_password_is_empty) {
+                // obfGetPw returns 0 if the password is retrieved successfully. Therefore, we
+                // do NOT need a password in this case. This being the case, we conclude that
+                // the user has already been authenticated via PAM with the server. We proceed
+                // with steps for native authentication which will use the stored password. This
+                // is the legacy behavior for the PAM authentication plugin.
+                if (const bool need_password = obfGetPw(nullptr); !need_password) {
+                    resp[irods_auth::next_operation] = perform_native_auth;
+                    return resp;
+                }
+
+                // There's no password stored, so we need to prompt the client for one.
+                resp[irods::AUTH_PASSWORD_KEY] = get_password_from_client_stdin();
+            }
+
+            // Need to perform the PAM authentication steps before we authenticate with the
+            // iRODS server. Take the stored password and check it with PAM. After this checks
+            // out, the native authentication steps will be performed.
+            resp[irods_auth::next_operation] = AUTH_CLIENT_AUTH_REQUEST;
+
+            return resp;
+        } // auth_client_start
+
+        json pam_auth_client_request(rcComm_t& comm, const json& req)
+        {
+            json svr_req{req};
+
+            svr_req[irods_auth::next_operation] = AUTH_AGENT_AUTH_REQUEST;
+
+            // Need to enable SSL here if it is not already being used because the PAM password
+            // is sent to the server in the clear.
+            const bool using_ssl = irods::CS_NEG_USE_SSL == comm.negotiation_results;
+            const auto end_ssl_if_we_enabled_it = irods::at_scope_exit{[&comm, using_ssl] {
+                if (!using_ssl)  {
+                    sslEnd(&comm);
+                }
+            }};
+
+            if (!using_ssl) {
+                if (const int ec = sslStart(&comm); ec) {
+                    THROW(ec, "failed to enable SSL");
+                }
+            }
+
+            auto resp = irods_auth::request(comm, svr_req);
+
+            irods_auth::throw_if_request_message_is_missing_key(
+                resp, {"request_result"}
+            );
+
+            // Save the PAM password-based generated password so that the client remains
+            // authenticated with the server while the password is still valid.
+            //
+            // TODO: we should only perform this step if running iinit. The auth plugins
+            // should support an option which instruct it to save the password (doesn't save
+            // it by default). The result is that running ils and entering the password will
+            // save the password. Maybe this a good thing, but does not reflect the historic
+            // behavior.
+            const auto& pw = resp.at("request_result").get_ref<const std::string&>();
+            if (const int ec = obfSavePw(0, 0, 0, pw.data()); ec < 0) {
+                THROW(ec, "failed to save obfuscated password");
+            }
+
+            // Now that the password has been vetted with PAM and found to be good, the newly
+            // generated password in the server can be used to authenticate with the iRODS
+            // server.
+            resp[irods_auth::next_operation] = perform_native_auth;
+
+            return resp;
+        } // pam_auth_client_request
+
+        json pam_auth_client_perform_native_auth(rcComm_t& comm, const json& req)
+        {
+            // This operation is basically just running the entire native authentication flow
+            // because this is how the PAM authentication plugin has worked historically. This
+            // is done in order to minimize communications with the PAM server as iRODS does
+            // not use proper "sessions".
+            json resp{req};
+
+            static constexpr char* auth_scheme_native = "native";
+            rodsEnv env{};
+            std::strncpy(env.rodsAuthScheme, auth_scheme_native, NAME_LEN);
+            irods_auth::authenticate_client(comm, env, json{});
+
+            // If everything completes successfully, the flow is completed and we can
+            // consider the user "logged in". Again, the entire native authentication flow
+            // was run and so we trust the result.
+            resp[irods_auth::next_operation] = irods_auth::flow_complete;
+
+            comm.loggedIn = 1;
+
+            return resp;
+        } // pam_auth_client_perform_native_auth
+
+#ifdef RODS_SERVER
+        json pam_auth_agent_request(rsComm_t& comm, const json& req)
+        {
+            using log_auth = irods::experimental::log::authentication;
+
+            const std::vector<std::string_view> required_keys{"user_name",
+                                                              "zone_name",
+                                                              irods::AUTH_PASSWORD_KEY};
+            irods_auth::throw_if_request_message_is_missing_key(
+                req, required_keys
+            );
+
+            rodsServerHost_t* host = nullptr;
+
+            log_auth::trace("connecting to catalog provider");
+
+            if (const int ec = getAndConnRcatHost(&comm, MASTER_RCAT, comm.clientUser.rodsZone, &host); ec < 0) {
+                THROW(ec, "getAndConnRcatHost failed.");
+            }
+
+            if (LOCAL_HOST != host->localFlag) {
+                const auto disconnect = irods::at_scope_exit{[host]
+                    {
+                        rcDisconnect(host->conn);
+                        host->conn = nullptr;
+                    }
+                };
+
+                log_auth::trace("redirecting call to CSP");
+
+                if (const auto ec = sslStart(host->conn); ec) {
+                    THROW(ec, "could not establish SSL connection");
+                }
+
+                const auto end_ssl = irods::at_scope_exit{[host] { sslEnd(host->conn); }};
+
+                return irods_auth::request(*host->conn, req);
+            }
+
+            json resp{req};
+
+            log_auth::trace("getting TTL param");
+
+            int ttl = 0;
+            if (req.contains(irods::AUTH_TTL_KEY)) {
+                if (const auto& ttl_str = req.at(irods::AUTH_TTL_KEY).get_ref<const std::string&>();
+                    !ttl_str.empty()) {
+                    try {
+                        ttl = boost::lexical_cast<int>(ttl_str);
+                    }
+                    catch (const boost::bad_lexical_cast& e) {
+                        THROW(SYS_INVALID_INPUT_PARAM, fmt::format("invalid TTL [{}]", ttl_str));
+                    }
+                }
+            }
+
+            const auto username = req.at("user_name").get_ref<const std::string&>();
+            const auto password = req.at(irods::AUTH_PASSWORD_KEY).get_ref<const std::string&>();
+
+            log_auth::trace("performing PAM auth check for [{}]", username);
+
+            run_pam_auth_check(username, password);
+
+            log_auth::trace("PAM auth check done", username);
+
+            char password_out[MAX_NAME_LEN]{};
+            char* pw_ptr = &password_out[0];
+            const int ec = chlUpdateIrodsPamPassword(&comm,
+                                                     const_cast<char*>(username.c_str()),
+                                                     ttl,
+                                                     nullptr,
+                                                     &pw_ptr);
+            if (ec < 0) {
+                THROW(ec, "failed updating iRODS pam password");
+            }
+
+            resp["request_result"] = password_out;
+
+            if (comm.auth_scheme) {
+                free(comm.auth_scheme);
+            }
+
+            static constexpr char* auth_scheme_pam = "pam";
+            comm.auth_scheme = strdup(auth_scheme_pam);
+
+            return resp;
+        } // pam_auth_agent_request
+#endif // #ifdef RODS_SERVER
+    }; // class pam_authentication
+} // namespace irods
+
+extern "C"
+irods::pam_authentication* plugin_factory(const std::string&, const std::string&)
+{
+    return new irods::pam_authentication{};
+}


### PR DESCRIPTION
I'm going to leave this in draft for now as this is still being tested.

Currently, the name of this plugin is "pam". We have discussed using "pam_password" for this as the "interactive" PAM plugin being developed in the Authentication Working Group will completely replace this later, and the existing implementation is a simple password verification.

Also up for discussion: Should this be a separate plugin which exists outside of the main server?