### PR TITLE
Various authentication plugin fixes (main)

### DIFF
--- a/lib/core/include/irods/authentication_plugin_framework.hpp
+++ b/lib/core/include/irods/authentication_plugin_framework.hpp
@@ -163,14 +163,10 @@ namespace irods::experimental::auth
 
         const std::string* next_operation = &irods::AUTH_CLIENT_START;
 
-        json req{}, resp{};
+        json req{_ctx}, resp{};
 
         req["scheme"] = scheme;
         req[auth::next_operation] = *next_operation;
-
-        for (const auto& [k, v] : _ctx.items()) {
-            req[k] = v;
-        }
 
         while (true) {
             resp = auth->call(_comm, *next_operation, req);

--- a/lib/core/include/irods/authentication_plugin_framework.hpp
+++ b/lib/core/include/irods/authentication_plugin_framework.hpp
@@ -28,6 +28,7 @@ namespace irods::experimental::auth
 {
     static const char* const flow_complete{"authentication_flow_complete"};
     static const char* const next_operation{"next_operation"};
+    static const char* const force_password_prompt{"force_password_prompt"};
 
     /// \brief Base class for authentication plugin implementations.
     ///

--- a/lib/core/src/clientLogin.cpp
+++ b/lib/core/src/clientLogin.cpp
@@ -361,7 +361,7 @@ int clientLogin(rcComm_t* _comm, const char* _context, const char* _scheme_overr
                 std::strncpy(env.rodsAuthScheme, auth_scheme.data(), NAME_LEN);
             }
 
-            return authenticate_with_plugin_framework(*_comm, env, _context ? json{_context} : json{});
+            return authenticate_with_plugin_framework(*_comm, env, _context ? json::parse(_context) : json{});
         }
         catch (const irods::exception& e) {
             const auto ec = e.code();

--- a/lib/core/src/clientLogin.cpp
+++ b/lib/core/src/clientLogin.cpp
@@ -373,6 +373,16 @@ int clientLogin(rcComm_t* _comm, const char* _context, const char* _scheme_overr
 
             return ec;
         }
+        catch (const json::exception& e) {
+            const auto ec = SYS_LIBRARY_ERROR;
+            const std::string msg = fmt::format("JSON error occurred: [{}]", e.what());
+
+            log_auth::info(msg);
+
+            printError(_comm, ec, const_cast<char*>(msg.data()));
+
+            return ec;
+        }
     }
 
     // =-=-=-=-=-=-=-

--- a/lib/core/src/getRodsEnv.cpp
+++ b/lib/core/src/getRodsEnv.cpp
@@ -699,12 +699,10 @@ extern "C" {
                 strlen( rodsEnvArg->rodsZone ) > 0 ) {
             snprintf( rodsEnvArg->rodsHome,  MAX_NAME_LEN, "/%s/home/%s",
                         rodsEnvArg->rodsZone, rodsEnvArg->rodsUserName );
-            rodsLog( LOG_NOTICE, "created irodsHome=%s", rodsEnvArg->rodsHome );
         }
         if ( strlen( rodsEnvArg->rodsCwd ) == 0 &&
                 strlen( rodsEnvArg->rodsHome ) > 0 ) {
             rstrcpy( rodsEnvArg->rodsCwd, rodsEnvArg->rodsHome, MAX_NAME_LEN );
-            rodsLog( LOG_NOTICE, "created irodsCwd=%s", rodsEnvArg->rodsCwd );
         }
 
         return 0;

--- a/lib/core/src/irods_server_properties.cpp
+++ b/lib/core/src/irods_server_properties.cpp
@@ -214,13 +214,17 @@ namespace irods
         std::string svr_fn;
         irods::error ret = irods::get_full_path_for_config_file(SERVER_CONFIG_FILE, svr_fn);
         if (!ret.ok()) {
-            return;
+            THROW(ret.code(),
+                  fmt::format("[{}:{}] - Failed to find server config file [{}]", __func__, __LINE__, ret.result()));
         }
 
         std::ifstream svr{svr_fn};
-        if (svr.is_open()) {
-            config_props_ = json::parse(svr);
+
+        if (!svr) {
+            THROW(FILE_OPEN_ERR, fmt::format("[{}:{}] - Failed to open server config file", __func__, __LINE__));
         }
+
+        config_props_ = json::parse(svr);
     } // capture
 
     void server_properties::remove(const std::string& _key)

--- a/plugins/auth/src/native.cpp
+++ b/plugins/auth/src/native.cpp
@@ -66,11 +66,11 @@ namespace irods
 
         json native_auth_establish_context(rcComm_t&, const json& req)
         {
-            json resp{req};
-
             irods_auth::throw_if_request_message_is_missing_key(
                 req, {"user_name", "zone_name", "request_result"}
             );
+
+            json resp{req};
 
             auto request_result = req.at("request_result").get<std::string>();
             request_result.resize(CHALLENGE_LEN);
@@ -112,6 +112,7 @@ namespace irods
                 std::string password{};
                 getline(std::cin, password);
                 strncpy(md5_buf + CHALLENGE_LEN, password.c_str(), MAX_PASSWORD_LEN);
+                fmt::print("\n");
                 tty.c_lflag = oldflag;
                 if (tcsetattr(STDIN_FILENO, TCSANOW, &tty)) {
                     fmt::print("Error reinstating echo mode.");

--- a/scripts/core_tests_list.json
+++ b/scripts/core_tests_list.json
@@ -1,5 +1,6 @@
 [
     "test_all_rules",
+    "test_auth",
     "test_catalog",
     "test_collection_mtime",
     "test_control_plane",

--- a/scripts/irods/test/resource_suite.py
+++ b/scripts/irods/test/resource_suite.py
@@ -337,7 +337,9 @@ class ResourceSuite(ResourceBase):
                     filepath = lib.create_local_testfile(filename)
                     IrodsController().restart(test_mode=True)
 
-                    self.admin.assert_icommand(['iinit', self.admin.password])
+                    self.admin.assert_icommand('iinit', 'STDOUT_SINGLELINE',
+                                               'Enter your current iRODS password:',
+                                               input=f'{self.admin.password}\n')
                     self.admin.assert_icommand(['iput', filename])
                     self.admin.assert_icommand(['ils', '-L', filename], 'STDOUT_SINGLELINE', filename)
 
@@ -400,7 +402,9 @@ class ResourceSuite(ResourceBase):
                             ).restart(test_mode=True)
 
                     # reinitialize
-                    self.admin.assert_icommand(['iinit', self.admin.password])
+                    self.admin.assert_icommand('iinit', 'STDOUT_SINGLELINE',
+                                               'Enter your current iRODS password:',
+                                               input=f'{self.admin.password}\n')
 
                     #
                     # do the encrypted put

--- a/scripts/irods/test/session.py
+++ b/scripts/irods/test/session.py
@@ -100,7 +100,8 @@ class IrodsSession(object):
         self._session_id = datetime.datetime.utcnow().strftime('%Y-%m-%dZ%H:%M:%S--') + os.path.basename(self._local_session_dir)
 
         if self._password is not None:
-            self.assert_icommand(['iinit', self._password])
+            self.assert_icommand('iinit', 'STDOUT_SINGLELINE',
+                                 input=f'{self._password}\n')
         if self._manage_irods_data:
             self.assert_icommand(['imkdir', self.session_collection])
             self.assert_icommand(['icd', self.session_collection])


### PR DESCRIPTION
Companion PR: https://github.com/irods/irods_client_icommands/pull/300

Two commits in the middle seem contradictory because they are. I wasn't sure if we wanted to support the password keyword in the pam_password plugin or not. I think this is only being used by `iinit` and that support is being removed in the referenced issue, #6382... but just in case I left support for it there.

Should we support the password key in the request message to the PAM plugin? If so, I will squash the two commits referencing #6382. If not, I will delete the second commit.

Still need to run through tests, but works when tested by hand