### PR TITLE
Configuration reload [#5821] 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ packaging/unattended_setup.json
 .ycm_extra_conf.py
 compile_commands.json
 CMakeLists.txt.user
+*.~undo-tree~
 
 # old submodule
 /irods_schema_messaging

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(
   "${CMAKE_CURRENT_SOURCE_DIR}/src/irods_stacktrace.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/irods_string_tokenize.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/irods_virtual_path.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/json_events.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/key_value_proxy.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/list.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/msParam.cpp"

--- a/lib/core/include/irods/json_events.hpp
+++ b/lib/core/include/irods/json_events.hpp
@@ -1,0 +1,114 @@
+#ifndef IRODS_JSON_EVENTS_HPP
+#define IRODS_JSON_EVENTS_HPP
+
+/// \file
+
+#include <nlohmann/json.hpp>
+
+#include <vector>
+#include <string>
+#include <unordered_map>
+
+namespace irods::experimental::json_events
+{
+    /// \brief The string used for the catch-all hooks that are called on every configuration change.
+    /// \see hook
+    extern const std::string KW_ALL_KEYS;
+
+    /// \brief Hooks are functions called with the pathname of the json value that
+    /// has changed, as well as the new operation performed, removal versus
+    /// replacement versus insertion etc.
+    ///
+    /// Hooks are invoked in two stages for each entry in a list of json patches.
+    ///
+    /// The first is the \p KW_ALL_KEYS stage, where hooks that are run for every
+    /// configuration change occurs. The second is based on the specific json
+    /// path of the changed configuration value.
+    ///
+    /// For example, if you change the delay server's sleep duration, the
+    /// \p KW_ALL_KEYS hooks will be run first in order of addition, followed by
+    /// the hooks associated with
+    /// "/advanced_settings/delay_server_sleep_time_in_seconds", also in order
+    /// of addition.
+    using hook = std::function<void(const std::string&, const nlohmann::json&)>;
+
+    namespace detail
+    {
+        std::vector<hook>& get_hooks();
+        std::unordered_multimap<std::string, std::size_t>& get_edge_sets();
+    } // namespace detail
+
+    /// \brief Adds a hook to be run whenever a key on the list of hooks changes.
+    ///        \see hook
+    ///
+    /// \param [in] hook_triggers An array or container of json paths to match, this
+    ///             container must support begin and end iterators.
+    ///
+    ///             The special value \p KW_ALL_KEYS matches any property that has changed and gets run first
+    /// \param [in] hook The function to run when the json path matches.
+    ///
+    /// \b Example
+    /// \code{.cpp}
+    /// namespace je = irods::experimental::json_events;
+    ///
+    /// je::add_hook({je::KW_ALL_KEYS}, [&](const std::string& json_path,
+    ///                                     const nlohmann::json& json_patch_op)
+    /// {
+    ///     if(json_path.substr(0,29) != "/example_configuration_object") {
+    ///         return;
+    ///     }
+    ///     handle_update(json_patch_op);
+    /// });
+    ///
+    /// je::add_hook({"/example_configuration_object/circumference_to_diameter_ratio"},
+    ///               [](const std::string& json_path, const nlohmann::json& json_patch_op)
+    /// {
+    ///     // Update the "PI" global value in the static lua state.
+    ///     if(json_patch_op.at("op")=="insert"||json_patch_op.at("op")=="replace"){
+    ///         lua_pushnumber( Lua_state, json_patch_op.at("value").get<double>());
+    ///         lua_setglobal( Lua_state, "PI");
+    ///     }
+    /// });
+    /// je::run_hooks({{"path","/example_configuration_object/circumference_to_diameter_ratio"},
+    ///                {"op","replace"}, {"value",4}});
+    /// \endcode
+    void add_hook(const auto& hook_triggers, hook&& hook)
+    {
+        using namespace irods::experimental::json_events::detail;
+        auto& hooks = get_hooks();
+        auto& edge_sets = get_edge_sets();
+        size_t id = hooks.size();
+        // Take ownership, we don't need to deal with any missing closures.
+        // those can be nasty to debug.
+        hooks.emplace_back(std::move(hook));
+        for (const auto& name : hook_triggers) {
+            edge_sets.insert(std::make_pair(name, id));
+        }
+    }
+
+    /// \brief Run the hooks, the changes are a list of json patches.
+    ///
+    /// \param [in] changes The list of changes in json patch format, see
+    /// RFC6902 for more details about that format.
+    ///
+    /// \code{.cpp}
+    /// namespace je = irods::experimental::json_events;
+    ///
+    /// je::add_hook({je::KW_ALL_KEYS},
+    ///              [](const std::string& json_path, const nlohmann::json& patch)
+    /// {
+    ///    std::cout << patch << std::endl;
+    /// });
+    /// // Simulate changing the delay server sleep interval
+    /// je::run_hooks({{"path", "/advanced_settings/delay_server_sleep_time_in_seconds"},
+    ///                {"op", "replace"},{"value", 12}});
+    /// \endcode
+    /// Change the delay_server_sleep_time_in_seconds in the configuration and send a
+    /// SIGHUP signal to the toplevel irods process. The server should write
+    /// something like
+    /// `{ "path":"/advanced_settings/delay_server_sleep_time_in_seconds",
+    ///    "op":"replace", "value":12 }` to stdout.
+    void run_hooks(const nlohmann::json& changes);
+} // namespace irods::experimental::json_events
+
+#endif // IRODS_JSON_EVENTS_HPP

--- a/lib/core/src/json_events.cpp
+++ b/lib/core/src/json_events.cpp
@@ -1,0 +1,49 @@
+#include "irods/json_events.hpp"
+
+namespace irods::experimental::json_events
+{
+    const std::string KW_ALL_KEYS("ALL_KEYS");
+
+    namespace detail
+    {
+        // This is where the function objects are stored, given that they will not be removed or reordered, their index
+        // is what edge_sets' value refers to.
+        std::vector<hook> hooks;
+        // Edge sets, as in edge-triggered, contains an association between the changed property and an index into
+        // hooks.
+        std::unordered_multimap<std::string, std::size_t> edge_sets;
+
+        std::vector<hook>& get_hooks()
+        {
+            return hooks;
+        }
+
+        std::unordered_multimap<std::string, size_t>& get_edge_sets()
+        {
+            return edge_sets;
+        }
+    } // namespace detail
+
+    void run_hooks(const nlohmann::json& changes)
+    {
+        using namespace irods::experimental::json_events::detail;
+
+        // The ALL_KEYS hook is triggered on every change in configuration value.
+        auto all_key_hooks = edge_sets.equal_range(KW_ALL_KEYS);
+        auto& hooks = get_hooks();
+        auto& edge_sets = get_edge_sets();
+
+        for (const auto& operation : changes) {
+            const std::string& name = operation.at("path").get_ref<const std::string&>();
+
+            for (auto it = all_key_hooks.first; it != all_key_hooks.second; ++it) {
+                hooks[it->second](name, operation);
+            }
+
+            auto range = edge_sets.equal_range(name);
+            for (auto it = range.first; it != range.second; ++it) {
+                hooks[it->second](name, operation);
+            }
+        }
+    }
+} // namespace irods::experimental::json_events

--- a/plugins/microservices/CMakeLists.txt
+++ b/plugins/microservices/CMakeLists.txt
@@ -16,6 +16,7 @@ set(
   get_open_data_obj_l1desc_index
   get_file_descriptor_info
   get_hostname
+  get_server_property
 )
 
 foreach(plugin IN LISTS IRODS_MICROSERVICE_PLUGINS)

--- a/plugins/microservices/src/get_server_property.cpp
+++ b/plugins/microservices/src/get_server_property.cpp
@@ -1,0 +1,105 @@
+#include "irods/irods_server_properties.hpp"
+#include "irods/irods_ms_plugin.hpp"
+#include "irods/irods_re_structs.hpp"
+#include "irods/msParam.h"
+#include "irods/rodsErrorTable.h"
+#include "irods/irods_error.hpp"
+#include "irods/irods_logger.hpp"
+
+#include <exception>
+#include <functional>
+#include <string>
+
+namespace
+{
+    using log_msi = irods::experimental::log::microservice;
+
+    auto msi_impl(msParam_t* _in_name, msParam_t* _out_value, ruleExecInfo_t* rei) -> int
+    {
+        if (!rei || !rei->rsComm) {
+            log_msi::error("msi_get_server_property: input rei or rsComm is NULL.");
+            return SYS_INTERNAL_NULL_INPUT_ERR;
+        }
+
+        // ensure that this user is an admin
+        if (rei->uoic->authInfo.authFlag < LOCAL_PRIV_USER_AUTH) {
+            log_msi::error("msi_get_server_property: User {} is not local admin. status = {}",
+                           rei->uoic->userName,
+                           CAT_INSUFFICIENT_PRIVILEGE_LEVEL);
+            return CAT_INSUFFICIENT_PRIVILEGE_LEVEL;
+        }
+
+        try {
+            const std::string name = parseMspForStr(_in_name);
+            const nlohmann::json* json_value = nullptr;
+            const auto& config = irods::server_properties::server_properties::instance().map();
+
+            try {
+                if (name.find("/") != std::string::npos) {
+                    json_value = &config.at(nlohmann::json::json_pointer(name));
+                }
+                else {
+                    json_value = &config.at(name);
+                }
+            }
+            catch (nlohmann::json::out_of_range& e) {
+                log_msi::error("Property not found. An error occurred {}", e.what());
+                return KEY_NOT_FOUND;
+            }
+            catch (nlohmann::json::parse_error& e) {
+                log_msi::error("Parse error in key. {}", e.what());
+                return KEY_NOT_FOUND;
+            }
+
+            const std::string value = json_value->dump();
+            fillStrInMsParam(_out_value, value.c_str());
+            return 0;
+        }
+        catch (const irods::exception& e) {
+            log_msi::error(e.what());
+            return e.code();
+        }
+        catch (const std::exception& e) {
+            log_msi::error(e.what());
+            return SYS_INTERNAL_ERR;
+        }
+        catch (...) {
+            log_msi::error("An unknown error occurred while processing the request.");
+            return SYS_UNKNOWN_ERROR;
+        }
+    } // msi_impl
+
+    template <typename... Args, typename Function>
+    auto make_msi(const std::string& name, Function func) -> irods::ms_table_entry*
+    {
+        auto* msi = new irods::ms_table_entry{sizeof...(Args)};
+        msi->add_operation(name, std::function<int(Args..., ruleExecInfo_t*)>(func));
+        return msi;
+    } // make_msi
+} // anonymous namespace
+
+extern "C" auto plugin_factory() -> irods::ms_table_entry*
+{
+    return make_msi<msParam_t*, msParam_t*>("msi_get_server_property", msi_impl);
+}
+
+#ifdef IRODS_FOR_DOXYGEN
+/// \brief Gets the value of a value in the server_properties map. Requires administrative
+/// permissions.
+///
+/// \param[in]      in_name   The name of the property to retrieve, may be a json pointer or a simple
+///                           name.
+/// \param[out]     out_value The value of the property. It is in serialized form if it is an object,
+///                           otherwise it is converted to a string.
+/// \param[in,out]  rei       The rule execution context. Ignore this parameter as a user.
+///
+/// \return An integer.
+/// \retval 0        On success
+/// \retval Non-zero On failure
+/// \retval CAT_INSUFFICIENT_PRIVILEGE_LEVEL The calling user isn't an administrator
+/// \retval KEY_NOT_FOUND The key provided does not have a set value in the configuration
+/// \retval INVALID_OBJECT_NAME The key provided is an invalid json pointer
+///
+/// \since 4.3.1
+auto msi_get_server_property(msParam_t* in_name, msParam_t out_value, ruleExecInfo_t* rei) -> int;
+#endif // IRODS_FOR_DOXYGEN

--- a/scripts/core_tests_list.json
+++ b/scripts/core_tests_list.json
@@ -3,6 +3,7 @@
     "test_auth",
     "test_catalog",
     "test_collection_mtime",
+    "test_configuration_reload",
     "test_control_plane",
     "test_delay_queue",
     "test_dynamic_peps",

--- a/scripts/irods/controller.py
+++ b/scripts/irods/controller.py
@@ -258,6 +258,12 @@ class IrodsController(object):
         self.stop()
         self.start(write_to_stdout, test_mode)
 
+    def reload_configuration(self):
+        """Send the SIGHUP signal to the server, causing it to reload the configuration."""
+        import signal
+        server_process = self.get_server_proc()
+        os.kill(server_process.pid, signal.SIGHUP)
+
     def status(self):
         l = logging.getLogger(__name__)
         l.debug('Calling status on IrodsController')

--- a/scripts/irods/test/test_configuration_reload.py
+++ b/scripts/irods/test/test_configuration_reload.py
@@ -1,0 +1,85 @@
+import unittest
+
+import json
+import os
+
+from . import session
+from ..controller import IrodsController
+from .. import lib
+from .. import paths
+
+SessionsMixin = session.make_sessions_mixin([('otherrods', 'rods')], [])
+
+
+class TestConfigurationReload(SessionsMixin, unittest.TestCase):
+    def setUp(self):
+        super(TestConfigurationReload, self).setUp()
+        self.admin = self.admin_sessions[0]
+        self.testdir = os.path.join(self.admin.session_collection, 'testdir')
+
+    @staticmethod
+    def prepare_rule(property_name):
+        """Prepare a query about the server settings."""
+        return f"""
+        msi_get_server_property("{property_name}",*thing);
+        writeLine("stdout","*thing");
+        """
+
+    # Test to see that it recognizes the  configuration's change
+    def test_server_correctly_detects_change_in_server_config(self):
+        irodsctl = IrodsController()
+        server_config_filename = paths.server_config_path()
+        PROP_NAME = "is_issue_6456_done"
+        with lib.file_backed_up(server_config_filename):
+            with open(server_config_filename) as f:
+                svr_cfg = json.load(f)
+            svr_cfg[PROP_NAME] = "No?"
+            with open(server_config_filename, 'w') as f:
+                f.write(json.dumps(svr_cfg, sort_keys=True,
+                        indent=4, separators=(',', ': ')))
+
+            irodsctl.reload_configuration()
+            self.admin.assert_icommand(['irule', TestConfigurationReload.prepare_rule(
+                f"/{PROP_NAME}"), 'null', 'ruleExecOut'], "STDOUT", ["?"])
+            svr_cfg[PROP_NAME] = "#6456 is done"
+            with open(server_config_filename, 'w') as f:
+                f.write(json.dumps(svr_cfg, sort_keys=True,
+                        indent=4, separators=(',', ': ')))
+
+            irodsctl.reload_configuration()
+            self.admin.assert_icommand(['irule', TestConfigurationReload.prepare_rule(
+                f"/{PROP_NAME}"), 'null', 'ruleExecOut'], "STDOUT", ["#6456 is done"])
+
+    def test_how_long_reloading_takes(self):
+        test_count = 100
+        server_config_filename = paths.server_config_path()
+        with open(server_config_filename) as f:
+            svr_config = json.load(f)
+        property_name = "Hello"
+        with lib.file_backed_up(server_config_filename):
+            rule = TestConfigurationReload.prepare_rule(property_name)
+            for i in range(test_count):
+                svr_config[property_name] = i
+                with open(server_config_filename, 'w') as f:
+                    f.write(json.dumps(svr_config))
+
+                IrodsController().reload_configuration()
+                self.admin.assert_icommand(
+                    ['irule', rule, 'null', 'ruleExecOut'], "STDOUT", [str(i)])
+
+    def test_how_long_restarting_takes(self):
+        test_count = 100
+        server_config_filename = paths.server_config_path()
+        with open(server_config_filename) as f:
+            svr_config = json.load(f)
+        property_name = "Hello"
+        with lib.file_backed_up(server_config_filename):
+            rule = TestConfigurationReload.prepare_rule(property_name)
+            for i in range(test_count):
+                svr_config[property_name] = i
+                with open(server_config_filename, 'w') as f:
+                    f.write(json.dumps(svr_config))
+
+                IrodsController().restart(test_mode=True)
+                self.admin.assert_icommand(
+                    ['irule', rule, 'null', 'ruleExecOut'], "STDOUT", [str(i)])

--- a/scripts/irods/test/test_delay_queue.py
+++ b/scripts/irods/test/test_delay_queue.py
@@ -319,7 +319,7 @@ class Test_Delay_Queue(session.make_sessions_mixin([('otherrods', 'rods')], [('a
                 f.write(new_server_config)
 
             # Bounce server to apply setting
-            irodsctl.restart(test_mode=True)
+            irodsctl.reload_configuration()
 
             # Fire off rule and wait for message to get written out to serverLog
             self.admin.assert_icommand(['irule', '-F', rule_file], 'STDOUT_SINGLELINE', "rule queued")
@@ -370,8 +370,7 @@ class Test_Delay_Queue(session.make_sessions_mixin([('otherrods', 'rods')], [('a
                         config.client_environment_path,
                         {'irods_connection_pool_refresh_time_in_seconds' : 2})
 
-                    # Bounce server to apply setting
-                    irodsctl.restart(test_mode=True)
+                    irodsctl.reload_configuration()
 
                     # Fire off rule and ensure the delay queue is correctly populated
                     self.admin.assert_icommand(['irule', '-F', rule_file])
@@ -400,7 +399,7 @@ class Test_Delay_Queue(session.make_sessions_mixin([('otherrods', 'rods')], [('a
 
         finally:
             os.remove(rule_file)
-            irodsctl.restart(test_mode=True)
+            irodsctl.reload_configuration()
 
     @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Delete this line on resolution of #4094')
     def test_sigpipe_in_delay_server(self):
@@ -432,8 +431,7 @@ class Test_Delay_Queue(session.make_sessions_mixin([('otherrods', 'rods')], [('a
                 with open(server_config_filename, 'w') as f:
                     f.write(new_server_config)
 
-                # Bounce server to apply setting
-                irodsctl.restart(test_mode=True)
+                irodsctl.reload_configuration()
 
                 # Fire off rule and wait for message to get written out to serverLog
                 self.admin.assert_icommand(['irule', '-F', rule_file], 'STDOUT_SINGLELINE', "rule queued")
@@ -459,7 +457,7 @@ class Test_Delay_Queue(session.make_sessions_mixin([('otherrods', 'rods')], [('a
         finally:
             os.remove(rule_file)
             self.admin.run_icommand(['iqdel', '-a'])
-            irodsctl.restart(test_mode=True)
+            irodsctl.reload_configuration()
 
     @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Delete this line on resolution of #4094')
     @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'odbc.ini file does not exist on Catalog Service Consumer')
@@ -500,8 +498,7 @@ class Test_Delay_Queue(session.make_sessions_mixin([('otherrods', 'rods')], [('a
                         config.client_environment_path,
                         {'irods_connection_pool_refresh_time_in_seconds' : 2})
 
-                    # Bounce server to apply setting
-                    irodsctl.restart(test_mode=True)
+                    irodsctl.reload_configuration()
                     with lib.file_backed_up(odbc_ini_file):
                         self.admin.assert_icommand(['irule', '-F', rule_file])
                         time.sleep(2)
@@ -536,7 +533,7 @@ class Test_Delay_Queue(session.make_sessions_mixin([('otherrods', 'rods')], [('a
             # Lower the delay server's sleep time so that rules are executed quicker.
             config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
             lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-            IrodsController().restart(test_mode=True)
+            IrodsController().reload_configuration()
 
             core_re_path = os.path.join(config.core_re_directory, 'core.re')
 
@@ -568,7 +565,7 @@ class Test_Delay_Queue(session.make_sessions_mixin([('otherrods', 'rods')], [('a
                 lib.delayAssert(lambda: assert_metadata_exists)
 
         # Restore the server's configuration settings.
-        IrodsController().restart(test_mode=True)
+        IrodsController().reload_configuration()
 
     @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Skip for PREP and Topology Testing')
     def test_session_variables_can_be_used_in_delay_rules_indirectly(self):
@@ -578,7 +575,7 @@ class Test_Delay_Queue(session.make_sessions_mixin([('otherrods', 'rods')], [('a
             # Lower the delay server's sleep time so that rules are executed quicker.
             config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
             lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-            IrodsController().restart(test_mode=True)
+            IrodsController().reload_configuration()
 
             core_re_path = os.path.join(config.core_re_directory, 'core.re')
 
@@ -613,7 +610,7 @@ class Test_Delay_Queue(session.make_sessions_mixin([('otherrods', 'rods')], [('a
                 lib.delayAssert(lambda: assert_metadata_exists)
 
         # Restore the server's configuration settings.
-        IrodsController().restart(test_mode=True)
+        IrodsController().reload_configuration()
 
     @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Skip for PREP and Topology Testing')
     def test_delay_rule_priority_level_defaults_to_5_when_no_priority_level_is_specified__issue_2759(self):

--- a/scripts/irods/test/test_icommands_file_operations.py
+++ b/scripts/irods/test/test_icommands_file_operations.py
@@ -63,7 +63,7 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
             self.assertTrue(occur[1].group(1) == b'logical_path'    and occur[1].group(2).startswith(b'/'))
             self.assertTrue(occur[2].group(1) == b'proxy_user_name' and occur[2].group(2).decode('utf-8') == self.admin.username)
         finally:
-            IrodsController().restart()
+            IrodsController().reload_configuration()
 
     @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-python', 'only applicable for python REP')
     def test_re_serialization__prep_55(self):
@@ -83,7 +83,7 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
             self.assertTrue(1 == len(occur))
             self.assertTrue(occur[0].group(1) == b'user_rods_zone' and occur[0].group(2).decode('utf-8') == self.admin.zone_name)
         finally:
-            IrodsController().restart()
+            IrodsController().reload_configuration()
 
     def iput_r_large_collection(self, user_session, base_name, file_count, file_size):
         local_dir = os.path.join(self.testing_tmp_dir, base_name)
@@ -218,7 +218,7 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
                 with open(server_config_filename, 'w') as f:
                     f.write(new_server_config)
 
-                IrodsController().restart()
+                IrodsController().reload_configuration()
 
                 # get log offset
                 initial_size_of_server_log = lib.get_file_size_by_path(IrodsConfig().server_log_path)

--- a/server/delay_server/src/irodsDelayServer.cpp
+++ b/server/delay_server/src/irodsDelayServer.cpp
@@ -678,11 +678,11 @@ int main(int argc, char** argv)
         }
 
         return irods::default_delay_server_sleep_time_in_seconds;
-    }();
+    };
 
     const auto go_to_sleep = [&sleep_time] {
         const auto start_time = std::chrono::system_clock::now();
-        const auto allowed_sleep_time = std::chrono::seconds{sleep_time};
+        const auto allowed_sleep_time = std::chrono::seconds{sleep_time()};
 
         // Loop until the server is signaled to shutdown or the max amount of time
         // to sleep has been reached.

--- a/server/main_server/src/main_server_control_plane.cpp
+++ b/server/main_server/src/main_server_control_plane.cpp
@@ -547,7 +547,8 @@ namespace irods
     void server_control_executor::operator()()
     {
         signal( SIGINT, ctrl_plane_handle_shutdown_signal );
-        signal( SIGHUP, ctrl_plane_handle_shutdown_signal );
+        // SIGHUP is the signal to reload the configuration. This shouldn't interact with it
+        signal(SIGHUP, SIG_IGN);
         signal( SIGTERM, ctrl_plane_handle_shutdown_signal );
 
         int port, num_hash_rounds;

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -46,6 +46,7 @@ set(
   get_file_descriptor_info
   hierarchy_parser
   hostname_cache
+  json_events
   key_value_proxy
   lifetime_manager
   linked_list_iterator

--- a/unit_tests/cmake/test_config/irods_json_events.cmake
+++ b/unit_tests/cmake/test_config/irods_json_events.cmake
@@ -1,0 +1,10 @@
+set(IRODS_TEST_TARGET irods_json_events)
+
+set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/src/test_json_events.cpp)
+
+set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
+ 
+set(IRODS_TEST_LINK_LIBRARIES irods_common
+                              ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)

--- a/unit_tests/src/test_json_events.cpp
+++ b/unit_tests/src/test_json_events.cpp
@@ -1,0 +1,38 @@
+#include <catch2/catch.hpp>
+
+#include "irods/json_events.hpp"
+
+namespace je = irods::experimental::json_events;
+
+using json = nlohmann::json;
+
+TEST_CASE("Test json_events", "[json_events]")
+{
+    SECTION("KW_ALL_KEYS and specific hooks work")
+    {
+        bool catchall_fired = false;
+        bool specific_hook_fired = false;
+        bool incorrect_hook_not_fired = true;
+        int hooks_so_far = 0;
+        // There are 4 semantics that matter here
+        // The hook associated with the specific key should fire
+        je::add_hook(std::vector<std::string>{"/test_thing"}, [&](const std::string& _path, const json& _op) {
+            specific_hook_fired = true;
+            // Specifically it should fire second
+            REQUIRE(++hooks_so_far == 2);
+        });
+        // The hook that is not associated with another specific key should not fire
+        je::add_hook(std::vector<std::string>{"/incorrect_thing"},
+                     [&](const std::string& _path, const json& _op) { incorrect_hook_not_fired = false; });
+        // The catchall hook should fire
+        je::add_hook(std::vector<std::string>{je::KW_ALL_KEYS}, [&](const std::string& _path, const json& _op) {
+            catchall_fired = true;
+            // And it should be the first to fire.
+            REQUIRE(++hooks_so_far == 1);
+        });
+        je::run_hooks({{{"path", "/test_thing"}, {"op", "replace"}, {"value", 3}}});
+        REQUIRE(catchall_fired);
+        REQUIRE(specific_hook_fired);
+        REQUIRE(incorrect_hook_not_fired);
+    }
+}

--- a/unit_tests/src/test_server_properties.cpp
+++ b/unit_tests/src/test_server_properties.cpp
@@ -1,10 +1,13 @@
 #include <catch2/catch.hpp>
 
+#include "irods/irods_at_scope_exit.hpp"
 #include "irods/irods_configuration_keywords.hpp"
 #include "irods/irods_configuration_parser.hpp"
 #include "irods/irods_server_properties.hpp"
 
 #include <fmt/format.h>
+
+#include <thread>
 
 TEST_CASE("server_properties", "[exceptions]")
 {
@@ -27,5 +30,29 @@ TEST_CASE("server_properties", "[exceptions]")
                                  irods::KW_CFG_PLUGIN_CONFIGURATION,
                                  irods::KW_CFG_PLUGIN_TYPE_DATABASE,
                                  irods::KW_CFG_DB_PASSWORD));
+    }
+}
+
+// The goal here is to ensure that the server_properties object is locked and unlocked
+// safely while using the normal api
+TEST_CASE("server_properties is threadsafe", "[thread-safety]")
+{
+    const auto limit = 1000;
+
+    // Start a thread that will generally get in the way a lot by writing
+    // to the irods::server_properties object
+    std::thread a([]() {
+        for (auto i = 0; i < limit; i++) {
+            irods::set_server_property(std::to_string(i), i);
+        }
+    });
+    irods::at_scope_exit([&a]() { a.join(); });
+    auto i = 0;
+    while (i < limit) {
+        auto key = std::to_string(i);
+        if (irods::server_property_exists(key)) {
+            REQUIRE(irods::get_server_property<int>(key) == i);
+            i++;
+        }
     }
 }

--- a/unit_tests/unit_tests_list.json
+++ b/unit_tests/unit_tests_list.json
@@ -17,6 +17,7 @@
     "irods_hierarchy_parser",
     "irods_hostname_cache",
     "irods_json_apis_from_client",
+    "irods_json_events",
     "irods_key_value_proxy",
     "irods_lifetime_manager",
     "irods_linked_list_iterator",


### PR DESCRIPTION
This is meant to address the need for a configuration reload facility in iRODS. 

It seems like this will lead to ongoing projects to bring its capabilities up to expected:
* handling auth changes
* making the delay server able to adjust the number of workers

Then there are fun questions here that need testing, such as changing delay server executors(the remote ones) which may or may not need additional changes to work properly.

There's probably more I'm not thinking about of course, and there is of course the positively terrifying possibility of adding an `msi_set_server_property()` microservice.

But primarily, this introduces the configuration reloading to the code and attempts to provide a facility that permits it to notify structures of settings changing in a relatively extensible manner.