### PR TITLE
Postgresql: added SSL communication

### DIFF
--- a/scripts/irods/database_connect.py
+++ b/scripts/irods/database_connect.py
@@ -60,7 +60,31 @@ def dump_odbc_ini(odbc_dict, f):
         print('', file=f)
 
 def get_odbc_entry(db_config, catalog_database_type):
-    if catalog_database_type == 'postgres' or catalog_database_type == 'cockroachdb':
+    if catalog_database_type == 'postgres' and 'db_sslmode' in db_config and db_config['db_sslmode'] == 'require':
+        return {
+            'Description': 'iRODS Catalog',
+            'Driver': db_config['db_odbc_driver'],
+            'Trace': 'No',
+            'Debug': '0',
+            'CommLog': '0',
+            'TraceFile': '',
+            'Database': db_config['db_name'],
+            'Servername': db_config['db_host'],
+            'Port': str(db_config['db_port']),
+            'ReadOnly': 'No',
+            'Ksqo': '0',
+            'RowVersioning': 'No',
+            'ShowSystemTables': 'No',
+            'ShowOidColumn': 'No',
+            'FakeOidIndex': 'No',
+            'ConnSettings': '',
+            'SSL': 'on',
+            'SSLMode': 'require',
+            'SSLRootCert': db_config['db_sslrootcert'],
+            'SSLCert': db_config['db_sslcert'],
+            'SSLKey': db_config['db_sslkey']
+        }
+    elif catalog_database_type == 'postgres' or catalog_database_type == 'cockroachdb':
         return {
             'Description': 'iRODS Catalog',
             'Driver': db_config['db_odbc_driver'],
@@ -180,6 +204,12 @@ def get_connection_string(db_config, irods_config):
     odbc_dict['UID'] = db_config['db_username']
     if irods_config.catalog_database_type == 'cockroachdb':
         odbc_dict['sslrootcert'] = irods_config.database_config['sslrootcert']
+        odbc_dict['sslmode'] = 'require'
+        odbc_dict['ssl'] = 'true'
+    if irods_config.catalog_database_type == 'postgres' and 'db_sslmode' in db_config and db_config['db_sslmode'] == 'require':
+        odbc_dict['sslkey'] = db_config['db_sslkey']
+        odbc_dict['sslrootcert'] = db_config['db_sslrootcert']
+        odbc_dict['sslcert'] =  db_config['db_sslcert']
         odbc_dict['sslmode'] = 'require'
         odbc_dict['ssl'] = 'true'
 


### PR DESCRIPTION
Hi everyone,
this is my first contribution, so try to :see_no_evil:

My team is using the postgresql service from external provider, so I have created a few lines within the `database_connect.py` in order that the database communication was using TLS. That was few months ago for the v4.2.11 and I reported this in the issue #6387. Back then I have simply hard-linked our configuration values into the python script and I was happy about it.

Since then we have updated our iCAT to v4.3.0. And there has been some updates in the `database_connect.py` script, so I had to do it again. This time I used irods calls in the script, so that the `database_connect.py` should work for everyone. I would be happy is this can be made part of the irods, as communication without TLS is asking for troubles :fearful:

There are two things that should be mentioned:

**First**, it should be written in the documentation that the linux user `irods` (one that runs the irods service) needs to have inside home a subfolder named `~/.postgresql` with the (according to https://www.postgresql.org/docs/current/libpq-ssl.html) following 4 files:
- `~/.postgresql/postgresql.key` the clients (the iCAT machine) key
- `~/.postgresql/postgresql.crt` the clients (iCAT) certificate 
- `~/.postgresql/root.crt` the CA certificate of the remote psql server
- `~/.postgresql/root.crl` corresponding revocation list (I just created an empty file)
While I understand that this is not exactly *irods's issue*, I think that (based on the number of postgresql users) it should be mentioned.

**Secondly**, I have tested the script and it works, but my testing environment is limited.

Regards,
Sandi