### PR TITLE
[4421] Added detached mode for unixfilesystem resource (main)

### DIFF
--- a/plugins/resources/CMakeLists.txt
+++ b/plugins/resources/CMakeLists.txt
@@ -6,6 +6,7 @@ add_custom_target(all-plugins-resources)
 add_dependencies(all-plugins_no_database all-plugins-resources)
 
 add_subdirectory(replication)
+add_subdirectory(unixfilesystem)
 
 set(
   IRODS_RESOURCE_PLUGINS

--- a/plugins/resources/unixfilesystem/CMakeLists.txt
+++ b/plugins/resources/unixfilesystem/CMakeLists.txt
@@ -1,0 +1,76 @@
+cmake_minimum_required(VERSION 3.12.0 FATAL_ERROR)
+# target_link_libraries for object targets
+
+# anything being unit tested needs to be split out into an object library.
+add_library(
+  irods_resource_plugin_obj-unixfilesystem
+  OBJECT
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/irods_is_in_host_list.cpp"
+)
+target_link_libraries(
+  irods_resource_plugin_obj-unixfilesystem
+  PUBLIC
+  irods_common
+)
+target_include_directories(
+  irods_resource_plugin_obj-unixfilesystem
+  PUBLIC
+  "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
+  "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
+  "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+)
+target_compile_definitions(
+  irods_resource_plugin_obj-unixfilesystem
+  PRIVATE
+  ${IRODS_COMPILE_DEFINITIONS_PRIVATE}
+  IRODS_ENABLE_SYSLOG
+)
+
+add_library(
+  irods_resource_plugin-unixfilesystem
+  MODULE
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/unixfilesystem.cpp"
+)
+set_property(TARGET irods_resource_plugin-unixfilesystem PROPERTY LIBRARY_OUTPUT_NAME "unixfilesystem")
+target_link_objects(
+  irods_resource_plugin-unixfilesystem
+  PRIVATE
+  irods_resource_plugin_obj-unixfilesystem
+)
+target_link_libraries(
+  irods_resource_plugin-unixfilesystem
+  PRIVATE
+  irods_common
+  irods_server
+  "${IRODS_EXTERNALS_FULLPATH_ARCHIVE}/lib/libarchive.so"
+  "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so"
+  "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so"
+  "${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so"
+  OpenSSL::Crypto
+)
+target_include_directories(
+  irods_resource_plugin-unixfilesystem
+  PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "${IRODS_EXTERNALS_FULLPATH_ARCHIVE}/include"
+  "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
+  "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
+  "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
+)
+target_compile_definitions(
+  irods_resource_plugin-unixfilesystem
+  PRIVATE
+  ${IRODS_COMPILE_DEFINITIONS_PRIVATE}
+  ENABLE_RE
+  IRODS_ENABLE_SYSLOG
+)
+
+add_dependencies(all-plugins-resources irods_resource_plugin-unixfilesystem)
+install(
+  TARGETS
+  irods_resource_plugin-unixfilesystem
+  LIBRARY
+  DESTINATION "${IRODS_PLUGINS_DIRECTORY}/resources"
+  COMPONENT ${IRODS_PACKAGE_COMPONENT_SERVER_NAME}
+)

--- a/plugins/resources/unixfilesystem/include/irods/private/irods_is_in_host_list.hpp
+++ b/plugins/resources/unixfilesystem/include/irods/private/irods_is_in_host_list.hpp
@@ -1,0 +1,13 @@
+#ifndef IRODS_IS_IN_HOST_LIST_HPP
+#define IRODS_IS_IN_HOST_LIST_HPP
+
+#include "irods/irods_lookup_table.hpp"
+
+#include <string_view>
+
+namespace irods
+{
+    auto is_host_in_host_list(irods::plugin_property_map& prop_map, const std::string_view& resource_hostname) -> bool;
+} // namespace irods
+
+#endif // IRODS_IS_IN_HOST_LIST_HPP

--- a/plugins/resources/unixfilesystem/src/irods_is_in_host_list.cpp
+++ b/plugins/resources/unixfilesystem/src/irods_is_in_host_list.cpp
@@ -1,0 +1,45 @@
+#include "irods/private/irods_is_in_host_list.hpp"
+
+#include "irods/irods_error.hpp"
+#include "irods/irods_string_tokenize.hpp"
+#include "irods/filesystem/path.hpp"
+
+// boost includes
+#include <boost/algorithm/string/predicate.hpp>
+
+// stl includes
+#include <vector>
+#include <string_view>
+
+namespace irods
+{
+    const std::string HOST_LIST("host_list");
+
+    // returns true if there is no host_list or if the current host is in
+    // the list
+    auto is_host_in_host_list(irods::plugin_property_map& prop_map, const std::string_view& resource_hostname) -> bool
+    {
+        std::string host_list_str;
+
+        if (!prop_map.get<std::string>(HOST_LIST, host_list_str).ok()) {
+            // no HOST_LIST parameter, all hosts assumed to be able to handle request
+            // and original vault path used for all hosts
+            return true;
+        }
+
+        // There is a host_list=x,y,z in the resource's context string.
+        // Check to see if the resource_hostname is in the comma delimited list.
+
+        // split parameter by delimiter (,)
+        const std::string delimiter = ",";
+        std::vector<std::string> tokens;
+        irods::string_tokenize(host_list_str, delimiter, tokens);
+
+        for (const std::string& token : tokens) {
+            if (boost::iequals(token, resource_hostname)) {
+                return true;
+            }
+        }
+        return false;
+    } // is_host_in_host_list
+} // namespace irods

--- a/scripts/irods/paths.py
+++ b/scripts/irods/paths.py
@@ -535,3 +535,16 @@ def possible_shm_locations():
     if _possible_shm_locations_str_cache is None:
         _possible_shm_locations_str_cache = frozenset(str(shm_dir) for shm_dir in _possible_shm_locations())
     return _possible_shm_locations_str_cache
+
+# This is a common mount point used by topology tests when testing detached mode
+# behavior for unixfilesystem resources.  In detached mode the servers are expected
+# to have a common mount where the vault exists.
+_test_mount_directory_cache = None
+def _test_mount_directory():
+    global _test_mount_directory_cache
+    if _test_mount_directory_cache is None:
+        _test_mount_directory_cache = pathlib.Path(os.sep, 'irods_testing_environment_mount_dir')
+    return _test_mount_directory_cache
+
+def test_mount_directory():
+    return str(_test_mount_directory())

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -76,6 +76,7 @@ set(
   json_apis_from_client
   zone_report
   ticket_administration
+  host_list_context_string
 )
 
 foreach(test IN LISTS IRODS_UNIT_TESTS)

--- a/unit_tests/cmake/test_config/irods_host_list_context_string.cmake
+++ b/unit_tests/cmake/test_config/irods_host_list_context_string.cmake
@@ -1,0 +1,14 @@
+set(IRODS_TEST_TARGET irods_host_list_context_string)
+
+set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/src/test_host_list_context_string.cpp)
+
+set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
+
+set(IRODS_TEST_LINK_OBJLIBRARIES irods_resource_plugin_obj-unixfilesystem)
+
+set(IRODS_TEST_LINK_LIBRARIES irods_common
+                              irods_client
+                              irods_plugin_dependencies
+                              ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)

--- a/unit_tests/src/test_host_list_context_string.cpp
+++ b/unit_tests/src/test_host_list_context_string.cpp
@@ -1,0 +1,74 @@
+#include <catch2/catch.hpp>
+
+#include <string_view>
+#include <sstream>
+#include <vector>
+
+#include "irods/irods_plugin_base.hpp"
+#include "irods/filesystem/path.hpp"
+#include "irods/private/irods_is_in_host_list.hpp"
+
+TEST_CASE("host list tests", "[detached_mode_host_list]")
+{
+    const std::string_view resource_hostname = "myhost";
+    irods::plugin_property_map prop_map;
+
+    SECTION("not in host list")
+    {
+        prop_map.set<std::string>("host_list", "host2,host3");
+        REQUIRE_FALSE(is_host_in_host_list(prop_map, resource_hostname));
+    }
+
+    SECTION("not in host list but hostname with common prefix")
+    {
+        prop_map.set<std::string>("host_list", "myhost1,myhost2,host2,host3,myhost3");
+        REQUIRE_FALSE(is_host_in_host_list(prop_map, resource_hostname));
+    }
+
+    SECTION("at beginning of host list")
+    {
+        prop_map.set<std::string>("host_list", "myhost,host2,host3");
+        REQUIRE(is_host_in_host_list(prop_map, resource_hostname));
+    }
+
+    SECTION("at end of host list no path")
+    {
+        prop_map.set<std::string>("host_list", "host2,host3,myhost");
+        REQUIRE(is_host_in_host_list(prop_map, resource_hostname));
+    }
+
+    SECTION("in middle of host list no path")
+    {
+        prop_map.set<std::string>("host_list", "host2,myhost,host3");
+        REQUIRE(is_host_in_host_list(prop_map, resource_hostname));
+    }
+
+    SECTION("at beginning of host list not case match")
+    {
+        prop_map.set<std::string>("host_list", "MYHOST,host2,host3");
+        REQUIRE(is_host_in_host_list(prop_map, resource_hostname));
+    }
+
+    SECTION("at end of host list not case match")
+    {
+        prop_map.set<std::string>("host_list", "host2,host3,MYHOST");
+        REQUIRE(is_host_in_host_list(prop_map, resource_hostname));
+    }
+
+    SECTION("in middle of host list not case match")
+    {
+        prop_map.set<std::string>("host_list", "host2,MYHOST,host3");
+        REQUIRE(is_host_in_host_list(prop_map, resource_hostname));
+    }
+
+    SECTION("empty host list")
+    {
+        prop_map.set<std::string>("host_list", "");
+        REQUIRE_FALSE(is_host_in_host_list(prop_map, resource_hostname));
+    }
+
+    SECTION("no host list - all hosts in list")
+    {
+        REQUIRE(is_host_in_host_list(prop_map, resource_hostname));
+    }
+}


### PR DESCRIPTION
Adding detached mode for unixfilesystem resources.

Notes:

1. Right now, all servers in the zone would have to have a mount at the same location, as the location of the vault path is not server dependent.
2. If we wanted to limit the servers which can serve the request, we could add some type of list in the context string meaning only the servers in the list can serve it.
3. If we really wanted to make it configurable, the list from 2 could have two parts - the server name and the vault path.

For 3 we could do something like:
 ```"HOST_MODE=detached;SERVER_LIST=server1.irods.org:/lustre_mount/resource1,server2.irods.org:/mounts/lustre_mount/resource1"```

in the context string.

I haven't researched this fully to determine if it is possible or could be done efficiently.  Just throwing it out there as an idea.