### PR TITLE
[6529] Remote configuration reload

### DIFF
--- a/lib/core/src/irods_server_properties.cpp
+++ b/lib/core/src/irods_server_properties.cpp
@@ -273,7 +273,7 @@ namespace irods
         auto lock = acquire_write_lock();
         // TODO uncomment when issue #6470 is fixed
         // log_server::error("Before patch '{}'", config_props_.dump());
-        config_props_.patch(patch);
+        config_props_ = config_props_.patch(patch);
         // log_server::error("After patch '{}'", config_props_.dump());
         return patch;
     } // reload

--- a/server/control_plane/include/irods/irods_server_control_plane.hpp
+++ b/server/control_plane/include/irods/irods_server_control_plane.hpp
@@ -25,6 +25,7 @@ namespace irods
     inline const std::string SERVER_CONTROL_RESUME( "server_control_resume" );
     inline const std::string SERVER_CONTROL_STATUS( "server_control_status" );
     inline const std::string SERVER_CONTROL_PING( "server_control_ping" );
+    inline const std::string SERVER_CONTROL_RELOAD("server_control_reload");
 
     inline const std::string SERVER_CONTROL_ALL_OPT( "all" );
     inline const std::string SERVER_CONTROL_HOSTS_OPT( "hosts" );

--- a/server/irods_grid/src/irods-grid.cpp
+++ b/server/irods_grid/src/irods-grid.cpp
@@ -64,6 +64,7 @@ irods::error parse_program_options(
     irods::control_plane_command& _cmd ) {
 
     namespace po = boost::program_options;
+    // clang-format off
     po::options_description opt_desc( "options" );
     opt_desc.add_options()
     ( "action", "either 'status', 'ping', 'shutdown', 'pause', or 'resume'" )
@@ -76,7 +77,9 @@ irods::error parse_program_options(
     ( "status", "display status a server(s)" )
     ( "shutdown", "gracefully shutdown a server(s)" )
     ( "pause", "refuse new client connections" )
+    ( "reload", "Reload a server(s) configuration")
     ( "resume", "allow new client connections" );
+    // clang-format on
 
     po::positional_options_description pos_desc;
     pos_desc.add( "action", 1 );
@@ -106,11 +109,14 @@ irods::error parse_program_options(
         try {
             const std::string& action = vm["action"].as<std::string>();
             boost::unordered_map< std::string, std::string > cmd_map;
+            // clang-format off
             cmd_map[ "status"   ] = irods::SERVER_CONTROL_STATUS;
             cmd_map[ "ping"     ] = irods::SERVER_CONTROL_PING;
             cmd_map[ "pause"    ] = irods::SERVER_CONTROL_PAUSE;
             cmd_map[ "resume"   ] = irods::SERVER_CONTROL_RESUME;
             cmd_map[ "shutdown" ] = irods::SERVER_CONTROL_SHUTDOWN;
+            cmd_map[ "reload"   ] = irods::SERVER_CONTROL_RELOAD;
+            // clang-format on
 
             if ( cmd_map.end() == cmd_map.find( action ) ) {
                 std::cerr << "invalid subcommand ["


### PR DESCRIPTION
Adding support to trigging the configuration reload to
the control plane enables easier use in clusters or
multiple instance setups.

The current command doesn't support any options other than
the standard ones, and thus is invoked like
"irods-grid reload"