### PR TITLE
[#6465] allow NREP remote execution hints to target INST_NAME

### DIFF
--- a/plugins/rule_engines/irods_rule_language/src/functions.cpp
+++ b/plugins/rule_engines/irods_rule_language/src/functions.cpp
@@ -1907,7 +1907,12 @@ Res *smsi_remoteExec( Node** paramsr, int, Node* node, ruleExecInfo_t* rei, int,
 
     try {
         auto taggedValues = getTaggedValues(params[1]->text);
-        auto it = taggedValues.find("ZONE");
+        auto it = taggedValues.find("INST_NAME");
+        if (it != taggedValues.end()) {
+            addKeyVal(&execMyRuleInp.condInput, INSTANCE_NAME_KW, it->second.front().c_str());
+            taggedValues.erase(it);
+        }
+        it = taggedValues.find("ZONE");
         if ( it != taggedValues.end() ) {
             strncpy(execMyRuleInp.addr.zoneName, it->second.front().c_str(), NAME_LEN);
             taggedValues.erase(it);


### PR DESCRIPTION
Includes tests, which are written for the Python RE plugin suite
and append the NREP to test behavior with multiple rule engine plugins
loaded.