### PR TITLE
[#6622]  closeAllL1desc should not call PEPs

### DIFF
--- a/server/core/src/objDesc.cpp
+++ b/server/core/src/objDesc.cpp
@@ -111,7 +111,7 @@ closeAllL1desc( rsComm_t *rsComm ) {
     for ( i = 3; i < NUM_L1_DESC; i++ ) {
         if ( L1desc[i].inuseFlag == FD_INUSE &&
                 L1desc[i].l3descInx > 2 ) {
-            l3Close( rsComm, i );
+            close( FileDesc[L1desc[i].l3descInx].fd );
         }
     }
     return 0;


### PR DESCRIPTION
closeAllL1desc is (only) called from a forked process which is preparing to execute an external program.  It should not do anything other than close the open resources. See issue #6622.

Applies to main, 4-3-stable, 4-2-stable.