### PR TITLE
[#6579] Fix `ichmod` permission bypass (4-3-stable)

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -10208,34 +10208,21 @@ irods::error db_mod_access_control_op(
                 return ERROR( CAT_INVALID_ARGUMENT, "unknown collection or file" );
             }
             if ( status1 != CAT_UNKNOWN_COLLECTION ) {
-                if ( logSQL != 0 ) {
-                    log_sql::debug("chlModAccessControl SQL 12");
-                }
-                int status = cmlCheckDirOwn( _path_name,
-                                             _ctx.comm()->clientUser.userName,
-                                             _ctx.comm()->clientUser.rodsZone,
-                                             &icss );
-                if ( status < 0 ) {
-                    return ERROR( status1, "cmlCheckDirOwn failed" );
-                }
-                snprintf( collIdStr, MAX_NAME_LEN, "%d", status );
+                return ERROR(
+                    status1,
+                    fmt::format(
+                        "User [{}] has insufficient permission to modifiy collection: [{}]",
+                        _ctx.comm()->clientUser.userName,
+                        _path_name));
             }
             else {
                 if ( status2 == CAT_NO_ACCESS_PERMISSION ) {
-                    /* See if this user is the owner (with no access, but still
-                       allowed to ichmod) */
-                    if ( logSQL != 0 ) {
-                        log_sql::debug("chlModAccessControl SQL 13");
-                    }
-                    int status = cmlCheckDataObjOwn( logicalParentDirName, logicalEndName,
-                                                     _ctx.comm()->clientUser.userName,
-                                                     _ctx.comm()->clientUser.rodsZone,
-                                                     &icss );
-                    if ( status < 0 ) {
-                        _rollback( "chlModAccessControl" );
-                        return ERROR( status2, "cmlCheckDataObjOwn failed" );
-                    }
-                    objId = status;
+                    return ERROR(
+                        status2,
+                        fmt::format(
+                            "User [{}] has insufficient permission to modifiy data object: [{}]",
+                            _ctx.comm()->clientUser.userName,
+                            _path_name));
                 }
                 else {
                     return ERROR( status2, "cmlCheckDataObjOnly failed" );

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -544,15 +544,15 @@ OUTPUT ruleExecOut
             self.rods_session.assert_icommand("irule -F " + data_obj_rule_file, 'STDOUT_MULTILINE', ['result=0$', 'result=0$', 'result=0$'],
                 use_regex=True)
 
-            self.rods_session.assert_icommand('ichmod read rods test_file_3309')
+            self.rods_session.assert_icommand('ichmod -M read rods test_file_3309')
             self.rods_session.assert_icommand("irule -F " + data_obj_rule_file, 'STDOUT_MULTILINE', ['result=1$', 'result=0$', 'result=0$'],
                 use_regex=True)
 
-            self.rods_session.assert_icommand('ichmod write rods test_file_3309')
+            self.rods_session.assert_icommand('ichmod -M write rods test_file_3309')
             self.rods_session.assert_icommand("irule -F " + data_obj_rule_file, 'STDOUT_MULTILINE', ['result=1$', 'result=1$', 'result=0$'],
                 use_regex=True)
 
-            self.rods_session.assert_icommand('ichmod own rods test_file_3309')
+            self.rods_session.assert_icommand('ichmod -M own rods test_file_3309')
             self.rods_session.assert_icommand("irule -F " + data_obj_rule_file, 'STDOUT_MULTILINE', ['result=1$', 'result=1$', 'result=1$'],
                 use_regex=True)
 
@@ -561,15 +561,15 @@ OUTPUT ruleExecOut
 
             self.rods_session.assert_icommand('ichmod null rods test_file_3309')
 
-            self.rods_session.assert_icommand('ichmod read group2_3309 test_file_3309')
+            self.rods_session.assert_icommand('ichmod -M read group2_3309 test_file_3309')
             self.rods_session.assert_icommand("irule -F " + data_obj_rule_file, 'STDOUT_MULTILINE', ['result=1$', 'result=0$', 'result=0$'],
                 use_regex=True)
 
-            self.rods_session.assert_icommand('ichmod write group2_3309 test_file_3309')
+            self.rods_session.assert_icommand('ichmod -M write group2_3309 test_file_3309')
             self.rods_session.assert_icommand("irule -F " + data_obj_rule_file, 'STDOUT_MULTILINE', ['result=1$', 'result=1$', 'result=0$'],
                 use_regex=True)
 
-            self.rods_session.assert_icommand('ichmod own group2_3309 test_file_3309')
+            self.rods_session.assert_icommand('ichmod -M own group2_3309 test_file_3309')
             self.rods_session.assert_icommand("irule -F " + data_obj_rule_file, 'STDOUT_MULTILINE', ['result=1$', 'result=1$', 'result=1$'],
                 use_regex=True)
 
@@ -582,15 +582,15 @@ OUTPUT ruleExecOut
             self.rods_session.assert_icommand("irule -F " + collection_rule_file, 'STDOUT_MULTILINE', ['result=0$', 'result=0$', 'result=0$'],
                 use_regex=True)
 
-            self.rods_session.assert_icommand('ichmod read rods test_collection_3309')
+            self.rods_session.assert_icommand('ichmod -M read rods test_collection_3309')
             self.rods_session.assert_icommand("irule -F " + collection_rule_file, 'STDOUT_MULTILINE', ['result=1$', 'result=0$', 'result=0$'],
                 use_regex=True)
 
-            self.rods_session.assert_icommand('ichmod write rods test_collection_3309')
+            self.rods_session.assert_icommand('ichmod -M write rods test_collection_3309')
             self.rods_session.assert_icommand("irule -F " + collection_rule_file, 'STDOUT_MULTILINE', ['result=1$', 'result=1$', 'result=0$'],
                 use_regex=True)
 
-            self.rods_session.assert_icommand('ichmod own rods test_collection_3309')
+            self.rods_session.assert_icommand('ichmod -M own rods test_collection_3309')
             self.rods_session.assert_icommand("irule -F " + collection_rule_file, 'STDOUT_MULTILINE', ['result=1$', 'result=1$', 'result=1$'],
                 use_regex=True)
 
@@ -599,15 +599,15 @@ OUTPUT ruleExecOut
 
             self.rods_session.assert_icommand('ichmod null rods test_collection_3309')
 
-            self.rods_session.assert_icommand('ichmod read group2_3309 test_collection_3309')
+            self.rods_session.assert_icommand('ichmod -M read group2_3309 test_collection_3309')
             self.rods_session.assert_icommand("irule -F " + collection_rule_file, 'STDOUT_MULTILINE', ['result=1$', 'result=0$', 'result=0$'],
                 use_regex=True)
 
-            self.rods_session.assert_icommand('ichmod write group2_3309 test_collection_3309')
+            self.rods_session.assert_icommand('ichmod -M write group2_3309 test_collection_3309')
             self.rods_session.assert_icommand("irule -F " + collection_rule_file, 'STDOUT_MULTILINE', ['result=1$', 'result=1$', 'result=0$'],
                 use_regex=True)
 
-            self.rods_session.assert_icommand('ichmod own group2_3309 test_collection_3309')
+            self.rods_session.assert_icommand('ichmod -M own group2_3309 test_collection_3309')
             self.rods_session.assert_icommand("irule -F " + collection_rule_file, 'STDOUT_MULTILINE', ['result=1$', 'result=1$', 'result=1$'],
                 use_regex=True)
 

--- a/scripts/irods/test/test_icommands_file_operations.py
+++ b/scripts/irods/test/test_icommands_file_operations.py
@@ -148,12 +148,12 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
         rods_files = [f for f in lib.get_object_names_from_entries(ils_out)]
 
         self.admin.assert_icommand(['ichmod','-r','null',self.admin.username,base_name])
-        self.admin.assert_icommand(['ichmod','read',self.admin.username,base_name+'/'+rods_files[-1]])
+        self.admin.assert_icommand(['ichmod','-M','read',self.admin.username,base_name+'/'+rods_files[-1]])
         self.admin.assert_icommand(['iget','-r',base_name,self.admin.local_session_dir],'STDERR_SINGLELINE','CAT_NO_ACCESS_PERMISSION')
 
         assert os.path.isfile(os.path.join(self.admin.local_session_dir,base_name,rods_files[-1]))
 
-        self.admin.assert_icommand(['ichmod','-r','own',self.admin.username,base_name])
+        self.admin.assert_icommand(['ichmod','-M','-r','own',self.admin.username,base_name])
 
     def test_iput_r(self):
         self.iput_r_large_collection(self.user0, "test_iput_r_dir", file_count=1000, file_size=100)

--- a/scripts/irods/test/test_native_rule_engine_plugin.py
+++ b/scripts/irods/test/test_native_rule_engine_plugin.py
@@ -181,7 +181,7 @@ class Test_Native_Rule_Engine_Plugin(resource_suite.ResourceBase, unittest.TestC
 
         finally:
 
-            self.admin.run_icommand('ichmod own {} {}'.format(self.admin.username,temp_base))
+            self.admin.run_icommand('ichmod -M own {} {}'.format(self.admin.username,temp_base))
             os.unlink(largefile)
             if extrafile and os.path.isfile(extrafile):
                 os.unlink(extrafile)


### PR DESCRIPTION
User should now not be able to `ichmod` data objects and collections back to `own`, after setting to a lower permission.