### PR TITLE
Add where clause in delete from R_ObjectId_seq_tbl (main)

### DIFF
--- a/plugins/database/src/mysql_functions.sql.in
+++ b/plugins/database/src/mysql_functions.sql.in
@@ -5,7 +5,7 @@ returns bigint
 begin
    insert into R_ObjectId_seq_tbl values (NULL) ;
    set @R_ObjectId_val=LAST_INSERT_ID() ;
-   delete from R_ObjectId_seq_tbl ;
+   delete from R_ObjectId_seq_tbl where nextval = @R_ObjectId_val ;
    return @R_ObjectId_val ;
 end
 %%


### PR DESCRIPTION
The mysql function R_ObjectId_nextval() is not safe for parallel database updates, that some of our users can trigger by opening a large number of parallel connections. This can be simulated by

```
(for i in $(seq 0 10); do echo 'echo "SELECT R_ObjectID_nextval();" |
mysql -h (...) -u(...) -p(...) irods'; done) | parallel -j 10
```

This results in "Deadlock found when trying to get lock; try restarting transaction". After restricting the delete to only remove the row that that instance of the function has inserted, the deadlock is avoided.

Signed-off-by: Peter Verraedt <peter.verraedt@kuleuven.be>