### PR TITLE
[#6579] Mimic old ichmod behavior in filesystem unit test (4-3-stable)

### DIFF
--- a/unit_tests/src/filesystem/test_filesystem.cpp
+++ b/unit_tests/src/filesystem/test_filesystem.cpp
@@ -352,7 +352,7 @@ TEST_CASE("filesystem")
         permissions_match(status.permissions()[0], new_perms);
 
         new_perms = fs::perms::own;
-        fs::client::permissions(conn, p, env.rodsUserName, new_perms);
+        fs::client::permissions(fs::admin, conn, p, env.rodsUserName, new_perms);
         status = fs::client::status(conn, p);
         REQUIRE_FALSE(status.permissions().empty());
         permissions_match(status.permissions()[0], new_perms);


### PR DESCRIPTION
Fix unit test relying on previous ichmod behavior by adding admin command where old behavior is expected.

