### PR TITLE
[#6638] Deprecate SimpleQuery (main)

### DIFF
--- a/lib/api/include/irods/apiTable.hpp
+++ b/lib/api/include/irods/apiTable.hpp
@@ -299,6 +299,7 @@ static irods::apidef_t client_api_table_inp[] = {
 #else
 #error "exactly one of {CREATE_API_TABLE_FOR_SERVER, CREATE_API_TABLE_FOR_CLIENT} must be defined"
 #endif
+    // clang-format off
     {
         GET_MISC_SVR_INFO_AN, RODS_API_VERSION, NO_USER_AUTH, NO_USER_AUTH,
         NULL, 0, "MiscSvrInfo_PI", 0,
@@ -563,7 +564,11 @@ static irods::apidef_t client_api_table_inp[] = {
     {
         SIMPLE_QUERY_AN, RODS_API_VERSION, LOCAL_PRIV_USER_AUTH, LOCAL_PRIV_USER_AUTH,
         "simpleQueryInp_PI", 0,  "simpleQueryOut_PI", 0,
+        // rsSimpleQuery is deprecated, but we need to continue to support it until its removal.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         boost::any(std::function<int(rsComm_t*,simpleQueryInp_t*,simpleQueryOut_t**)>(RS_SIMPLE_QUERY)),
+#pragma clang diagnostic pop
         "api_simple_query", irods::clearInStruct_noop,
         (funcPtr)CALL_SIMPLEQUERYINP_SIMPLEQUERYOUT
     },
@@ -1248,6 +1253,7 @@ static irods::apidef_t client_api_table_inp[] = {
         "api_exec_rule_expression", irods::clearInStruct_noop,
         (funcPtr)CALL_EXECRULEEXPRESSIONINP
     },
+    // clang-format on
 }; // _api_table_inp
 
 #endif	/* API_TABLE_H */

--- a/lib/api/include/irods/simpleQuery.h
+++ b/lib/api/include/irods/simpleQuery.h
@@ -25,6 +25,7 @@ typedef struct {
 #ifdef __cplusplus
 extern "C"
 #endif
-int rcSimpleQuery( rcComm_t *conn, simpleQueryInp_t *simpleQueryInp, simpleQueryOut_t **simpleQueryOut );
+__attribute__((deprecated("SimpleQuery is deprecated. Use GenQuery or SpecificQuery instead.")))
+int rcSimpleQuery(rcComm_t* conn, simpleQueryInp_t* simpleQueryInp, simpleQueryOut_t** simpleQueryOut);
 
 #endif

--- a/lib/api/src/rcSimpleQuery.cpp
+++ b/lib/api/src/rcSimpleQuery.cpp
@@ -11,37 +11,38 @@
 #include "irods/procApiRequest.h"
 #include "irods/apiNumber.h"
 /**
-* \fn rcSimpleQuery (rcComm_t *conn, simpleQueryInp_t *simpleQueryInp, simpleQueryOut_t **simpleQueryOut)
-*
-* \brief Perform a simple (pre-defined) query, allowed for Admin only, used in iadmin
-*
-* \user client
-*
-* \ingroup metadata
-*
-* \since 1.0
-*
-*
-* \remark none
-*
-* \note none
-*
-* \usage
-* Perform a simple (pre-defined) query:
-* \n See the SQL-Based_Queries on irods.org
-* \n and examples in iquest.c (function execAndShowSimpleQuery).
-*
-* \param[in] conn - A rcComm_t connection handle to the server.
-* \param[in] simpleQueryInp - input sql or alias (must match definition on server), and arguments
-* \param[out] simpleQueryOut - the same returned structure as general-query.
-* \return integer
-* \retval 0 on success
-*
-* \sideeffect none
-* \pre none
-* \post none
-* \sa none
-**/
+ * \fn rcSimpleQuery (rcComm_t *conn, simpleQueryInp_t *simpleQueryInp, simpleQueryOut_t **simpleQueryOut)
+ *
+ * \brief Perform a simple (pre-defined) query, allowed for Admin only, used in iadmin
+ *
+ * \user client
+ *
+ * \ingroup metadata
+ *
+ * \since 1.0
+ *
+ * \remark none
+ *
+ * \note none
+ *
+ * \usage
+ * Perform a simple (pre-defined) query:
+ * \n See the SQL-Based_Queries on irods.org
+ * \n and examples in iquest.c (function execAndShowSimpleQuery).
+ *
+ * \param[in] conn - A rcComm_t connection handle to the server.
+ * \param[in] simpleQueryInp - input sql or alias (must match definition on server), and arguments
+ * \param[out] simpleQueryOut - the same returned structure as general-query.
+ * \return integer
+ * \retval 0 on success
+ *
+ * \sideeffect none
+ * \pre none
+ * \post none
+ * \sa none
+ *
+ * \deprecated Deprecated in 4.3.1. Use rcGenQuery or rcSpecificQuery instead.
+ **/
 
 int
 rcSimpleQuery( rcComm_t *conn, simpleQueryInp_t *simpleQueryInp,

--- a/lib/core/include/irods/rodsErrorTable.h
+++ b/lib/core/include/irods/rodsErrorTable.h
@@ -881,6 +881,7 @@ NEW_ERROR(OOI_REVID_NOT_FOUND,                         -2211000)
  * @{
  */
 NEW_ERROR(DEPRECATED_PARAMETER,                        -3000000)
+NEW_ERROR(DEPRECATED_API,                              -3001000)
 /** @} */
 
 /* XML parsing and TDS error */

--- a/server/api/include/irods/rsSimpleQuery.hpp
+++ b/server/api/include/irods/rsSimpleQuery.hpp
@@ -4,7 +4,11 @@
 #include "irods/rcConnect.h"
 #include "irods/simpleQuery.h"
 
-int rsSimpleQuery( rsComm_t *rsComm, simpleQueryInp_t *simpleQueryInp, simpleQueryOut_t **simpleQueryOut );
-int _rsSimpleQuery( rsComm_t *rsComm, simpleQueryInp_t *simpleQueryInp, simpleQueryOut_t **simpleQueryOut );
+// clang-format off
+
+[[deprecated("SimpleQuery is deprecated. Use GenQuery or SpecificQuery instead.")]]
+auto rsSimpleQuery(rsComm_t* rsComm, simpleQueryInp_t* simpleQueryInp, simpleQueryOut_t** simpleQueryOut) -> int;
+
+// clang-format on
 
 #endif


### PR DESCRIPTION
This change deprecates the use of SimpleQuery as well as its client API endpoint and server-side shortcut API.

---

The deprecated functions are no longer being used, so I didn't run the test suite.