### PR TITLE
[#6638] SimpleQuery: Deprecate types, constants, and functions (main)

### DIFF
--- a/lib/api/include/irods/apiNumberData.h
+++ b/lib/api/include/irods/apiNumberData.h
@@ -37,6 +37,7 @@ API_NUMBER(DATA_PUT_AN,                             607)
 API_NUMBER(DATA_OBJ_GET_AN,                         608)
 API_NUMBER(DATA_GET_AN,                             609)
 API_NUMBER(DATA_COPY_AN,                            611)
+// DEPRECATED: SimpleQuery is deprecated. Use GenQuery or SpecificQuery instead.
 API_NUMBER(SIMPLE_QUERY_AN,                         614)
 API_NUMBER(DATA_OBJ_UNLINK_AN,                      615)
 API_NUMBER(REG_DATA_OBJ_AN,                         619)

--- a/lib/api/include/irods/apiTable.hpp
+++ b/lib/api/include/irods/apiTable.hpp
@@ -561,17 +561,16 @@ static irods::apidef_t client_api_table_inp[] = {
         "api_data_copy", irods::clearInStruct_noop,
         (funcPtr)CALL_DATACOPYINP
     },
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     {
         SIMPLE_QUERY_AN, RODS_API_VERSION, LOCAL_PRIV_USER_AUTH, LOCAL_PRIV_USER_AUTH,
         "simpleQueryInp_PI", 0,  "simpleQueryOut_PI", 0,
-        // rsSimpleQuery is deprecated, but we need to continue to support it until its removal.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         boost::any(std::function<int(rsComm_t*,simpleQueryInp_t*,simpleQueryOut_t**)>(RS_SIMPLE_QUERY)),
-#pragma clang diagnostic pop
         "api_simple_query", irods::clearInStruct_noop,
         (funcPtr)CALL_SIMPLEQUERYINP_SIMPLEQUERYOUT
     },
+#pragma clang diagnostic pop
     {
         GENERAL_ADMIN_AN, RODS_API_VERSION, LOCAL_PRIV_USER_AUTH, LOCAL_PRIV_USER_AUTH,
         "generalAdminInp_PI", 0, NULL, 0,

--- a/lib/api/include/irods/simpleQuery.h
+++ b/lib/api/include/irods/simpleQuery.h
@@ -3,6 +3,7 @@
 
 #include "irods/rcConnect.h"
 
+__attribute__((deprecated("SimpleQuery is deprecated. Use GenQuery or SpecificQuery instead.")))
 typedef struct {
     char *sql;
     char *arg1;
@@ -15,6 +16,7 @@ typedef struct {
 } simpleQueryInp_t;
 #define simpleQueryInp_PI "str *sql; str *arg1; str *arg2; str *arg3; str *arg4; int control; int form; int maxBufSize;"
 
+__attribute__((deprecated("SimpleQuery is deprecated. Use GenQuery or SpecificQuery instead.")))
 typedef struct {
     int control;
     char *outBuf;

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -5995,7 +5995,7 @@ irods::error db_simple_query_op_vector(
     cmlFreeStatement(stmtNum, &icss);
     return SUCCESS();
 
-} // db_simple_query_op
+} // db_simple_query_op_vector
 
 irods::error db_simple_query_op(
     irods::plugin_context& _ctx,
@@ -6023,7 +6023,7 @@ irods::error db_simple_query_op(
         }
     }
     return db_simple_query_op_vector( _ctx, _sql, bindVars, _format, _control, _out_buf, _max_out_buf );
-}
+} // db_simple_query_op
 
 // =-=-=-=-=-=-=-
 // commit the transaction
@@ -15070,10 +15070,13 @@ irods::database* plugin_factory(
         DATABASE_OP_DEL_ZONE,
         function<error(plugin_context&,const char*)>(
             db_del_zone_op ) );
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     pg->add_operation(
         DATABASE_OP_SIMPLE_QUERY,
         function<error(plugin_context&,const char*,const char*,const char*,const char*,const char*,int,int*,char*,int)>(
             db_simple_query_op ) );
+#pragma clang diagnostic pop
     pg->add_operation(
         DATABASE_OP_DEL_COLL_BY_ADMIN,
         function<error(plugin_context&,collInfo_t*)>(

--- a/server/api/src/rsSimpleQuery.cpp
+++ b/server/api/src/rsSimpleQuery.cpp
@@ -6,6 +6,9 @@
 #include "irods/miscServerFunct.hpp"
 #include "irods/rodsConnect.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 namespace
 {
     auto _rsSimpleQuery(rsComm_t* rsComm, simpleQueryInp_t* simpleQueryInp, simpleQueryOut_t** simpleQueryOut) -> int
@@ -87,3 +90,5 @@ rsSimpleQuery( rsComm_t *rsComm, simpleQueryInp_t *simpleQueryInp,
     }
     return status;
 }
+
+#pragma clang diagnostic pop // ignored "-Wdeprecated-declarations"

--- a/server/core/include/irods/irods_api_calling_functions.hpp
+++ b/server/core/include/irods/irods_api_calling_functions.hpp
@@ -361,6 +361,7 @@ int call_dataCopyInp(
 #endif
 
 #ifdef CREATE_API_TABLE_FOR_SERVER
+[[deprecated("SimpleQuery is deprecated. Use GenQuery or SpecificQuery instead.")]]
 int call_simpleQueryInp_simpleQueryOut(
     irods::api_entry*,
     rsComm_t*,

--- a/server/core/include/irods/irods_database_constants.hpp
+++ b/server/core/include/irods/irods_database_constants.hpp
@@ -34,6 +34,7 @@ namespace irods {
     const std::string DATABASE_OP_REG_COLL_BY_ADMIN( "database_reg_coll_by_admin" );
     const std::string DATABASE_OP_REG_COLL( "database_reg_coll" );
     const std::string DATABASE_OP_MOD_COLL( "database_mod_coll" );
+    [[deprecated("SimpleQuery is deprecated. Use GenQuery or SpecificQuery instead.")]]
     const std::string DATABASE_OP_SIMPLE_QUERY( "database_simple_query" );
     const std::string DATABASE_OP_GEN_QUERY( "database_gen_query" );
     const std::string DATABASE_OP_GEN_QUERY_ACCESS_CONTROL_SETUP( "database_gen_query_access_control_setup" );

--- a/server/core/src/irods_api_calling_functions.cpp
+++ b/server/core/src/irods_api_calling_functions.cpp
@@ -387,6 +387,8 @@ int call_dataCopyInp(
                    _inp);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 int call_simpleQueryInp_simpleQueryOut(
     irods::api_entry*   _api,
     rsComm_t*           _comm,
@@ -399,6 +401,7 @@ int call_simpleQueryInp_simpleQueryOut(
                    _inp,
                    _out);
 }
+#pragma clang diagnostic pop
 
 int call_generalAdminInp(
     irods::api_entry*  _api,

--- a/server/icat/include/irods/icatHighLevelRoutines.hpp
+++ b/server/icat/include/irods/icatHighLevelRoutines.hpp
@@ -49,6 +49,7 @@ int chlRegCollByAdmin( rsComm_t *rsComm, collInfo_t *collInfo );
 int chlRegColl( rsComm_t *rsComm, collInfo_t *collInfo );
 int chlModColl( rsComm_t *rsComm, collInfo_t *collInfo );
 
+[[deprecated("SimpleQuery is deprecated. Use GenQuery or SpecificQuery instead.")]]
 int chlSimpleQuery( rsComm_t *rsComm, const char *sql,
                     const char *arg1, const char *arg2, const char *arg3, const char *arg4,
                     int format,


### PR DESCRIPTION
Addresses #6638 (the rest of it)

Follow-up to #6657 

Just left a comment for the API number, but the rest has now received a deprecation attribute. Had to wrap some bits to ignore the deprecated declarations warnings that are now generated.