### PR TITLE
[#6619] Refactored resource administration lib to prefer exceptions (main)

### DIFF
--- a/lib/administration/resource/include/irods/resource_administration.hpp
+++ b/lib/administration/resource/include/irods/resource_administration.hpp
@@ -5,28 +5,40 @@
 
 #undef NAMESPACE_IMPL
 #undef RxComm
+#undef rxGeneralAdmin
 
 #ifdef IRODS_RESOURCE_ADMINISTRATION_ENABLE_SERVER_SIDE_API
-    #define NAMESPACE_IMPL      server
-    #define RxComm              RsComm
+#  define NAMESPACE_IMPL server
+#  define RxComm         RsComm
+#  define rxGeneralAdmin rsGeneralAdmin
 
-    struct RsComm;
+#  include "irods/rsGeneralAdmin.hpp"
+
+struct RsComm;
 #else
-    #define NAMESPACE_IMPL      client
-    #define RxComm              RcComm
+#  define NAMESPACE_IMPL client
+#  define RxComm         RcComm
+#  define rxGeneralAdmin rcGeneralAdmin
 
-    struct RcComm;
+#  include "irods/generalAdmin.h"
+
+struct RcComm;
 #endif // IRODS_RESOURCE_ADMINISTRATION_ENABLE_SERVER_SIDE_API
+
+#include "irods/rodsErrorTable.h"
+#include "irods/irods_exception.hpp"
+
+#include <fmt/format.h>
 
 #include <cstdint>
 #include <string>
 #include <string_view>
-#include <system_error>
-#include <tuple>
 #include <optional>
 #include <chrono>
+#include <type_traits>
+#include <concepts>
 
-/// \brief A namespace that encapsulates administrative types and operations.
+/// A namespace that encapsulates administrative types and operations.
 namespace irods::experimental::administration
 {
     // clang-format off
@@ -41,29 +53,28 @@ namespace irods::experimental::administration
     // Forward declaration for "resource_info" class.
     namespace NAMESPACE_IMPL
     {
-        auto resource_info(RxComm&, const resource_name_type)
-            -> std::tuple<std::error_code, std::optional<class resource_info>>;
+        auto resource_info(RxComm&, const resource_name_type) -> std::optional<class resource_info>;
     } // namespace NAMESPACE_IMPL
 
-    /// \brief A namespace defining the default set of resource types.
+    /// A namespace defining the default set of resource types.
     namespace resource_type
     {
         // clang-format off
-        const std::string_view compound       = "compound";
-        const std::string_view deferred       = "deferred";
-        const std::string_view load_balanced  = "load_balanced";
-        const std::string_view mockarchive    = "mockarchive";
-        const std::string_view nonblocking    = "nonblocking";
-        const std::string_view passthrough    = "passthru";
-        const std::string_view random         = "random";
-        const std::string_view replication    = "replication";
-        const std::string_view struct_file    = "structfile";
-        const std::string_view universal_mss  = "univmss";
-        const std::string_view unixfilesystem = "unixfilesystem";
+        inline constexpr const char* compound       = "compound";
+        inline constexpr const char* deferred       = "deferred";
+        inline constexpr const char* load_balanced  = "load_balanced";
+        inline constexpr const char* mockarchive    = "mockarchive";
+        inline constexpr const char* nonblocking    = "nonblocking";
+        inline constexpr const char* passthrough    = "passthru";
+        inline constexpr const char* random         = "random";
+        inline constexpr const char* replication    = "replication";
+        inline constexpr const char* struct_file    = "structfile";
+        inline constexpr const char* universal_mss  = "univmss";
+        inline constexpr const char* unixfilesystem = "unixfilesystem";
         // clang-format on
     } // namespace resource_type
 
-    /// \brief An enumeration defining all valid resource status values.
+    /// An enumeration defining all valid resource status values.
     enum class resource_status
     {
         up,     ///< The resource is available.
@@ -71,30 +82,30 @@ namespace irods::experimental::administration
         unknown ///< The library does not understand the value.
     }; // enum class resource_status
 
-    /// \brief A type that holds information about an existing resource.
+    /// A type that holds information about an existing resource.
     class resource_info
     {
     public:
         // clang-format off
-        auto id() const noexcept -> const std::string&                       { return id_; }
-        auto name() const noexcept -> const std::string&                     { return name_; }
-        auto type() const noexcept -> const std::string&                     { return type_; }
-        auto zone_name() const noexcept -> const std::string&                { return zone_name_; }
-        auto host_name() const noexcept -> const std::string&                { return host_name_; }
-        auto vault_path() const noexcept -> const std::string&               { return vault_path_; }
-        auto status() const noexcept -> resource_status                      { return status_; }
-        auto context_string() const noexcept -> const std::string&           { return context_string_; }
-        auto comments() const noexcept -> const std::string&                 { return comments_; }
-        auto information() const noexcept -> const std::string&              { return info_; }
-        auto free_space() const noexcept -> const std::string&               { return free_space_; }
-        auto free_space_last_modified() const noexcept -> resource_time_type { return free_space_time_; }
-        auto parent_id() const noexcept -> const std::string&                { return parent_id_; }
-        auto created() const noexcept -> resource_time_type                  { return ctime_; }
-        auto last_modified() const noexcept -> resource_time_type            { return mtime_; }
-        // clang-format on
+        [[nodiscard]] auto id() const noexcept -> const std::string&                       { return id_; }
+        [[nodiscard]] auto name() const noexcept -> const std::string&                     { return name_; }
+        [[nodiscard]] auto type() const noexcept -> const std::string&                     { return type_; }
+        [[nodiscard]] auto zone_name() const noexcept -> const std::string&                { return zone_name_; }
+        [[nodiscard]] auto host_name() const noexcept -> const std::string&                { return host_name_; }
+        [[nodiscard]] auto vault_path() const noexcept -> const std::string&               { return vault_path_; }
+        [[nodiscard]] auto status() const noexcept -> resource_status                      { return status_; }
+        [[nodiscard]] auto context_string() const noexcept -> const std::string&           { return context_string_; }
+        [[nodiscard]] auto comments() const noexcept -> const std::string&                 { return comments_; }
+        [[nodiscard]] auto information() const noexcept -> const std::string&              { return info_; }
+        [[nodiscard]] auto free_space() const noexcept -> const std::string&               { return free_space_; }
+        [[nodiscard]] auto free_space_last_modified() const noexcept -> resource_time_type { return free_space_time_; }
+        [[nodiscard]] auto parent_id() const noexcept -> const std::string&                { return parent_id_; }
+        [[nodiscard]] auto created() const noexcept -> resource_time_type                  { return ctime_; }
+        [[nodiscard]] auto last_modified() const noexcept -> resource_time_type            { return mtime_; }
 
         friend auto NAMESPACE_IMPL::resource_info(RxComm&, const resource_name_type)
-            -> std::tuple<std::error_code, std::optional<class resource_info>>;
+            -> std::optional<class resource_info>;
+        // clang-format on
 
     private:
         resource_info() = default;
@@ -105,7 +116,7 @@ namespace irods::experimental::administration
         std::string zone_name_;
         std::string host_name_;
         std::string vault_path_;
-        resource_status status_;
+        resource_status status_ = resource_status::unknown;
         std::string context_string_;
         std::string comments_;
         std::string info_;
@@ -116,7 +127,7 @@ namespace irods::experimental::administration
         resource_time_type mtime_;
     }; // class resource_info
 
-    /// \brief A type that holds the necessary information needed to add a new resource to the system.
+    /// A type that holds the necessary information needed to add a new resource to the system.
     struct resource_registration_info
     {
         std::string resource_name;
@@ -126,191 +137,322 @@ namespace irods::experimental::administration
         std::string context_string;
     }; // class resource_registration_info
 
-    /// \brief A namespace defining the set of client-side or server-side API functions.
+    /// An input type used to update the type property of a resource.
+    ///
+    /// Primarily used to modify a resource.
+    ///
+    /// \since 4.3.1
+    struct resource_type_property
+    {
+        std::string value;
+    }; // struct resource_type_property
+
+    /// An input type used to update the host name property of a resource.
+    ///
+    /// Primarily used to modify a resource.
+    ///
+    /// \since 4.3.1
+    struct host_name_property
+    {
+        std::string value;
+    }; // struct host_name_property
+
+    /// An input type used to update the vault path property of a resource.
+    ///
+    /// Primarily used to modify a resource.
+    ///
+    /// \since 4.3.1
+    struct vault_path_property
+    {
+        std::string value;
+    }; // struct vault_path_property
+
+    /// An input type used to update the status property of a resource.
+    ///
+    /// Primarily used to modify a resource.
+    ///
+    /// \since 4.3.1
+    struct resource_status_property
+    {
+        resource_status value;
+    }; // struct resource_status_property
+
+    /// An input type used to update the comments property of a resource.
+    ///
+    /// Primarily used to modify a resource.
+    ///
+    /// \since 4.3.1
+    struct resource_comments_property
+    {
+        std::string value;
+    }; // struct resource_comments_property
+
+    /// An input type used to update the info property of a resource.
+    ///
+    /// Primarily used to modify a resource.
+    ///
+    /// \since 4.3.1
+    struct resource_info_property
+    {
+        std::string value;
+    }; // struct resource_info_property
+
+    /// An input type used to update the free space property of a resource.
+    ///
+    /// Primarily used to modify a resource.
+    ///
+    /// \since 4.3.1
+    struct free_space_property
+    {
+        std::string value;
+    }; // struct free_space_property
+
+    /// An input type used to update the context string property of a resource.
+    ///
+    /// Primarily used to modify a resource.
+    ///
+    /// \since 4.3.1
+    struct context_string_property
+    {
+        std::string value;
+    }; // struct context_string_property
+
+    // clang-format off
+    /// The \p ResourceProperty concept is satisfied if and only if \p T matches one of the following types:
+    /// - \p resource_type_property
+    /// - \p host_name_property
+    /// - \p vault_path_property
+    /// - \p resource_status_property
+    /// - \p resource_comments_property
+    /// - \p resource_info_property
+    /// - \p free_space_property
+    /// - \p context_string_property
+    ///
+    /// \since 4.3.1
+    template <typename T>
+    concept ResourceProperty = std::same_as<T, resource_type_property> ||
+        std::same_as<T, resource_type_property> ||
+        std::same_as<T, host_name_property> ||
+        std::same_as<T, vault_path_property> ||
+        std::same_as<T, resource_status_property> ||
+        std::same_as<T, resource_comments_property> ||
+        std::same_as<T, resource_info_property> ||
+        std::same_as<T, free_space_property> ||
+        std::same_as<T, context_string_property>;
+    // clang-format on
+
+    /// Converts a resource property type to its string representation.
+    ///
+    /// \tparam Property The type of the resource property.
+    ///
+    /// \since 4.3.1
+    template <ResourceProperty Property>
+    constexpr auto to_string() -> const char*
+    {
+        if constexpr (std::is_same_v<Property, resource_type_property>) {
+            return "resource type";
+        }
+        else if constexpr (std::is_same_v<Property, host_name_property>) {
+            return "resource host name";
+        }
+        else if constexpr (std::is_same_v<Property, vault_path_property>) {
+            return "resource vault path";
+        }
+        else if constexpr (std::is_same_v<Property, resource_status_property>) {
+            return "resource status";
+        }
+        else if constexpr (std::is_same_v<Property, resource_comments_property>) {
+            return "resource comments";
+        }
+        else if constexpr (std::is_same_v<Property, resource_info_property>) {
+            return "resource information";
+        }
+        else if constexpr (std::is_same_v<Property, free_space_property>) {
+            return "resource free space";
+        }
+        else if constexpr (std::is_same_v<Property, context_string_property>) {
+            return "resource context";
+        }
+    } // to_string
+
+    /// Converts the resource status string to its corresponding enumeration if a mapping exists.
+    ///
+    /// \param[in] _status The string representation of a resource enumeration.
+    ///
+    /// \return A resource_status enumeration.
+    ///
+    /// \since 4.3.1
+    constexpr auto to_resource_status(const std::string_view _status) -> resource_status
+    {
+        // clang-format off
+        if (_status == "up")   { return resource_status::up; }
+        if (_status == "down") { return resource_status::down; }
+        // clang-format on
+
+        return resource_status::unknown;
+    } // to_resource_status
+
+    /// A namespace defining the set of client-side or server-side API functions.
     ///
     /// This namespace's name changes based on the presence of a special macro. If the following macro
     /// is defined, then the NAMESPACE_IMPL will be \p server, else it will be \p client.
-    /// 
+    ///
     ///     - IRODS_RESOURCE_ADMINISTRATION_ENABLE_SERVER_SIDE_API
     ///
     namespace NAMESPACE_IMPL
     {
-        // clang-format off
-
-        /// \brief Adds a new resource to the system.
+        /// Adds a new resource to the system.
         ///
         /// \param[in] _comm The communication object.
         /// \param[in] _info The resource information.
         ///
-        /// \returns A std::error_code.
-        auto add_resource(RxComm& _comm, const resource_registration_info& _info) -> std::error_code;
+        /// \throws irods::exception If an error occurs.
+        auto add_resource(RxComm& _comm, const resource_registration_info& _info) -> void;
 
-        /// \brief Removes a resource from the system.
+        /// Removes a resource from the system.
         ///
         /// \param[in] _comm The communication object.
         /// \param[in] _name The name of the resource.
         ///
-        /// \returns A std::error_code.
-        auto remove_resource(RxComm& _comm, const resource_name_type _name) -> std::error_code;
+        /// \throws irods::exception If an error occurs.
+        auto remove_resource(RxComm& _comm, const resource_name_type _name) -> void;
 
-        /// \brief Makes a resource a child of another resource.
+        /// Makes a resource a child of another resource.
         ///
-        /// \param[in] _comm            The communication object.
-        /// \param[in] _parent          The name of the parent resource.
-        /// \param[in] _child           The name of the child resource.
-        /// \param[in] _context_string  Information used by the parent resource to manage the
-        ///                             child resource.
+        /// \param[in] _comm           The communication object.
+        /// \param[in] _parent         The name of the parent resource.
+        /// \param[in] _child          The name of the child resource.
+        /// \param[in] _context_string Information used by the parent resource to manage the
+        ///                            child resource.
         ///
-        /// \returns A std::error_code.
-        auto add_child_resource(RxComm& _comm,
-                                const resource_name_type _parent,
-                                const resource_name_type _child,
-                                const std::string_view _context_string = "") -> std::error_code;
+        /// \throws irods::exception If an error occurs.
+        auto add_child_resource(
+            RxComm& _comm,
+            const resource_name_type _parent,
+            const resource_name_type _child,
+            const std::string_view _context_string = "") -> void;
 
-        /// \brief Removes a child resource from a parent resource.
+        /// Removes a child resource from a parent resource.
         ///
         /// \param[in] _comm   The communication object.
         /// \param[in] _parent The name of the parent resource.
         /// \param[in] _child  The name of the child resource.
         ///
-        /// \returns A std::error_code.
-        auto remove_child_resource(RxComm& _comm,
-                                   const resource_name_type _parent,
-                                   const resource_name_type _child) -> std::error_code;
+        /// \throws irods::exception If an error occurs.
+        auto remove_child_resource(RxComm& _comm, const resource_name_type _parent, const resource_name_type _child)
+            -> void;
 
-        /// \brief Checks if a resource exists.
+        /// Checks if a resource exists.
         ///
         /// \param[in] _comm The communication object.
         /// \param[in] _name The name of the resource.
+        ///
+        /// \throws irods::exception If an error occurs.
         ///
         /// \returns A tuple containing error information and the existence results.
-        auto resource_exists(RxComm& _comm, const resource_name_type _name)
-            -> std::tuple<std::error_code, bool>;
+        auto resource_exists(RxComm& _comm, const resource_name_type _name) -> bool;
 
-        /// \brief Retrieves information about a resource.
+        /// Retrieves information about a resource.
         ///
         /// \param[in] _comm The communication object.
         /// \param[in] _name The name of the resource.
+        ///
+        /// \throws irods::exception If an error occurs.
         ///
         /// \returns A tuple containing error information and the resource information.
-        auto resource_info(RxComm& _comm, const resource_name_type _name)
-            -> std::tuple<std::error_code, std::optional<class resource_info>>;
+        auto resource_info(RxComm& _comm, const resource_name_type _name) -> std::optional<class resource_info>;
 
-        /// \brief Sets the type of a resource.
+        /// Modifies a property of a resource.
         ///
-        /// \param[in] _comm      The communication object.
-        /// \param[in] _name      The name of the resource.
-        /// \param[in] _new_value The new resource type.
+        /// \tparam Property \parblock The type of the property to modify.
         ///
-        /// \returns A std::error_code.
-        auto set_resource_type(RxComm& _comm,
-                               const resource_name_type _name,
-                               const std::string_view _new_value) -> std::error_code;
+        /// Property must satisfy the ResourceProperty concept. Failing to do so will result in a compile-time error.
+        /// \endparblock
+        ///
+        /// \param[in] _comm     The communication object.
+        /// \param[in] _name     The name of the resource.
+        /// \param[in] _property An object containing the required information for applying the change.
+        ///
+        /// \throws irods::exception If an error occurs.
+        ///
+        /// \since 4.3.1
+        template <ResourceProperty Property>
+        auto modify_resource(RxComm& _comm, const resource_name_type _name, const Property& _property) -> void
+        {
+            generalAdminInp_t input{};
+            input.arg0 = "modify";
+            input.arg1 = "resource";
+            input.arg2 = _name.data();
 
-        /// \brief Sets the host name of a resource.
-        ///
-        /// \param[in] _comm      The communication object.
-        /// \param[in] _name      The name of the resource.
-        /// \param[in] _new_value The new host name.
-        ///
-        /// \returns A std::error_code.
-        auto set_resource_host_name(RxComm& _comm,
-                                    const resource_name_type _name,
-                                    const std::string_view _new_value) -> std::error_code;
+            if constexpr (std::is_same_v<Property, resource_type_property>) {
+                input.arg3 = "type";
+                input.arg4 = _property.value.data();
+            }
+            else if constexpr (std::is_same_v<Property, host_name_property>) {
+                input.arg3 = "host";
+                input.arg4 = _property.value.data();
+            }
+            else if constexpr (std::is_same_v<Property, vault_path_property>) {
+                input.arg3 = "path";
+                input.arg4 = _property.value.data();
+            }
+            else if constexpr (std::is_same_v<Property, resource_status_property>) {
+                input.arg3 = "status";
 
-        /// \brief Sets the vault path of a resource.
-        ///
-        /// \param[in] _comm      The communication object.
-        /// \param[in] _name      The name of the resource.
-        /// \param[in] _new_value The new vault path.
-        ///
-        /// \returns A std::error_code.
-        auto set_resource_vault_path(RxComm& _comm,
-                                     const resource_name_type _name,
-                                     const std::string_view _new_value) -> std::error_code;
+                if (_property.value == resource_status::up) {
+                    input.arg4 = "up";
+                }
+                else if (_property.value == resource_status::down) {
+                    input.arg4 = "down";
+                }
+                else {
+                    THROW(SYS_INVALID_INPUT_PARAM, "Invalid value for resource status");
+                }
+            }
+            else if constexpr (std::is_same_v<Property, resource_comments_property>) {
+                input.arg3 = "comment";
+                input.arg4 = _property.value.data();
+            }
+            else if constexpr (std::is_same_v<Property, resource_info_property>) {
+                input.arg3 = "info";
+                input.arg4 = _property.value.data();
+            }
+            else if constexpr (std::is_same_v<Property, free_space_property>) {
+                input.arg3 = "free_space";
+                input.arg4 = _property.value.data();
+            }
+            else if constexpr (std::is_same_v<Property, context_string_property>) {
+                input.arg3 = "context";
+                input.arg4 = _property.value.data();
+            }
 
-        /// \brief Sets the status of a resource.
-        ///
-        /// \param[in] _comm      The communication object.
-        /// \param[in] _name      The name of the resource.
-        /// \param[in] _new_value The new status. Passing resource_status::unknown results
-        ///                       in an error.
-        ///
-        /// \returns A std::error_code.
-        auto set_resource_status(RxComm& _comm,
-                                 const resource_name_type _name,
-                                 resource_status _new_value) -> std::error_code;
+            if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
+                constexpr char* msg = "Could not change {} from [{}] to [{}] for resource [{}]";
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                THROW(ec, fmt::format(msg, to_string<Property>(), input.arg3, input.arg4, _name));
+            }
+        } // modify_resource
 
-        /// \brief Sets comments on a resource.
-        ///
-        /// This is a destructive update and will result in an overwrite of the existing
-        /// comments value if not careful.
-        ///
-        /// \param[in] _comm      The communication object.
-        /// \param[in] _name      The name of the resource.
-        /// \param[in] _new_value The new comments.
-        ///
-        /// \returns A std::error_code.
-        auto set_resource_comments(RxComm& _comm,
-                                   const resource_name_type _name,
-                                   const std::string_view _new_value) -> std::error_code;
-
-        /// \brief Sets textual information on a resource.
-        ///
-        /// This is a destructive update and will result in an overwrite of the existing
-        /// information value if not careful.
-        ///
-        /// \param[in] _comm      The communication object.
-        /// \param[in] _name      The name of the resource.
-        /// \param[in] _new_value The new information string.
-        ///
-        /// \returns A std::error_code.
-        auto set_resource_info_string(RxComm& _comm,
-                                      const resource_name_type _name,
-                                      const std::string_view _new_value) -> std::error_code;
-
-        /// \brief Sets the free space on a resource.
-        ///
-        /// \param[in] _comm      The communication object.
-        /// \param[in] _name      The name of the resource.
-        /// \param[in] _new_value The new free space value.
-        ///
-        /// \returns A std::error_code.
-        auto set_resource_free_space(RxComm& _comm,
-                                     const resource_name_type _name,
-                                     const std::string_view _new_value) -> std::error_code;
-
-        /// \brief Sets the context string of a resource.
-        ///
-        /// \param[in] _comm      The communication object.
-        /// \param[in] _name      The name of the resource.
-        /// \param[in] _new_value The new context string.
-        ///
-        /// \returns A std::error_code.
-        auto set_resource_context_string(RxComm& _comm,
-                                         const resource_name_type _name,
-                                         const std::string_view _new_value) -> std::error_code;
-
-        /// \brief Starts a rebalance on a resource.
+        /// Starts a rebalance on a resource.
         ///
         /// \param[in] _comm The communication object.
         /// \param[in] _name The name of the resource.
         ///
+        /// \throws irods::exception If an error occurs.
+        ///
         /// \returns A std::error_code.
-        auto rebalance_resource(RxComm& _comm, const resource_name_type _name) -> std::error_code;
+        auto rebalance_resource(RxComm& _comm, const resource_name_type _name) -> void;
 
-        /// \brief Retrieves the name of a resource given a resource ID.
+        /// Retrieves the name of a resource given a resource ID.
         ///
         /// \param[in] _comm The communication object.
         /// \param[in] _name The ID of the resource.
         ///
+        /// \throws irods::exception If an error occurs.
+        ///
         /// \returns A tuple containing error information and the resource name.
-        auto resource_name(RxComm& _comm, const resource_id_type _id)
-            -> std::tuple<std::error_code, std::optional<std::string>>;
-
-        // clang-format on
+        auto resource_name(RxComm& _comm, const resource_id_type _id) -> std::optional<std::string>;
     } // namespace NAMESPACE_IMPL
 } // namespace irods::experimental::administration
 
 #endif // IRODS_RESOURCE_ADMINISTRATION_HPP
-

--- a/lib/administration/resource/src/resource_administration.cpp
+++ b/lib/administration/resource/src/resource_administration.cpp
@@ -3,12 +3,12 @@
 #undef rxGeneralAdmin
 
 #ifdef IRODS_RESOURCE_ADMINISTRATION_ENABLE_SERVER_SIDE_API
-    #include "irods/rsGeneralAdmin.hpp"
-    #define rxGeneralAdmin  rsGeneralAdmin
-    #define IRODS_QUERY_ENABLE_SERVER_SIDE_API
+#  include "irods/rsGeneralAdmin.hpp"
+#  define rxGeneralAdmin rsGeneralAdmin
+#  define IRODS_QUERY_ENABLE_SERVER_SIDE_API
 #else
-    #include "irods/generalAdmin.h"
-    #define rxGeneralAdmin  rcGeneralAdmin
+#  include "irods/generalAdmin.h"
+#  define rxGeneralAdmin rcGeneralAdmin
 #endif // IRODS_RESOURCE_ADMINISTRATION_ENABLE_SERVER_SIDE_API
 
 #include "irods/rodsErrorTable.h"
@@ -18,7 +18,7 @@
 
 namespace irods::experimental::administration::NAMESPACE_IMPL
 {
-    auto add_resource(RxComm& _comm, const resource_registration_info& _info) -> std::error_code
+    auto add_resource(RxComm& _comm, const resource_registration_info& _info) -> void
     {
         std::string location;
 
@@ -36,13 +36,13 @@ namespace irods::experimental::administration::NAMESPACE_IMPL
         input.arg6 = ""; // Zone name (cannot be null).
 
         if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
-            return std::error_code{ec, std::generic_category()};
+            constexpr char* msg = "Could not create resource [name=[{}], type=[{}], location=[{}], context=[{}]]";
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(ec, fmt::format(msg, _info.resource_name, _info.resource_type, location, _info.context_string));
         }
-
-        return {};
     }
 
-    auto remove_resource(RxComm& _comm, const resource_name_type _name) -> std::error_code
+    auto remove_resource(RxComm& _comm, const resource_name_type _name) -> void
     {
         generalAdminInp_t input{};
         input.arg0 = "rm";
@@ -51,16 +51,16 @@ namespace irods::experimental::administration::NAMESPACE_IMPL
         input.arg3 = ""; // Dryrun flag (cannot be null).
 
         if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
-            return std::error_code{ec, std::generic_category()};
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(ec, fmt::format("Could not remove resource [{}]", _name));
         }
-
-        return {};
     }
 
-    auto add_child_resource(RxComm& _comm,
-                            const resource_name_type _parent,
-                            const resource_name_type _child,
-                            const std::string_view _context_string) -> std::error_code
+    auto add_child_resource(
+        RxComm& _comm,
+        const resource_name_type _parent,
+        const resource_name_type _child,
+        const std::string_view _context_string) -> void
     {
         generalAdminInp_t input{};
         input.arg0 = "add";
@@ -70,15 +70,12 @@ namespace irods::experimental::administration::NAMESPACE_IMPL
         input.arg4 = _context_string.data();
 
         if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
-            return std::error_code{ec, std::generic_category()};
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(ec, fmt::format("Could not add child resource [{}] to resource [{}]", _child, _parent));
         }
-
-        return {};
     }
 
-    auto remove_child_resource(RxComm& _comm,
-                               const resource_name_type _parent,
-                               const resource_name_type _child) -> std::error_code
+    auto remove_child_resource(RxComm& _comm, const resource_name_type _parent, const resource_name_type _child) -> void
     {
         generalAdminInp_t input{};
         input.arg0 = "rm";
@@ -87,51 +84,44 @@ namespace irods::experimental::administration::NAMESPACE_IMPL
         input.arg3 = _child.data();
 
         if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
-            return std::error_code{ec, std::generic_category()};
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(ec, fmt::format("Could not remove child resource [{}] from resource [{}]", _child, _parent));
         }
-
-        return {};
     }
 
-    auto resource_exists(RxComm& _comm, const resource_name_type _name)
-        -> std::tuple<std::error_code, bool>
+    auto resource_exists(RxComm& _comm, const resource_name_type _name) -> bool
     {
         try {
-            const auto gql = fmt::format("select RESC_ID where RESC_NAME = '{}'", _name);
-            return {std::error_code{}, query_builder{}.build(_comm, gql).size() > 0};
+            return query_builder{}.build(_comm, fmt::format("select RESC_ID where RESC_NAME = '{}'", _name)).size() > 0;
+        }
+        catch (const std::exception& e) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(SYS_LIBRARY_ERROR, e.what());
         }
         catch (...) {
-            return {std::error_code{SYS_UNKNOWN_ERROR, std::generic_category()}, false};
+            constexpr char* msg = "An unknown error occurred while verifying existence of resource [{}]";
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(SYS_UNKNOWN_ERROR, fmt::format(msg, _name));
         }
     }
 
-    auto resource_info(RxComm& _comm, const resource_name_type _name)
-        -> std::tuple<std::error_code, std::optional<class resource_info>>
+    auto resource_info(RxComm& _comm, const resource_name_type _name) -> std::optional<class resource_info>
     {
-        const auto to_resource_status = [](const std::string_view _status)
-        {
-            // clang-format off
-            if (_status == "up")   return resource_status::up;
-            if (_status == "down") return resource_status::down;
-            // clang-format on
-
-            return resource_status::unknown;
-        };
-
-        class resource_info info;
-        info.name_ = _name.data();
-
         try {
-            // clang-format off
-            const auto gql = fmt::format("select RESC_ID, RESC_TYPE_NAME, RESC_ZONE_NAME,"
-                                         "       RESC_LOC, RESC_VAULT_PATH, RESC_STATUS,"
-                                         "       RESC_CONTEXT, RESC_COMMENT, RESC_INFO,"
-                                         "       RESC_FREE_SPACE, RESC_FREE_SPACE_TIME,"
-                                         "       RESC_PARENT, RESC_CREATE_TIME, RESC_MODIFY_TIME "
-                                         "where RESC_NAME = '{}'", _name);
-            // clang-format on
+            const auto gql = fmt::format(
+                "select RESC_ID, RESC_TYPE_NAME, RESC_ZONE_NAME, "
+                "RESC_LOC, RESC_VAULT_PATH, RESC_STATUS, "
+                "RESC_CONTEXT, RESC_COMMENT, RESC_INFO, "
+                "RESC_FREE_SPACE, RESC_FREE_SPACE_TIME, "
+                "RESC_PARENT, RESC_CREATE_TIME, RESC_MODIFY_TIME "
+                "where RESC_NAME = '{}'",
+                _name);
 
             for (auto&& row : query_builder{}.build(_comm, gql)) {
+                class resource_info info;
+                info.name_ = std::string{_name};
+
+                // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
                 info.id_ = row[0];
                 info.type_ = row[1];
                 info.zone_name_ = row[2];
@@ -149,168 +139,25 @@ namespace irods::experimental::administration::NAMESPACE_IMPL
                 if (!row[10].empty()) {
                     info.free_space_time_ = resource_time_type{std::chrono::seconds{std::stoull(row[10])}};
                 }
+                // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
+
+                return info;
             }
 
-            return {std::error_code{}, std::move(info)};
+            return std::nullopt;
+        }
+        catch (const std::exception& e) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(SYS_LIBRARY_ERROR, e.what());
         }
         catch (...) {
-            return {std::error_code{SYS_UNKNOWN_ERROR, std::generic_category()}, std::nullopt};
+            constexpr char* msg = "An unknown error occurred while retrieving information about resource [{}]";
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(SYS_UNKNOWN_ERROR, fmt::format(msg, _name));
         }
     }
 
-    auto set_resource_type(RxComm& _comm,
-                           const resource_name_type _name,
-                           const std::string_view _new_value) -> std::error_code
-    {
-        generalAdminInp_t input{};
-        input.arg0 = "modify";
-        input.arg1 = "resource";
-        input.arg2 = _name.data();
-        input.arg3 = "type";
-        input.arg4 = _new_value.data();
-
-        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
-            return std::error_code{ec, std::generic_category()};
-        }
-
-        return {};
-    }
-
-    auto set_resource_host_name(RxComm& _comm,
-                                const resource_name_type _name,
-                                const std::string_view _new_value) -> std::error_code
-    {
-        generalAdminInp_t input{};
-        input.arg0 = "modify";
-        input.arg1 = "resource";
-        input.arg2 = _name.data();
-        input.arg3 = "host";
-        input.arg4 = _new_value.data();
-
-        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
-            return std::error_code{ec, std::generic_category()};
-        }
-
-        return {};
-    }
-
-    auto set_resource_vault_path(RxComm& _comm,
-                                 const resource_name_type _name,
-                                 const std::string_view _new_value) -> std::error_code
-    {
-        generalAdminInp_t input{};
-        input.arg0 = "modify";
-        input.arg1 = "resource";
-        input.arg2 = _name.data();
-        input.arg3 = "path";
-        input.arg4 = _new_value.data();
-
-        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
-            return std::error_code{ec, std::generic_category()};
-        }
-
-        return {};
-    }
-
-    auto set_resource_status(RxComm& _comm,
-                             const resource_name_type _name,
-                             resource_status _new_value) -> std::error_code
-    {
-        generalAdminInp_t input{};
-        input.arg0 = "modify";
-        input.arg1 = "resource";
-        input.arg2 = _name.data();
-        input.arg3 = "status";
-
-        // new value
-        switch (_new_value) {
-            // clang-format off
-            case resource_status::up:      input.arg4 = "up"; break;
-            case resource_status::down:    input.arg4 = "down"; break;
-            case resource_status::unknown: return std::error_code{SYS_INVALID_INPUT_PARAM, std::generic_category()};
-            // clang-format on
-        }
-
-        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
-            return std::error_code{ec, std::generic_category()};
-        }
-
-        return {};
-    }
-
-    auto set_resource_comments(RxComm& _comm,
-                               const resource_name_type _name,
-                               const std::string_view _new_value) -> std::error_code
-    {
-        generalAdminInp_t input{};
-        input.arg0 = "modify";
-        input.arg1 = "resource";
-        input.arg2 = _name.data();
-        input.arg3 = "comment";
-        input.arg4 = _new_value.data();
-
-        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
-            return std::error_code{ec, std::generic_category()};
-        }
-
-        return {};
-    }
-
-    auto set_resource_info_string(RxComm& _comm,
-                                  const resource_name_type _name,
-                                  const std::string_view _new_value) -> std::error_code
-    {
-        generalAdminInp_t input{};
-        input.arg0 = "modify";
-        input.arg1 = "resource";
-        input.arg2 = _name.data();
-        input.arg3 = "info";
-        input.arg4 = _new_value.data();
-
-        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
-            return std::error_code{ec, std::generic_category()};
-        }
-
-        return {};
-    }
-
-    auto set_resource_free_space(RxComm& _comm,
-                                 const resource_name_type _name,
-                                 const std::string_view _new_value) -> std::error_code
-    {
-        generalAdminInp_t input{};
-        input.arg0 = "modify";
-        input.arg1 = "resource";
-        input.arg2 = _name.data();
-        input.arg3 = "free_space";
-        input.arg4 = _new_value.data();
-
-        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
-            return std::error_code{ec, std::generic_category()};
-        }
-
-        return {};
-    }
-
-    auto set_resource_context_string(RxComm& _comm,
-                                     const resource_name_type _name,
-                                     const std::string_view _new_value) -> std::error_code
-    {
-        generalAdminInp_t input{};
-        input.arg0 = "modify";
-        input.arg1 = "resource";
-        input.arg2 = _name.data();
-        input.arg3 = "context";
-        input.arg4 = _new_value.data();
-
-        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
-            return std::error_code{ec, std::generic_category()};
-        }
-
-        return {};
-    }
-
-    auto rebalance_resource(RxComm& _comm, const resource_name_type _name) -> std::error_code
+    auto rebalance_resource(RxComm& _comm, const resource_name_type _name) -> void
     {
         generalAdminInp_t input{};
         input.arg0 = "modify";
@@ -320,26 +167,30 @@ namespace irods::experimental::administration::NAMESPACE_IMPL
         input.arg4 = ""; // Required to avoid segfaults in server.
 
         if (const auto ec = rxGeneralAdmin(&_comm, &input); ec < 0) {
-            return std::error_code{ec, std::generic_category()};
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(ec, fmt::format("Encountered rebalance error for resource [{}]", _name));
         }
-
-        return {};
     }
 
-    auto resource_name(RxComm& _comm, const resource_id_type _id)
-        -> std::tuple<std::error_code, std::optional<std::string>>
+    auto resource_name(RxComm& _comm, const resource_id_type _id) -> std::optional<std::string>
     {
         try {
             const auto gql = fmt::format("select RESC_NAME where RESC_ID = '{}'", _id);
 
             for (auto&& row : query_builder{}.build(_comm, gql)) {
-                return {std::error_code{}, row[0]};
+                return row[0];
             }
 
-            return {std::error_code{}, std::nullopt};
+            return std::nullopt;
+        }
+        catch (const std::exception& e) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(SYS_LIBRARY_ERROR, e.what());
         }
         catch (...) {
-            return {std::error_code{SYS_UNKNOWN_ERROR, std::generic_category()}, std::nullopt};
+            constexpr char* msg = "An unknown error occurred while retrieving resource name with id [{}]";
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(SYS_UNKNOWN_ERROR, fmt::format(msg, _id));
         }
     }
 } // namespace irods::experimental::administration::NAMESPACE_IMPL

--- a/unit_tests/cmake/test_config/irods_filesystem.cmake
+++ b/unit_tests/cmake/test_config/irods_filesystem.cmake
@@ -4,7 +4,8 @@ set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
                             ${CMAKE_CURRENT_SOURCE_DIR}/src/filesystem/test_path.cpp
                             ${CMAKE_CURRENT_SOURCE_DIR}/src/filesystem/test_filesystem.cpp)
 
-set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+set(IRODS_TEST_INCLUDE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src # For unit_test_utils.hpp
+                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
                             ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
  
 set(IRODS_TEST_LINK_LIBRARIES irods_common

--- a/unit_tests/cmake/test_config/irods_resource_administration.cmake
+++ b/unit_tests/cmake/test_config/irods_resource_administration.cmake
@@ -3,7 +3,9 @@ set(IRODS_TEST_TARGET irods_resource_administration)
 set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
                             ${CMAKE_CURRENT_SOURCE_DIR}/src/test_resource_administration.cpp)
 
-set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include)
+set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
  
 set(IRODS_TEST_LINK_LIBRARIES irods_common
-                              irods_client)
+                              irods_client
+                              ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)

--- a/unit_tests/cmake/test_config/irods_zone_report.cmake
+++ b/unit_tests/cmake/test_config/irods_zone_report.cmake
@@ -3,7 +3,8 @@ set(IRODS_TEST_TARGET irods_zone_report)
 set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
                             ${CMAKE_CURRENT_SOURCE_DIR}/src/test_zone_report.cpp)
 
-set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include)
+set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
  
 set(IRODS_TEST_LINK_LIBRARIES irods_common
                               irods_client)

--- a/unit_tests/src/test_data_object_finalize.cpp
+++ b/unit_tests/src/test_data_object_finalize.cpp
@@ -57,11 +57,11 @@ TEST_CASE("finalize", "[finalize]")
         irods::experimental::client_connection conn;
         RcComm& comm = static_cast<RcComm&>(conn);
 
-        if (const auto [ec, exists] = adm::client::resource_exists(comm, _name); exists) {
-            REQUIRE(adm::client::remove_resource(comm, _name));
+        if (adm::client::resource_exists(comm, _name)) {
+            REQUIRE_NOTHROW(adm::client::remove_resource(comm, _name));
         }
 
-        REQUIRE(unit_test_utils::add_ufs_resource(comm, _name, "vault_for_"s + _name.data()));
+        REQUIRE_NOTHROW(unit_test_utils::add_ufs_resource(comm, _name, "vault_for_"s + _name.data()));
     };
 
     mkresc(resc_0);

--- a/unit_tests/src/test_logical_locking.cpp
+++ b/unit_tests/src/test_logical_locking.cpp
@@ -53,11 +53,11 @@ namespace
         irods::experimental::client_connection conn;
         RcComm& comm = static_cast<RcComm&>(conn);
 
-        if (const auto [ec, exists] = adm::client::resource_exists(comm, _name); exists) {
-            REQUIRE(adm::client::remove_resource(comm, _name));
+        if (adm::client::resource_exists(comm, _name)) {
+            REQUIRE_NOTHROW(adm::client::remove_resource(comm, _name));
         }
 
-        REQUIRE(unit_test_utils::add_ufs_resource(comm, _name, "vault_for_"s + _name.data()));
+        REQUIRE_NOTHROW(unit_test_utils::add_ufs_resource(comm, _name, "vault_for_"s + _name.data()));
     } // mkresc
 } // anonymous namespace
 

--- a/unit_tests/src/test_parallel_transfer_engine.cpp
+++ b/unit_tests/src/test_parallel_transfer_engine.cpp
@@ -215,9 +215,7 @@ TEST_CASE("stream factory utilities")
         }};
 
         // Verify that the resource exists.
-        auto [ec, exists] = adm::client::resource_exists(conn, resc_name);
-        REQUIRE(!ec);
-        REQUIRE(exists);
+        REQUIRE(adm::client::resource_exists(conn, resc_name));
 
         // Create the sandbox for testing.
         rodsEnv env;

--- a/unit_tests/src/test_replica.cpp
+++ b/unit_tests/src/test_replica.cpp
@@ -71,7 +71,7 @@ TEST_CASE("replica", "[replica]")
     {
         // create resource.
         irods::experimental::client_connection conn;
-        REQUIRE(unit_test_utils::add_ufs_resource(conn, resc_name, "unit_test_vault"));
+        REQUIRE_NOTHROW(unit_test_utils::add_ufs_resource(conn, resc_name, "unit_test_vault"));
     }
 
     {

--- a/unit_tests/src/unit_test_utils.hpp
+++ b/unit_tests/src/unit_test_utils.hpp
@@ -38,7 +38,7 @@ namespace unit_test_utils
 
     inline auto get_hostname() noexcept -> std::string
     {
-        char hostname[256] {};
+        char hostname[HOST_NAME_MAX]{};
         gethostname(hostname, sizeof(hostname));
         return hostname;
     }
@@ -62,9 +62,8 @@ namespace unit_test_utils
         return vault.c_str();
     }
 
-    inline auto add_ufs_resource(RcComm& _comm,
-                                 const std::string_view _resc_name,
-                                 const std::string_view _vault_name) -> bool
+    inline auto add_ufs_resource(RcComm& _comm, const std::string_view _resc_name, const std::string_view _vault_name)
+        -> void
     {
         namespace adm = irods::experimental::administration;
 
@@ -74,11 +73,11 @@ namespace unit_test_utils
         // The new resource's information.
         adm::resource_registration_info ufs_info;
         ufs_info.resource_name = _resc_name.data();
-        ufs_info.resource_type = adm::resource_type::unixfilesystem.data();
+        ufs_info.resource_type = adm::resource_type::unixfilesystem;
         ufs_info.host_name = host_name;
         ufs_info.vault_path = vault_path;
 
-        return adm::client::add_resource(_comm, ufs_info).value() == 0;
+        adm::client::add_resource(_comm, ufs_info);
     }
 
     inline auto replicate_data_object(RcComm& _comm,


### PR DESCRIPTION
All unit tests passed.

~Running core tests.~

We can skip running the core tests because nothing in the server outside of unit tests use the resource administration library.