### PR TITLE
Refactored user administration library to throw exceptions (main)

### DIFF
--- a/lib/administration/user/CMakeLists.txt
+++ b/lib/administration/user/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.12.0 FATAL_ERROR)
 add_library(
   irods_user_administration_common
   OBJECT
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/detail.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/group.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/user.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/utilities.cpp"
@@ -19,6 +20,11 @@ target_include_directories(
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<BUILD_INTERFACE:${CMAKE_IRODS_SOURCE_DIR}/lib/administration/zone/include>"
+  "$<BUILD_INTERFACE:${CMAKE_IRODS_SOURCE_DIR}/lib/core/include>"
+  "$<BUILD_INTERFACE:${CMAKE_IRODS_SOURCE_DIR}/lib/api/include>"
+  PRIVATE
+  "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
+  "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
 )
 target_compile_definitions(
   irods_user_administration_common

--- a/lib/administration/user/include/irods/user_administration.hpp
+++ b/lib/administration/user/include/irods/user_administration.hpp
@@ -4,85 +4,147 @@
 /// \file
 
 #undef NAMESPACE_IMPL
-#undef rxComm
+#undef RxComm
+#undef rxGeneralAdmin
 
 #ifdef IRODS_USER_ADMINISTRATION_ENABLE_SERVER_SIDE_API
-    #define NAMESPACE_IMPL      server
-    #define rxComm              RsComm
-    struct RsComm;
-#else 
-    #define NAMESPACE_IMPL      client
-    #define rxComm              RcComm
-    struct RcComm;
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+#  define NAMESPACE_IMPL server
+#  define RxComm         RsComm
+#  define rxGeneralAdmin rsGeneralAdmin
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+#  include "irods/rsGeneralAdmin.hpp"
+
+struct RsComm;
+#else
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+#  define NAMESPACE_IMPL client
+#  define RxComm         RcComm
+#  define rxGeneralAdmin rcGeneralAdmin
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+#  include "irods/generalAdmin.h"
+
+struct RcComm;
 #endif // IRODS_USER_ADMINISTRATION_ENABLE_SERVER_SIDE_API
 
 #include "irods/user.hpp"
 #include "irods/group.hpp"
 #include "irods/zone_type.hpp"
+#include "irods/irods_exception.hpp"
+#include "irods/rodsErrorTable.h"
 
-#include <vector>
-#include <string>
+#include <fmt/format.h>
+
 #include <optional>
-#include <ostream>
-#include <system_error>
 #include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
 
 /// \since 4.2.8
 namespace irods::experimental::administration
 {
-    /// A namespace that allows other variations of the library while also making
-    /// this interface (and implementation) the default version.
+    /// Defines the user types supported by the user administration library.
     ///
     /// \since 4.2.8
-    inline namespace v1
+    enum class user_type
     {
-        /// \brief Defines the user types supported by the user administration library.
-        ///
-        /// \since 4.2.8
-        enum class user_type
-        {
-            rodsuser,   ///< Identifies users that do not have administrative privileges.
-            groupadmin, ///< Identifies users that have limited administrative privileges. 
-            rodsadmin   ///< Identifies users that have full administrative privileges.
-        }; // enum class user_type
+        // clang-format off
+        rodsuser,   ///< Identifies users that do not have administrative privileges.
+        groupadmin, ///< Identifies users that have limited administrative privileges.
+        rodsadmin   ///< Identifies users that have full administrative privileges.
+        // clang-format on
+    }; // enum class user_type
 
-        /// \brief The generic exception type used by the user administration library.
-        ///
-        /// \since 4.2.8
-        class user_management_error
-            : std::runtime_error
-        {
-        public:
-            using std::runtime_error::runtime_error;
-        }; // class user_management_error
+    /// Defines the set of operations for manipulating user authentication names.
+    ///
+    /// \since 4.3.1
+    enum class user_authentication_operation
+    {
+        // clang-format off
+        add,   ///< Indicates that the authentication name should be available to the user.
+        remove ///< Indicates that the authentication name should not be available to the user.
+        // clang-format on
+    }; // enum class user_auth_property_operation
 
-        /// \brief Converts a string to a user_type enumeration.
-        ///
-        /// \param[in] user_type_string The string to convert.
-        ///
-        /// \throws user_management_error If the string cannot be converted to an enumeration.
-        ///
-        /// \return A user_type enumeration.
-        ///
-        /// \since 4.3.1
-        auto to_user_type(const std::string_view user_type_string) -> user_type;
+    /// Holds the new password for a user. Primarily used to modify a user.
+    ///
+    /// \since 4.3.1
+    struct user_password_property
+    {
+        std::string value;
+    }; // struct user_password_property
 
-        /// \brief Converts a user_type enumeration to a string.
-        ///
-        /// The string returned is a read-only string and must not be modified by the caller. Attempting
-        /// to modify the string will result in undefined behavior.
-        ///
-        /// \param[in] user_type The enumeration to convert.
-        ///
-        /// \throws user_management_error If the enumeration cannot be converted to a string.
-        ///
-        /// \return A C string.
-        ///
-        /// \since 4.3.1
-        auto to_c_str(user_type user_type) -> const char*;
-    } // namespace v1
+    /// Holds the new type of a user. Primarily used to modify a user.
+    ///
+    /// \since 4.3.1
+    struct user_type_property
+    {
+        user_type value;
+    }; // struct user_type_property
 
-    /// \brief A namespace defining the set of client-side or server-side API functions.
+    /// Holds the new password for a user. Primarily used to modify a user.
+    ///
+    /// \since 4.3.1
+    struct user_authentication_property
+    {
+        // clang-format off
+        user_authentication_operation op; ///< The operation to execute.
+        std::string value;                ///< The authentication name.
+        // clang-format on
+    }; // struct user_authentication_property
+
+    // clang-format off
+    /// The \p UserProperty concept is satisfied if and only if \p T matches one of the following types:
+    /// - \p user_password_property
+    /// - \p user_type_property
+    /// - \p user_authentication_property
+    ///
+    /// \since 4.3.1
+    template <typename T>
+    concept UserProperty = std::same_as<T, user_password_property> ||
+        std::same_as<T, user_type_property> ||
+        std::same_as<T, user_authentication_property>;
+    // clang-format on
+
+    /// Converts a string to a user_type enumeration.
+    ///
+    /// \param[in] user_type_string The string to convert.
+    ///
+    /// \throws irods::exception If an error occurs.
+    ///
+    /// \return A user_type enumeration.
+    ///
+    /// \since 4.3.1
+    auto to_user_type(const std::string_view user_type_string) -> user_type;
+
+    /// Converts a user_type enumeration to a string.
+    ///
+    /// The string returned is a read-only string and must not be modified by the caller. Attempting
+    /// to modify the string will result in undefined behavior.
+    ///
+    /// \param[in] user_type The enumeration to convert.
+    ///
+    /// \throws irods::exception If an error occurs.
+    ///
+    /// \return A C string.
+    ///
+    /// \since 4.3.1
+    auto to_c_str(user_type user_type) -> const char*;
+
+    /// Reserved for the implementation of the library.
+    ///
+    /// Users of this library MUST NOT use anything defined in this namespace.
+    ///
+    /// \since 4.3.1
+    namespace detail
+    {
+        auto obfuscate_password(const std::string_view new_password) -> std::string;
+    } // namespace detail
+
+    /// A namespace defining the set of client-side or server-side API functions.
     ///
     /// This namespace's name changes based on the presence of a special macro. If the following macro
     /// is defined, then the NAMESPACE_IMPL will be \p server, else it will be \p client.
@@ -92,257 +154,268 @@ namespace irods::experimental::administration
     /// \since 4.2.8
     namespace NAMESPACE_IMPL
     {
+        /// Returns the unique name of a user in the local zone.
+        ///
+        /// \param[in] _comm The communication object.
+        /// \param[in] _user The user to produce the unique name for.
+        ///
+        /// \throws irods::exception If an error occurs.
+        ///
+        /// \return A string representing the unique name of the user within the local zone.
+        ///
         /// \since 4.2.8
-        inline namespace v1
+        auto local_unique_name(RxComm& _comm, const user& _user) -> std::string;
+
+        /// Adds a new user to the system.
+        ///
+        /// \param[in] _comm      The communication object.
+        /// \param[in] _user      The user to add.
+        /// \param[in] _user_type The type of the user.
+        /// \param[in] _zone_type The zone that is responsible for the user.
+        ///
+        /// \throws irods::exception If an error occurs.
+        ///
+        /// \return An error code.
+        ///
+        /// \since 4.2.8
+        auto add_user(
+            RxComm& _comm,
+            const user& _user,
+            user_type _user_type = user_type::rodsuser,
+            zone_type _zone_type = zone_type::local) -> void;
+
+        /// Removes a user from the system.
+        ///
+        /// \param[in] _comm The communication object.
+        /// \param[in] _user The user to remove.
+        ///
+        /// \return An error code.
+        ///
+        /// \since 4.2.8
+        auto remove_user(RxComm& _comm, const user& _user) -> void;
+
+        /// Modifies a property of a user.
+        ///
+        /// \tparam Property \parblock The type of the property to modify.
+        ///
+        /// Property must satisfy the UserProperty concept. Failing to do so will result in a compile-time error.
+        /// \endparblock
+        ///
+        /// \param[in] _comm     The communication object.
+        /// \param[in] _user     The user to modify.
+        /// \param[in] _property An object containing the required information for applying the change.
+        ///
+        /// \throws irods::exception If an error occurs.
+        ///
+        /// \since 4.3.1
+        template <UserProperty Property>
+        auto modify_user(RxComm& _comm, const user& _user, const Property& _property) -> void
         {
-            /// \brief Adds a new user to the system.
-            ///
-            /// \throws user_management_error If the user type cannot be converted to a string.
-            ///
-            /// \param[in] conn      The communication object.
-            /// \param[in] user      The user to add.
-            /// \param[in] user_type The type of the user.
-            /// \param[in] zone_type The zone that is responsible for the user.
-            ///
-            /// \return An error code.
-            ///
-            /// \since 4.2.8
-            auto add_user(rxComm& conn,
-                          const user& user,
-                          user_type user_type = user_type::rodsuser,
-                          zone_type zone_type = zone_type::local) -> std::error_code;
+            const auto name = local_unique_name(_comm, _user);
+            [[maybe_unused]] std::string obfuscated_password;
 
-            /// \brief Removes a user from the system.
-            ///
-            /// \param[in] conn The communication object.
-            /// \param[in] user The user to remove.
-            ///
-            /// \return An error code.
-            ///
-            /// \since 4.2.8
-            auto remove_user(rxComm& conn, const user& user) -> std::error_code;
+            GeneralAdminInput input{};
+            input.arg0 = "modify";
+            input.arg1 = "user";
+            input.arg2 = name.c_str();
 
-            /// \brief Changes the password of a user.
-            ///
-            /// \param[in] conn         The communication object.
-            /// \param[in] user         The user to update.
-            /// \param[in] new_password The new password of the user.
-            ///
-            /// \return An error code.
-            ///
-            /// \since 4.2.8
-            auto set_user_password(rxComm& conn, const user& user, std::string_view new_password) -> std::error_code;
+            // clang-format off
+            const auto execute = [&]<typename... Args>(fmt::format_string<Args...> _msg, Args&&... _args)
+            {
+                if (const auto ec = rxGeneralAdmin(&_comm, &input); ec != 0) {
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                    THROW(ec, fmt::format(_msg, std::forward<Args>(_args)...));
+                }
+            };
+            // clang-format on
 
-            /// \brief Changes the type of a user.
-            ///
-            /// \throws user_management_error If the new user type cannot be converted to a string.
-            ///
-            /// \param[in] conn          The communication object.
-            /// \param[in] user          The user to update.
-            /// \param[in] new_user_type The new type of the user.
-            ///
-            /// \return An error code.
-            ///
-            /// \since 4.2.8
-            auto set_user_type(rxComm& conn, const user& user, user_type new_user_type) -> std::error_code;
+            if constexpr (std::is_same_v<Property, user_password_property>) {
+                obfuscated_password = detail::obfuscate_password(_property.value);
+                input.arg3 = "password";
+                input.arg4 = obfuscated_password.c_str();
+                execute("Failed to set password for user [{}].", name);
+            }
+            else if constexpr (std::is_same_v<Property, user_type_property>) {
+                input.arg3 = "type";
+                input.arg4 = to_c_str(_property.value);
+                execute("Failed to set user type to [{}] for user [{}].", input.arg4, name);
+            }
+            else if constexpr (std::is_same_v<Property, user_authentication_property>) {
+                input.arg4 = _property.value.c_str();
 
-            /// \brief Adds an authentication name to a user.
-            ///
-            /// \param[in] conn The communication object.
-            /// \param[in] user The user to update.
-            /// \param[in] auth The authentication name to add.
-            ///
-            /// \return An error code.
-            ///
-            /// \since 4.2.8
-            auto add_user_auth(rxComm& conn, const user& user, std::string_view auth) -> std::error_code;
+                if (_property.op == user_authentication_operation::add) {
+                    input.arg3 = "addAuth";
+                    execute("Failed to add authentication name [{}] to user [{}].", input.arg4, name);
+                }
+                else {
+                    input.arg3 = "rmAuth";
+                    execute("Failed to remove authentication name [{}] from user [{}].", input.arg4, name);
+                }
+            }
+        } // modify_user
 
-            /// \brief Removes an authentication name from a user.
-            ///
-            /// \param[in] conn The communication object.
-            /// \param[in] user The user to update.
-            /// \param[in] auth The authentication name to remove.
-            ///
-            /// \return An error code.
-            ///
-            /// \since 4.2.8
-            auto remove_user_auth(rxComm& conn, const user& user, std::string_view auth) -> std::error_code;
+        /// Adds a new group to the system.
+        ///
+        /// \param[in] _comm  The communication object.
+        /// \param[in] _group The group to add.
+        ///
+        /// \throws irods::exception If an error occurs.
+        ///
+        /// \since 4.2.8
+        auto add_group(RxComm& _comm, const group& _group) -> void;
 
-            /// \brief Adds a new group to the system.
-            ///
-            /// \param[in] conn  The communication object.
-            /// \param[in] group The group to add.
-            ///
-            /// \return An error code.
-            ///
-            /// \since 4.2.8
-            auto add_group(rxComm& conn, const group& group) -> std::error_code;
+        /// Removes a group from the system.
+        ///
+        /// \param[in] _comm  The communication object.
+        /// \param[in] _group The group to remove.
+        ///
+        /// \throws irods::exception If an error occurs.
+        ///
+        /// \since 4.2.8
+        auto remove_group(RxComm& _comm, const group& _group) -> void;
 
-            /// \brief Removes a group from the system.
-            ///
-            /// \param[in] conn  The communication object.
-            /// \param[in] group The group to remove.
-            ///
-            /// \return An error code.
-            ///
-            /// \since 4.2.8
-            auto remove_group(rxComm& conn, const group& group) -> std::error_code;
+        /// Adds a user to a group.
+        ///
+        /// \param[in] _comm  The communication object.
+        /// \param[in] _group The group that will hold the user.
+        /// \param[in] _user  The user to add to the group.
+        ///
+        /// \throws irods::exception If an error occurs.
+        ///
+        /// \since 4.2.8
+        auto add_user_to_group(RxComm& _comm, const group& _group, const user& _user) -> void;
 
-            /// \brief Adds a user to a group.
-            ///
-            /// \param[in] conn  The communication object.
-            /// \param[in] group The group that will hold the user.
-            /// \param[in] user  The user to add to the group.
-            ///
-            /// \return An error code.
-            ///
-            /// \since 4.2.8
-            auto add_user_to_group(rxComm& conn, const group& group, const user& user) -> std::error_code;
+        /// Removes a user from a group.
+        ///
+        /// \param[in] _comm  The communication object.
+        /// \param[in] _group The group that contains the user.
+        /// \param[in] _user  The user to remove from the group.
+        ///
+        /// \throws irods::exception If an error occurs.
+        ///
+        /// \since 4.2.8
+        auto remove_user_from_group(RxComm& _comm, const group& _group, const user& _user) -> void;
 
-            /// \brief Removes a user from a group.
-            ///
-            /// \param[in] conn  The communication object.
-            /// \param[in] group The group that contains the user.
-            /// \param[in] user  The user to remove from the group.
-            ///
-            /// \return An error code.
-            ///
-            /// \since 4.2.8
-            auto remove_user_from_group(rxComm& conn, const group& group, const user& user) -> std::error_code;
+        /// Returns all users in the local zone.
+        ///
+        /// \param[in] _comm The communication object.
+        ///
+        /// \return A list of users.
+        ///
+        /// \since 4.2.8
+        auto users(RxComm& _comm) -> std::vector<user>;
 
-            /// \brief Returns all users in the local zone.
-            ///
-            /// \param[in] conn The communication object.
-            ///
-            /// \return A list of users.
-            ///
-            /// \since 4.2.8
-            auto users(rxComm& conn) -> std::vector<user>;
+        /// Returns all users in a group.
+        ///
+        /// \param[in] _comm  The communication object.
+        /// \param[in] _group The group to check.
+        ///
+        /// \return A list of users.
+        ///
+        /// \since 4.2.8
+        auto users(RxComm& _comm, const group& _group) -> std::vector<user>;
 
-            /// \brief Returns all members of a group.
-            ///
-            /// \param[in] conn  The communication object.
-            /// \param[in] group The group to check.
-            ///
-            /// \return A list of users.
-            ///
-            /// \since 4.2.8
-            auto users(rxComm& conn, const group& group) -> std::vector<user>;
+        /// Returns all groups in the local zone.
+        ///
+        /// \param[in] _comm The communication object.
+        ///
+        /// \return A list of groups.
+        ///
+        /// \since 4.2.8
+        auto groups(RxComm& _comm) -> std::vector<group>;
 
-            /// \brief Returns all groups in the local zone.
-            ///
-            /// \param[in] conn The communication object.
-            ///
-            /// \return A list of groups.
-            ///
-            /// \since 4.2.8
-            auto groups(rxComm& conn) -> std::vector<group>;
+        /// Returns all groups a user is a member of.
+        ///
+        /// \param[in] _comm The communication object.
+        /// \param[in] _user The user to check for.
+        ///
+        /// \return A list of groups.
+        ///
+        /// \since 4.2.8
+        auto groups(RxComm& _comm, const user& _user) -> std::vector<group>;
 
-            /// \brief Returns all groups a user is a member of.
-            ///
-            /// \param[in] conn The communication object.
-            /// \param[in] user The user to check for.
-            ///
-            /// \return A list of groups.
-            ///
-            /// \since 4.2.8
-            auto groups(rxComm& conn, const user& user) -> std::vector<group>;
+        /// Checks if a user exists.
+        ///
+        /// \param[in] _comm The communication object.
+        /// \param[in] _user The user to verify exists.
+        ///
+        /// \return A boolean.
+        /// \retval true  If the user exists.
+        /// \retval false Otherwise.
+        ///
+        /// \since 4.2.8
+        auto exists(RxComm& _comm, const user& _user) -> bool;
 
-            /// \brief Checks if a user exists.
-            ///
-            /// \param[in] conn The communication object.
-            ///
-            /// \return A boolean.
-            /// \retval true  If the user exists.
-            /// \retval false Otherwise.
-            ///
-            /// \since 4.2.8
-            auto exists(rxComm& conn, const user& user) -> bool;
+        /// Checks if a group exists.
+        ///
+        /// \param[in] _comm  The communication object.
+        /// \param[in] _group The group to verify exists.
+        ///
+        /// \return A boolean.
+        /// \retval true  If the user exists.
+        /// \retval false Otherwise.
+        ///
+        /// \since 4.2.8
+        auto exists(RxComm& _comm, const group& _group) -> bool;
 
-            /// \brief Checks if a group exists.
-            ///
-            /// \param[in] conn The communication object.
-            ///
-            /// \return A boolean.
-            /// \retval true  If the user exists.
-            /// \retval false Otherwise.
-            ///
-            /// \since 4.2.8
-            auto exists(rxComm& conn, const group& group) -> bool;
+        /// Returns the ID of a user.
+        ///
+        /// \param[in] _comm The communication object.
+        /// \param[in] _user The user to find.
+        ///
+        /// \return A std::optional object containing the ID as a string if the user
+        ///         exists in the local zone.
+        ///
+        /// \since 4.2.8
+        auto id(RxComm& _comm, const user& _user) -> std::optional<std::string>;
 
-            /// \brief Returns the ID of a user.
-            ///
-            /// \param[in] conn The communication object.
-            /// \param[in] user The user to find.
-            ///
-            /// \return A std::optional object containing the ID as a string if the user
-            ///         exists in the local zone.
-            ///
-            /// \since 4.2.8
-            auto id(rxComm& conn, const user& user) -> std::optional<std::string>;
+        /// Returns the ID of a group.
+        ///
+        /// \param[in] _comm  The communication object.
+        /// \param[in] _group The group to find.
+        ///
+        /// \return A std::optional object containing the ID as a string if the group
+        ///         exists in the local zone.
+        ///
+        /// \since 4.2.8
+        auto id(RxComm& _comm, const group& _group) -> std::optional<std::string>;
 
-            /// \brief Returns the ID of a group.
-            ///
-            /// \param[in] conn The communication object.
-            /// \param[in] user The group to find.
-            ///
-            /// \return A std::optional object containing the ID as a string if the group
-            ///         exists in the local zone.
-            ///
-            /// \since 4.2.8
-            auto id(rxComm& conn, const group& group) -> std::optional<std::string>;
+        /// Returns the type of a user.
+        ///
+        /// \param[in] _comm The communication object.
+        /// \param[in] _user The user to find.
+        ///
+        /// \throws irods::exception If an error occurs.
+        ///
+        /// \return A std::optional object containing the user's type if the user
+        ///         exists in the local zone.
+        ///
+        /// \since 4.2.8
+        auto type(RxComm& _comm, const user& _user) -> std::optional<user_type>;
 
-            /// \brief Returns the type of a user.
-            ///
-            /// \throws user_management_error If the value within the catalog cannot be converted
-            ///                               to an appropriate user_type.
-            ///
-            /// \param[in] conn The communication object.
-            /// \param[in] user The user to find.
-            ///
-            /// \return A std::optional object containing the user's type if the user
-            ///         exists in the local zone.
-            ///
-            /// \since 4.2.8
-            auto type(rxComm& conn, const user& user) -> std::optional<user_type>;
+        /// Returns the authentication names (methods) used by the user.
+        ///
+        /// \param[in] _comm The communication object.
+        /// \param[in] _user The user to fetch authentication names for.
+        ///
+        /// \return A list of strings.
+        ///
+        /// \since 4.2.8
+        auto auth_names(RxComm& _comm, const user& _user) -> std::vector<std::string>;
 
-            /// \brief Returns the authentication names (methods) used by the user.
-            ///
-            /// \param[in] conn The communication object.
-            /// \param[in] user The user to fetch authentication names for.
-            ///
-            /// \return A list of strings.
-            ///
-            /// \since 4.2.8
-            auto auth_names(rxComm& conn, const user& user) -> std::vector<std::string>;
-
-            /// \brief Checks if a user is a member of a group.
-            ///
-            /// \param[in] conn  The communication object.
-            /// \param[in] group The group to check.
-            /// \param[in] user  The user to look for.
-            ///
-            /// \return A boolean.
-            /// \retval true  If the user is a member of the group.
-            /// \retval false Otherwise.
-            ///
-            /// \since 4.2.8
-            auto user_is_member_of_group(rxComm& conn, const group& group, const user& user) -> bool;
-
-            /// \brief Returns the unique name of a user in the local zone.
-            ///
-            /// \throws user_management_error If the local zone cannot be retrieved (client-side only).
-            ///
-            /// \param[in] conn The communication object.
-            /// \param[in] user The user to produce the unique name for.
-            ///
-            /// \return A string representing the unique name of the user within the local zone.
-            ///
-            /// \since 4.2.8
-            auto local_unique_name(rxComm& conn, const user& user) -> std::string;
-        } // namespace v1
+        /// Checks if a user is a member of a group.
+        ///
+        /// \param[in] _comm  The communication object.
+        /// \param[in] _group The group to check.
+        /// \param[in] _user  The user to look for.
+        ///
+        /// \return A boolean.
+        /// \retval true  If the user is a member of the group.
+        /// \retval false Otherwise.
+        ///
+        /// \since 4.2.8
+        auto user_is_member_of_group(RxComm& _comm, const group& _group, const user& _user) -> bool;
     } // namespace NAMESPACE_IMPL
 } // namespace irods::experimental::administration
 
 #endif // IRODS_USER_ADMINISTRATION_HPP
-

--- a/lib/administration/user/src/detail.cpp
+++ b/lib/administration/user/src/detail.cpp
@@ -1,0 +1,48 @@
+#include "irods/user_administration.hpp"
+
+#include "irods/obf.h"
+#include "irods/authenticate.h" // For MAX_PASSWORD_LEN
+#include "irods/rodsErrorTable.h"
+#include "irods/irods_exception.hpp"
+
+#include <cstring>
+#include <array>
+#include <string>
+#include <string_view>
+
+namespace irods::experimental::administration::detail
+{
+    auto obfuscate_password(const std::string_view _new_password) -> std::string
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+        std::array<char, MAX_PASSWORD_LEN + 10> plain_text_password{};
+        std::strncpy(plain_text_password.data(), _new_password.data(), MAX_PASSWORD_LEN);
+
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+        if (const auto lcopy = MAX_PASSWORD_LEN - 10 - _new_password.size(); lcopy > 15) {
+            // The random string (second argument) is used for padding and must match
+            // what is defined on the server-side.
+            std::strncat(plain_text_password.data(), "1gCBizHWbwIYyWLoysGzTe6SyzqFKMniZX05faZHWAwQKXf6Fs", lcopy);
+        }
+
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+        std::array<char, MAX_PASSWORD_LEN + 10> admin_password{};
+
+        // Get the plain text password of the iRODS user.
+        // "obfGetPw" decodes the obfuscated password stored in .irods/irodsA.
+        if (const auto ec = obfGetPw(admin_password.data()); ec != 0) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(ec, "Failed to decode obfuscated password in .irodsA file.");
+        }
+
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+        std::array<char, MAX_PASSWORD_LEN + 100> obfuscated_password{};
+        obfEncodeByKeyV2(
+            plain_text_password.data(),
+            admin_password.data(),
+            getSessionSignatureClientside(),
+            obfuscated_password.data());
+
+        return obfuscated_password.data();
+    } // obfuscate_password
+} // namespace irods::experimental::administration::detail

--- a/lib/administration/user/src/user_administration.cpp
+++ b/lib/administration/user/src/user_administration.cpp
@@ -1,457 +1,329 @@
 #include "irods/user_administration.hpp"
 
-#undef rxGeneralAdmin
-
 #ifdef IRODS_USER_ADMINISTRATION_ENABLE_SERVER_SIDE_API
-    #include "irods/rsGeneralAdmin.hpp"
-    #define rxGeneralAdmin rsGeneralAdmin
-    #define IRODS_QUERY_ENABLE_SERVER_SIDE_API // For irods::query<rsComm_t>
-#else
-    #include "irods/generalAdmin.h"
-    #define rxGeneralAdmin rcGeneralAdmin
+#  define IRODS_QUERY_ENABLE_SERVER_SIDE_API
 #endif // IRODS_USER_ADMINISTRATION_ENABLE_SERVER_SIDE_API
 
-#include "irods/obf.h"
-#include "irods/authenticate.h"
 #include "irods/irods_query.hpp"
 #include "irods/query_builder.hpp"
-#include "irods/rcConnect.h"
-
-#include <array>
-#include <iostream>
 
 namespace irods::experimental::administration::NAMESPACE_IMPL
 {
-    inline namespace v1
+    namespace
     {
-        namespace
+        auto get_local_zone([[maybe_unused]] RxComm& _comm) -> std::string
         {
-            auto get_local_zone(rxComm& conn) -> std::string
-            {
 #ifdef IRODS_USER_ADMINISTRATION_ENABLE_SERVER_SIDE_API
-                return getLocalZoneName();
+            return getLocalZoneName();
 #else
-                for (auto&& row : irods::query{&conn, "select ZONE_NAME where ZONE_TYPE = 'local'"}) {
-                    return row[0];
-                }
+            for (auto&& row : irods::query{&_comm, "select ZONE_NAME where ZONE_TYPE = 'local'"}) {
+                return row[0];
+            }
 
-                throw user_management_error{"cannot get local zone name"};
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(CAT_NO_ROWS_FOUND, "Cannot get local zone name.");
 #endif // IRODS_USER_ADMINISTRATION_ENABLE_SERVER_SIDE_API
-            }
+        } // get_local_zone
+    } // anonymous namespace
 
-            auto obfuscate_password(const std::string_view new_password) -> std::string
-            {
-                std::array<char, MAX_PASSWORD_LEN + 10> plain_text_password{};
-                std::strncpy(plain_text_password.data(), new_password.data(), MAX_PASSWORD_LEN);
-
-                if (const auto lcopy = MAX_PASSWORD_LEN - 10 - new_password.size(); lcopy > 15) {
-                    // The random string (second argument) is used for padding and must match 
-                    // what is defined on the server-side.
-                    std::strncat(plain_text_password.data(), "1gCBizHWbwIYyWLoysGzTe6SyzqFKMniZX05faZHWAwQKXf6Fs", lcopy);
-                }
-
-                std::array<char, MAX_PASSWORD_LEN + 10> admin_password{};
-
-                // Get the plain text password of the iRODS user.
-                // "obfGetPw" decodes the obfuscated password stored in .irods/irodsA.
-                if (obfGetPw(admin_password.data()) != 0) {
-                    throw user_management_error{"failed to unobfuscate password in .irodsA file."};
-                }
-
-                std::array<char, MAX_PASSWORD_LEN + 100> obfuscated_password{};
-                obfEncodeByKeyV2(plain_text_password.data(),
-                                 admin_password.data(),
-                                 getSessionSignatureClientside(),
-                                 obfuscated_password.data());
-
-                return obfuscated_password.data();
-            }
-        } // anonymous namespace
-
-        auto add_user(rxComm& conn,
-                      const user& user,
-                      user_type user_type,
-                      zone_type zone_type) -> std::error_code
-        {
-            std::string name = local_unique_name(conn, user);
-            std::string zone;
-
-            if (zone_type::local == zone_type) {
-                zone = get_local_zone(conn);
-            }
-
-            generalAdminInp_t input{};
-            input.arg0 = "add";
-            input.arg1 = "user";
-            input.arg2 = name.data();
-            input.arg3 = to_c_str(user_type);
-            input.arg4 = zone.data();
-
-            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
-                return std::error_code{ec, std::generic_category()};
-            }
-
-            return {};
+    auto local_unique_name(RxComm& _comm, const user& _user) -> std::string
+    {
+        // Implies that the user belongs to the local zone and
+        // is not a remote user (i.e. federation).
+        if (_user.zone.empty()) {
+            return _user.name;
         }
 
-        auto remove_user(rxComm& conn, const user& user) -> std::error_code
-        {
-            const auto name = local_unique_name(conn, user);
+        auto name = _user.name;
 
-            generalAdminInp_t input{};
-            input.arg0 = "rm";
-            input.arg1 = "user";
-            input.arg2 = name.data();
-            input.arg3 = user.zone.data();
-
-            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
-                return std::error_code{ec, std::generic_category()};
-            }
-
-            return {};
+        if (_user.zone != get_local_zone(_comm)) {
+            name += '#';
+            name += _user.zone;
         }
 
-        auto set_user_password(rxComm& conn, const user& user, std::string_view new_password) -> std::error_code
-        {
-            const auto obfuscated_password = obfuscate_password(new_password);
+        return name;
+    } // local_unique_name
 
-            generalAdminInp_t input{};
-            input.arg0 = "modify";
-            input.arg1 = "user";
-            input.arg2 = user.name.data();
-            input.arg3 = "password";
-            input.arg4 = obfuscated_password.data();
+    auto add_user(RxComm& _comm, const user& _user, user_type _user_type, zone_type _zone_type) -> void
+    {
+        std::string name = local_unique_name(_comm, _user);
+        std::string zone;
 
-            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
-                return std::error_code{ec, std::generic_category()};
-            }
-
-            return {};
+        if (zone_type::local == _zone_type) {
+            zone = get_local_zone(_comm);
         }
 
-        auto set_user_type(rxComm& conn, const user& user, user_type new_user_type) -> std::error_code
-        {
-            const auto name = local_unique_name(conn, user);
+        GeneralAdminInput input{};
+        input.arg0 = "add";
+        input.arg1 = "user";
+        input.arg2 = name.data();
+        input.arg3 = to_c_str(_user_type);
+        input.arg4 = zone.data();
 
-            generalAdminInp_t input{};
-            input.arg0 = "modify";
-            input.arg1 = "user";
-            input.arg2 = name.data();
-            input.arg3 = "type";
-            input.arg4 = to_c_str(new_user_type);
+        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec != 0) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(ec, fmt::format("Failed to add user [{}].", name));
+        }
+    } // add_user
 
-            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
-                return std::error_code{ec, std::generic_category()};
-            }
+    auto remove_user(RxComm& _comm, const user& _user) -> void
+    {
+        const auto name = local_unique_name(_comm, _user);
 
-            return {};
+        GeneralAdminInput input{};
+        input.arg0 = "rm";
+        input.arg1 = "user";
+        input.arg2 = name.data();
+        input.arg3 = _user.zone.data();
+
+        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec != 0) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(ec, fmt::format("Failed to remove user [{}].", name));
+        }
+    } // remove_user
+
+    auto add_group(RxComm& _comm, const group& _group) -> void
+    {
+        const auto zone = get_local_zone(_comm);
+
+        GeneralAdminInput input{};
+        input.arg0 = "add";
+        input.arg1 = "user";
+        input.arg2 = _group.name.data();
+        input.arg3 = "rodsgroup";
+        input.arg4 = zone.data();
+
+        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec != 0) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(ec, fmt::format("Failed to add group [{}].", _group.name));
+        }
+    } // add_group
+
+    auto remove_group(RxComm& _comm, const group& _group) -> void
+    {
+        const auto zone = get_local_zone(_comm);
+
+        GeneralAdminInput input{};
+        input.arg0 = "rm";
+        input.arg1 = "user";
+        input.arg2 = _group.name.data();
+        input.arg3 = zone.data();
+
+        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec != 0) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(ec, fmt::format("Failed to remove group [{}].", _group.name));
+        }
+    } // remove_group
+
+    auto add_user_to_group(RxComm& _comm, const group& _group, const user& _user) -> void
+    {
+        GeneralAdminInput input{};
+        input.arg0 = "modify";
+        input.arg1 = "group";
+        input.arg2 = _group.name.data();
+        input.arg3 = "add";
+        input.arg4 = _user.name.data();
+        input.arg5 = _user.zone.data();
+
+        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec != 0) {
+            const auto name = local_unique_name(_comm, _user);
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(ec, fmt::format("Failed to add user [{}] to group [{}].", name, _group.name));
+        }
+    } // add_user_to_group
+
+    auto remove_user_from_group(RxComm& _comm, const group& _group, const user& _user) -> void
+    {
+        GeneralAdminInput input{};
+        input.arg0 = "modify";
+        input.arg1 = "group";
+        input.arg2 = _group.name.data();
+        input.arg3 = "remove";
+        input.arg4 = _user.name.data();
+        input.arg5 = _user.zone.data();
+
+        if (const auto ec = rxGeneralAdmin(&_comm, &input); ec != 0) {
+            const auto name = local_unique_name(_comm, _user);
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(ec, fmt::format("Failed to remove user [{}] from group [{}].", name, _group.name));
+        }
+    } // remove_user_from_group
+
+    auto users(RxComm& _comm) -> std::vector<user>
+    {
+        std::vector<user> users;
+
+        for (auto&& row : irods::query{&_comm, "select USER_NAME, USER_ZONE where USER_TYPE != 'rodsgroup'"}) {
+            users.emplace_back(row[0], row[1]);
         }
 
-        auto add_user_auth(rxComm& conn, const user& user, std::string_view auth) -> std::error_code
-        {
-            const auto name = local_unique_name(conn, user);
+        return users;
+    } // users
 
-            generalAdminInp_t input{};
-            input.arg0 = "modify";
-            input.arg1 = "user";
-            input.arg2 = name.data();
-            input.arg3 = "addAuth";
-            input.arg4 = auth.data();
+    auto users(RxComm& _comm, const group& _group) -> std::vector<user>
+    {
+        std::vector<user> users;
 
-            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
-                return std::error_code{ec, std::generic_category()};
-            }
+        std::string gql = "select USER_NAME, USER_ZONE where USER_TYPE != 'rodsgroup' and USER_GROUP_NAME = '";
+        gql += _group.name;
+        gql += "'";
 
-            return {};
+        for (auto&& row : irods::query{&_comm, gql}) {
+            users.emplace_back(row[0], row[1]);
         }
 
-        auto remove_user_auth(rxComm& conn, const user& user, std::string_view auth) -> std::error_code
-        {
-            const auto name = local_unique_name(conn, user);
+        return users;
+    } // users
 
-            generalAdminInp_t input{};
-            input.arg0 = "modify";
-            input.arg1 = "user";
-            input.arg2 = name.data();
-            input.arg3 = "rmAuth";
-            input.arg4 = auth.data();
+    auto groups(RxComm& _comm) -> std::vector<group>
+    {
+        std::vector<group> groups;
 
-            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
-                return std::error_code{ec, std::generic_category()};
-            }
-
-            return {};
+        for (auto&& row : irods::query{&_comm, "select USER_GROUP_NAME where USER_TYPE = 'rodsgroup'"}) {
+            groups.emplace_back(row[0]);
         }
 
-        // Group Management
+        return groups;
+    } // groups
 
-        auto add_group(rxComm& conn, const group& group) -> std::error_code
-        {
-            const auto zone = get_local_zone(conn);
+    auto groups(RxComm& _comm, const user& _user) -> std::vector<group>
+    {
+        std::vector<std::string> args{local_unique_name(_comm, _user)};
 
-            generalAdminInp_t input{};
-            input.arg0 = "add";
-            input.arg1 = "user";
-            input.arg2 = group.name.data();
-            input.arg3 = "rodsgroup";
-            input.arg4 = zone.data();
+        query_builder qb;
 
-            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
-                return std::error_code{ec, std::generic_category()};
+        // clang-format off
+        qb.type(query_type::specific)
+          .zone_hint(_user.zone.empty() ? get_local_zone(_comm) : _user.zone)
+          .bind_arguments(args);
+        // clang-format on
+
+        std::vector<group> groups;
+
+        try {
+            for (auto&& row : qb.build(_comm, "listGroupsForUser")) {
+                groups.emplace_back(row[1]);
             }
-
-            return {};
         }
+        catch (...) {
+            // GenQuery fallback.
+            groups.clear();
 
-        auto remove_group(rxComm& conn, const group& group) -> std::error_code
-        {
-            const auto zone = get_local_zone(conn);
-
-            generalAdminInp_t input{};
-            input.arg0 = "rm";
-            input.arg1 = "user";
-            input.arg2 = group.name.data();
-            input.arg3 = zone.data();
-
-            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
-                return std::error_code{ec, std::generic_category()};
-            }
-
-            return {};
-        }
-
-        auto add_user_to_group(rxComm& conn, const group& group, const user& user) -> std::error_code
-        {
-            generalAdminInp_t input{};
-            input.arg0 = "modify";
-            input.arg1 = "group";
-            input.arg2 = group.name.data();
-            input.arg3 = "add";
-            input.arg4 = user.name.data();
-            input.arg5 = user.zone.data();
-
-            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
-                return std::error_code{ec, std::generic_category()};
-            }
-
-            return {};
-        }
-
-        auto remove_user_from_group(rxComm& conn, const group& group, const user& user) -> std::error_code
-        {
-            generalAdminInp_t input{};
-            input.arg0 = "modify";
-            input.arg1 = "group";
-            input.arg2 = group.name.data();
-            input.arg3 = "remove";
-            input.arg4 = user.name.data();
-            input.arg5 = user.zone.data();
-
-            if (const auto ec = rxGeneralAdmin(&conn, &input); ec != 0) {
-                return std::error_code{ec, std::generic_category()};
-            }
-
-            return {};
-        }
-
-        // Query
-
-        auto users(rxComm& conn) -> std::vector<user>
-        {
-            std::vector<user> users;
-
-            for (auto&& row : irods::query{&conn, "select USER_NAME, USER_ZONE where USER_TYPE != 'rodsgroup'"}) {
-                users.emplace_back(row[0], row[1]);
-            }
-
-            return users;
-        }
-
-        auto users(rxComm& conn, const group& group) -> std::vector<user>
-        {
-            std::vector<user> users;
-
-            std::string gql = "select USER_NAME, USER_ZONE "
-                              "where USER_TYPE != 'rodsgroup' and USER_GROUP_NAME = '";
-            gql += group.name;
-            gql += "'";
-
-            for (auto&& row : irods::query{&conn, gql}) {
-                users.emplace_back(row[0], row[1]);
-            }
-
-            return users;
-        }
-
-        auto groups(rxComm& conn) -> std::vector<group>
-        {
-            std::vector<group> groups;
-
-            for (auto&& row : irods::query{&conn, "select USER_GROUP_NAME where USER_TYPE = 'rodsgroup'"}) {
-                groups.emplace_back(row[0]);
-            }
-
-            return groups;
-        }
-
-        auto groups(rxComm& conn, const user& user) -> std::vector<group>
-        {
-            std::vector<std::string> args{local_unique_name(conn, user)};
-
-            query_builder qb;
-            
-            qb.type(query_type::specific)
-              .zone_hint(user.zone.empty() ? get_local_zone(conn) : user.zone)
-              .bind_arguments(args);
-
-            std::vector<group> groups;
-
-            try {
-                for (auto&& row : qb.build(conn, "listGroupsForUser")) {
-                    groups.emplace_back(row[1]);
+            for (auto&& g : NAMESPACE_IMPL::groups(_comm)) {
+                if (user_is_member_of_group(_comm, g, _user)) {
+                    groups.push_back(std::move(g));
                 }
             }
-            catch (...) {
-                // GenQuery fallback.
-                groups.clear();
-
-                for (auto&& g : NAMESPACE_IMPL::groups(conn)) {
-                    if (user_is_member_of_group(conn, g, user)) {
-                        groups.push_back(std::move(g));
-                    }
-                }
-            }
-
-            return groups;
         }
 
-        auto exists(rxComm& conn, const user& user) -> bool
-        {
-            std::string gql = "select USER_ID where USER_TYPE != 'rodsgroup' and USER_NAME = '";
-            gql += user.name;
-            gql += "' and USER_ZONE = '";
-            gql += (user.zone.empty() ? get_local_zone(conn) : user.zone);
-            gql += "'";
+        return groups;
+    } // groups
 
-            for (auto&& row : irods::query{&conn, gql}) {
-                static_cast<void>(row);
-                return true;
-            }
+    auto exists(RxComm& _comm, const user& _user) -> bool
+    {
+        std::string gql = "select USER_ID where USER_TYPE != 'rodsgroup' and USER_NAME = '";
+        gql += _user.name;
+        gql += "' and USER_ZONE = '";
+        gql += (_user.zone.empty() ? get_local_zone(_comm) : _user.zone);
+        gql += "'";
 
-            return false;
+        for (auto&& row : irods::query{&_comm, gql}) { // NOLINTNEXTLINE(readability-use-anyofallof)
+            static_cast<void>(row);
+            return true;
         }
 
-        auto exists(rxComm& conn, const group& group) -> bool
-        {
-            std::string gql = "select USER_GROUP_ID where USER_TYPE = 'rodsgroup' and USER_GROUP_NAME = '";
-            gql += group.name;
-            gql += "'";
+        return false;
+    } // exists
 
-            for (auto&& row : irods::query{&conn, gql}) {
-                static_cast<void>(row);
-                return true;
-            }
+    auto exists(RxComm& _comm, const group& _group) -> bool
+    {
+        std::string gql = "select USER_GROUP_ID where USER_TYPE = 'rodsgroup' and USER_GROUP_NAME = '";
+        gql += _group.name;
+        gql += "'";
 
-            return false;
+        for (auto&& row : irods::query{&_comm, gql}) { // NOLINTNEXTLINE(readability-use-anyofallof)
+            static_cast<void>(row);
+            return true;
         }
 
-        auto id(rxComm& conn, const user& user) -> std::optional<std::string>
-        {
-            std::string gql = "select USER_ID where USER_TYPE != 'rodsgroup' and USER_NAME = '";
-            gql += user.name;
-            gql += "' and USER_ZONE = '";
-            gql += (user.zone.empty() ? get_local_zone(conn) : user.zone);
-            gql += "'";
+        return false;
+    } // exists
 
-            for (auto&& row : irods::query{&conn, gql}) {
-                return row[0];
-            }
+    auto id(RxComm& _comm, const user& _user) -> std::optional<std::string>
+    {
+        std::string gql = "select USER_ID where USER_TYPE != 'rodsgroup' and USER_NAME = '";
+        gql += _user.name;
+        gql += "' and USER_ZONE = '";
+        gql += (_user.zone.empty() ? get_local_zone(_comm) : _user.zone);
+        gql += "'";
 
-            return std::nullopt;
+        for (auto&& row : irods::query{&_comm, gql}) {
+            return row[0];
         }
 
-        auto id(rxComm& conn, const group& group) -> std::optional<std::string>
-        {
-            std::string gql = "select USER_GROUP_ID where USER_TYPE = 'rodsgroup' and USER_GROUP_NAME = '";
-            gql += group.name;
-            gql += "'";
+        return std::nullopt;
+    } // id
 
-            for (auto&& row : irods::query{&conn, gql}) {
-                return row[0];
-            }
+    auto id(RxComm& _comm, const group& _group) -> std::optional<std::string>
+    {
+        std::string gql = "select USER_GROUP_ID where USER_TYPE = 'rodsgroup' and USER_GROUP_NAME = '";
+        gql += _group.name;
+        gql += "'";
 
-            return std::nullopt;
+        for (auto&& row : irods::query{&_comm, gql}) {
+            return row[0];
         }
 
-        auto type(rxComm& conn, const user& user) -> std::optional<user_type>
-        {
-            std::string gql = "select USER_TYPE where USER_TYPE != 'rodsgroup' and USER_NAME = '";
-            gql += user.name;
-            gql += "' and USER_ZONE = '";
-            gql += (user.zone.empty() ? get_local_zone(conn) : user.zone);
-            gql += "'";
+        return std::nullopt;
+    } // id
 
-            for (auto&& row : irods::query{&conn, gql}) {
-                return to_user_type(row[0]);
-            }
+    auto type(RxComm& _comm, const user& _user) -> std::optional<user_type>
+    {
+        std::string gql = "select USER_TYPE where USER_TYPE != 'rodsgroup' and USER_NAME = '";
+        gql += _user.name;
+        gql += "' and USER_ZONE = '";
+        gql += (_user.zone.empty() ? get_local_zone(_comm) : _user.zone);
+        gql += "'";
 
-            return std::nullopt;
+        for (auto&& row : irods::query{&_comm, gql}) {
+            return to_user_type(row[0]);
         }
 
-        auto auth_names(rxComm& conn, const user& user) -> std::vector<std::string>
-        {
-            std::vector<std::string> auth_names;
+        return std::nullopt;
+    } // type
 
-            std::string gql = "select USER_DN where USER_TYPE != 'rodsgroup' and USER_NAME = '";
-            gql += user.name;
-            gql += "' and USER_ZONE = '";
-            gql += (user.zone.empty() ? get_local_zone(conn) : user.zone);
-            gql += "'";
+    auto auth_names(RxComm& _comm, const user& _user) -> std::vector<std::string>
+    {
+        std::vector<std::string> auth_names;
 
-            for (auto&& row : irods::query{&conn, gql}) {
-                auth_names.push_back(row[0]);
-            }
+        std::string gql = "select USER_DN where USER_TYPE != 'rodsgroup' and USER_NAME = '";
+        gql += _user.name;
+        gql += "' and USER_ZONE = '";
+        gql += (_user.zone.empty() ? get_local_zone(_comm) : _user.zone);
+        gql += "'";
 
-            return auth_names;
+        for (auto&& row : irods::query{&_comm, gql}) {
+            auth_names.push_back(row[0]);
         }
 
-        auto user_is_member_of_group(rxComm& conn, const group& group, const user& user) -> bool
-        {
-            std::string gql = "select USER_ID where USER_TYPE != 'rodsgroup' and USER_NAME = '";
-            gql += user.name;
-            gql += "' and USER_ZONE = '";
-            gql += (user.zone.empty() ? get_local_zone(conn) : user.zone);
-            gql += "' and USER_GROUP_NAME = '";
-            gql += group.name;
-            gql += "'";
+        return auth_names;
+    } // auth_names
 
-            for (auto&& row : irods::query{&conn, gql}) {
-                static_cast<void>(row);
-                return true;
-            }
+    auto user_is_member_of_group(RxComm& _comm, const group& _group, const user& _user) -> bool
+    {
+        std::string gql = "select USER_ID where USER_TYPE != 'rodsgroup' and USER_NAME = '";
+        gql += _user.name;
+        gql += "' and USER_ZONE = '";
+        gql += (_user.zone.empty() ? get_local_zone(_comm) : _user.zone);
+        gql += "' and USER_GROUP_NAME = '";
+        gql += _group.name;
+        gql += "'";
 
-            return false;
+        for (auto&& row : irods::query{&_comm, gql}) { // NOLINTNEXTLINE(readability-use-anyofallof)
+            static_cast<void>(row);
+            return true;
         }
 
-        // Utility
-
-        auto local_unique_name(rxComm& conn, const user& user) -> std::string
-        {
-            // Implies that the user belongs to the local zone and
-            // is not a remote user (i.e. federation).
-            if (user.zone.empty()) {
-                return user.name;
-            }
-
-            auto name = user.name;
-
-            if (user.zone != get_local_zone(conn)) {
-                name += '#';
-                name += user.zone;
-            }
-
-            return name;
-        }
-    } // namespace v1
+        return false;
+    } // user_is_member_of_group
 } // namespace irods::experimental::administration::NAMESPACE_IMPL
-

--- a/lib/administration/user/src/utilities.cpp
+++ b/lib/administration/user/src/utilities.cpp
@@ -1,6 +1,11 @@
 #include "irods/user_administration.hpp"
 
-namespace irods::experimental::administration::inline v1
+#include "irods/rodsErrorTable.h"
+#include "irods/irods_exception.hpp"
+
+#include <fmt/format.h>
+
+namespace irods::experimental::administration
 {
     auto to_user_type(const std::string_view user_type_string) -> user_type
     {
@@ -10,8 +15,9 @@ namespace irods::experimental::administration::inline v1
         if (user_type_string == "rodsadmin")  { return user_type::rodsadmin; }
         // clang-format on
 
-        throw user_management_error{"undefined user type"};
-    }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+        THROW(SYS_INVALID_INPUT_PARAM, fmt::format("Undefined user type [{}].", user_type_string));
+    } // to_user_type
 
     auto to_c_str(user_type user_type) -> const char*
     {
@@ -24,7 +30,7 @@ namespace irods::experimental::administration::inline v1
         }
         // clang-format on
 
-        throw user_management_error{"cannot convert user_type to string"};
-    }
-} // namespace irods::experimental::administration::inline v1
-
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+        THROW(SYS_INVALID_INPUT_PARAM, "Cannot convert user_type to string.");
+    } // to_c_str
+} // namespace irods::experimental::administration

--- a/lib/api/include/irods/generalAdmin.h
+++ b/lib/api/include/irods/generalAdmin.h
@@ -1,9 +1,11 @@
-#ifndef GENERAL_ADMIN_H__
-#define GENERAL_ADMIN_H__
+#ifndef IRODS_GENERAL_ADMIN_H
+#define IRODS_GENERAL_ADMIN_H
 
-#include "irods/rcConnect.h"
+struct RcComm;
 
-typedef struct {
+// NOLINTNEXTLINE(modernize-use-using)
+typedef struct GeneralAdminInput
+{
     const char *arg0;
     const char *arg1;
     const char *arg2;
@@ -15,11 +17,19 @@ typedef struct {
     const char *arg8;
     const char *arg9;
 } generalAdminInp_t;
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define generalAdminInp_PI "str *arg0; str *arg1; str *arg2; str *arg3; str *arg4; str *arg5; str *arg6; str *arg7;  str *arg8;  str *arg9;"
 
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
-int rcGeneralAdmin( rcComm_t *conn, generalAdminInp_t *generalAdminInp );
 
+// NOLINTNEXTLINE(modernize-use-trailing-return-type)
+int rcGeneralAdmin(struct RcComm* conn, struct GeneralAdminInput* generalAdminInp);
+
+#ifdef __cplusplus
+} // extern "C"
 #endif
+
+#endif // IRODS_GENERAL_ADMIN_H

--- a/unit_tests/cmake/test_config/irods_atomic_apply_acl_operations.cmake
+++ b/unit_tests/cmake/test_config/irods_atomic_apply_acl_operations.cmake
@@ -3,10 +3,12 @@ set(IRODS_TEST_TARGET irods_atomic_apply_acl_operations)
 set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
                             ${CMAKE_CURRENT_SOURCE_DIR}/src/test_atomic_apply_acl_operations.cpp)
 
-set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include)
+set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
  
 set(IRODS_TEST_LINK_LIBRARIES irods_common
                               irods_client
                               irods_plugin_dependencies
                               ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so
-                              ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so)
+                              ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
+                              ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)

--- a/unit_tests/cmake/test_config/irods_user_administration.cmake
+++ b/unit_tests/cmake/test_config/irods_user_administration.cmake
@@ -6,4 +6,5 @@ set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
 set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include)
  
 set(IRODS_TEST_LINK_LIBRARIES irods_common
-                              irods_client)
+                              irods_client
+                              ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)

--- a/unit_tests/src/test_rc_switch_user.cpp
+++ b/unit_tests/src/test_rc_switch_user.cpp
@@ -53,10 +53,9 @@ TEST_CASE("rc_switch_user basic usage")
 
     // Create a test user.
     const adm::user alice{"test_user_alice", env.rodsZone};
-    REQUIRE(adm::client::add_user(conn, alice).value() == 0);
+    REQUIRE_NOTHROW(adm::client::add_user(conn, alice));
 
-    irods::at_scope_exit remove_test_user{
-        [&conn, &alice] { REQUIRE(adm::client::remove_user(conn, alice).value() == 0); }};
+    irods::at_scope_exit remove_test_user{[&conn, &alice] { REQUIRE_NOTHROW(adm::client::remove_user(conn, alice)); }};
 
     // Give the test user permission to see the admin's data object and the contents of
     // the sandbox collection.
@@ -119,10 +118,9 @@ TEST_CASE("rc_switch_user honors permission model following successful invocatio
 
     // Create a test user.
     const adm::user alice{"test_user_alice", env.rodsZone};
-    REQUIRE(adm::client::add_user(conn, alice).value() == 0);
+    REQUIRE_NOTHROW(adm::client::add_user(conn, alice));
 
-    irods::at_scope_exit remove_test_user{
-        [&conn, &alice] { REQUIRE(adm::client::remove_user(conn, alice).value() == 0); }};
+    irods::at_scope_exit remove_test_user{[&conn, &alice] { REQUIRE_NOTHROW(adm::client::remove_user(conn, alice)); }};
 
     // Become the test user.
     auto* conn_ptr = static_cast<RcComm*>(conn);
@@ -236,11 +234,11 @@ TEST_CASE("rc_switch_user supports remote zones")
 
     // Create a test user for the remote zone.
     const adm::user alice{"test_user_alice", zone_name};
-    REQUIRE(adm::client::add_user(conn, alice, adm::user_type::rodsuser, adm::zone_type::remote).value() == 0);
+    REQUIRE_NOTHROW(adm::client::add_user(conn, alice, adm::user_type::rodsuser, adm::zone_type::remote));
 
     irods::at_scope_exit remove_test_user{[&alice] {
         irods::experimental::client_connection conn;
-        REQUIRE(adm::client::remove_user(conn, alice).value() == 0);
+        REQUIRE_NOTHROW(adm::client::remove_user(conn, alice));
     }};
 
     // Become the test user.
@@ -271,11 +269,10 @@ TEST_CASE("rc_switch_user cannot be invoked by non-admins")
 
     // Create a test user.
     const adm::user alice{"test_user_alice", env.rodsZone};
-    REQUIRE(adm::client::add_user(conn, alice).value() == 0);
-    REQUIRE(adm::client::set_user_password(conn, alice, "rods").value() == 0);
+    REQUIRE_NOTHROW(adm::client::add_user(conn, alice));
+    REQUIRE_NOTHROW(adm::client::modify_user(conn, alice, adm::user_password_property{"rods"}));
 
-    irods::at_scope_exit remove_test_user{
-        [&conn, &alice] { REQUIRE(adm::client::remove_user(conn, alice).value() == 0); }};
+    irods::at_scope_exit remove_test_user{[&conn, &alice] { REQUIRE_NOTHROW(adm::client::remove_user(conn, alice)); }};
 
     // Connect to the server as the test user.
     rErrMsg_t error;


### PR DESCRIPTION
All unit tests pass.

Nothing other than the unit tests and the switch user api plugin uses this library so I don't think core tests need to be run for this.

I'm considering changing more components of the library as well.

TODOs:
- [x] Add unit test for remote zone users
- [x] Add unit test for authentication names (e.g. `iadmin aua`)