### PR TITLE
gethostname and client_api_whitelist (4-2-stable)

### DIFF
--- a/server/core/src/client_api_whitelist.cpp
+++ b/server/core/src/client_api_whitelist.cpp
@@ -185,20 +185,23 @@ namespace irods
 
     auto client_api_whitelist::enforce(const rsComm_t& comm) const noexcept -> bool
     {
-        if (!irods::is_privileged_client(comm)) {
-            try {
-                using T = const std::string&;
-                const auto& keyword = irods::CFG_CLIENT_API_WHITELIST_POLICY_KW;
-                return "enforce" == irods::get_server_property<T>(keyword) && is_client_to_agent_connection();
+        try {
+            if (!irods::is_privileged_client(comm)) {
+                try {
+                    using T = const std::string&;
+                    const auto& keyword = irods::CFG_CLIENT_API_WHITELIST_POLICY_KW;
+                    return "enforce" == irods::get_server_property<T>(keyword) && is_client_to_agent_connection();
+                }
+                catch (const irods::exception&) {
+                    rodsLog(LOG_DEBUG, "Skipping client API whitelist. Server is not configured to enforce the API "
+                                       "or the connection is not a client-to-agent connection.");
+                }
             }
-            catch (const irods::exception&) {
-                rodsLog(LOG_DEBUG, "Skipping client API whitelist. Server is not configured to enforce the API "
-                                   "or the connection is not a client-to-agent connection.");
+            else {
+                rodsLog(LOG_DEBUG, "Skipping client API whitelist. Client has administrative privileges.");
             }
         }
-        else {
-            rodsLog(LOG_DEBUG, "Skipping client API whitelist. Client has administrative privileges.");
-        }
+        catch (...) {}
 
         return false;
     }

--- a/unit_tests/src/test_resource_administration.cpp
+++ b/unit_tests/src/test_resource_administration.cpp
@@ -17,7 +17,7 @@ TEST_CASE("resource administration")
     repl_info.resource_name = "unit_test_repl";
     repl_info.resource_type = adm::resource_type::replication.data();
 
-    char host_name[64] {};
+    char host_name[HOST_NAME_MAX + 1] {};
     REQUIRE(gethostname(host_name, sizeof(host_name)) == 0);
 
     adm::resource_registration_info ufs_info;

--- a/unit_tests/src/test_zone_report.cpp
+++ b/unit_tests/src/test_zone_report.cpp
@@ -15,7 +15,7 @@ TEST_CASE("json zone report")
 {
     namespace adm = irods::experimental::administration;
 
-    char host_name[64] {};
+    char host_name[HOST_NAME_MAX + 1] {};
     REQUIRE(gethostname(host_name, sizeof(host_name)) == 0);
 
     adm::resource_registration_info ufs_info;


### PR DESCRIPTION
These changes are trivial and don't require a full run of the test suites. I

I think compiling and executing an icommand to verify things work is acceptable. On top of that, I'll run the unit tests to make sure things are in order.