### PR TITLE
Expose some new configuration values (CRON tasks, socket timeouts) (main)

### DIFF
--- a/lib/core/include/irods/irods_configuration_keywords.hpp
+++ b/lib/core/include/irods/irods_configuration_keywords.hpp
@@ -85,6 +85,8 @@ namespace irods
     extern const char* const KW_CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS;
     extern const char* const KW_CFG_MAX_SIZE_OF_DELAY_QUEUE_IN_BYTES;
     extern const char* const KW_CFG_STACKTRACE_FILE_PROCESSOR_SLEEP_TIME_IN_SECONDS;
+    extern const char* const KW_CFG_AGENT_FACTORY_WATCHER_SLEEP_TIME_IN_SECONDS;
+    extern const char* const KW_CFG_MIGRATE_DELAY_SERVER_SLEEP_TIME_IN_SECONDS;
 
     extern const char* const KW_CFG_RE_CACHE_SALT;
     extern const char* const KW_CFG_DELAY_SERVER_SLEEP_TIME_IN_SECONDS;
@@ -94,6 +96,7 @@ namespace irods
 
     extern const char* const KW_CFG_SHARED_MEMORY_SIZE_IN_BYTES;
     extern const char* const KW_CFG_EVICTION_AGE_IN_SECONDS;
+    extern const char* const KW_CFG_CACHE_CLEARER_SLEEP_TIME_IN_SECONDS;
 
     // service_account_environment.json keywords
     extern const char* const KW_CFG_IRODS_USER_NAME;

--- a/lib/core/src/irods_configuration_keywords.cpp
+++ b/lib/core/src/irods_configuration_keywords.cpp
@@ -80,6 +80,8 @@ namespace irods
     const char* const KW_CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS{"number_of_concurrent_delay_rule_executors"};
     const char* const KW_CFG_MAX_SIZE_OF_DELAY_QUEUE_IN_BYTES{"maximum_size_of_delay_queue_in_bytes"};
     const char* const KW_CFG_STACKTRACE_FILE_PROCESSOR_SLEEP_TIME_IN_SECONDS{"stacktrace_file_processor_sleep_time_in_seconds"};
+    const char* const KW_CFG_AGENT_FACTORY_WATCHER_SLEEP_TIME_IN_SECONDS{"agent_factory_watcher_sleep_time_in_seconds"};
+    const char* const KW_CFG_MIGRATE_DELAY_SERVER_SLEEP_TIME_IN_SECONDS{"migrate_delay_server_sleep_time_in_seconds"};
 
     const char* const KW_CFG_RE_CACHE_SALT{"reCacheSalt"};
     const char* const KW_CFG_DELAY_SERVER_SLEEP_TIME_IN_SECONDS{"delay_server_sleep_time_in_seconds"};
@@ -89,6 +91,7 @@ namespace irods
 
     const char* const KW_CFG_SHARED_MEMORY_SIZE_IN_BYTES{"shared_memory_size_in_bytes"};
     const char* const KW_CFG_EVICTION_AGE_IN_SECONDS{"eviction_age_in_seconds"};
+    const char* const KW_CFG_CACHE_CLEARER_SLEEP_TIME_IN_SECONDS{"cache_clearer_sleep_time_in_seconds"};
 
     // service_account_environment.json keywords
     const char* const KW_CFG_IRODS_USER_NAME{"irods_user_name"};

--- a/packaging/server_config.json.template
+++ b/packaging/server_config.json.template
@@ -2,21 +2,25 @@
     "schema_name": "server_config",
     "schema_version": "v4",
     "advanced_settings": {
+        "agent_factory_watcher_sleep_time_in_seconds": 5,
         "default_number_of_transfer_threads": 4,
         "default_temporary_password_lifetime_in_seconds": 120,
         "delay_rule_executors": [],
         "delay_server_sleep_time_in_seconds" : 30,
         "dns_cache": {
             "shared_memory_size_in_bytes": 5000000,
-            "eviction_age_in_seconds": 3600
+            "eviction_age_in_seconds": 3600,
+            "cache_clearer_sleep_time_in_seconds": 600
         },
         "hostname_cache": {
             "shared_memory_size_in_bytes": 2500000,
-            "eviction_age_in_seconds": 3600
+            "eviction_age_in_seconds": 3600,
+            "cache_clearer_sleep_time_in_seconds": 600
         },
         "maximum_size_for_single_buffer_in_megabytes": 32,
         "maximum_size_of_delay_queue_in_bytes": 0,
         "maximum_temporary_password_lifetime_in_seconds": 1000,
+        "migrate_delay_server_sleep_time_in_seconds": 5,
         "number_of_concurrent_delay_rule_executors": 4,
         "stacktrace_file_processor_sleep_time_in_seconds": 10,
         "transfer_buffer_size_for_parallel_transfer_in_megabytes": 4,

--- a/schemas/configuration/v4/server_config.json.in
+++ b/schemas/configuration/v4/server_config.json.in
@@ -6,6 +6,7 @@
         "advanced_settings": {
             "type": "object",
             "properties": {
+                "agent_factory_watcher_sleep_time_in_seconds": {"type": "integer"},
                 "default_number_of_transfer_threads": {"type": "integer"},
                 "default_temporary_password_lifetime_in_seconds": {"type": "integer"},
                 "delay_rule_executors": {
@@ -18,19 +19,22 @@
                     "type": "object",
                     "properties": {
                         "shared_memory_size_in_bytes": {"type": "integer"},
-                        "eviction_age_in_seconds": {"type": "integer"}
+                        "eviction_age_in_seconds": {"type": "integer"},
+                        "cache_clearer_sleep_time_in_seconds": {"type": "integer"}
                     }
                 },
                 "hostname_cache": {
                     "type": "object",
                     "properties": {
                         "shared_memory_size_in_bytes": {"type": "integer"},
-                        "eviction_age_in_seconds": {"type": "integer"}
+                        "eviction_age_in_seconds": {"type": "integer"},
+                        "cache_clearer_sleep_time_in_seconds": {"type": "integer"}
                     }
                 },
                 "maximum_size_for_single_buffer_in_megabytes": {"type": "integer"},
                 "maximum_size_of_delay_queue_in_bytes": {"type": "integer"},
                 "maximum_temporary_password_lifetime_in_seconds": {"type": "integer"},
+                "migrate_delay_server_sleep_time_in_seconds":  {"type": "integer"},
                 "number_of_concurrent_delay_rule_executors": {"type": "integer"},
                 "stacktrace_file_processor_sleep_time_in_seconds": {"type": "integer"},
                 "transfer_buffer_size_for_parallel_transfer_in_megabytes": {"type": "integer"},


### PR DESCRIPTION
Addresses #6342 
Addresses #6370 

Core tests passed on ubuntu:20.04.

Couple of notes:
1. Open to changing any and all names and default values for the configurations as well as their affiliated variables in the code.
2. I thought about making `get_advanced_setting` a template function based on the type of the configuration value, but this seemed a little overboard considering everything is just `int`s (for now) and the function is only available in the one file so it doesn't need to be so general. Any thoughts on this would be appreciated.
3. I'm happy to hold on merging this to yield to #6673 due to impending conflicts.
4. Ignoring the clang-tidy issue because it's just getting confused by the generated header file for the control plane commands.