### PR TITLE
[2279] Remove unneeded sleep calls, leave imports for other functions (main)

### DIFF
--- a/scripts/irods/test/test_auth.py
+++ b/scripts/irods/test/test_auth.py
@@ -162,9 +162,7 @@ class Test_Auth(resource_suite.ResourceBase, unittest.TestCase):
                     }
 
                     with temporary_core_file() as core:
-                        time.sleep(1)  # remove once file hash fix is committed #2279
                         core.add_rule(pep_map[self.plugin_name])
-                        time.sleep(1)  # remove once file hash fix is committed #2279
 
                         IrodsController().start()
 

--- a/scripts/irods/test/test_federation.py
+++ b/scripts/irods/test/test_federation.py
@@ -1493,9 +1493,7 @@ pep_api_data_obj_put_finally (*INSTANCE_NAME, *COMM, *DATAOBJINP, *BUFFER, *PORT
             test_session.assert_icommand(['iput', local_file, local_logical_path])
 
             with temporary_core_file() as core:
-                time.sleep(1)  # remove once file hash fix is committed #2279
                 core.add_rule(put_peps)
-                time.sleep(1)  # remove once file hash fix is committed #2279
 
                 # peps to check for the first, successful put
                 peps = ['data-obj-put-pre', 'data-obj-put-post', 'data-obj-put-finally']

--- a/scripts/irods/test/test_iadmin.py
+++ b/scripts/irods/test/test_iadmin.py
@@ -1232,9 +1232,7 @@ class Test_Iadmin(resource_suite.ResourceBase, unittest.TestCase):
         my_ip = socket.gethostbyname(socket.gethostname())
 
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(1)  # remove once file hash fix is committed #2279
 
             # restart the server to reread the new core.re
             IrodsController().restart(test_mode=True)
@@ -1277,9 +1275,7 @@ class Test_Iadmin(resource_suite.ResourceBase, unittest.TestCase):
         }
 
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(1)  # remove once file hash fix is committed #2279
 
             # restart the server to reread the new core.re
             IrodsController().restart()
@@ -1359,9 +1355,7 @@ class Test_Iadmin(resource_suite.ResourceBase, unittest.TestCase):
         hostname = lib.get_hostname()
         testresc1 = 'TestResc'
         with temporary_core_file() as core:
-            time.sleep(2)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(2)  # remove once file hash fix is committed #2279
 
             trigger_file = 'file_to_trigger_acSetRescSchemeForCreate'
             lib.make_file(trigger_file, 10)
@@ -1371,7 +1365,6 @@ class Test_Iadmin(resource_suite.ResourceBase, unittest.TestCase):
 
             os.unlink(trigger_file)
             self.user0.assert_icommand('irm -f ' + trigger_file)
-        time.sleep(2)  # remove once file hash fix is committed #2279
 
     def test_storageadmin_role(self):
         self.admin.assert_icommand("iadmin mkuser nopes storageadmin", 'STDERR_SINGLELINE', "CAT_INVALID_USER_TYPE")

--- a/scripts/irods/test/test_icommands_file_operations.py
+++ b/scripts/irods/test/test_icommands_file_operations.py
@@ -790,9 +790,7 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
             ''')
         }
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(1)  # remove once file hash fix is committed #2279
 
             initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
             with tempfile.NamedTemporaryFile(prefix='test_delay_in_dynamic_pep__3342') as f:
@@ -830,9 +828,7 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
             lib.make_large_local_tmp_dir(dirname, number_of_files, filesize)
             # manipulate core.re and check the server log
             with temporary_core_file() as core:
-                time.sleep(1)  # remove once file hash fix is committed #2279
                 core.add_rule(pep_map[self.plugin_name])
-                time.sleep(1)  # remove once file hash fix is committed #2279
 
                 initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
                 self.admin.assert_icommand(['iput', '-frb', dirname], "STDOUT_SINGLELINE", ustrings.recurse_ok_string())
@@ -889,9 +885,7 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
 
         # manipulate core.re and check the server log
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(1)  # remove once file hash fix is committed #2279
 
             # test as rodsuser
             self.user0.assert_icommand(['ils', '-l', filename], 'STDERR_SINGLELINE', 'does not exist')
@@ -933,9 +927,7 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
         filepath = lib.create_local_testfile(filename)
 
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(1)  # remove once file hash fix is committed #2279
 
             # test as rodsuser
             self.user0.assert_icommand(['ils', '-l', filename], 'STDERR_SINGLELINE', 'does not exist')
@@ -977,9 +969,7 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
         filepath = lib.create_local_testfile(filename)
 
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(1)  # remove once file hash fix is committed #2279
 
             # test as rodsuser
             self.user0.assert_icommand(['ils', '-l', filename], 'STDERR_SINGLELINE', 'does not exist')

--- a/scripts/irods/test/test_native_rule_engine_plugin.py
+++ b/scripts/irods/test/test_native_rule_engine_plugin.py
@@ -70,9 +70,7 @@ class Test_Native_Rule_Engine_Plugin(resource_suite.ResourceBase, unittest.TestC
             raise TypeError('values_to_check_for must be a dict')
 
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(rules_to_add)
-            time.sleep(1)  # remove once file hash fix is committed #2279
             self.admin.run_icommand(icommand)
 
         def assert_presence_of_attr_value_avu(attr, value, assert_true=True):
@@ -95,9 +93,7 @@ class Test_Native_Rule_Engine_Plugin(resource_suite.ResourceBase, unittest.TestC
 
     def helper_test_pep(self, rules_to_add, icommand, strings_to_check_for=['THIS IS AN OUT VARIABLE'], number_of_strings_to_look_for=1):
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(rules_to_add)
-            time.sleep(1)  # remove once file hash fix is committed #2279
             initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
             self.admin.run_icommand(icommand)
 
@@ -702,9 +698,7 @@ class Test_Native_Rule_Engine_Plugin(resource_suite.ResourceBase, unittest.TestC
         with lib.file_backed_up(coredvm):
             lib.prepend_string_to_file('oprType||rei->doinp->oprType\n', coredvm)
             with temporary_core_file() as core:
-                time.sleep(1)  # remove once file hash fix is committed #2279
                 core.add_rule(rule_text.format('put'))
-                time.sleep(1)  # remove once file hash fix is committed #2279
 
                 trigger_file = 'file_to_trigger_acSetNumThreads'
                 lib.make_file(trigger_file, 4 * pow(10, 7))
@@ -723,9 +717,7 @@ class Test_Native_Rule_Engine_Plugin(resource_suite.ResourceBase, unittest.TestC
                 os.unlink(trigger_file)
 
             with temporary_core_file() as core:
-                time.sleep(1)  # remove once file hash fix is committed #2279
                 core.add_rule(rule_text.format('get'))
-                time.sleep(1)  # remove once file hash fix is committed #2279
 
                 initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
                 self.admin.assert_icommand('iget {0}'.format(trigger_file), use_unsafe_shell=True)
@@ -864,8 +856,6 @@ OUTPUT ruleExecOut
         }
 
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(1)  # remove once file hash fix is committed #2279
             self.user0.assert_icommand(['ils'], 'STDOUT', self.user0.session_collection)
 

--- a/scripts/irods/test/test_quotas.py
+++ b/scripts/irods/test/test_quotas.py
@@ -42,9 +42,7 @@ class Test_Quotas(resource_suite.ResourceBase, unittest.TestCase):
         filename_1 = 'test_iquota__3044_1'
         filename_2 = 'test_iquota__3044_2'
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(1)  # remove once file hash fix is committed #2279
             for quotatype in [['sgq', 'public']]: # group
                 for quotaresc in [self.testresc, 'total']: # resc and total
                     cmd = 'iadmin {0} {1} {2} 10000000'.format(quotatype[0], quotatype[1], quotaresc) # set high quota
@@ -75,7 +73,6 @@ class Test_Quotas(resource_suite.ResourceBase, unittest.TestCase):
                     self.admin.assert_icommand(cmd.split())
                     cmd = 'irm -rf {0}'.format(filename_2) # clean up
                     self.admin.assert_icommand(cmd.split())
-            time.sleep(2)  # remove once file hash fix is committed #2279
 
     def test_iquota_empty__3048(self):
         cmd = 'iadmin suq' # no arguments

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -503,9 +503,7 @@ OUTPUT ruleExecOut
             lib.make_dir_p(self.admin.get_vault_path('demoResc'))
 
             with temporary_core_file() as core:
-                time.sleep(1)  # remove once file hash fix is committed #2279
                 core.add_rule(pep_map[self.plugin_name])
-                time.sleep(1)  # remove once file hash fix is committed #2279
 
                 self.user0.assert_icommand(['iput', filename])
                 free_space = psutil.disk_usage(self.admin.get_vault_path('demoResc')).free
@@ -2435,9 +2433,7 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
 
         # manipulate the core.re to add the new policy
         with temporary_core_file() as core:
-            time.sleep(2)  # remove once file hash fix is committed #2279
             core.add_rule(rule_map[self.plugin_name])
-            time.sleep(2)  # remove once file hash fix is committed #2279
 
             self.admin.assert_icommand("irm -f " + filename)
 
@@ -2482,9 +2478,7 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
 
         # manipulate the core.re to add the new policy
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(1)  # remove once file hash fix is committed #2279
 
             # restart the server to reread the new core.re
             IrodsController().restart()
@@ -3249,9 +3243,7 @@ class Test_Resource_ReplicationToTwoCompound(ChunkyDevTest, ResourceSuite, unitt
 
         # manipulate the core.re to add the new policy
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(1)  # remove once file hash fix is committed #2279
 
             # restart the server to reread the new core.re
             IrodsController().restart()
@@ -3613,9 +3605,7 @@ class Test_Resource_ReplicationToTwoCompoundResourcesWithPreferArchive(ChunkyDev
         backupcorefilepath = core.filepath + "--" + self._testMethodName
         shutil.copy(core.filepath, backupcorefilepath)
 
-        time.sleep(1)  # remove once file hash fix is committed #2279
         core.add_rule(pep_map[self.plugin_name])
-        time.sleep(1)  # remove once file hash fix is committed #2279
 
         with session.make_session_for_existing_admin() as admin_session:
             admin_session.assert_icommand("iadmin modresc demoResc name origResc", 'STDOUT_SINGLELINE', 'rename', input='yes\n')

--- a/scripts/irods/test/test_rule_engine_plugin_framework.py
+++ b/scripts/irods/test/test_rule_engine_plugin_framework.py
@@ -10,7 +10,7 @@ import json
 import os
 import socket
 import tempfile
-import time  # remove once file hash fix is committed #2279
+import time
 import subprocess
 import mmap
 import shutil

--- a/scripts/irods/test/test_rulebase.py
+++ b/scripts/irods/test/test_rulebase.py
@@ -9,7 +9,7 @@ import json
 import os
 import socket
 import tempfile
-import time  # remove once file hash fix is committed #2279
+import time
 import subprocess
 import textwrap
 
@@ -47,9 +47,7 @@ class Test_Rulebase(ResourceBase, unittest.TestCase):
         }
 
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(1)  # remove once file hash fix is committed #2279
 
             client_update = {
                 'irods_client_server_policy': 'CS_NEG_REFUSE'
@@ -121,9 +119,7 @@ class Test_Rulebase(ResourceBase, unittest.TestCase):
         }
 
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(1)  # remove once file hash fix is committed #2279
 
             test_file = 'rulebasetestfile'
             lib.touch(test_file)
@@ -182,9 +178,7 @@ class Test_Rulebase(ResourceBase, unittest.TestCase):
         tfile = "rulebasetestfile"
         try:
             with temporary_core_file() as core:
-                time.sleep(1)  # remove once file hash fix is committed #2279
                 core.add_rule(pep_map[self.plugin_name])
-                time.sleep(1)  # remove once file hash fix is committed #2279
 
                 # put data
                 lib.touch(tfile)
@@ -211,7 +205,6 @@ class Test_Rulebase(ResourceBase, unittest.TestCase):
                 # check replicas
                 self.admin.assert_icommand(['ils', '-L', tfile], 'STDOUT_MULTILINE', [' demoResc ', ' r1 ', ' r2 '])
 
-            time.sleep(2)  # remove once file hash fix is committed #2279
 
         finally:
             # clean up and remove new resources
@@ -234,9 +227,7 @@ class Test_Rulebase(ResourceBase, unittest.TestCase):
         }
 
         with temporary_core_file() as core:
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(pep_map[self.plugin_name])
-            time.sleep(1)  # remove once file hash fix is committed #2279
 
             # check rei functioning
             self.admin.assert_icommand("iget " + self.testfile + " - ", 'STDOUT_SINGLELINE', self.testfile)
@@ -325,9 +316,7 @@ class Test_Rulebase(ResourceBase, unittest.TestCase):
     def test_update_core_multiple_agents__3184(self):
         with temporary_core_file() as core:
             for l in range(100):
-                time.sleep(1)  # remove once file hash fix is committed #2279
                 core.add_rule("multiple_agents {}")
-                time.sleep(1)  # remove once file hash fix is committed #2279
 
                 processes = []
                 initial_log_size = lib.get_file_size_by_path(paths.server_log_path())
@@ -869,9 +858,7 @@ class Test_Resource_Session_Vars__3024(ResourceBase, unittest.TestCase):
             # write pep rule into test_re
 #            with open(test_re, 'w') as f:
 #                f.write(test_rule)
-            time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(test_rule)
-            time.sleep(1)  # remove once file hash fix is committed #2279
 
 #            # repave the existing server_config.json to add test_re
 #            with open(server_config_filename, 'w') as f:


### PR DESCRIPTION
The `time.sleep(...)` calls are safe to remove, however, the `import time`s are still used by other functions, so imports will remain.

Comments on removing `import time` are removed to avoid confusion in the future.