### PR TITLE
[#6198] Added admin_mode option to rx_atomic_apply_acl_operations() (4-2-stable)

### DIFF
--- a/lib/api/include/atomic_apply_acl_operations.h
+++ b/lib/api/include/atomic_apply_acl_operations.h
@@ -18,6 +18,7 @@ extern "C" {
 /// \p json_input must have the following JSON structure:
 /// \code{.js}
 /// {
+///   "admin_mode": boolean,
 ///   "logical_path": string,
 ///   "operations": [
 ///     {
@@ -27,6 +28,9 @@ extern "C" {
 ///   ]
 /// }
 /// \endcode
+///
+/// \p admin_mode a boolean value instructing the server to execute the operations as an
+/// administrator (i.e. rodsadmin).
 ///
 /// \p logical_path must be an absolute path to a data object or collection.
 ///

--- a/server/api/include/rs_atomic_apply_acl_operations.hpp
+++ b/server/api/include/rs_atomic_apply_acl_operations.hpp
@@ -18,6 +18,7 @@ extern "C" {
 /// \p json_input must have the following JSON structure:
 /// \code{.js}
 /// {
+///   "admin_mode": boolean,
 ///   "logical_path": string,
 ///   "operations": [
 ///     {
@@ -27,6 +28,9 @@ extern "C" {
 ///   ]
 /// }
 /// \endcode
+///
+/// \p admin_mode a boolean value instructing the server to execute the operations as an
+/// administrator (i.e. rodsadmin).
 ///
 /// \p logical_path must be an absolute path to a data object or collection.
 ///

--- a/unit_tests/src/test_atomic_apply_acl_operations.cpp
+++ b/unit_tests/src/test_atomic_apply_acl_operations.cpp
@@ -1,21 +1,27 @@
 #include "catch.hpp"
 
+#include "rcConnect.h"
 #include "rodsClient.h"
 #include "atomic_apply_acl_operations.h"
 
-#include "connection_pool.hpp"
+#include "client_connection.hpp"
 #include "filesystem.hpp"
+#include "rodsErrorTable.h"
 #include "user_administration.hpp"
 #include "irods_at_scope_exit.hpp"
+#include "transport/default_transport.hpp"
+#include "dstream.hpp"
 
 #include "json.hpp"
 
 #include <cstdlib>
 #include <string>
 #include <iostream>
+#include <utility>
 
 namespace fs = irods::experimental::filesystem;
 namespace ua = irods::experimental::administration;
+namespace io = irods::experimental::io;
 
 using json = nlohmann::json;
 
@@ -27,8 +33,7 @@ TEST_CASE("atomic_apply_acl_operations")
 
     load_client_api_plugins();
 
-    auto conn_pool = irods::make_connection_pool();
-    auto conn = conn_pool->get_connection();
+    irods::experimental::client_connection conn;
 
     rodsEnv env;
     _getRodsEnv(env);
@@ -172,6 +177,235 @@ TEST_CASE("atomic_apply_acl_operations")
         REQUIRE_FALSE(rc_atomic_apply_acl_operations(static_cast<rcComm_t*>(conn), json_input.c_str(), &json_error_string) == 0);
         REQUIRE(contains_error_information(json_error_string));
     }
+}
+
+TEST_CASE("Administrators are allowed to use the admin_mode option")
+{
+    //
+    // This test requires that the environment represent a rodsadmin user.
+    //
+
+    using namespace std::string_literals;
+
+    load_client_api_plugins();
+
+    irods::experimental::client_connection conn;
+
+    // Create a test rodsuser.
+    ua::user test_user{"unit_test_test_user"};
+    irods::at_scope_exit remove_user{[&conn, &test_user] { ua::client::remove_user(conn, test_user); }};
+    REQUIRE(ua::client::add_user(conn, test_user).value() == 0);
+
+    // Create a test rodsgroup.
+    ua::group test_group{"unit_test_test_group"};
+    irods::at_scope_exit remove_group{[&conn, &test_group] { ua::client::remove_group(conn, test_group); }};
+    REQUIRE(ua::client::add_group(conn, test_group).value() == 0);
+
+    // Capture the home collection of the test user.
+    rodsEnv env;
+    _getRodsEnv(env);
+    const auto test_user_home = fs::path{"/"} / env.rodsZone / "home" / test_user.name;
+
+    // Show that the administrator (identified by "conn") cannot manipulate metadata on the
+    // test user's home collection.
+    const fs::metadata avu{"attr_name_6198", "attr_value_6198", "attr_units_6198"};
+    CHECK_THROWS(fs::client::add_metadata(conn, test_user_home, avu));
+
+    // Show that the admin can grant permissions to themself via the admin mode option.
+    const auto json_input = json{
+        {"admin_mode", true},
+        {"logical_path", test_user_home.c_str()},
+        {"operations", json::array({
+            {
+                {"entity_name", env.rodsUserName},
+                {"acl", "write"}
+            },
+            {
+                {"entity_name", test_group.name},
+                {"acl", "read"}
+            }
+        })}
+    }.dump();
+
+    char* json_error_string{};
+    irods::at_scope_exit free_memory{[&json_error_string] { std::free(json_error_string); }};
+
+    CHECK(rc_atomic_apply_acl_operations(static_cast<RcComm*>(conn), json_input.c_str(), &json_error_string) == 0);
+    CHECK(json_error_string == "{}"s);
+
+    // Show that the permissions were updated successfully.
+    const auto perms = fs::client::status(conn, test_user_home).permissions();
+    auto b = std::begin(perms);
+    auto e = std::end(perms);
+
+    const auto check_rodsadmin_perms = [&env](const fs::entity_permission& _p) {
+        return _p.name == env.rodsUserName && _p.prms == fs::perms::write;
+    };
+    CHECK(std::find_if(b, e, check_rodsadmin_perms) != e);
+
+    const auto check_test_group_perms = [&test_group](const fs::entity_permission& _p) {
+        return _p.name == test_group.name && _p.prms == fs::perms::read;
+    };
+    CHECK(std::find_if(b, e, check_test_group_perms) != e);
+
+    // Show that the administrator can now manipulate metadata on the test user's home collection.
+    CHECK_NOTHROW(fs::client::add_metadata(conn, test_user_home, avu));
+    const auto metadata = fs::client::get_metadata(conn, test_user_home);
+    REQUIRE(!metadata.empty());
+    CHECK(metadata[0].attribute == avu.attribute);
+    CHECK(metadata[0].value == avu.value);
+    CHECK(metadata[0].units == avu.units);
+}
+
+TEST_CASE("Non-admin users are not allowed to use the admin_mode option")
+{
+    //
+    // This test requires that the environment represent a rodsadmin user.
+    //
+
+    using namespace std::string_literals;
+
+    load_client_api_plugins();
+
+    irods::experimental::client_connection conn;
+
+    // Create a test rodsuser.
+    ua::user test_user{"unit_test_test_user"};
+    irods::at_scope_exit remove_user{[&conn, &test_user] {
+        conn.disconnect();
+        conn.connect();
+        ua::client::remove_user(conn, test_user);
+    }};
+    CHECK(ua::client::add_user(conn, test_user).value() == 0);
+    REQUIRE(ua::client::set_user_password(conn, test_user, "rods").value() == 0);
+
+    // Connect to server as the test user.
+    conn.disconnect();
+    rodsEnv env;
+    _getRodsEnv(env);
+    conn.connect(env.rodsHost, env.rodsPort, test_user.name.c_str(), env.rodsZone);
+
+    // Capture the home collection of the test user.
+    const auto test_user_home = fs::path{"/"} / env.rodsZone / "home" / test_user.name;
+
+    // Show that the test user cannot use the admin_mode option to grant permissions
+    // even on their own collection.
+
+    const auto test_input = {
+        std::pair<std::string_view, int>{env.rodsHome, OBJ_PATH_DOES_NOT_EXIST},
+        std::pair<std::string_view, int>{test_user_home.c_str(), CAT_INSUFFICIENT_PRIVILEGE_LEVEL}
+    };
+
+    for (auto&& [path, ec] : test_input) {
+        const auto json_input = json{
+            {"admin_mode", true},
+            {"logical_path", path},
+            {"operations", json::array({
+                {
+                    {"entity_name", env.rodsUserName},
+                    {"acl", "read"}
+                }
+            })}
+        }.dump();
+
+        char* json_error_string{};
+        irods::at_scope_exit free_memory{[&json_error_string] { std::free(json_error_string); }};
+
+        CHECK(rc_atomic_apply_acl_operations(static_cast<RcComm*>(conn), json_input.c_str(), &json_error_string) == ec);
+        CHECK(contains_error_information(json_error_string));
+    }
+
+    // Show that the permissions have not changed.
+    CHECK(fs::client::status(conn, test_user_home).permissions().size() == 1);
+}
+
+TEST_CASE("Non-admin users can modify ACLs of collections and data objects")
+{
+    //
+    // This test requires that the environment represent a rodsadmin user.
+    //
+
+    using namespace std::string_literals;
+
+    load_client_api_plugins();
+
+    irods::experimental::client_connection conn;
+
+    // Create a test rodsuser.
+    ua::user test_user{"unit_test_test_user"};
+    irods::at_scope_exit remove_user{[&conn, &test_user] {
+        conn.disconnect();
+        conn.connect();
+        ua::client::remove_user(conn, test_user);
+    }};
+    CHECK(ua::client::add_user(conn, test_user).value() == 0);
+    REQUIRE(ua::client::set_user_password(conn, test_user, "rods").value() == 0);
+
+    // Capture the local user's environment information.
+    rodsEnv env;
+    _getRodsEnv(env);
+
+    // Connect to server as the test user.
+    rErrMsg_t error;
+    auto* conn_ptr = rcConnect(env.rodsHost, env.rodsPort, test_user.name.c_str(), env.rodsZone, 0, &error);
+    REQUIRE(conn_ptr);
+    irods::at_scope_exit disconnect_test_user{[conn_ptr] { rcDisconnect(conn_ptr); }};
+    char password[] = "rods";
+    REQUIRE(clientLoginWithPassword(conn_ptr, password) == 0);
+
+    // Capture the home collection of the test user.
+    const auto test_user_home = fs::path{"/"} / env.rodsZone / "home" / test_user.name;
+
+    // Create a test data object.
+    const auto test_data_object = test_user_home / "unit_test_test_object.txt";
+
+    {
+        io::client::default_transport tp{*conn_ptr};
+        io::odstream{tp, test_data_object} << "this is some test data.";
+        REQUIRE(fs::client::exists(*conn_ptr, test_data_object));
+    }
+
+    irods::at_scope_exit delete_data_object{[conn_ptr, &test_data_object] {
+        fs::client::remove(*conn_ptr, test_data_object, fs::remove_options::no_trash);
+    }};
+
+    // Show that the test user can modify permissions on collections and data objects they
+    // have access to.
+
+    const auto test_input = {
+        std::pair<fs::path, std::string_view>{test_user_home, "read"},
+        std::pair<fs::path, std::string_view>{test_data_object, "write"}
+    };
+
+    for (auto&& [path, permission] : test_input) {
+        const auto json_input = json{
+            {"logical_path", path},
+            {"operations", json::array({
+                {
+                    {"entity_name", env.rodsUserName},
+                    {"acl", permission}
+                }
+            })}
+        }.dump();
+
+        char* json_error_string{};
+        irods::at_scope_exit free_memory{[&json_error_string] { std::free(json_error_string); }};
+
+        CHECK(rc_atomic_apply_acl_operations(conn_ptr, json_input.c_str(), &json_error_string) == 0);
+        CHECK(json_error_string == "{}"s);
+    }
+
+    // Show that the permissions were updated successfully.
+    const auto has_expected_permissions = [conn_ptr, &env](const auto& _path, const auto& _perm) {
+        const auto perms = fs::client::status(*conn_ptr, _path).permissions();
+
+        return std::find_if(std::begin(perms), std::end(perms), [&env, _perm](const fs::entity_permission& _p) {
+            return _p.name == env.rodsUserName && _p.prms == _perm;
+        }) != std::end(perms);
+    };
+
+    CHECK(has_expected_permissions(test_user_home, fs::perms::read));
+    CHECK(has_expected_permissions(test_data_object, fs::perms::write));
 }
 
 auto contains_error_information(const char* _json_string) -> bool


### PR DESCRIPTION
Unit tests for this API plugin passed.

Nothing in the server uses this API plugin so it's safe to merge based on unit test results alone.