### PR TITLE
[#6754] Deprecated member variables of the `l1desc` data type (4-2-stable)

### DIFF
--- a/plugins/api/src/get_file_descriptor_info.cpp
+++ b/plugins/api/src/get_file_descriptor_info.cpp
@@ -208,7 +208,10 @@ namespace
             {"data_object_input_replica_flag", _fd_info.dataObjInpReplFlag},
             {"data_object_input", to_json(_fd_info.dataObjInp)},
             {"data_object_info", to_json(_fd_info.dataObjInfo)},
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             {"other_data_object_info", to_json(_fd_info.otherDataObjInfo)},
+#pragma clang diagnostic pop
             {"copies_needed", _fd_info.copiesNeeded},
             {"bytes_written", _fd_info.bytesWritten},
             {"data_size", _fd_info.dataSize},
@@ -221,7 +224,10 @@ namespace
             {"purge_cache_flag", _fd_info.purgeCacheFlag},
             {"lock_file_descriptor", _fd_info.lockFd},
             {"plugin_data", nullptr}, // Not used anywhere as of 2019-01-28
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             {"replication_data_object_info", to_json(_fd_info.replDataObjInfo)},
+#pragma clang diagnostic pop
             {"remote_zone_host", to_json(_fd_info.remoteZoneHost)},
             {"in_pdmo", _fd_info.in_pdmo},
             {"replica_token", _fd_info.replica_token}

--- a/server/core/include/objDesc.hpp
+++ b/server/core/include/objDesc.hpp
@@ -30,7 +30,21 @@
 //
 // DO NOT call std::memset() on this data type. Use init_l1desc().
 // DO NOT call std::memcpy() on this data type. Use the assignment operator.
-typedef struct l1desc {
+typedef struct l1desc
+{
+    l1desc() = default;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    l1desc(const l1desc&) = default;
+    auto operator=(const l1desc&) -> l1desc& = default;
+
+    l1desc(l1desc&&) = default;
+    auto operator=(l1desc&&) -> l1desc& = default;
+#pragma clang diagnostic pop
+
+    ~l1desc() = default;
+
     int l3descInx;
     int inuseFlag;
     int oprType;
@@ -39,7 +53,7 @@ typedef struct l1desc {
     int dataObjInpReplFlag;
     dataObjInp_t *dataObjInp;
     dataObjInfo_t *dataObjInfo;
-    dataObjInfo_t *otherDataObjInfo;
+    [[deprecated]] dataObjInfo_t *otherDataObjInfo;
     int copiesNeeded;
     rodsLong_t bytesWritten; /* mark whether it has been written */
     rodsLong_t dataSize;     /* this is the target size. The size in dataObjInfo is the registered size */
@@ -51,8 +65,8 @@ typedef struct l1desc {
     int stageFlag;
     int purgeCacheFlag;
     int lockFd;
-    boost::any pluginData;
-    dataObjInfo_t *replDataObjInfo; // if non NULL, repl to this dataObjInfo on close.
+    [[deprecated]] boost::any pluginData;
+    [[deprecated]] dataObjInfo_t *replDataObjInfo; // if non NULL, repl to this dataObjInfo on close.
     rodsServerHost_t *remoteZoneHost;
     char in_pdmo[MAX_NAME_LEN];
 

--- a/server/core/src/finalize_utilities.cpp
+++ b/server/core/src/finalize_utilities.cpp
@@ -199,7 +199,7 @@ namespace irods
 
     auto duplicate_l1_descriptor(const l1desc& _src) -> l1desc
     {
-        l1desc dest = _src;
+        auto dest = _src;
 
         if (_src.dataObjInp) {
             DataObjInp* doi = static_cast<DataObjInp*>(std::malloc(sizeof(DataObjInp)));
@@ -214,8 +214,11 @@ namespace irods
 
         // TODO: need duplication logic
         dest.remoteZoneHost = nullptr;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         dest.otherDataObjInfo = nullptr;
         dest.replDataObjInfo = nullptr;
+#pragma clang diagnostic pop
 
         return dest;
     } // duplicate_l1_descriptor

--- a/server/core/src/objDesc.cpp
+++ b/server/core/src/objDesc.cpp
@@ -56,15 +56,19 @@ auto init_l1desc(l1desc& _l1d) -> void
 
     _l1d.dataObjInp = nullptr;
     _l1d.dataObjInfo = nullptr;
-    _l1d.otherDataObjInfo = nullptr;
-    _l1d.replDataObjInfo = nullptr;
     _l1d.remoteZoneHost = nullptr;
 
-    _l1d.pluginData.clear();
     _l1d.replica_token.clear();
 
     std::memset(_l1d.chksum, 0, sizeof(l1desc::chksum));
     std::memset(_l1d.in_pdmo, 0, sizeof(l1desc::in_pdmo));
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    _l1d.otherDataObjInfo = nullptr;
+    _l1d.replDataObjInfo = nullptr;
+    _l1d.pluginData.clear();
+#pragma clang diagnostic pop
 } // init_l1desc
 
 int
@@ -160,6 +164,8 @@ int freeL1desc_struct(l1desc& _l1desc)
         //freeAllDataObjInfo(_l1desc.dataObjInfo);
     }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if (_l1desc.otherDataObjInfo) {
         freeAllDataObjInfo(_l1desc.otherDataObjInfo);
     }
@@ -168,6 +174,7 @@ int freeL1desc_struct(l1desc& _l1desc)
         freeDataObjInfo(_l1desc.replDataObjInfo);
         //freeAllDataObjInfo(_l1desc.replDataObjInfo);
     }
+#pragma clang diagnostic pop
 
     if (_l1desc.dataObjInpReplFlag == 1 && _l1desc.dataObjInp) {
         clearDataObjInp(_l1desc.dataObjInp);


### PR DESCRIPTION
All unit tests passed.

Will run the core tests soon.