### PR TITLE
[#6754] Deprecated member variables of the l1desc data type (main)

### DIFF
--- a/plugins/api/src/get_file_descriptor_info.cpp
+++ b/plugins/api/src/get_file_descriptor_info.cpp
@@ -196,6 +196,7 @@ namespace
 
     auto to_json(const l1desc& _fd_info) -> json
     {
+        // clang-format off
         return {
             {"l3descInx", _fd_info.l3descInx},
             {"in_use", static_cast<bool>(_fd_info.inuseFlag)},
@@ -205,7 +206,10 @@ namespace
             {"data_object_input_replica_flag", _fd_info.dataObjInpReplFlag},
             {"data_object_input", to_json(_fd_info.dataObjInp)},
             {"data_object_info", to_json(_fd_info.dataObjInfo)},
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             {"other_data_object_info", to_json(_fd_info.otherDataObjInfo)},
+#pragma clang diagnostic pop
             {"copies_needed", _fd_info.copiesNeeded},
             {"bytes_written", _fd_info.bytesWritten},
             {"data_size", _fd_info.dataSize},
@@ -218,11 +222,15 @@ namespace
             {"purge_cache_flag", _fd_info.purgeCacheFlag},
             {"lock_file_descriptor", _fd_info.lockFd},
             {"plugin_data", nullptr}, // Not used anywhere as of 2019-01-28
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             {"replication_data_object_info", to_json(_fd_info.replDataObjInfo)},
+#pragma clang diagnostic pop
             {"remote_zone_host", to_json(_fd_info.remoteZoneHost)},
             {"in_pdmo", _fd_info.in_pdmo},
             {"replica_token", _fd_info.replica_token}
         };
+        // clang-format on
     }
 
     auto call_get_file_descriptor_info(irods::api_entry* _api,

--- a/server/core/include/irods/objDesc.hpp
+++ b/server/core/include/irods/objDesc.hpp
@@ -32,6 +32,19 @@
 // DO NOT call std::memcpy() on this data type. Use the assignment operator.
 struct l1desc
 {
+    l1desc() = default;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    l1desc(const l1desc&) = default;
+    auto operator=(const l1desc&) -> l1desc& = default;
+
+    l1desc(l1desc&&) = default;
+    auto operator=(l1desc&&) -> l1desc& = default;
+#pragma clang diagnostic pop
+
+    ~l1desc() = default;
+
     int l3descInx;
     int inuseFlag;
     int oprType;
@@ -40,7 +53,8 @@ struct l1desc
     int dataObjInpReplFlag;
     dataObjInp_t *dataObjInp;
     dataObjInfo_t *dataObjInfo;
-    dataObjInfo_t *otherDataObjInfo;
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    [[deprecated]] dataObjInfo_t* otherDataObjInfo;
     int copiesNeeded;
     rodsLong_t bytesWritten; /* mark whether it has been written */
     rodsLong_t dataSize; /* this is the target size. The size in dataObjInfo is the registered size */
@@ -52,8 +66,10 @@ struct l1desc
     int stageFlag;
     int purgeCacheFlag;
     int lockFd;
-    boost::any pluginData;
-    dataObjInfo_t* replDataObjInfo; // if not a nullptr, repl to this dataObjInfo on close.
+    // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
+    [[deprecated]] boost::any pluginData;
+    [[deprecated]] dataObjInfo_t* replDataObjInfo; // if not a nullptr, repl to this dataObjInfo on close.
+    // NOLINTEND(misc-non-private-member-variables-in-classes)
     rodsServerHost_t *remoteZoneHost;
     char in_pdmo[MAX_NAME_LEN];
 

--- a/server/core/src/finalize_utilities.cpp
+++ b/server/core/src/finalize_utilities.cpp
@@ -238,8 +238,11 @@ namespace irods
 
         // TODO: need duplication logic
         dest.remoteZoneHost = nullptr;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         dest.otherDataObjInfo = nullptr;
         dest.replDataObjInfo = nullptr;
+#pragma clang diagnostic pop
 
         return dest;
     } // duplicate_l1_descriptor

--- a/server/core/src/objDesc.cpp
+++ b/server/core/src/objDesc.cpp
@@ -57,17 +57,21 @@ auto init_l1desc(l1desc& _l1d) -> void
 
     _l1d.dataObjInp = nullptr;
     _l1d.dataObjInfo = nullptr;
-    _l1d.otherDataObjInfo = nullptr;
-    _l1d.replDataObjInfo = nullptr;
     _l1d.remoteZoneHost = nullptr;
 
-    _l1d.pluginData.clear();
     _l1d.replica_token.clear();
 
     // NOLINTBEGIN(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     std::memset(_l1d.chksum, 0, sizeof(l1desc::chksum));
     std::memset(_l1d.in_pdmo, 0, sizeof(l1desc::in_pdmo));
     // NOLINTEND(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    _l1d.otherDataObjInfo = nullptr;
+    _l1d.replDataObjInfo = nullptr;
+    _l1d.pluginData.clear();
+#pragma clang diagnostic pop
 } // init_l1desc
 
 int
@@ -163,6 +167,8 @@ int freeL1desc_struct(l1desc& _l1desc)
         //freeAllDataObjInfo(_l1desc.dataObjInfo);
     }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if (_l1desc.otherDataObjInfo) {
         freeAllDataObjInfo(_l1desc.otherDataObjInfo);
     }
@@ -171,6 +177,7 @@ int freeL1desc_struct(l1desc& _l1desc)
         freeDataObjInfo(_l1desc.replDataObjInfo);
         //freeAllDataObjInfo(_l1desc.replDataObjInfo);
     }
+#pragma clang diagnostic pop
 
     if (_l1desc.dataObjInpReplFlag == 1 && _l1desc.dataObjInp) {
         clearDataObjInp(_l1desc.dataObjInp);


### PR DESCRIPTION
Ported from #6793.

Will run unit tests and core tests soon.