### PR TITLE
[_6794] change message() for filesystem_error

### DIFF
--- a/lib/filesystem/include/filesystem/detail.hpp
+++ b/lib/filesystem/include/filesystem/detail.hpp
@@ -6,15 +6,28 @@
 
 #include "rodsDef.h"
 #include "rodsErrorTable.h"
+#include "rodsLog.h"
 
 #include <cstring>
 #include <system_error>
 
 namespace irods::experimental::filesystem::detail
 {
+    struct irods_category : std::error_category {
+        virtual auto message(int condition) -> std::string const override {
+            char *subName{};
+            std::string s{ rodsErrorName(condition, &subName) };
+            if (subName && *subName) {
+                s += (std::string{" ("} + subName + ")");
+            }
+            free(subName);
+            return s;
+        }
+    };
+
     inline auto make_error_code(int _ec) noexcept -> std::error_code
     {
-        return {_ec, std::system_category()};
+        return {_ec, irods_category()};
     }
 
     inline auto is_separator(path::value_type _c) noexcept -> bool


### PR DESCRIPTION
Making this pull request not because I consider it viable (it coesn't even compile yet) ... but because I need help.  

I thought I was going about this rightly, overriding an error category and changing the virtual message ( ) function.

A few things lack.

Firstly, I seem to be overriding incorrectly and/or inconsistently to the base class  std::error_category; but according to cppreference.com it looks right to me.

Secondly, the code that I'm replacing calls `system_category` to fetch, I think, an already constructed object.  I'm convinced what we need is an `irods_category` where the message( ) method prints the output from `rodsErrorName` but then where do we go from there?  Instantiate it as another std::error_category choice and provide a utility method to retrieve it - much like std::system_category? 

Thirdly, I guess we need to override the `name` method too (also virtual = 0, apparently, like `message`) . Not sure what's needed there.

Or I'm totally on the wrong track. @korydraughn ?