### PR TITLE
[#6482] Deleting a delay rule now verifies zone of the connected client (4-2-stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,6 +578,7 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/api/src/rc_atomic_apply_metadata_operations.cpp
   ${CMAKE_SOURCE_DIR}/lib/api/src/rc_data_object_finalize.cpp
   ${CMAKE_SOURCE_DIR}/lib/api/src/rc_data_object_modify_info.cpp
+  ${CMAKE_SOURCE_DIR}/lib/api/src/rc_get_delay_rule_info.cpp
   ${CMAKE_SOURCE_DIR}/lib/api/src/rc_get_file_descriptor_info.cpp
   ${CMAKE_SOURCE_DIR}/lib/api/src/rc_register_physical_path.cpp
   ${CMAKE_SOURCE_DIR}/lib/api/src/rc_replica_close.cpp
@@ -704,6 +705,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/api/src/rs_atomic_apply_acl_operations.cpp
   ${CMAKE_SOURCE_DIR}/server/api/src/rs_atomic_apply_metadata_operations.cpp
   ${CMAKE_SOURCE_DIR}/server/api/src/rs_data_object_finalize.cpp
+  ${CMAKE_SOURCE_DIR}/server/api/src/rs_get_delay_rule_info.cpp
   ${CMAKE_SOURCE_DIR}/server/api/src/rs_get_file_descriptor_info.cpp
   ${CMAKE_SOURCE_DIR}/server/api/src/rs_register_physical_path.cpp
   ${CMAKE_SOURCE_DIR}/server/api/src/rs_replica_close.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1383,7 +1383,6 @@ target_link_libraries(
   ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_thread.so
   ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_container.so
   ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so
-  ${IRODS_EXTERNALS_FULLPATH_NANODBC}/lib/libnanodbc.so
   rt
   Threads::Threads
   ${CMAKE_DL_LIBS}
@@ -1401,7 +1400,6 @@ target_include_directories(
   ${CMAKE_SOURCE_DIR}/lib/api/include
   ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
   ${IRODS_EXTERNALS_FULLPATH_FMT}/include
-  ${IRODS_EXTERNALS_FULLPATH_NANODBC}/include
   )
 target_compile_definitions(irodsReServer PRIVATE ${IRODS_COMPILE_DEFINITIONS})
 target_compile_options(irodsReServer PRIVATE -Wno-write-strings)

--- a/cmake/development_library.cmake
+++ b/cmake/development_library.cmake
@@ -249,6 +249,7 @@ set(
   ${CMAKE_SOURCE_DIR}/lib/api/include/fileUnlink.h
   ${CMAKE_SOURCE_DIR}/lib/api/include/fileWrite.h
   ${CMAKE_SOURCE_DIR}/lib/api/include/genQuery.h
+  ${CMAKE_SOURCE_DIR}/lib/api/include/get_delay_rule_info.h
   ${CMAKE_SOURCE_DIR}/lib/api/include/get_file_descriptor_info.h
   ${CMAKE_SOURCE_DIR}/lib/api/include/generalAdmin.h
   ${CMAKE_SOURCE_DIR}/lib/api/include/generalRowInsert.h
@@ -343,6 +344,7 @@ set(
   ${CMAKE_SOURCE_DIR}/server/api/include/rs_atomic_apply_acl_operations.hpp
   ${CMAKE_SOURCE_DIR}/server/api/include/rs_atomic_apply_metadata_operations.hpp
   ${CMAKE_SOURCE_DIR}/server/api/include/rs_data_object_finalize.hpp
+  ${CMAKE_SOURCE_DIR}/server/api/include/rs_get_delay_rule_info.hpp
   ${CMAKE_SOURCE_DIR}/server/api/include/rs_get_file_descriptor_info.hpp
   ${CMAKE_SOURCE_DIR}/server/api/include/rs_register_physical_path.hpp
   ${CMAKE_SOURCE_DIR}/server/api/include/rs_replica_open.hpp

--- a/lib/api/include/get_delay_rule_info.h
+++ b/lib/api/include/get_delay_rule_info.h
@@ -1,0 +1,34 @@
+#ifndef IRODS_GET_DELAY_RULE_INFO_H
+#define IRODS_GET_DELAY_RULE_INFO_H
+
+/// \file
+
+struct RcComm;
+struct BytesBuf;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Returns information about a specific delay rule.
+///
+/// \param[in]     _comm    A pointer to a RcComm.
+/// \param[in]     _rule_id The ID of the rule to fetch information for. It must be greater
+///                         than zero.
+/// \param[in,out] _output  The address to a BytesBuf pointer. On success, it will point
+///                         to a JSON string containing all information about the delay rule.
+///                         The string will be allocated on the heap and must be free'd by
+///                         the caller using free(). On failure, the pointer is not modified.
+///
+/// \return An integer.
+/// \retval  0 On success.
+/// \retval <0 On failure.
+///
+/// \since 4.2.12
+int rc_get_delay_rule_info(struct RcComm* _comm, const char* _rule_id, BytesBuf** _output);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // IRODS_GET_DELAY_RULE_INFO_H

--- a/lib/api/include/ruleExecDel.h
+++ b/lib/api/include/ruleExecDel.h
@@ -1,10 +1,11 @@
-#ifndef RULE_EXEC_DEL_H__
-#define RULE_EXEC_DEL_H__
+#ifndef IRODS_RULE_EXEC_DEL_H
+#define IRODS_RULE_EXEC_DEL_H
 
-#include "rcConnect.h"
 #include "rodsDef.h"
 
-typedef struct {
+struct RcComm;
+
+typedef struct RuleExecDeleteInput {
     char ruleExecId[NAME_LEN];
 } ruleExecDelInp_t;
 
@@ -13,6 +14,6 @@ typedef struct {
 #ifdef __cplusplus
 extern "C"
 #endif
-int rcRuleExecDel( rcComm_t *conn, ruleExecDelInp_t *ruleExecDelInp );
+int rcRuleExecDel(struct RcComm* conn, ruleExecDelInp_t* ruleExecDelInp);
 
-#endif
+#endif // IRODS_RULE_EXEC_DEL_H

--- a/lib/api/src/rc_get_delay_rule_info.cpp
+++ b/lib/api/src/rc_get_delay_rule_info.cpp
@@ -1,0 +1,19 @@
+#include "get_delay_rule_info.h"
+
+#include "api_plugin_number.h"
+#include "procApiRequest.h"
+#include "rodsErrorTable.h"
+
+#include <cstdlib>
+#include <cstring>
+
+auto rc_get_delay_rule_info(RcComm* _comm, const char* _rule_id, BytesBuf** _output) -> int
+{
+    if (!_rule_id || !_output) {
+        return SYS_INVALID_INPUT_PARAM;
+    }
+
+    return procApiRequest(_comm, GET_DELAY_RULE_INFO_APN,
+                          const_cast<char*>(_rule_id), nullptr,
+                          reinterpret_cast<void**>(_output), nullptr);
+}

--- a/plugins/api/CMakeLists.txt
+++ b/plugins/api/CMakeLists.txt
@@ -93,6 +93,37 @@ set(
   irods_client
   )
 
+# get_delay_rule_info API
+set(
+  IRODS_API_PLUGIN_SOURCES_irods_get_delay_rule_info_server
+  ${CMAKE_SOURCE_DIR}/plugins/api/src/get_delay_rule_info.cpp
+  )
+
+set(
+  IRODS_API_PLUGIN_SOURCES_irods_get_delay_rule_info_client
+  ${CMAKE_SOURCE_DIR}/plugins/api/src/get_delay_rule_info.cpp
+  )
+
+set(
+  IRODS_API_PLUGIN_COMPILE_DEFINITIONS_irods_get_delay_rule_info_server
+  RODS_SERVER
+  ENABLE_RE
+  )
+
+set(
+  IRODS_API_PLUGIN_COMPILE_DEFINITIONS_irods_get_delay_rule_info_client
+  )
+
+set(
+  IRODS_API_PLUGIN_LINK_LIBRARIES_irods_get_delay_rule_info_server
+  irods_server
+  )
+
+set(
+  IRODS_API_PLUGIN_LINK_LIBRARIES_irods_get_delay_rule_info_client
+  irods_client
+  )
+
 # atomic_apply_acl_operations API
 set(
   IRODS_API_PLUGIN_SOURCES_irods_atomic_apply_acl_operations_server
@@ -327,6 +358,8 @@ set(
   irods_data_object_finalize_server
   irods_data_object_modify_info_client
   irods_data_object_modify_info_server
+  irods_get_delay_rule_info_client
+  irods_get_delay_rule_info_server
   irods_get_file_descriptor_info_client
   irods_get_file_descriptor_info_server
   irods_register_physical_path_client

--- a/plugins/api/include/api_plugin_number_data.h
+++ b/plugins/api/include/api_plugin_number_data.h
@@ -8,3 +8,8 @@ API_PLUGIN_NUMBER(ATOMIC_APPLY_ACL_OPERATIONS_APN,              20005)
 API_PLUGIN_NUMBER(DATA_OBJECT_FINALIZE_APN,                     20006)
 API_PLUGIN_NUMBER(TOUCH_APN,                                    20007)
 API_PLUGIN_NUMBER(REGISTER_PHYSICAL_PATH_APN,                   20008)
+//
+// API plugin numbers 20009-20012 are mapped to API plugins only
+// available in the 4.3 series.
+//
+API_PLUGIN_NUMBER(GET_DELAY_RULE_INFO_APN,                      20013)

--- a/plugins/api/src/get_delay_rule_info.cpp
+++ b/plugins/api/src/get_delay_rule_info.cpp
@@ -1,0 +1,195 @@
+#include "apiHandler.hpp"
+#include "api_plugin_number.h"
+#include "client_api_whitelist.hpp"
+#include "rcConnect.h"
+#include "rodsErrorTable.h"
+#include "rodsPackInstruct.h"
+
+#include <functional>
+
+#ifdef RODS_SERVER
+
+//
+// Server-side Implementation
+//
+
+#include "get_delay_rule_info.h"
+
+#include "catalog.hpp"
+#include "catalog_utilities.hpp"
+#include "icatHighLevelRoutines.hpp"
+#include "irods_re_serialization.hpp"
+#include "irods_server_api_call.hpp"
+#include "rodsLog.h"
+#include "server_utilities.hpp"
+
+#include <json.hpp>
+#include <fmt/format.h>
+
+#include <string>
+
+namespace
+{
+    //
+    // Function Prototypes
+    //
+
+    auto call_get_delay_rule_info(irods::api_entry*, RsComm*, const char*, BytesBuf**) -> int;
+
+    auto rs_get_delay_rule_info_impl(RsComm*, const char*, BytesBuf**) -> int;
+
+    auto is_valid_input(const char*) -> bool;
+
+    //
+    // Function Implementations
+    //
+
+    auto call_get_delay_rule_info(irods::api_entry* _api, RsComm* _comm, const char* _rule_id, BytesBuf** _output) -> int
+    {
+        return _api->call_handler<const char*, BytesBuf**>(_comm, _rule_id, _output);
+    } // call_get_delay_rule_info
+
+    auto is_valid_input(const char* _rule_id, BytesBuf** _output) -> bool
+    {
+        if (!_rule_id || !_output) {
+            rodsLog(LOG_ERROR, "Invalid input: _rule_id or _output is null");
+            return false;
+        }
+
+        // 64-bit integers can use up to 20 digits.
+        // We add 1 to the value to accomodate for the null byte.
+        // This size does not consider negative, hexidecimal, or octal values.
+        constexpr std::size_t max_number_of_digits = 20 + 1;
+
+        if (!is_non_empty_string(_rule_id, max_number_of_digits)) {
+            rodsLog(LOG_ERROR, "Invalid input: _rule_id is empty or cannot be represented by a 64-bit integer.");
+            return false;
+        }
+
+        // Try to parse the string into a valid signed 64-bit integer.
+        try {
+            if (const auto i = std::stoll(_rule_id); i <= 0) {
+                rodsLog(LOG_ERROR, "Invalid input: _rule_id [%d] must be greater than zero.", i);
+                return false;
+            }
+        }
+        catch (...) {
+            rodsLog(LOG_ERROR, "Invalid input: could not parse _rule_id [%s] into a signed integer.", _rule_id);
+            return false;
+        }
+
+        return true;
+    } // is_valid_input
+
+    auto rs_get_delay_rule_info_impl(RsComm* _comm, const char* _rule_id, BytesBuf** _output) -> int
+    {
+        if (!is_valid_input(_rule_id, _output)) {
+            return SYS_INVALID_INPUT_PARAM;
+        }
+
+        rodsLog(LOG_DEBUG, "%s: _rule_id = [%s]", __func__, _rule_id);
+
+        try {
+            namespace ic = irods::experimental::catalog;
+
+            if (!ic::connected_to_catalog_provider(*_comm)) {
+                irods::log(LOG_DEBUG8, "Redirecting request to catalog service provider ...");
+                auto* host_info = ic::redirect_to_catalog_provider(*_comm);
+                return rc_get_delay_rule_info(host_info->conn, _rule_id, _output);
+            }
+
+            ic::throw_if_catalog_provider_service_role_is_invalid();
+        }
+        catch (const irods::exception& e) {
+            rodsLog(LOG_ERROR, e.what());
+            return e.code();
+        }
+
+        std::vector<std::string> row;
+
+        if (const auto ec = chl_get_delay_rule_info(*_comm, _rule_id, &row); ec != 0) {
+            rodsLog(LOG_ERROR, "Could not get delay rule information [rule id=[%s]]", _rule_id);
+            return ec;
+        }
+
+        try {
+            using json = nlohmann::json;
+
+            const auto json_string = json{
+                {"rule_id", _rule_id},
+                {"rule_name", row.at(0)},
+                {"rei_file_path", row.at(1)},
+                {"user_name", row.at(2)},
+                {"exe_address", row.at(3)},
+                {"exe_time", row.at(4)},
+                {"exe_frequency", row.at(5)},
+                {"priority", row.at(6)},
+                {"last_exe_time", row.at(7)},
+                {"exe_status", row.at(8)},
+                {"estimated_exe_time", row.at(9)},
+                {"notification_addr", row.at(10)},
+                {"exe_context", row.at(11)}
+            }.dump();
+
+            *_output = irods::to_bytes_buffer(json_string);
+        }
+        catch (const std::exception& e) {
+            rodsLog(LOG_ERROR, "An error occurred while serializing the JSON object: %s", e.what());
+            return SYS_LIBRARY_ERROR;
+        }
+        catch (...) {
+            rodsLog(LOG_ERROR, "An unknown error occurred while serializing the JSON object");
+            return SYS_UNKNOWN_ERROR;
+        }
+
+        return 0;
+    } // rs_get_delay_rule_info_impl
+
+    using operation = std::function<int(RsComm*, const char*, BytesBuf**)>;
+    const operation op = rs_get_delay_rule_info_impl;
+    #define CALL_GET_DELAY_RULE_INFO call_get_delay_rule_info
+} // anonymous namespace
+
+#else // RODS_SERVER
+
+//
+// Client-side Implementation
+//
+
+namespace
+{
+    using operation = std::function<int(RsComm*, const char*, BytesBuf**)>;
+    const operation op{};
+    #define CALL_GET_DELAY_RULE_INFO nullptr
+} // anonymous namespace
+
+#endif // RODS_SERVER
+
+// The plugin factory function must always be defined.
+extern "C"
+auto plugin_factory(const std::string& _instance_name,
+                    const std::string& _context) -> irods::api_entry*
+{
+    // clang-format off
+    irods::apidef_t def{GET_DELAY_RULE_INFO_APN,         // API number
+                        RODS_API_VERSION,                // API version
+                        LOCAL_PRIV_USER_AUTH,            // Client auth
+                        LOCAL_PRIV_USER_AUTH,            // Proxy auth
+                        "STR_PI", 0,                     // In PI / bs flag
+                        "BinBytesBuf_PI", 0,             // Out PI / bs flag
+                        op,                              // Operation
+                        "api_get_delay_rule_info",       // Operation name
+                        nullptr,                         // Clear function
+                        (funcPtr) CALL_GET_DELAY_RULE_INFO};
+    // clang-format on
+
+    auto* api = new irods::api_entry{def};
+
+    api->in_pack_key = "STR_PI";
+    api->in_pack_value = STR_PI;
+
+    api->out_pack_key = "BinBytesBuf_PI";
+    api->out_pack_value = BytesBuf_PI;
+
+    return api;
+} // plugin_factory

--- a/plugins/database/CMakeLists.txt
+++ b/plugins/database/CMakeLists.txt
@@ -87,6 +87,7 @@ foreach(PLUGIN ${IRODS_DATABASE_PLUGINS})
     ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
     ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_regex.so
     ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so
+    ${IRODS_EXTERNALS_FULLPATH_NANODBC}/lib/libnanodbc.so
     ${ODBC_LIBRARY}
     )
 

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -3699,50 +3699,12 @@ irods::error db_del_rule_exec_op(
                    "null parameter" );
     }
 
-    // =-=-=-=-=-=-=-
-    // get a postgres object from the context
-    /*irods::postgres_object_ptr pg;
-    ret = make_db_ptr( _ctx.fco(), pg );
-    if ( !ret.ok() ) {
-        return PASS( ret );
-
-    }*/
-
-    // =-=-=-=-=-=-=-
-    // extract the icss property
-//        icatSessionStruct icss;
-//        _ctx.prop_map().get< icatSessionStruct >( ICSS_PROP, icss );
-    char userName[MAX_NAME_LEN + 2];
-
     if ( logSQL != 0 ) {
         rodsLog( LOG_SQL, "chlDelRuleExec" );
     }
 
     if ( !icss.status ) {
         return ERROR( CATALOG_NOT_CONNECTED, "catalog not connected" );
-    }
-
-    if ( _ctx.comm()->proxyUser.authInfo.authFlag < LOCAL_PRIV_USER_AUTH ) {
-        if ( _ctx.comm()->proxyUser.authInfo.authFlag == LOCAL_USER_AUTH ) {
-            if ( logSQL != 0 ) {
-                rodsLog( LOG_SQL, "chlDelRuleExec SQL 1 " );
-            }
-            int status;
-            {
-                std::vector<std::string> bindVars;
-                bindVars.push_back( _re_id );
-                status = cmlGetStringValueFromSql(
-                             "select user_name from R_RULE_EXEC where rule_exec_id=?",
-                             userName, MAX_NAME_LEN, bindVars, &icss );
-            }
-            if ( status != 0 || strncmp( userName, _ctx.comm()->clientUser.userName, MAX_NAME_LEN )
-                    != 0 ) {
-                return ERROR( CAT_NO_ACCESS_PERMISSION, "no access permission" );
-            }
-        }
-        else {
-            return ERROR( CAT_INSUFFICIENT_PRIVILEGE_LEVEL, "insufficient privilege" );
-        }
     }
 
     cllBindVars[cllBindVarCount++] = _re_id;
@@ -3782,7 +3744,6 @@ irods::error db_del_rule_exec_op(
     }
 
     return CODE( status );
-
 } // db_del_rule_exec_op
 
 

--- a/scripts/irods/lib.py
+++ b/scripts/irods/lib.py
@@ -763,3 +763,7 @@ def replica_exists(session, data_name, replica_number):
         .format(data_name, str(replica_number))])[0]
 
     return 'CAT_NO_ROWS_FOUND' not in out
+
+
+def get_first_delay_rule_id(session):
+    return session.run_icommand(['iquest', '%s', "select RULE_EXEC_ID"])[0].strip()

--- a/scripts/irods/test/session.py
+++ b/scripts/irods/test/session.py
@@ -124,6 +124,10 @@ class IrodsSession(object):
         return self._environment_file_contents['irods_user_name']
 
     @property
+    def qualified_username(self):
+        return self.username + '#' + self.zone_name
+
+    @property
     def password(self):
         return self._password
 
@@ -189,7 +193,7 @@ class IrodsSession(object):
             log_string = ' '.join(arg)
 
         message = ' --- IrodsSession: icommand executed by [{0}] [{1}] --- \n'.format(
-            self.username, log_string)
+            self.qualified_username, log_string)
         if IrodsConfig().version_tuple < (4, 2, 0):
             server_log_dir = os.path.join(paths.irods_directory(), 'iRODS', 'server', 'log')
             server_log_path = sorted([os.path.join(server_log_dir, name)

--- a/scripts/irods/test/test_federation.py
+++ b/scripts/irods/test/test_federation.py
@@ -1123,6 +1123,22 @@ OUTPUT ruleExecOut
         finally:
             user.run_icommand(['irm', '-f', parameters['remote_data_object']])
 
+    def test_itouch__issue_6849(self):
+        user = self.user_sessions[0]
+        parameters = self.config.copy()
+
+        parameters['filename'] = 'itouch_test_file.txt'
+        parameters['user_name'] = user.username
+        parameters['remote_home_collection'] = '/{remote_zone}/home/{user_name}#{local_zone}'.format(**parameters)
+        parameters['remote_data_object'] = '{remote_home_collection}/{filename}'.format(**parameters)
+
+        try:
+            user.assert_icommand('itouch {remote_data_object}'.format(**parameters))
+            user.assert_icommand('ils {remote_data_object}'.format(**parameters), 'STDOUT', [parameters['remote_data_object']])
+
+        finally:
+            user.run_icommand(['irm', '-f', parameters['remote_data_object']])
+
 class Test_Admin_Commands(unittest.TestCase):
 
     '''

--- a/scripts/irods/test/test_federation.py
+++ b/scripts/irods/test/test_federation.py
@@ -11,6 +11,7 @@ import socket
 import tempfile
 import time
 import ustrings
+from textwrap import dedent
 
 from . import session
 from . import settings
@@ -1600,3 +1601,97 @@ pep_api_data_obj_put_finally (*INSTANCE_NAME, *COMM, *DATAOBJINP, *BUFFER, *PORT
             test_session.run_icommand(['irm', '-f', local_logical_path])
             test_session.run_icommand(['irm', '-f', logical_path])
             self.admin.assert_icommand(['iadmin', 'rum'])
+
+class Test_Delay_Rule_Removal(SessionsMixin, unittest.TestCase):
+
+    # This test suite expects tempZone to contain the following users:
+    #
+    #   - rods#tempZone
+    #   - zonehopper#tempZone (created by the irods_testing_environment)
+    #   - zonehopper#otherZone (created by the irods_testing_environment)
+    #
+    # otherZone must contain the following users:
+    #
+    #   - rods#otherZone
+    #
+    # The test suite must be launched from a server in otherZone. That means tempZone
+    # is identified as the remote federated zone.
+    #
+    # Just before the tests are run, the base class will create three additional users
+    # in otherZone. The following users will appear:
+    #
+    #   - admin#otherZone
+    #   - zonehopper#otherZone
+    #   - zonehopper#tempZone (created by setUp())
+
+    plugin_name = IrodsConfig().default_rule_engine_plugin
+
+    def setUp(self):
+        super(Test_Delay_Rule_Removal, self).setUp()
+
+        # session.make_sessions_mixin() creates admins and users that connect to the host
+        # identified by lib.get_hostname().
+        #
+        # For this particular set of tests, that means these users connect to the host where
+        # "otherZone" runs.
+        self.local_admin = self.admin_sessions[0] # admin#otherZone
+        self.local_user = self.user_sessions[0]   # zonehopper#otherZone
+
+        # Create session for zonehopper#tempZone. The session will be connected to tempZone.
+        password = test.settings.FEDERATION.RODSUSER_NAME_PASSWORD_LIST[0][1]
+        host = test.settings.FEDERATION.REMOTE_HOST
+        zone = test.settings.FEDERATION.REMOTE_ZONE
+        self.remote_user = session.make_session_for_existing_user(self.local_user.username, password, host, zone)
+
+        # Create zonehopper#tempZone in otherZone. This must be handled by the test suite rather
+        # than the session.make_sessions_mixin() because that function only knows about the local zone.
+        self.remote_user_home_collection = self.remote_user.remote_home_collection(self.local_user.zone_name)
+        self.local_admin.assert_icommand(['iadmin', 'mkuser', self.remote_user.qualified_username, 'rodsuser'])
+
+        # Validity check: If the remote user's home collection does not exist in the zone these tests
+        # are run from, then the testing environment is in a bad state.
+        self.local_admin.assert_icommand(['ils', self.remote_user_home_collection], 'STDOUT', [self.remote_user.qualified_username])
+
+        # Make sure there are no left over delay rules.
+        self.local_admin.run_icommand(['iqdel', '-a'])
+
+    def tearDown(self):
+        self.remote_user.__exit__()
+        self.local_admin.run_icommand(['iadmin', 'rmuser', self.remote_user.qualified_username])
+        super(Test_Delay_Rule_Removal, self).tearDown()
+
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Skip if testing the PREP')
+    def test_local_zone_user_is_not_allowed_to_delete_delay_rules_created_by_remote_user_with_the_same_username__issue_6482(self):
+        try:
+            with temporary_core_file() as core_re:
+                # Users in a federated environment are not allowed to create delay rules in the
+                # remote zone directly. Remote users can only create delay rules indirectly
+                # (e.g. through a PEP in the federated zone).
+                core_re.add_rule(dedent('''
+                    pep_api_touch_pre(*a, *b, *c)
+                    {
+                        delay("<INST_NAME>irods_rule_engine_plugin-irods_rule_language-instance</INST_NAME><PLUSET>3600s</PLUSET>") {
+                            writeLine("serverLog", "#6482");
+                        }
+                    }
+                '''))
+
+                # Trigger the PEP so that a delay rule is created.
+                self.remote_user.assert_icommand(['itouch', self.remote_user_home_collection])
+
+                # For debug purposes (allows developers to see the delay rule in the test output).
+                self.local_admin.assert_icommand(['iqstat', '-a'], 'STDOUT')
+
+            # Capture the ID of the new delay rule.
+            rule_id = lib.get_first_delay_rule_id(self.local_admin)
+
+            # Show that the local zone user cannot delete a remote zone user's rule by ID even when
+            # they share identical unqualified usernames.
+            expected_error_msg = ['rcRuleExecDel failed with error -350000 USER_ACCESS_DENIED']
+            self.local_user.assert_icommand(['iqdel', rule_id], 'STDERR_SINGLELINE', expected_error_msg)
+
+            # Show that the local user cannot delete a remote zone user's rule by username either.
+            self.local_user.assert_icommand(['iqdel', '-u', self.remote_user.username], 'STDERR_SINGLELINE', expected_error_msg)
+
+        finally:
+            self.local_admin.run_icommand(['iqdel', '-a'])

--- a/scripts/manual_cleanup.py
+++ b/scripts/manual_cleanup.py
@@ -7,7 +7,7 @@ from irods.test import session
 from irods.configuration import IrodsConfig
 from irods.test import settings
 
-test_user_list = ['alice', 'bobby', 'otherrods', 'zonehopper', 'admin']
+test_user_list = ['alice', 'bobby', 'otherrods', 'zonehopper', 'admin', 'zonehopper#tempZone']
 test_resc_list = ['AnotherResc', 'TestResc', 'pt', 'leaf']
 
 # make admin session

--- a/server/api/include/rsRuleExecDel.hpp
+++ b/server/api/include/rsRuleExecDel.hpp
@@ -1,8 +1,10 @@
-#ifndef RS_RULE_EXEC_DEL_HPP
-#define RS_RULE_EXEC_DEL_HPP
+#ifndef IRODS_RS_RULE_EXEC_DEL_HPP
+#define IRODS_RS_RULE_EXEC_DEL_HPP
 
 #include "ruleExecDel.h"
 
-int rsRuleExecDel( rsComm_t *rsComm, ruleExecDelInp_t *ruleExecDelInp );
+struct RsComm;
 
-#endif
+int rsRuleExecDel(RsComm* rsComm, ruleExecDelInp_t* ruleExecDelInp);
+
+#endif // IRODS_RS_RULE_EXEC_DEL_HPP

--- a/server/api/include/rs_get_delay_rule_info.hpp
+++ b/server/api/include/rs_get_delay_rule_info.hpp
@@ -1,0 +1,34 @@
+#ifndef IRODS_RS_GET_DELAY_RULE_INFO_HPP
+#define IRODS_RS_GET_DELAY_RULE_INFO_HPP
+
+/// \file
+
+struct RsComm;
+struct BytesBuf;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Returns information about a specific delay rule.
+///
+/// \param[in]     _comm    A pointer to a RsComm.
+/// \param[in]     _rule_id The ID of the rule to fetch information for. It must be greater
+///                         than zero.
+/// \param[in,out] _output  The address to a BytesBuf pointer. On success, it will point
+///                         to a JSON string containing all information about the delay rule.
+///                         The string will be allocated on the heap and must be free'd by
+///                         the caller using free(). On failure, the pointer is not modified.
+///
+/// \return An integer.
+/// \retval  0 On success.
+/// \retval <0 On failure.
+///
+/// \since 4.2.12
+int rs_get_delay_rule_info(RsComm* _comm, const char* _rule_id, BytesBuf** _output);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // IRODS_RS_GET_DELAY_RULE_INFO_HPP

--- a/server/api/src/rs_get_delay_rule_info.cpp
+++ b/server/api/src/rs_get_delay_rule_info.cpp
@@ -1,0 +1,18 @@
+#include "rs_get_delay_rule_info.hpp"
+
+#include "api_plugin_number.h"
+#include "rodsErrorTable.h"
+
+#include "irods_server_api_call.hpp"
+
+#include <cstdlib>
+#include <cstring>
+
+auto rs_get_delay_rule_info(RsComm* _comm, const char* _rule_id, BytesBuf** _output) -> int
+{
+    if (!_rule_id || !_output) {
+        return SYS_INVALID_INPUT_PARAM;
+    }
+
+    return irods::server_api_call_without_policy(GET_DELAY_RULE_INFO_APN, _comm, _rule_id, _output);
+}

--- a/server/core/include/irods_database_constants.hpp
+++ b/server/core/include/irods_database_constants.hpp
@@ -112,6 +112,7 @@ namespace irods {
     const std::string DATABASE_OP_GET_REPL_LIST_FOR_LEAF_BUNDLES( "database_get_repl_list_for_leaf_bundles" );
     const std::string DATABASE_OP_CHECK_PERMISSION_TO_MODIFY_DATA_OBJECT{"database_check_permission_to_modify_data_object"};
     const std::string DATABASE_OP_UPDATE_TICKET_WRITE_BYTE_COUNT{"database_update_ticket_write_byte_count"};
+    const std::string DATABASE_OP_GET_DELAY_RULE_INFO{"database_get_delay_rule_info"};
 }; // namespace irods
 
 #endif // __IRODS_DATABASE_CONSTANTS_HPP__

--- a/server/icat/include/icatHighLevelRoutines.hpp
+++ b/server/icat/include/icatHighLevelRoutines.hpp
@@ -273,4 +273,19 @@ auto chl_check_permission_to_modify_data_object(RsComm& _comm, const rodsLong_t 
 /// \since 4.2.9
 auto chl_update_ticket_write_byte_count(RsComm& _comm, const rodsLong_t _data_id, const rodsLong_t _bytes_written) -> int;
 
+/// \brief High-level wrapper for fetching the all information about a delay rule.
+///
+/// Triggers policy associated with database operations.
+///
+/// \param[in]     _comm    The communication object.
+/// \param[in]     _rule_id The ID of the delay rule.
+/// \param[in,out] _info    A pointer to a vector of strings that will hold the row information.
+///
+/// \returns An error code representing whether the operation was successful.
+/// \retval  0 On success.
+/// \retval <0 On failure.
+///
+/// \since 4.2.12
+auto chl_get_delay_rule_info(RsComm& _comm, const char* _rule_id, std::vector<std::string>* _info) -> int;
+
 #endif // IRODS_ICAT_HIGHLEVEL_ROUTINES_HPP

--- a/server/icat/src/icatHighLevelRoutines.cpp
+++ b/server/icat/src/icatHighLevelRoutines.cpp
@@ -4711,3 +4711,28 @@ auto chl_update_ticket_write_byte_count(RsComm& _comm, const rodsLong_t _data_id
     return ret.code();
 } // chl_update_ticket_write_byte_count
 
+auto chl_get_delay_rule_info(RsComm& _comm, const char* _rule_id, std::vector<std::string>* _info) -> int
+{
+    irods::database_object_ptr db_obj_ptr;
+    if (const auto ret = irods::database_factory(database_plugin_type, db_obj_ptr); !ret.ok()) {
+        irods::log(PASS(ret));
+        return ret.code();
+    }
+
+    irods::plugin_ptr db_plug_ptr;
+    if (const auto ret = db_obj_ptr->resolve(irods::DATABASE_INTERFACE, db_plug_ptr); !ret.ok()) {
+        irods::log(PASSMSG("failed to resolve database interface", ret));
+        return ret.code();
+    }
+
+    irods::first_class_object_ptr ptr = boost::dynamic_pointer_cast<irods::first_class_object>(db_obj_ptr);
+    irods::database_ptr db = boost::dynamic_pointer_cast<irods::database>(db_plug_ptr);
+
+    const auto ret = db->call<const char*, std::vector<std::string>*>(&_comm,
+                                                                      irods::DATABASE_OP_GET_DELAY_RULE_INFO,
+                                                                      ptr,
+                                                                      _rule_id,
+                                                                      _info);
+
+    return ret.code();
+} // chl_get_delay_rule_info

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -45,6 +45,7 @@ set(TEST_INCLUDE_LIST test_config/irods_atomic_apply_acl_operations
                       test_config/irods_dstream
                       test_config/irods_filesystem
                       test_config/irods_fixed_buffer_resource
+                      test_config/irods_get_delay_rule_info
                       test_config/irods_get_file_descriptor_info
                       test_config/irods_hierarchy_parser
                       test_config/irods_hostname_cache

--- a/unit_tests/cmake/test_config/irods_get_delay_rule_info.cmake
+++ b/unit_tests/cmake/test_config/irods_get_delay_rule_info.cmake
@@ -1,0 +1,21 @@
+set(IRODS_TEST_TARGET irods_get_delay_rule_info)
+
+set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/src/test_get_delay_rule_info.cpp)
+
+set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
+                            ${CMAKE_SOURCE_DIR}/lib/core/include
+                            ${CMAKE_SOURCE_DIR}/lib/api/include
+                            ${CMAKE_SOURCE_DIR}/lib/filesystem/include
+                            ${CMAKE_SOURCE_DIR}/plugins/api/include
+                            ${CMAKE_SOURCE_DIR}/server/core/include
+                            ${CMAKE_SOURCE_DIR}/server/icat/include
+                            ${CMAKE_SOURCE_DIR}/server/re/include
+                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
+                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include
+                            ${IRODS_EXTERNALS_FULLPATH_JSON}/include)
+ 
+set(IRODS_TEST_LINK_LIBRARIES irods_client
+                              irods_common
+                              ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)

--- a/unit_tests/src/test_get_delay_rule_info.cpp
+++ b/unit_tests/src/test_get_delay_rule_info.cpp
@@ -1,0 +1,109 @@
+#include "catch.hpp"
+
+#include "client_connection.hpp"
+#include "getRodsEnv.h"
+#include "get_delay_rule_info.h"
+#include "irods_at_scope_exit.hpp"
+#include "irods_query.hpp"
+#include "rodsClient.h"
+#include "rodsDef.h"
+#include "rodsErrorTable.h"
+#include "user_administration.hpp"
+
+#include <json.hpp>
+
+#include <cstdlib>
+#include <string>
+#include <utility>
+
+TEST_CASE("rc_get_delay_rule_info")
+{
+    using json = nlohmann::json;
+
+    load_client_api_plugins();
+
+    irods::experimental::client_connection conn;
+    auto* conn_ptr = static_cast<RcComm*>(conn);
+
+    SECTION("delay rule exists")
+    {
+        // Schedule a delay rule and get its ID.
+        REQUIRE(std::system(R"_(irule -r irods_rule_engine_plugin-irods_rule_language-instance 'delay("<INST_NAME>irods_rule_engine_plugin-irods_rule_language-instance</INST_NAME><PLUSET>3600s</PLUSET>") { writeLine("serverLog", "Testing API plugin."); }' null ruleExecOut)_") == 0);
+
+        std::string rule_id;
+        for (auto&& row : irods::query{conn_ptr, "select RULE_EXEC_ID"}) {
+            rule_id = row[0];
+            break;
+        }
+
+        INFO("GenQuery returned rule_id = " << rule_id);
+
+        BytesBuf* bbuf{};
+        REQUIRE(rc_get_delay_rule_info(conn_ptr, rule_id.c_str(), &bbuf) == 0);
+
+        CHECK(bbuf->buf);
+        CHECK(bbuf->len > 0);
+
+        const auto* p = static_cast<char*>(bbuf->buf);
+        const auto info = json::parse(p, p + bbuf->len);
+
+        CHECK(info.size() == 13);
+        CHECK(info.at("rule_id").get_ref<const std::string&>() == rule_id);
+        CHECK(info.count("rule_name"));
+        CHECK(info.count("rei_file_path"));
+        CHECK(info.count("user_name"));
+        CHECK(info.count("exe_address"));
+        CHECK(info.count("exe_time"));
+        CHECK(info.count("exe_frequency"));
+        CHECK(info.count("priority"));
+        CHECK(info.count("last_exe_time"));
+        CHECK(info.count("exe_status"));
+        CHECK(info.count("estimated_exe_time"));
+        CHECK(info.count("notification_addr"));
+        CHECK(info.count("exe_context"));
+    }
+
+    SECTION("invalid input")
+    {
+        BytesBuf* bbuf{};
+        CHECK(rc_get_delay_rule_info(conn_ptr,     nullptr,   &bbuf) == SYS_INVALID_INPUT_PARAM);
+        CHECK(rc_get_delay_rule_info(conn_ptr,     "00000", nullptr) == SYS_INVALID_INPUT_PARAM);
+        CHECK(rc_get_delay_rule_info(conn_ptr,          "",   &bbuf) == SYS_INVALID_INPUT_PARAM);
+        CHECK(rc_get_delay_rule_info(conn_ptr, "bad_input",   &bbuf) == SYS_INVALID_INPUT_PARAM);
+        CHECK(rc_get_delay_rule_info(conn_ptr,        "-1",   &bbuf) == SYS_INVALID_INPUT_PARAM);
+    }
+
+    SECTION("only invocable by rodsadmins")
+    {
+        namespace adm = irods::experimental::administration;
+
+        rodsEnv env;
+        _getRodsEnv(env);
+
+        const auto test_cases = {
+            std::make_pair(adm::user_type::rodsuser, "rodsuser"),
+            std::make_pair(adm::user_type::groupadmin, "groupadmin")
+        };
+
+        for (auto&& test_case : test_cases) {
+            DYNAMIC_SECTION("fails as " << test_case.second)
+            {
+                // Create a new user that is not a rodsadmin.
+                adm::user alice{"alice"};
+                REQUIRE(adm::client::add_user(conn, alice, test_case.first).value() == 0);
+                irods::at_scope_exit remove_user{[&] { adm::client::remove_user(conn, alice); }};
+
+                // Give alice a password so that we can authenticate as them.
+                REQUIRE(adm::client::set_user_password(conn, alice, "rods").value() == 0);
+
+                // Connect to the server as the test user.
+                irods::experimental::client_connection alice_conn{env.rodsHost, env.rodsPort, alice.name.c_str(), env.rodsZone};
+                REQUIRE(alice_conn);
+
+                // Show that the non-admin user is not allowed to invoke the API endpoint.
+                BytesBuf* bbuf{};
+                REQUIRE(rc_get_delay_rule_info(static_cast<RcComm*>(alice_conn), "not_important", &bbuf) == SYS_NO_API_PRIV);
+            }
+        }
+    }
+}

--- a/unit_tests/unit_tests_list.json
+++ b/unit_tests/unit_tests_list.json
@@ -13,6 +13,7 @@
     "irods_dstream",
     "irods_filesystem",
     "irods_fixed_buffer_resource",
+    "irods_get_delay_rule_info",
     "irods_get_file_descriptor_info",
     "irods_hierarchy_parser",
     "irods_hostname_cache",


### PR DESCRIPTION
This has not been tested and is still a work in progress.