### PR TITLE
[4063] Ensure AVUs set properly (4-2-stable)

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -155,6 +155,18 @@ validateAndParseUserName( const char *fullUserNameIn, char *userName, char *user
     return 0;
 } // validateAndParseUserName
 
+[[nodiscard]] auto is_valid_avu(const char *_attribute, const char *_value, const char *_unit) noexcept -> bool
+{
+    if (_attribute == nullptr || _value == nullptr || _unit == nullptr) {
+        return false;
+    }
+    if (*_attribute == '\0' || *_value == '\0') {
+        return false;
+    }
+
+    return true;
+}
+
 // =-=-=-=-=-=-=-
 // helper fcn to handle cast to pg object
 irods::error make_db_ptr(
@@ -9253,6 +9265,10 @@ irods::error db_set_avu_metadata_op(
     /* Treat unspecified unit as empty string */
     if ( _new_unit == NULL ) {
         _new_unit = "";
+    }
+
+    if (!is_valid_avu(_attribute, _new_value, _new_unit)) {
+        return ERROR(CAT_INVALID_ARGUMENT, "invalid AVU");
     }
 
     /* Query to see if the attribute exists for this object

--- a/scripts/irods/test/test_imeta_set.py
+++ b/scripts/irods/test/test_imeta_set.py
@@ -355,6 +355,28 @@ class Test_ImetaSet(ResourceBase, unittest.TestCase):
         self.admin.assert_icommand(['imeta', 'ls', '-C', os.path.join(collection) + '/'],  'STDOUT', ['None'])
         self.admin.assert_icommand(['imeta', 'ls', '-C', os.path.join(collection) + '//'], 'STDOUT', ['None'])
 
+    def test_imeta_cannot_set_shared_avu_value_to_empty_string__issue_4063(self):
+        # Generate collections for test
+        collections = ['games', 'super_secret_documents']
+        collections = [os.path.join(self.admin.session_collection, col) for col in collections]
+
+        # Create collections
+        for collection in collections:
+            self.admin.assert_icommand(['imkdir', collection])
+
+        # Set the same AVUs for the collections
+        for collection in collections:
+            self.admin.assert_icommand(['imeta', 'set', '-C', collection, 'is_cool', 'yes'])
+
+        # Attempt to clear value of second collection
+        expected_err = 'ERROR: rcModAVUMetadata failed with error -816000 CAT_INVALID_ARGUMENT'
+        self.admin.assert_icommand(['imeta', 'set', '-C', collections[1], 'is_cool', ''], 'STDERR_SINGLELINE', expected_err, desired_rc=4)
+
+        # Check that the value is unaffected for both collections
+        for collection in collections:
+            expected_value = 'value: yes'
+            self.admin.assert_icommand(['imeta', 'ls', '-C', collection], 'STDOUT', expected_value)
+
 class Test_ImetaQu(ResourceBase, unittest.TestCase):
 
     def helper_imeta_qu_comparison_2748(self, irods_object_option_flag):


### PR DESCRIPTION
Separate collections with similar AVUs should be able to be set their AVUs without errors.