### PR TITLE
Fix federation test failure, avoid collection mtime update in copy, adjust clang-tidy (4-3-stable)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -62,7 +62,8 @@ WarningsAsErrors:
     performance-*,
     portability-std-allocator-const,
     readability-*,
-    -readability-avoid-const-params-in-decls
+    -readability-avoid-const-params-in-decls,
+    -readability-implicit-bool-conversion
 FormatStyle:     none
 CheckOptions:
   - key:             llvm-else-after-return.WarnOnConditionVariables

--- a/.github/workflows/linter-irods-clang-tidy.yml
+++ b/.github/workflows/linter-irods-clang-tidy.yml
@@ -78,10 +78,10 @@ jobs:
                       clang-tidy-diff.py -p1 -path build/compile_commands.json -quiet | \
                       tee clang_tidy_output.txt
 
-                  # Return a failure if the output contains a clang-tidy error or warning.
+                  # Return a failure if the output contains a clang-tidy error.
                   # clang-tidy-diff.py doesn't report a non-zero error code when it finds violations.
                   clang_tidy_text=$(cat clang_tidy_output.txt)
-                  if [[ "$clang_tidy_text" == *": error: "* ]] || [[ "$clang_tidy_text" == *": warning: "* ]]; then
+                  if [[ "$clang_tidy_text" == *": error: "* ]] ; then
                       echo 'Source code needs some attention!'
                       echo
                       echo 'If the results are hard to follow, you can enable color by running the following command at the bench:'
@@ -92,6 +92,21 @@ jobs:
                       echo
 
                       exit 1
+                  fi
+
+                  # Print a message if the output contains warnings, but do not report a non-zero error code.
+                  # If there is a warning which needs to be an error, add it to the WarningsAsErrors section of the clang-tidy configuration.
+                  if [[ "$clang_tidy_text" == *": warning: "* ]] ; then
+                      echo 'The analysis generated warnings which you may want to consider fixing.'
+                      echo
+                      echo 'If the results are hard to follow, you can enable color by running the following command at the bench:'
+                      echo
+                      echo "    git diff -U0 $GITHUB_BASE_REF | clang-tidy-diff.py -p1 -use-color -path /path/to/build/compile_commands.json -quiet"
+                      echo
+                      echo 'This command only works while the branch associated with this pull request is checked out.'
+                      echo
+
+                      exit 0
                   fi
 
                   echo "Source code is tidy :-)"

--- a/server/api/src/rsDataObjCopy.cpp
+++ b/server/api/src/rsDataObjCopy.cpp
@@ -302,28 +302,7 @@ int rsDataObjCopy(rsComm_t* rsComm,
                   dataObjCopyInp_t* dataObjCopyInp,
                   transferStat_t** transStat)
 {
-    namespace fs = ix::filesystem;
-
-    const auto ec = rsDataObjCopy_impl(rsComm, dataObjCopyInp, transStat);
-    const auto parent_path = fs::path{dataObjCopyInp->destDataObjInp.objPath}.parent_path();
-
-    // Update the parent collection's mtime.
-    if (ec == 0 && fs::server::is_collection_registered(*rsComm, parent_path)) {
-        using std::chrono::system_clock;
-        using std::chrono::time_point_cast;
-
-        const auto mtime = time_point_cast<fs::object_time_type::duration>(system_clock::now());
-
-        try {
-            ix::scoped_privileged_client spc{*rsComm};
-            fs::server::last_write_time(*rsComm, parent_path, mtime);
-        }
-        catch (const fs::filesystem_error& e) {
-            ix::log::api::error(e.what());
-            return e.code().value();
-        }
-    }
-
-    return ec;
+    // Do not update the collection mtime here because the open API call for the destination data object does it.
+    return rsDataObjCopy_impl(rsComm, dataObjCopyInp, transStat);
 }
 

--- a/server/api/src/rsDataObjCopy.cpp
+++ b/server/api/src/rsDataObjCopy.cpp
@@ -33,9 +33,9 @@
 
 #include <chrono>
 
-namespace ix = irods::experimental;
-
-namespace {
+namespace
+{
+    using log_api = irods::experimental::log::api;
 
     int connect_to_remote_zone(
         rsComm_t *rsComm,
@@ -108,14 +108,23 @@ namespace {
         return srcL1descInx;
     } // open_source_data_obj
 
-    auto close_source_data_obj(RsComm* rsComm, const int _inx) -> int
+    auto close_source_data_obj(RsComm* _comm, const int _l1_index, const DataObjInp& _inp) -> int
     {
-        openedDataObjInp_t dataObjCloseInp{};
-        dataObjCloseInp.l1descInx = _inx;
+        // The L1 descriptor may not be available later, so we need to use the path from the DataObjInp.
+        const std::string_view path = static_cast<const char*>(_inp.objPath);
 
-        rodsLog(LOG_DEBUG8, "[%s:%d] - closing [%s]", __FUNCTION__, __LINE__, L1desc[_inx].dataObjInp->objPath);
+        log_api::trace("[{}:{}] - closing [{}]", __func__, __LINE__, path);
 
-        return rsDataObjClose(rsComm, &dataObjCloseInp);
+        openedDataObjInp_t close_inp{};
+        close_inp.l1descInx = _l1_index;
+
+        const int ec = rsDataObjClose(_comm, &close_inp);
+
+        if (ec < 0) {
+            log_api::error("[{}:{}] - failed closing [{}] with status [{}]", __func__, __LINE__, path, ec);
+        }
+
+        return ec;
     } // close_source_data_obj
 
     int open_destination_data_obj(rsComm_t *rsComm, dataObjInp_t& inp)
@@ -152,15 +161,55 @@ namespace {
         return destL1descInx;
     } // open_destination_data_obj
 
-    auto close_destination_data_obj(RsComm* rsComm, const int _inx) -> int
+    auto close_destination_data_obj(RsComm* _comm, const int _l1_index, const DataObjInp& _inp) -> int
     {
-        openedDataObjInp_t dataObjCloseInp{};
-        dataObjCloseInp.l1descInx = _inx;
-        dataObjCloseInp.bytesWritten = L1desc[L1desc[_inx].srcL1descInx].dataObjInfo->dataSize;
+        // The L1 descriptor may not be available at this point, so we need to use the path from the DataObjInp.
+        const std::string_view path = static_cast<const char*>(_inp.objPath);
 
-        rodsLog(LOG_DEBUG8, "[%s:%d] - closing [%s]", __FUNCTION__, __LINE__, L1desc[_inx].dataObjInp->objPath);
+        log_api::trace("[{}:{}] - closing [{}]", __func__, __LINE__, path);
 
-        return rsDataObjClose(rsComm, &dataObjCloseInp);
+        openedDataObjInp_t close_inp{};
+        close_inp.l1descInx = _l1_index;
+
+        // Declare this here because we need to return an error if the source index is invalid.
+        int ec = 0;
+
+        // The L1 descriptor index is const and bounds-checked before this function is called. Therefore, ignore linter.
+        //
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+        auto& l1_desc = L1desc[_l1_index];
+
+        const int source_l1_index = l1_desc.srcL1descInx;
+        if (source_l1_index < 3 || source_l1_index >= NUM_L1_DESC) {
+            log_api::error("[{}:{}] - Source L1 descriptor for [{}] is out of range: [{}]",
+                           __func__,
+                           __LINE__,
+                           path,
+                           source_l1_index);
+
+            // Set the error code, but continue to the close call so the destination data object can be finalized. The
+            // L1 descriptor oprType is also set so that rsDataObjClose knows that the operation encountered an issue.
+            // The data object should be marked stale because the source L1 descriptor has been corrupted and cannot be
+            // used for data verification in the finalization process of the new data object.
+            ec = SYS_FILE_DESC_OUT_OF_RANGE;
+            l1_desc.oprStatus = ec;
+        }
+        else {
+            // The L1 descriptor index is const and confirmed to be in-bounds above. Therefore, ignore linter.
+            //
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            close_inp.bytesWritten = L1desc[source_l1_index].dataObjInfo->dataSize;
+        }
+
+        if (const int close_ec = rsDataObjClose(_comm, &close_inp); close_ec < 0) {
+            ec = close_ec;
+        }
+
+        if (ec < 0) {
+            log_api::error("[{}:{}] - failed closing [{}] with status [{}]", __func__, __LINE__, path, ec);
+        }
+
+        return ec;
     } // close_destination_data_obj
 
     int rsDataObjCopy_impl(
@@ -169,10 +218,6 @@ namespace {
         transferStat_t **transStat)
     {
         namespace fs = irods::experimental::filesystem;
-
-        if (!dataObjCopyInp) {
-            return SYS_INTERNAL_NULL_INPUT_ERR;
-        }
 
         dataObjInp_t* srcDataObjInp = &dataObjCopyInp->srcDataObjInp;
         dataObjInp_t* destDataObjInp = &dataObjCopyInp->destDataObjInp;
@@ -195,12 +240,13 @@ namespace {
         resolveLinkedPath(rsComm, srcDataObjInp->objPath, &specCollCache, &srcDataObjInp->condInput);
         resolveLinkedPath(rsComm, destDataObjInp->objPath, &specCollCache, &destDataObjInp->condInput);
 
-        rodsServerHost_t *rodsServerHost;
+        rodsServerHost_t* rodsServerHost = nullptr;
         int remoteFlag = connect_to_remote_zone( rsComm, dataObjCopyInp, &rodsServerHost );
-        if ( remoteFlag < 0 ) {
+        if (remoteFlag < 0) {
             return remoteFlag;
         }
         else if ( remoteFlag == REMOTE_HOST ) {
+            // It is not possible to reach this case with rodsServerHost being nullptr, so no check is needed.
             return _rcDataObjCopy(rodsServerHost->conn, dataObjCopyInp, transStat);
         }
 
@@ -211,47 +257,9 @@ namespace {
             return USER_INPUT_PATH_ERR;
         }
 
-        int srcL1descInx{};
-        int destL1descInx{};
-        const auto close_objects{[&]() -> int {
-            int result = 0;
-
-            if (destL1descInx > 3) {
-                // The transferStat_t communicates information back to the client regarding
-                // the data transfer such as bytes written and how many threads were used.
-                // These must be saved before the L1 descriptor is free'd.
-                *transStat = (transferStat_t*)malloc(sizeof(transferStat_t));
-                memset(*transStat, 0, sizeof(transferStat_t));
-                (*transStat)->bytesWritten = L1desc[srcL1descInx].dataObjInfo->dataSize;
-                (*transStat)->numThreads = L1desc[destL1descInx].dataObjInp->numThreads;
-
-                if (const int ec = close_destination_data_obj(rsComm, destL1descInx); ec < 0) {
-                    irods::log(LOG_ERROR, fmt::format(
-                        "[{}:{}] - failed closing [{}] with status [{}]",
-                        __FUNCTION__, __LINE__, destDataObjInp->objPath, ec));
-
-                    result = ec;
-                }
-            }
-
-            if (srcL1descInx > 3) {
-                if (const int ec = close_source_data_obj(rsComm, srcL1descInx); ec < 0) {
-                    irods::log(LOG_ERROR, fmt::format(
-                        "[{}:{}] - failed closing [{}] with status [{}]",
-                        __FUNCTION__, __LINE__, srcDataObjInp->objPath, ec));
-
-                    if (!result) {
-                        result = ec;
-                    }
-                }
-            }
-
-            return result;
-        }};
-
-        srcL1descInx = open_source_data_obj(rsComm, *srcDataObjInp);
-        if (srcL1descInx < 0) {
-            return srcL1descInx;
+        const int srcL1descInx = open_source_data_obj(rsComm, *srcDataObjInp);
+        if (srcL1descInx < 3 || srcL1descInx >= NUM_L1_DESC) {
+            return srcL1descInx < 0 ? srcL1descInx : SYS_FILE_DESC_OUT_OF_RANGE;
         }
 
         const int createMode = std::atoi(L1desc[srcL1descInx].dataObjInfo->dataMode);
@@ -259,11 +267,11 @@ namespace {
             destDataObjInp->createMode = createMode;
         }
 
-        destL1descInx = open_destination_data_obj(rsComm, *destDataObjInp);
-        if (destL1descInx < 0) {
-            close_objects();
+        const int destL1descInx = open_destination_data_obj(rsComm, *destDataObjInp);
+        if (destL1descInx < 3 || destL1descInx >= NUM_L1_DESC) {
+            std::ignore = close_source_data_obj(rsComm, srcL1descInx, *srcDataObjInp);
 
-            return destL1descInx;
+            return destL1descInx < 0 ? destL1descInx : SYS_FILE_DESC_OUT_OF_RANGE;
         }
 
         L1desc[destL1descInx].srcL1descInx = srcL1descInx;
@@ -291,7 +299,26 @@ namespace {
             L1desc[destL1descInx].oprStatus = copy_ec;
         }
 
-        const auto close_ec = close_objects();
+        if (transStat) {
+            // The transferStat_t communicates information back to the client regarding
+            // the data transfer such as bytes written and how many threads were used.
+            // These must be saved before the L1 descriptor is free'd.
+            //
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-no-malloc)
+            *transStat = static_cast<transferStat_t*>(std::malloc(sizeof(transferStat_t)));
+            std::memset(*transStat, 0, sizeof(transferStat_t));
+
+            // The L1 descriptor indexes are const and confirmed to be in-bounds above. Therefore, ignore linter.
+            //
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            (*transStat)->bytesWritten = L1desc[srcL1descInx].dataObjInfo->dataSize;
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            (*transStat)->numThreads = L1desc[destL1descInx].dataObjInp->numThreads;
+        }
+
+        const auto close_dest_ec = close_destination_data_obj(rsComm, destL1descInx, *destDataObjInp);
+        const auto close_source_ec = close_source_data_obj(rsComm, srcL1descInx, *srcDataObjInp);
+        const auto close_ec = 0 == close_dest_ec ? close_source_ec : close_dest_ec;
 
         return copy_ec < 0 ? copy_ec : close_ec;
     } // rsDataObjCopy_impl
@@ -302,6 +329,10 @@ int rsDataObjCopy(rsComm_t* rsComm,
                   dataObjCopyInp_t* dataObjCopyInp,
                   transferStat_t** transStat)
 {
+    if (!rsComm || !dataObjCopyInp) {
+        return USER__NULL_INPUT_ERR;
+    }
+
     // Do not update the collection mtime here because the open API call for the destination data object does it.
     return rsDataObjCopy_impl(rsComm, dataObjCopyInp, transStat);
 }

--- a/server/api/src/rsModColl.cpp
+++ b/server/api/src/rsModColl.cpp
@@ -1,5 +1,6 @@
 #include "irods/catalog_utilities.hpp"
 #include "irods/client_connection.hpp"
+#include "irods/filesystem/path.hpp"
 #include "irods/icatHighLevelRoutines.hpp"
 #include "irods/irods_configuration_keywords.hpp"
 #include "irods/irods_rs_comm_query.hpp"
@@ -73,8 +74,24 @@ namespace
 auto rsModColl(rsComm_t* rsComm, collInp_t* modCollInp) -> int
 {
     namespace ic = irods::experimental::catalog;
+    namespace fs = irods::experimental::filesystem;
+
+    if (!rsComm || !modCollInp) {
+        return SYS_INTERNAL_NULL_INPUT_ERR;
+    }
 
     try {
+        // If the zone name cannot be derived from the collection name in the input, the path cannot be valid.
+        const auto zone_name = fs::zone_name(fs::path{static_cast<char*>(modCollInp->collName)});
+        if (!zone_name) {
+            return SYS_INVALID_FILE_PATH;
+        }
+
+        if (!isLocalZone(zone_name->c_str())) {
+            auto* host = ic::redirect_to_catalog_provider(*rsComm, static_cast<char*>(modCollInp->collName));
+            return rcModColl(host->conn, modCollInp);
+        }
+
         const auto catalog_provider_host = ic::get_catalog_provider_host();
 
         if (LOCAL_HOST == catalog_provider_host.localFlag) {

--- a/server/core/include/irods/catalog_utilities.hpp
+++ b/server/core/include/irods/catalog_utilities.hpp
@@ -186,12 +186,14 @@ namespace irods::experimental::catalog
 
     /// \brief Thin wrapper around getRcatHost
     ///
+    /// \param[in] _zone_hint Input to getZoneNameFromHint to derive the zone name from a path.
+    ///
     /// \returns Information about the catalog provider host
     ///
     /// \throws irods::exception If an error occurs while retrieving the host information
     ///
     /// \since 4.2.9
-    auto get_catalog_provider_host() -> rodsServerHost;
+    auto get_catalog_provider_host(const char* _zone_hint = nullptr) -> rodsServerHost;
 
     /// \brief Determine if connected to the catalog provider host
     ///
@@ -213,13 +215,14 @@ namespace irods::experimental::catalog
     /// is connected and so should not be free'd after use by the caller.
     ///
     /// \param[in] _comm iRODS connection structure
+    /// \param[in] _zone_hint Input to getZoneNameFromHint to derive the zone name from a path.
     ///
     /// \throws irods::exception If fails to find or connect to the catalog provider host.
     ///
     /// \returns rodsServerHost* pointer to rodsServerHost which is managed by ServerHostHead
     ///
     /// \since 4.2.9
-    auto redirect_to_catalog_provider(RsComm& _comm) -> rodsServerHost*;
+    auto redirect_to_catalog_provider(RsComm& _comm, const char* _zone_hint = nullptr) -> rodsServerHost*;
 } // namespace irods::experimental::catalog
 
 #endif // #ifndef IRODS_CATALOG_UTILITIES_HPP

--- a/server/core/src/catalog_utilities.cpp
+++ b/server/core/src/catalog_utilities.cpp
@@ -197,11 +197,11 @@ namespace irods::experimental::catalog
         }
     } // throw_if_service_role_is_invalid
 
-    auto get_catalog_provider_host() -> rodsServerHost
+    auto get_catalog_provider_host(const char* _zone_hint) -> rodsServerHost
     {
         rodsServerHost* host{};
 
-        if (const int status = getRcatHost(PRIMARY_RCAT, nullptr, &host); status < 0 || !host) {
+        if (const int status = getRcatHost(PRIMARY_RCAT, _zone_hint, &host); status < 0 || !host) {
             THROW(status, "failed getting catalog provider host");
         }
 
@@ -213,11 +213,11 @@ namespace irods::experimental::catalog
         return ::connected_to_catalog_provider(_comm, get_catalog_provider_host());
     } // connected_to_catalog_provider
 
-    auto redirect_to_catalog_provider(RsComm& _comm) -> rodsServerHost*
+    auto redirect_to_catalog_provider(RsComm& _comm, const char* _zone_hint) -> rodsServerHost*
     {
         rodsServerHost* host = nullptr;
 
-        if (const int ec = getAndConnRcatHost(&_comm, PRIMARY_RCAT, nullptr, &host); ec < 0) {
+        if (const int ec = getAndConnRcatHost(&_comm, PRIMARY_RCAT, _zone_hint, &host); ec < 0) {
             THROW(ec, "failed to connect to catalog provider host");
         }
 


### PR DESCRIPTION
Addresses https://github.com/irods/irods/issues/6842
In service of https://github.com/irods/irods/issues/6527
Related to https://github.com/irods/irods/pull/6840

Cherry-picked from #6844 

clang-tidy complaint is invalid. See https://github.com/irods/irods/pull/6844#discussion_r1081727761