### PR TITLE
[#6428] Add sleep to irm test for collection mtime update (4-3-stable)

### DIFF
--- a/scripts/irods/test/test_irm.py
+++ b/scripts/irods/test/test_irm.py
@@ -75,6 +75,8 @@ class Test_Irm(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', '
 
 
     def test_remove_data_object_in_collection_with_read_permissions__issue_6428(self):
+        import time
+
         def get_collection_mtime(session, collection_path):
             return session.run_icommand(['iquest', '%s',
                 f"select COLL_MODIFY_TIME where COLL_NAME = '{collection_path}'"])[0].strip()
@@ -89,10 +91,13 @@ class Test_Irm(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', '
             self.admin.assert_icommand(['itouch', logical_path])
             self.admin.assert_icommand(['ichmod', 'read', self.user.username, collection_path])
             self.admin.assert_icommand(['ichmod', 'own', self.user.username, logical_path])
+            self.assertTrue(lib.replica_exists(self.user, logical_path, 0))
 
             original_mtime = get_collection_mtime(self.admin, collection_path)
 
-            self.assertTrue(lib.replica_exists(self.user, logical_path, 0))
+            # Sleep here so that the collection mtime is guaranteed to be different if updated correctly.
+            time.sleep(1)
+
             self.user.assert_icommand(['irm', logical_path])
             self.assertFalse(lib.replica_exists(self.user, logical_path, 0))
 


### PR DESCRIPTION
Fixes timing issue in https://github.com/irods/irods/issues/6428

Cherry-picked from https://github.com/irods/irods/pull/6840