### PR TITLE
[6726] Make server_properties::map() thread-safe and read-only (4-3-stable)

### DIFF
--- a/plugins/microservices/src/get_server_property.cpp
+++ b/plugins/microservices/src/get_server_property.cpp
@@ -32,7 +32,8 @@ namespace
         try {
             const std::string name = parseMspForStr(_in_name);
             const nlohmann::json* json_value = nullptr;
-            const auto& config = irods::server_properties::server_properties::instance().map();
+            const auto config_handle{irods::server_properties::server_properties::instance().map()};
+            const auto& config{config_handle.get_json()};
 
             try {
                 if (name.find("/") != std::string::npos) {

--- a/server/core/src/catalog.cpp
+++ b/server/core/src/catalog.cpp
@@ -71,7 +71,9 @@ namespace irods::experimental::catalog {
             capture_database_info(config, db_instance_name, db_username, db_password);
         }
         else {
-            capture_database_info(server_properties::instance().map(), db_instance_name, db_username, db_password);
+            const auto config_handle{server_properties::instance().map()};
+            const auto& config{config_handle.get_json()};
+            capture_database_info(config, db_instance_name, db_username, db_password);
         }
 
         try {

--- a/server/core/src/client_api_allowlist.cpp
+++ b/server/core/src/client_api_allowlist.cpp
@@ -197,7 +197,8 @@ namespace irods::client_api_allowlist
                 return false;
             }
 
-            const auto& config = irods::server_properties::instance().map();
+            const auto config_handle{irods::server_properties::instance().map()};
+            const auto& config{config_handle.get_json()};
 
             if (const auto iter = config.find(irods::KW_CFG_CLIENT_API_ALLOWLIST_POLICY); iter != std::end(config)) {
                 return iter->get_ref<const std::string&>() == "enforce";

--- a/server/delay_server/src/irodsDelayServer.cpp
+++ b/server/delay_server/src/irodsDelayServer.cpp
@@ -127,7 +127,8 @@ namespace
 
     std::optional<std::string_view> next_executor()
     {
-        const auto& config = irods::server_properties::instance().map();
+        const auto config_handle{irods::server_properties::instance().map()};
+        const auto& config{config_handle.get_json()};
 
         const auto advanced_settings = config.find(irods::KW_CFG_ADVANCED_SETTINGS);
         if (advanced_settings == std::end(config)) {

--- a/server/harness/src/irods_configuration_test_harness.cpp
+++ b/server/harness/src/irods_configuration_test_harness.cpp
@@ -4,6 +4,7 @@
 
 int main(int argc, char* argv[])
 {
-    std::cout << irods::server_properties::instance().map().dump(4).c_str() << std::endl;
+    const auto config_handle{irods::server_properties::instance().map()};
+    std::cout << config_handle.get_json().dump(4).c_str() << '\n';
     return 0;
 } // main

--- a/server/main_server/src/main_server_control_plane.cpp
+++ b/server/main_server/src/main_server_control_plane.cpp
@@ -73,7 +73,8 @@ namespace irods
         boost::optional<std::string> encryption_algorithm;
         buffer_crypt::array_t shared_secret;
         try {
-            const auto& config = server_properties::instance().map();
+            const auto config_handle{server_properties::instance().map()};
+            const auto& config{config_handle.get_json()};
             time_out = config.at(KW_CFG_SERVER_CONTROL_PLANE_TIMEOUT).get<int>();
             port = config.at(_port_keyword).get<int>();
             num_hash_rounds = config.at(KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS).get<int>();
@@ -473,7 +474,9 @@ namespace irods
         local_server_hostname_ = my_env.rodsHost;
 
         // get the provider's hostname host for ordering
-        provider_hostname_ = server_properties::instance().map().at(KW_CFG_CATALOG_PROVIDER_HOSTS)[0].get_ref<const std::string&>();
+        const auto config_handle{server_properties::instance().map()};
+        const auto& config{config_handle.get_json()};
+        provider_hostname_ = config.at(KW_CFG_CATALOG_PROVIDER_HOSTS)[0].get_ref<const std::string&>();
 
         // repave provider_hostname_ as we do not want to process 'localhost'
         if ("localhost" == provider_hostname_) {
@@ -575,7 +578,8 @@ namespace irods
         boost::optional<std::string> encryption_algorithm;
         buffer_crypt::array_t shared_secret;
         try {
-            const auto& config = server_properties::instance().map();
+            const auto config_handle{server_properties::instance().map()};
+            const auto& config{config_handle.get_json()};
             port = config.at(port_prop_).get<int>();
             num_hash_rounds = config.at(KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS).get<int>();
             encryption_algorithm.reset(config.at(KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM).get_ref<const std::string&>());
@@ -988,7 +992,8 @@ namespace irods
         boost::optional<std::string> encryption_algorithm;
         buffer_crypt::array_t shared_secret;
         try {
-            const auto& config = server_properties::instance().map();
+            const auto config_handle{server_properties::instance().map()};
+            const auto& config{config_handle.get_json()};
             num_hash_rounds = config.at(KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_NUM_HASH_ROUNDS).get<int>();
             encryption_algorithm.reset(config.at(KW_CFG_SERVER_CONTROL_PLANE_ENCRYPTION_ALGORITHM).get_ref<const std::string&>());
             const auto& key = config.at(KW_CFG_SERVER_CONTROL_PLANE_KEY).get_ref<const std::string&>();

--- a/server/main_server/src/rodsServer.cpp
+++ b/server/main_server/src/rodsServer.cpp
@@ -225,7 +225,8 @@ namespace
     irods::error init_shared_memory_for_plugins()
     {
         try {
-            const auto& config = irods::server_properties::instance().map();
+            const auto config_handle{irods::server_properties::instance().map()};
+            const auto& config{config_handle.get_json()};
 
             for (const auto& item : config.at(irods::KW_CFG_PLUGIN_CONFIGURATION).items()) {
                 for (const auto& plugin : item.value().items()) {
@@ -260,7 +261,8 @@ namespace
     irods::error deinit_shared_memory_for_plugins()
     {
         try {
-            const auto& config = irods::server_properties::instance().map();
+            const auto config_handle{irods::server_properties::instance().map()};
+            const auto& config{config_handle.get_json()};
 
             for (const auto& item : config.at(irods::KW_CFG_PLUGIN_CONFIGURATION).items()) {
                 for (const auto& plugin : item.value().items()) {
@@ -377,8 +379,9 @@ namespace
     int get_stacktrace_file_processor_sleep_time()
     {
         try {
-            const auto adv_settings = irods::server_properties::instance().map()
-                .at(irods::KW_CFG_ADVANCED_SETTINGS);
+            const auto config_handle{irods::server_properties::instance().map()};
+            const auto& config{config_handle.get_json()};
+            const auto adv_settings{config.at(irods::KW_CFG_ADVANCED_SETTINGS)};
 
             const auto iter = adv_settings
                 .find(irods::KW_CFG_STACKTRACE_FILE_PROCESSOR_SLEEP_TIME_IN_SECONDS);


### PR DESCRIPTION
Cherry-pick from main to 4-3-stable.