### PR TITLE
[6743] nre.reLib1.cpp:extractVarNames: do not write past the end of varNames (main)

### DIFF
--- a/plugins/rule_engines/irods_rule_language/src/nre.reLib1.cpp
+++ b/plugins/rule_engines/irods_rule_language/src/nre.reLib1.cpp
@@ -274,7 +274,7 @@ int extractVarNames( char **varNames, const char *outBuf ) {
     const char *p = outBuf;
     const char *psrc = p;
 
-    for ( ;; ) {
+    while (n < MAX_PARAMS_LEN) {
         if ( *psrc == '%' ) {
             varNames[n++] = strndup( p, psrc - p );
             p = psrc + 1;


### PR DESCRIPTION
Addresses 6743 for main