### PR TITLE
Ensure that data objects cannot get stuck in locked status (main)

### DIFF
--- a/lib/core/include/irods/key_value_proxy.hpp
+++ b/lib/core/include/irods/key_value_proxy.hpp
@@ -1,10 +1,11 @@
 #ifndef IRODS_KEY_VALUE_PROXY_HPP
 #define IRODS_KEY_VALUE_PROXY_HPP
 
+#include "irods/lifetime_manager.hpp"
 #include "irods/objInfo.h"
 #include "irods/rcMisc.h"
 
-#include "irods/lifetime_manager.hpp"
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <limits>
@@ -344,7 +345,7 @@ namespace irods::experimental {
             if (contains(_k)) {
                 return {_k, *kvp_};
             }
-            throw std::out_of_range{"key not found"};
+            throw std::out_of_range{fmt::format("key not found [{}]", _k)};
         }
 
         /// \see https://en.cppreference.com/w/cpp/container/map/at
@@ -357,7 +358,7 @@ namespace irods::experimental {
             if (contains(_k)) {
                 return {_k, *kvp_};
             }
-            throw std::out_of_range{"key not found"};
+            throw std::out_of_range{fmt::format("key not found [{}]", _k)};
         }
 
         /// \see https://en.cppreference.com/w/cpp/container/map/operator_at

--- a/plugins/api/src/replica_close.cpp
+++ b/plugins/api/src/replica_close.cpp
@@ -157,10 +157,17 @@ namespace
 
     auto close_physical_object(rsComm_t& _comm, int _l3desc_index) -> int
     {
+        // The L3 descriptor index is set to -1 when the physical data has already been closed so that it can be
+        // detected on subsequent calls to replica_close. Return 0 here so that the rest of the close operations
+        // (i.e. finalizing) can complete since we do not need to close the data again.
+        if (_l3desc_index < 0) {
+            return 0;
+        }
+
         fileCloseInp_t input{};
         input.fileInx = _l3desc_index;
         return rsFileClose(&_comm, &input);
-    }
+    } // close_physical_object
 
     auto unlock_and_publish_replica(rsComm_t& _comm,
                                     const ir::replica_proxy_t& _replica,
@@ -343,7 +350,9 @@ namespace
         }
 
         const auto& l1desc = L1desc[l1desc_index];
+        const auto is_write_operation = (O_RDONLY != (l1desc.dataObjInp->openFlags & O_ACCMODE));
         const auto send_notifications = !json_input.contains("send_notifications") || json_input.at("send_notifications").get<bool>();
+        const auto update_status = !json_input.contains("update_status") || json_input.at("update_status").get<bool>();
 
         try {
             if (l1desc.inuseFlag != FD_INUSE) {
@@ -378,15 +387,27 @@ namespace
                 }
             }};
 
-            const auto is_write_operation = (O_RDONLY != (l1desc.dataObjInp->openFlags & O_ACCMODE));
+            const auto update_size = !json_input.contains("update_size") || json_input.at("update_size").get<bool>();
+            const auto compute_checksum =
+                json_input.contains("compute_checksum") && json_input.at("compute_checksum").get<bool>();
+
+            // Close the underlying file object.
+            if (const auto ec = close_physical_object(*_comm, l1desc.l3descInx); ec != 0) {
+                log::api::error("Failed to close file object [error_code={}].", ec);
+                if (is_write_operation && update_status) {
+                    update_replica_status_on_error(*_comm, l1desc);
+                    free_l1_descriptor(l1desc_index);
+                }
+                return ec;
+            }
+
+            // Set the L3 descriptor index to -1 here so that any subsequent calls to replica_close will not attempt to
+            // close the physical object again.
+            L1desc[l1desc_index].l3descInx = -1; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
 
             // Allow updates to the replica's catalog information if the stream supports
             // write operations (i.e. the stream is opened in write-only or read-write mode).
             if (is_write_operation) {
-                const auto update_size = !json_input.contains("update_size") || json_input.at("update_size").get<bool>();
-                const auto update_status = !json_input.contains("update_status") || json_input.at("update_status").get<bool>();
-                const auto compute_checksum = json_input.contains("compute_checksum") && json_input.at("compute_checksum").get<bool>();
-
                 // Update the replica's information in the catalog if requested.
                 if (update_size && update_status) {
                     if (const auto ec = update_replica_size_and_status(*_comm, l1desc, send_notifications); ec != 0) {
@@ -397,8 +418,11 @@ namespace
                 }
                 else if (update_size) {
                     if (const auto ec = update_replica_size(*_comm, l1desc, send_notifications); ec != 0) {
+                        // Intentionally do not update the replica status here. The client explicitly disabled updating
+                        // the status, so it is not updated. This leaves the data object in a locked status and the
+                        // caller is now responsible for unlocking/finalizing the data object. Note that the physical
+                        // data has been closed at this point.
                         log::api::error("Failed to update the replica size in the catalog [error_code={}].", ec);
-                        update_replica_status_on_error(*_comm, l1desc);
                         return ec;
                     }
                 }
@@ -436,51 +460,41 @@ namespace
                     constexpr const auto calculation = irods::experimental::replica::verification_calculation::always;
                     irods::experimental::replica::replica_checksum(*_comm, info.objPath, info.replNum, calculation);
                 }
+
+                // Remove the agent's PID from the replica access table for this replica. The replica access table entry
+                // is only erased when everythng else is successful.
+                irods::experimental::replica_access_table::erase_pid(l1desc.replica_token, getpid());
             }
 
-            // Remove the agent's PID from the replica access table.
-            auto entry = is_write_operation
-                ? ix::replica_access_table::erase_pid(l1desc.replica_token, getpid())
-                : std::nullopt;
-
-            // Close the underlying file object.
-            if (const auto ec = close_physical_object(*_comm, l1desc.l3descInx); ec != 0) {
-                if (entry) {
-                    ix::replica_access_table::restore(*entry);
-                }
-
-                log::api::error("Failed to close file object [error_code={}].", ec);
-                update_replica_status(*_comm, l1desc, STALE_REPLICA, false);
-                return ec;
-            }
-
-            const auto ec = free_l1_descriptor(l1desc_index);
-
-            if (ec != 0) {
-                update_replica_status_on_error(*_comm, l1desc);
-            }
-
-            return ec;
+            return free_l1_descriptor(l1desc_index);
         }
         catch (const json::type_error& e) {
             log::api::error("Failed to extract property from JSON object [error_code={}]", SYS_INTERNAL_ERR);
-            update_replica_status_on_error(*_comm, l1desc);
+            if (is_write_operation && update_status) {
+                update_replica_status_on_error(*_comm, l1desc);
+            }
             return SYS_INTERNAL_ERR;
         }
         catch (const irods::exception& e) {
             log::api::error("{} [error_code={}]", e.what(), e.code());
-            update_replica_status_on_error(*_comm, l1desc);
+            if (is_write_operation && update_status) {
+                update_replica_status_on_error(*_comm, l1desc);
+            }
             return e.code();
         }
         catch (const fs::filesystem_error& e) {
             log::api::error("{} [error_code={}]", e.what(), e.code().value());
-            update_replica_status_on_error(*_comm, l1desc);
+            if (is_write_operation && update_status) {
+                update_replica_status_on_error(*_comm, l1desc);
+            }
             return e.code().value();
         }
         catch (const std::exception& e) {
             log::api::error("An unexpected error occurred while closing the replica. {} [error_code={}]",
                             e.what(), SYS_INTERNAL_ERR);
-            update_replica_status_on_error(*_comm, l1desc);
+            if (is_write_operation && update_status) {
+                update_replica_status_on_error(*_comm, l1desc);
+            }
             return SYS_INTERNAL_ERR;
         }
     } // rs_replica_close

--- a/plugins/resources/src/compound.cpp
+++ b/plugins/resources/src/compound.cpp
@@ -805,8 +805,11 @@ irods::error repl_object(
         const auto free_out = irods::at_scope_exit{[&sync_out] { if (sync_out) std::free(sync_out); }};
         int status = rsFileSyncToArch(_ctx.comm(), &inp, &sync_out );
 
-        // Need to update the physical path with whatever the archive resource came up with
-        if (status >= 0 && CREATE_PATH == dst_create_path) {
+        if (status < 0) {
+            ret = ERROR(status, "rsFileSyncToArch failed");
+        }
+        else if (CREATE_PATH == dst_create_path) {
+            // Need to update the physical path with whatever the archive resource came up with
             rstrcpy( destDataObjInfo->filePath, sync_out->file_name, MAX_NAME_LEN );
         }
     }

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -2006,9 +2006,11 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
             admin_session.assert_icommand("iadmin mkresc demoResc compound", 'STDOUT_SINGLELINE', 'compound')
             irods_config = IrodsConfig()
             admin_session.assert_icommand("iadmin mkresc cacheResc 'unixfilesystem' " + test.settings.HOSTNAME_1 + ":" +
-                                          irods_config.irods_directory + "/cacheRescVault", 'STDOUT_SINGLELINE', 'unixfilesystem')
+                                          irods_config.irods_directory + "/cacheResc_vault", 'STDOUT_SINGLELINE', 'unixfilesystem')
             admin_session.assert_icommand("iadmin mkresc archiveResc 'unixfilesystem' " + test.settings.HOSTNAME_1 + ":" +
-                                          irods_config.irods_directory + "/archiveRescVault", 'STDOUT_SINGLELINE', 'unixfilesystem')
+                                          irods_config.irods_directory + "/archiveResc_vault", 'STDOUT_SINGLELINE', 'unixfilesystem')
+            self.cache_resc = 'cacheResc'
+            self.archive_resc = 'archiveResc'
             admin_session.assert_icommand("iadmin addchildtoresc demoResc cacheResc cache")
             admin_session.assert_icommand("iadmin addchildtoresc demoResc archiveResc archive")
         super(Test_Resource_Compound, self).setUp()
@@ -2023,8 +2025,8 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
             admin_session.assert_icommand("iadmin rmresc demoResc")
             admin_session.assert_icommand("iadmin modresc origResc name demoResc", 'STDOUT_SINGLELINE', 'rename', input='yes\n')
         irods_config = IrodsConfig()
-        shutil.rmtree(irods_config.irods_directory + "/archiveRescVault", ignore_errors=True)
-        shutil.rmtree("rm -rf " + irods_config.irods_directory + "/cacheRescVault", ignore_errors=True)
+        shutil.rmtree(os.path.join(irods_config.irods_directory, self.archive_resc + '_vault'), ignore_errors=True)
+        shutil.rmtree(os.path.join(irods_config.irods_directory, self.cache_resc + '_vault'), ignore_errors=True)
 
     def test_checksums_not_computed_for_archive__issue_6089(self):
         filename = 'test_checksums_not_computed_for_archive__issue_6089'
@@ -2336,7 +2338,7 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
 
         self.admin.assert_icommand("ils -L '{}'".format(filename), 'STDOUT_SINGLELINE', 'cacheResc')
 
-        physical_path = os.path.join(IrodsConfig().irods_directory, 'cacheRescVault')
+        physical_path = os.path.join(IrodsConfig().irods_directory, 'cacheResc_vault')
         physical_path = os.path.join(physical_path,os.path.basename(self.admin.session_collection))
         physical_path = os.path.join(physical_path,filename)
 
@@ -2465,7 +2467,7 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
 
         # manually update the replica in archive vault
         out, _, _ = self.admin.run_icommand('ils -L ' + filename)
-        archivereplicaphypath = [token for token in out.split() if "archiveRescVault" in token][0]
+        archivereplicaphypath = [token for token in out.split() if "archiveResc_vault" in token][0]
         with open(archivereplicaphypath, 'wt') as f:
             print('MANUALLY UPDATED ON ARCHIVE\n', file=f, end='')
         # get file
@@ -2485,7 +2487,7 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
 
             # manually update the replica in archive vault
             out, _, _ = self.admin.run_icommand('ils -L ' + filename)
-            archivereplicaphypath = [token for token in out.split() if "archiveRescVault" in token][0]
+            archivereplicaphypath = [token for token in out.split() if "archiveResc_vault" in token][0]
             with open(archivereplicaphypath, 'wt') as f:
                 print('UPDATED ARCHIVE AGAIN\n', file=f, end='')
 
@@ -2807,6 +2809,102 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
             self.admin.run_icommand(['iadmin', 'rmresc', archive_resc])
             self.admin.run_icommand(['iadmin', 'rmresc', cache_resc])
             self.admin.run_icommand(['iadmin', 'rmresc', comp_resc])
+
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Manipulates vault directory permissions on local host.")
+    def test_synctoarch_failure_returns_an_error_and_can_be_overwritten__issue_6886(self):
+        filename = 'test_iput_with_unwritable_archive_resource_vault__issue_6886'
+        logical_path = os.path.join(self.user0.session_collection, filename)
+        local_file = os.path.join(self.user0.local_session_dir, filename)
+        file_size_in_bytes = 10
+        archive_vault_path = os.path.join(IrodsConfig().irods_directory, self.archive_resc + '_vault')
+
+        try:
+            lib.make_file(local_file, file_size_in_bytes)
+
+            # Do a test put to make sure everything is in working order. This creates the vault directories as well.
+            self.user0.assert_icommand(['iput', local_file, logical_path])
+            self.assertTrue(lib.replica_exists_on_resource(self.user0, logical_path, self.cache_resc))
+            self.assertTrue(lib.replica_exists_on_resource(self.user0, logical_path, self.archive_resc))
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, os.path.basename(logical_path), 0))
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, os.path.basename(logical_path), 1))
+
+            # debugging
+            self.user0.assert_icommand(['ils', '-L', os.path.dirname(logical_path)], 'STDOUT', filename)
+
+            # Clean it up
+            self.user0.assert_icommand(['irm', '-f', logical_path])
+
+            # Make the service account have no permissions on the archive vault so that sync-to-archive fails.
+            os.chmod(archive_vault_path, 0o000)
+
+            # Try a put to the compound resource and make sure that a failure occurs. The archive replica should exist
+            # and be stale in addition to an error being returned from the operation.
+            self.user0.assert_icommand(['iput', local_file, logical_path], 'STDERR', 'UNIX_FILE_OPEN_ERR')
+            self.assertTrue(lib.replica_exists_on_resource(self.user0, logical_path, self.archive_resc))
+            self.assertTrue(lib.replica_exists_on_resource(self.user0, logical_path, self.cache_resc))
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, os.path.basename(logical_path), 0))
+            self.assertEqual(str(0), lib.get_replica_status(self.user0, os.path.basename(logical_path), 1))
+
+            # debugging
+            self.user0.assert_icommand(['ils', '-L', os.path.dirname(logical_path)], 'STDOUT', filename)
+
+            # Make sure the archive vault is put back to a workable permissions set.
+            os.chmod(archive_vault_path, 0o750)
+
+            # Try overwriting the object now that permissions are better and ensure that everything works.
+            self.user0.assert_icommand(['iput', '-f', local_file, logical_path])
+            self.assertTrue(lib.replica_exists_on_resource(self.user0, logical_path, self.cache_resc))
+            self.assertTrue(lib.replica_exists_on_resource(self.user0, logical_path, self.archive_resc))
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, os.path.basename(logical_path), 0))
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, os.path.basename(logical_path), 1))
+
+        finally:
+            # Make sure the archive vault is put back to a workable permissions set.
+            os.chmod(archive_vault_path, 0o750)
+
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Manipulates vault directory permissions on local host.")
+    def test_synctoarch_failure_returns_an_error_and_can_be_removed__issue_6886(self):
+        filename = 'test_iput_with_unwritable_archive_resource_vault__issue_6886'
+        logical_path = os.path.join(self.user0.session_collection, filename)
+        local_file = os.path.join(self.user0.local_session_dir, filename)
+        file_size_in_bytes = 10
+        archive_vault_path = os.path.join(IrodsConfig().irods_directory, self.archive_resc + '_vault')
+
+        try:
+            lib.make_file(local_file, file_size_in_bytes)
+
+            # Do a test put to make sure everything is in working order. This creates the vault directories as well.
+            self.user0.assert_icommand(['iput', local_file, logical_path])
+            self.assertTrue(lib.replica_exists_on_resource(self.user0, logical_path, self.cache_resc))
+            self.assertTrue(lib.replica_exists_on_resource(self.user0, logical_path, self.archive_resc))
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, os.path.basename(logical_path), 0))
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, os.path.basename(logical_path), 1))
+
+            # Clean it up
+            self.user0.assert_icommand(['irm', '-f', logical_path])
+
+            # Make the service account have no permissions on the archive vault so that sync-to-archive fails.
+            os.chmod(archive_vault_path, 0o000)
+
+            # Try a put to the compound resource and make sure that a failure occurs. The archive replica should exist
+            # and be stale in addition to an error being returned from the operation.
+            self.user0.assert_icommand(['iput', local_file, logical_path], 'STDERR', 'UNIX_FILE_OPEN_ERR')
+            self.assertTrue(lib.replica_exists_on_resource(self.user0, logical_path, self.archive_resc))
+            self.assertTrue(lib.replica_exists_on_resource(self.user0, logical_path, self.cache_resc))
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, os.path.basename(logical_path), 0))
+            self.assertEqual(str(0), lib.get_replica_status(self.user0, os.path.basename(logical_path), 1))
+
+            # Try to clean it up, even though the archive replica physical path does not exist.
+            self.user0.assert_icommand(['irm', '-f', logical_path])
+            self.assertFalse(lib.replica_exists_on_resource(self.user0, logical_path, self.cache_resc))
+            self.assertFalse(lib.replica_exists_on_resource(self.user0, logical_path, self.archive_resc))
+
+        finally:
+            # Make sure the archive vault is put back to a workable permissions set.
+            os.chmod(archive_vault_path, 0o750)
+
 
 class Test_Resource_ReplicationWithinReplication(ChunkyDevTest, ResourceSuite, unittest.TestCase):
 

--- a/server/core/src/initServer.cpp
+++ b/server/core/src/initServer.cpp
@@ -973,7 +973,7 @@ void close_all_l1_descriptors(RsComm& _comm)
                 irods::log(
                     LOG_ERROR, fmt::format("[{}:{}] - error closing replica; ec:[{}]", __FUNCTION__, __LINE__, ec));
 
-                continue;
+                // Even though closing failed, continue to the end of the loop so that the data object is finalized.
             }
 
             // Don't do anything for special collections - they do not enter intermediate state

--- a/server/core/src/rodsAgent.cpp
+++ b/server/core/src/rodsAgent.cpp
@@ -1,39 +1,39 @@
 #include "irods/rodsAgent.hpp"
 
-#include "irods/reconstants.hpp"
-#include "irods/rsApiHandler.hpp"
 #include "irods/icatHighLevelRoutines.hpp"
-#include "irods/miscServerFunct.hpp"
-#include "irods/irods_socket_information.hpp"
-#include "irods/irods_dynamic_cast.hpp"
-#include "irods/irods_signal.hpp"
-#include "irods/irods_client_server_negotiation.hpp"
-#include "irods/irods_network_factory.hpp"
-#include "irods/irods_auth_object.hpp"
+#include "irods/initServer.hpp"
+#include "irods/irods_at_scope_exit.hpp"
+#include "irods/irods_auth_constants.hpp"
 #include "irods/irods_auth_factory.hpp"
 #include "irods/irods_auth_manager.hpp"
+#include "irods/irods_auth_object.hpp"
 #include "irods/irods_auth_plugin.hpp"
-#include "irods/irods_auth_constants.hpp"
-#include "irods/irods_environment_properties.hpp"
-#include "irods/irods_server_properties.hpp"
-#include "irods/irods_server_api_table.hpp"
 #include "irods/irods_client_api_table.hpp"
+#include "irods/irods_client_server_negotiation.hpp"
+#include "irods/irods_dynamic_cast.hpp"
+#include "irods/irods_environment_properties.hpp"
+#include "irods/irods_logger.hpp"
+#include "irods/irods_network_factory.hpp"
 #include "irods/irods_pack_table.hpp"
-#include "irods/irods_server_state.hpp"
-#include "irods/irods_threads.hpp"
 #include "irods/irods_re_plugin.hpp"
 #include "irods/irods_re_serialization.hpp"
-#include "irods/irods_logger.hpp"
-#include "irods/irods_at_scope_exit.hpp"
+#include "irods/irods_server_api_table.hpp"
+#include "irods/irods_server_properties.hpp"
+#include "irods/irods_server_state.hpp"
+#include "irods/irods_signal.hpp"
+#include "irods/irods_socket_information.hpp"
+#include "irods/irods_threads.hpp"
+#include "irods/miscServerFunct.hpp"
+#include "irods/plugin_lifetime_manager.hpp"
 #include "irods/procLog.h"
-#include "irods/initServer.hpp"
+#include "irods/reconstants.hpp"
 #include "irods/replica_access_table.hpp"
+#include "irods/replica_state_table.hpp"
+#include "irods/rsApiHandler.hpp"
+#include "irods/server_utilities.hpp"
 #include "irods/sockCommNetworkInterface.hpp"
 #include "irods/sslSockComm.h"
-#include "irods/server_utilities.hpp"
-#include "irods/plugin_lifetime_manager.hpp"
 #include "irods/version.hpp"
-#include "irods/replica_state_table.hpp"
 
 #include <csignal>
 #include <cstdlib>
@@ -213,6 +213,9 @@ void cleanup()
 
     if (INITIAL_DONE == InitialState) {
         close_all_l1_descriptors(*ThisComm);
+
+        // This agent's PID must be erased from all replica access table entries as it will soon no longer exist.
+        irods::experimental::replica_access_table::erase_pid(getpid());
 
         irods::replica_state_table::deinit();
 
@@ -703,6 +706,16 @@ int runIrodsAgentFactory(sockaddr_un agent_addr)
         return ret.code();
     }
 
+    const auto cleanup_and_free_rsComm_members = [&rsComm] {
+        cleanup();
+        if (rsComm.thread_ctx) {
+            std::free(rsComm.thread_ctx); // NOLINT(cppcoreguidelines-no-malloc, cppcoreguidelines-owning-memory)
+        }
+        if (rsComm.auth_scheme) {
+            std::free(rsComm.auth_scheme); // NOLINT(cppcoreguidelines-no-malloc, cppcoreguidelines-owning-memory)
+        }
+    };
+
     new_net_obj->to_server(&rsComm);
     status = agentMain(&rsComm);
 
@@ -710,14 +723,13 @@ int runIrodsAgentFactory(sockaddr_un agent_addr)
     ret = sockAgentStop( new_net_obj );
     if (!ret.ok()) {
         log_agent::error(PASS(ret).result());
+        cleanup_and_free_rsComm_members();
         return ret.code();
     }
 
     new_net_obj->to_server(&rsComm);
-    // TODO: move this into an at_scope_exit
-    cleanup();
-    std::free(rsComm.thread_ctx);
-    std::free(rsComm.auth_scheme);
+
+    cleanup_and_free_rsComm_members();
 
     // clang-format off
     (0 == status)

--- a/unit_tests/cmake/test_config/irods_key_value_proxy.cmake
+++ b/unit_tests/cmake/test_config/irods_key_value_proxy.cmake
@@ -4,5 +4,8 @@ set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
                             ${CMAKE_CURRENT_SOURCE_DIR}/src/test_irods_key_value_proxy.cpp)
 
 set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include)
- 
-set(IRODS_TEST_LINK_LIBRARIES irods_common)
+
+set(IRODS_TEST_LINK_LIBRARIES
+    irods_common
+    "${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so"
+    )

--- a/unit_tests/src/test_replica_access_table.cpp
+++ b/unit_tests/src/test_replica_access_table.cpp
@@ -51,6 +51,9 @@ TEST_CASE("replica_access_table")
     REQUIRE(infos[0].token == infos[1].token);
     REQUIRE(infos[0].token != infos[2].token);
 
+    // Erase a PID which does not exist in the replica access table. This should be a no-op.
+    CHECK_NOTHROW(rat::erase_pid(7000));
+
     SECTION("erase and restore entry with single PID")
     {
         auto& info = infos[2];


### PR DESCRIPTION
Addresses #6154
Addresses #6378
Addresses #6479
Addresses #6880
Addresses #6882

Companion PR: https://github.com/irods/irods_resource_plugin_s3/pull/2094

The issues being addressed here are difficult to reproduce in the automated tests. I have some machinery for this in a separate branch which we can consider merging at another time. Tests for these things are in the companion PR.

Will run core tests soon, hence the draft PR.