### PR TITLE
[6502] mark replica stale if staging to cache fails (4-2-stable)

### DIFF
--- a/packaging/core.re.template
+++ b/packaging/core.re.template
@@ -701,7 +701,7 @@ acPostProcForDataCopyReceived(*leaf_resource) {}
 
 # =-=-=-=-=-=-=-
 # policy controlling when a dataObject is staged to cache from archive in a compound coordinating resource
-#  - the default is to stage when cache is not present ("when_necessary")
+#  - the default is to stage when cache is stale or not present ("when_necessary")
 # =-=-=-=-=-=-=-
 # pep_resource_resolve_hierarchy_pre(*INSTANCE, *CONTEXT, *OUT, *OPERATION, *HOST, *PARSER, *VOTE){*OUT="compound_resource_cache_refresh_policy=when_necessary";}  # default
 # pep_resource_resolve_hierarchy_pre(*INSTANCE, *CONTEXT, *OUT, *OPERATION, *HOST, *PARSER, *VOTE){*OUT="compound_resource_cache_refresh_policy=always";}

--- a/plugins/resources/compound/libcompound.cpp
+++ b/plugins/resources/compound/libcompound.cpp
@@ -22,6 +22,7 @@
 #include "irods_lexical_cast.hpp"
 #include "irods_random.hpp"
 #include "irods_at_scope_exit.hpp"
+#include "voting.hpp"
 
 #include <boost/lexical_cast.hpp>
 #include <boost/function.hpp>
@@ -531,12 +532,16 @@ namespace {
         return destination_l1descInx;
     } // open_destination_replica
 
-    int close_replica(
-        irods::plugin_context& _ctx,
-        const int l1descInx) {
+    int close_replica(irods::plugin_context& _ctx, const int l1descInx, const int operation_status = 0)
+    {
         openedDataObjInp_t data_obj_close_inp{};
         data_obj_close_inp.l1descInx = l1descInx;
-        L1desc[data_obj_close_inp.l1descInx].oprStatus = l1descInx;
+        if (operation_status == 0) {
+            L1desc[data_obj_close_inp.l1descInx].oprStatus = l1descInx;
+        }
+        else {
+            L1desc[data_obj_close_inp.l1descInx].oprStatus = operation_status;
+        }
         addKeyVal(&data_obj_close_inp.condInput, IN_PDMO_KW, L1desc[l1descInx].dataObjInfo->rescHier);
         int close_status = rsDataObjClose( _ctx.comm(), &data_obj_close_inp);
         if (close_status < 0) {
@@ -652,11 +657,17 @@ irods::error repl_object(
 
     int source_l1descInx{};
     int destination_l1descInx{};
+
+    // If we have an error on rsFileStageToCache, this needs to be set
+    // to the oprStatus on close to make sure the replica is staled.  A status of 0
+    // indicates no error and the oprStatus will be set to l1descInx as normal.
+    int error_code_set_to_oprStatus_on_dest_close = 0;
+
     const irods::at_scope_exit close_l1_descriptors{
         [&]()
         {
             if (destination_l1descInx > 0) {
-                close_replica(_ctx, destination_l1descInx);
+                close_replica(_ctx, destination_l1descInx, error_code_set_to_oprStatus_on_dest_close);
             }
             if (source_l1descInx > 0) {
                 close_replica(_ctx, source_l1descInx);
@@ -714,6 +725,7 @@ irods::error repl_object(
 
         int status = rsFileStageToCache(_ctx.comm(), &file_stage);
         if (status < 0) {
+            error_code_set_to_oprStatus_on_dest_close = status;
             ret = ERROR(status, "rsFileStageToCache failed");
         }
     }
@@ -1432,6 +1444,8 @@ irods::error compound_file_redirect_create(
     irods::hierarchy_parser* _out_parser,
     float*                   _out_vote)
 {
+    namespace irv = irods::experimental::resource::voting;
+
     // =-=-=-=-=-=-=-
     // determine if the resource is down
     int resc_status = 0;
@@ -1443,7 +1457,7 @@ irods::error compound_file_redirect_create(
     // =-=-=-=-=-=-=-
     // if the status is down, vote no.
     if ( INT_RESC_STATUS_DOWN == resc_status ) {
-        *_out_vote = 0.0f;
+        *_out_vote = irv::vote::zero;
         return SUCCESS();
     }
 
@@ -1479,6 +1493,8 @@ irods::error compound_file_redirect_unlink(
     const std::string*               _curr_host,
     irods::hierarchy_parser*         _out_parser,
     float*                           _out_vote ) {
+    namespace irv = irods::experimental::resource::voting;
+
     // =-=-=-=-=-=-=-
     // determine if the resource is down
     int resc_status = 0;
@@ -1490,7 +1506,7 @@ irods::error compound_file_redirect_unlink(
     // =-=-=-=-=-=-=-
     // if the status is down, vote no.
     if ( INT_RESC_STATUS_DOWN == resc_status ) {
-        ( *_out_vote ) = 0.0;
+        (*_out_vote) = irv::vote::zero;
         return SUCCESS();
     }
 
@@ -1515,7 +1531,7 @@ irods::error compound_file_redirect_unlink(
 
     // =-=-=-=-=-=-=-
     // if cache votes non zero we're done
-    if (*_out_vote > 0.0) {
+    if (*_out_vote > irv::vote::zero) {
         return SUCCESS();
     }
 
@@ -1551,6 +1567,8 @@ irods::error open_for_prefer_archive_policy(
     irods::hierarchy_parser& _out_parser,
     float&                   _out_vote)
 {
+    namespace irv = irods::experimental::resource::voting;
+
     // =-=-=-=-=-=-=-
     // get the archive resource
     irods::resource_ptr arch_resc;
@@ -1579,7 +1597,7 @@ irods::error open_for_prefer_archive_policy(
     int repl_requested = f_ptr->repl_requested();
     const irods::at_scope_exit restore_repl_requested{[&] { f_ptr->repl_requested(repl_requested); }};
 
-    float arch_check_vote = 0.0f;
+    float arch_check_vote = irv::vote::zero;
     irods::hierarchy_parser arch_check_parser = _out_parser;
 
     try {
@@ -1596,11 +1614,11 @@ irods::error open_for_prefer_archive_policy(
     }
     catch (const irods::exception& e) {
         // continue to the cache vote because failed vote isn't necessarily an error
-        arch_check_vote = 0.0;
+        arch_check_vote = irv::vote::zero;
         irods::log(LOG_DEBUG, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, e.what()));
     }
 
-    if ( !ret.ok() || 0.0 == arch_check_vote ) {
+    if (!ret.ok() || irv::vote::zero == arch_check_vote) {
         rodsLog(
             LOG_DEBUG,
             "replica not found in archive for [%s]",
@@ -1609,7 +1627,7 @@ irods::error open_for_prefer_archive_policy(
         // the archive query redirect failed, something terrible happened
         // or mounted collection hijinks are afoot.  ask the cache if it
         // has the data object in question, politely as a fallback
-        float cache_check_vote = 0.0;
+        float cache_check_vote = irv::vote::zero;
         irods::hierarchy_parser cache_check_parser = _out_parser;
         ret = cache_resc->call<const std::string*, const std::string*, irods::hierarchy_parser*, float*>(
             _ctx.comm(), irods::RESOURCE_OP_RESOLVE_RESC_HIER, _ctx.fco(),
@@ -1619,8 +1637,8 @@ irods::error open_for_prefer_archive_policy(
             return PASS( ret );
         }
 
-        if (0.0 == cache_check_vote ) {
-            _out_vote = 0.0;
+        if (irv::vote::zero == cache_check_vote) {
+            _out_vote = irv::vote::zero;
             return SUCCESS();
         }
 
@@ -1717,6 +1735,8 @@ irods::error open_for_prefer_cache_policy(
     irods::hierarchy_parser*        _out_parser,
     float*                           _out_vote )
 {
+    namespace irv = irods::experimental::resource::voting;
+
     // =-=-=-=-=-=-=-
     // check incoming parameters
     if ( !_curr_host ) {
@@ -1782,7 +1802,7 @@ irods::error open_for_prefer_cache_policy(
 
     // =-=-=-=-=-=-=-
     // ask the cache if it has the data object in question, politely
-    float                    cache_check_vote   = 0.0;
+    float cache_check_vote = irv::vote::zero;
     irods::hierarchy_parser cache_check_parser = ( *_out_parser );
     ret = cache_resc->call < const std::string*, const std::string*, irods::hierarchy_parser*, float* > (
         _ctx.comm(), irods::RESOURCE_OP_RESOLVE_RESC_HIER, _ctx.fco(),
@@ -1794,18 +1814,18 @@ irods::error open_for_prefer_cache_policy(
     }
 
     // =-=-=-=-=-=-=-
-    // if the vote is 0 then the cache doesn't have it so it will need be staged
-    if ( 0.0 == cache_check_vote ) {
+    // If the vote is irv::vote::low or less, either the replica does not exist in cache,
+    // the cache replica is stale, or the user requested a specific replica.
+    // In this case check the archive to see if it has a higher vote.
+    float arch_check_vote = irv::vote::zero;
+    irods::hierarchy_parser arch_check_parser = *_out_parser;
+    irods::file_object_ptr f_ptr = boost::dynamic_pointer_cast<irods::file_object>(_ctx.fco());
+
+    if (irv::vote::low >= cache_check_vote) {
         // =-=-=-=-=-=-=-
         // repave the repl requested temporarily
-        irods::file_object_ptr f_ptr = boost::dynamic_pointer_cast< irods::file_object >( _ctx.fco() );
         int repl_requested = f_ptr->repl_requested();
         f_ptr->repl_requested( -1 );
-
-        // =-=-=-=-=-=-=-
-        // ask the archive if it has the data object in question, politely
-        float arch_check_vote  = 0.0;
-        irods::hierarchy_parser arch_check_parser = *_out_parser;
 
         ret = arch_resc->call<const std::string*, const std::string*, irods::hierarchy_parser*, float*>(
             _ctx.comm(),
@@ -1816,13 +1836,22 @@ irods::error open_for_prefer_cache_policy(
             &arch_check_parser,
             &arch_check_vote);
 
+        // =-=-=-=-=-=-=-
+        // restore repl requested
+        f_ptr->repl_requested(repl_requested);
+
         if ( !ret.ok() ) {
             irods::log(ret);
             return PASS( ret );
         }
+    }
 
-        if( 0.0 == arch_check_vote ) {
-            *_out_vote = 0.0;
+    // =-=-=-=-=-=-=-
+    // If the archive voted higher it will need to be staged to cache
+    if ( arch_check_vote > cache_check_vote ) {
+
+        if( irv::vote::zero == arch_check_vote ) {
+            *_out_vote = irv::vote::zero;
             return SUCCESS();
         }
 
@@ -1854,10 +1883,6 @@ irods::error open_for_prefer_cache_policy(
             return PASS( ret );
         }
 
-        // =-=-=-=-=-=-=-
-        // restore repl requested
-        f_ptr->repl_requested( repl_requested );
-
         ( *_out_parser ) = cache_check_parser;
         ( *_out_vote ) = arch_check_vote;
     }
@@ -1882,6 +1907,8 @@ irods::error compound_file_redirect_open(
     irods::hierarchy_parser* _out_parser,
     float*                   _out_vote)
 {
+    namespace irv = irods::experimental::resource::voting;
+
     // =-=-=-=-=-=-=-
     // check incoming parameters
     if ( !_curr_host ) {
@@ -1905,7 +1932,7 @@ irods::error compound_file_redirect_open(
     // =-=-=-=-=-=-=-
     // if the status is down, vote no.
     if ( INT_RESC_STATUS_DOWN == resc_status ) {
-        ( *_out_vote ) = 0.0;
+        (*_out_vote) = irv::vote::zero;
         return SUCCESS();
     }
 
@@ -1968,6 +1995,8 @@ irods::error compound_file_resolve_hierarchy(
     irods::hierarchy_parser* _out_parser,
     float*                   _out_vote)
 {
+    namespace irv = irods::experimental::resource::voting;
+
     // =-=-=-=-=-=-=-
     // check the context validity
     irods::error ret = _ctx.valid< irods::file_object >();
@@ -1992,7 +2021,7 @@ irods::error compound_file_resolve_hierarchy(
         return ERROR( SYS_INVALID_INPUT_PARAM, "null outgoing vote" );
     }
 
-    ( *_out_vote ) = 0.0f;
+    (*_out_vote) = irv::vote::zero;
 
     // =-=-=-=-=-=-=-
     // get the name of this resource

--- a/plugins/resources/compound/libcompound.cpp
+++ b/plugins/resources/compound/libcompound.cpp
@@ -1899,10 +1899,14 @@ irods::error open_for_prefer_cache_policy(
     }
 
     // =-=-=-=-=-=-=-
-    // If the archive voted higher it will need to be staged to cache
-    if ( arch_check_vote > cache_check_vote ) {
-
-        if( irv::vote::zero == arch_check_vote ) {
+    // Determine if we need to replicate from archive to cache.
+    // On a read, this is true if the archive vote is greater than cache vote.
+    // On a write, stale replicas vote higher than good replicas (see issue 4010)
+    // so the replication needs to happen if archive vote is less than cache vote.
+    if ((irods::WRITE_OPERATION != *_opr && arch_check_vote > cache_check_vote) ||
+        (irods::WRITE_OPERATION == *_opr && arch_check_vote < cache_check_vote))
+    {
+        if (irv::vote::zero == arch_check_vote) {
             *_out_vote = irv::vote::zero;
             return SUCCESS();
         }

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -13,6 +13,7 @@ from threading import Timer
 import time
 import ustrings
 import socket
+import textwrap
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -2106,6 +2107,105 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
             self.admin.assert_icommand("irm -f " + filename)
             lib.remove_file_if_exists(filename)
             lib.remove_file_if_exists(stale_replica_filename)
+            lib.remove_file_if_exists(get_filename)
+
+    def test_direct_request_for_cache_archive_replicas__issue_6926(self):
+
+        try:
+            filename = "directrequestcachearchivereplica.txt"
+            get_filename = "getfile.txt"
+            lib.make_file(filename, 10, 'arbitrary')
+
+            logical_path = os.path.join(self.admin.session_collection, filename)
+
+            self.admin.assert_icommand("iput " + filename)
+
+            # attempt to get the replica directly from archive - should fail
+            self.admin.assert_icommand(['iget', '-n1', filename, get_filename], 'STDERR', 'HIERARCHY_ERROR')
+
+            # attempt to get the replica directly from cache - should pass
+            self.admin.assert_icommand(['iget', '-n0', filename, get_filename])
+
+            # assert that the retrieved file is the right size
+            self.assertEqual(os.path.getsize(get_filename), 10)
+            os.remove(get_filename)
+
+            # get the file without requesting replica or resource
+            self.admin.assert_icommand(['iget', filename, get_filename])
+
+            # assert that the retrieved file is the right size
+            self.assertEqual(os.path.getsize(get_filename), 10)
+            os.remove(get_filename)
+
+            # get the file specifying the compound resource - should pass
+            self.admin.assert_icommand(['iget', '-R', 'demoResc', filename, get_filename])
+
+            # assert that the retrieved file is the right size
+            self.assertEqual(os.path.getsize(get_filename), 10)
+            os.remove(get_filename)
+
+        finally:
+            # cleanup
+            self.admin.assert_icommand("irm -f " + filename)
+            lib.remove_file_if_exists(filename)
+            lib.remove_file_if_exists(get_filename)
+
+    def test_direct_request_for_cache_archive_replicas_when_policy_is_set_to_prefer_archive__issue_6926(self):
+
+        filename = "directrequestcachearchivereplica.txt"
+        get_filename = "getfile.txt"
+
+        try:
+            rule_map = {
+                'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent('''
+                    pep_resource_resolve_hierarchy_pre(*INSTANCE, *CONTEXT, *OUT, *OPERATION, *HOST, *PARSER, *VOTE){
+                        *OUT="compound_resource_cache_refresh_policy=always";
+                 '''),
+                 'irods_rule_engine_plugin-python': textwrap.dedent('''
+                     def pep_resource_resolve_hierarchy_pre(rule_args, callback, rei):
+                         rule_args[2] = 'compound_resource_cache_refresh_policy=always'
+                 ''')
+            }
+
+            # manipulate the core.re to add the new policy
+            with temporary_core_file() as core:
+
+                core.add_rule(rule_map[self.plugin_name])
+
+                lib.make_file(filename, 10, 'arbitrary')
+
+                logical_path = os.path.join(self.admin.session_collection, filename)
+
+                self.admin.assert_icommand("iput " + filename)
+
+                # attempt to get the replica directly from archive - should fail
+                self.admin.assert_icommand(['iget', '-n1', filename, get_filename], 'STDERR', 'HIERARCHY_ERROR')
+
+                # attempt to get the replica directly from cache - should pass
+                self.admin.assert_icommand(['iget', '-n0', filename, get_filename])
+
+                # assert that the retrieved file is the right size
+                self.assertEqual(os.path.getsize(get_filename), 10)
+                os.remove(get_filename)
+
+                # get the file without requesting replica or resource
+                self.admin.assert_icommand(['iget', filename, get_filename])
+
+                # assert that the retrieved file is the right size
+                self.assertEqual(os.path.getsize(get_filename), 10)
+                os.remove(get_filename)
+
+                # get the file specifying the compound resource - should pass
+                self.admin.assert_icommand(['iget', '-R', 'demoResc', filename, get_filename])
+
+                # assert that the retrieved file is the right size
+                self.assertEqual(os.path.getsize(get_filename), 10)
+                os.remove(get_filename)
+
+        finally:
+            # cleanup
+            self.admin.assert_icommand("irm -f " + filename)
+            lib.remove_file_if_exists(filename)
             lib.remove_file_if_exists(get_filename)
 
     def test_irm_specific_replica(self):

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -2069,6 +2069,45 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
         self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', 'cacheResc')
         self.admin.assert_icommand("ils -L " + filename, 'STDOUT_SINGLELINE', 'archiveResc')
 
+    def test_get_stale_cache_replica__issue_6502(self):
+
+        try:
+            filename = "testgetstalecachereplica.txt"
+            lib.make_file(filename, 10, 'arbitrary')
+            stale_replica_filename = "stalereplica.txt"
+            lib.make_file(stale_replica_filename, 20, 'arbitrary')
+
+            logical_path = os.path.join(self.admin.session_collection, filename)
+
+            self.admin.assert_icommand("iput " + filename)
+            self.admin.assert_icommand("iadmin modresc demoResc context \"auto_repl=off\"" )
+            self.admin.assert_icommand("iput -f " + stale_replica_filename + " " + filename)
+
+            # at this point the cache (repl 0) will be good and the archive (repl 1) will be stale
+            # swap the status of these two so archive is good and cache is stale
+            self.admin.assert_icommand("iadmin modrepl logical_path " + logical_path + " replica_number 0 DATA_REPL_STATUS 0")
+            self.admin.assert_icommand("iadmin modrepl logical_path " + logical_path + " replica_number 1 DATA_REPL_STATUS 1")
+
+            # get the stale replica
+            get_filename = "getfile.txt"
+            self.admin.assert_icommand("iget -n 0 " + filename + " " +  get_filename)
+
+            # assert on the stale replica file size
+            self.assertEqual(os.path.getsize(get_filename), 20)
+
+            # get the file without selecting the replica
+            self.admin.assert_icommand("iget -f " + filename + " " +  get_filename)
+
+            # assert on the good replica file size
+            self.assertEqual(os.path.getsize(get_filename), 10)
+
+        finally:
+            # cleanup
+            self.admin.assert_icommand("irm -f " + filename)
+            lib.remove_file_if_exists(filename)
+            lib.remove_file_if_exists(stale_replica_filename)
+            lib.remove_file_if_exists(get_filename)
+
     def test_irm_specific_replica(self):
         self.admin.assert_icommand("ils -L " + self.testfile, 'STDOUT_SINGLELINE', self.testfile)  # should be listed
         self.admin.assert_icommand("irepl -R " + self.testresc + " " + self.testfile)  # creates replica


### PR DESCRIPTION
Changed the compound behavior as follows:

If the policy is set to prefer the cache and the cache votes .25 (irc::vote::low) or less, get the vote from the archive.  If its vote is higher, repave the cache with the archive and return this.

If the cache votes > .25 then return the file from the cache.

Some situations where the vote is <= .25:

1. The replica does not exist in the cache.  (vote=0.0)
2. The replica exists but it stale.  (vote=.25)
3. The user requested a specific replica.  (vote=.25)

I have a test in the S3 plugin which covers this scenario with the archive file being in Glacier.