### PR TITLE
Ensure that data objects cannot get stuck in locked status (4-2-stable)

### DIFF
--- a/lib/core/include/key_value_proxy.hpp
+++ b/lib/core/include/key_value_proxy.hpp
@@ -1,10 +1,11 @@
 #ifndef IRODS_KEY_VALUE_PROXY_HPP
 #define IRODS_KEY_VALUE_PROXY_HPP
 
+#include "lifetime_manager.hpp"
 #include "objInfo.h"
 #include "rcMisc.h"
 
-#include "lifetime_manager.hpp"
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <limits>
@@ -344,7 +345,7 @@ namespace irods::experimental {
             if (contains(_k)) {
                 return {_k, *kvp_};
             }
-            throw std::out_of_range{"key not found"};
+            throw std::out_of_range{fmt::format("key not found [{}]", _k)};
         }
 
         /// \see https://en.cppreference.com/w/cpp/container/map/at
@@ -357,7 +358,7 @@ namespace irods::experimental {
             if (contains(_k)) {
                 return {_k, *kvp_};
             }
-            throw std::out_of_range{"key not found"};
+            throw std::out_of_range{fmt::format("key not found [{}]", _k)};
         }
 
         /// \see https://en.cppreference.com/w/cpp/container/map/operator_at

--- a/plugins/api/src/replica_close.cpp
+++ b/plugins/api/src/replica_close.cpp
@@ -56,7 +56,6 @@
 namespace
 {
     // clang-format off
-    namespace ix  = irods::experimental;
     namespace fs  = irods::experimental::filesystem;
     namespace ill = irods::logical_locking;
     namespace ir  = irods::experimental::replica;
@@ -85,7 +84,8 @@ namespace
     auto unlock_and_publish_replica(rsComm_t& _comm,
                                     const ir::replica_proxy_t& _replica,
                                     const l1desc& _l1desc,
-                                    const bool _send_notifications) -> int;
+                                    const bool _send_notifications,
+                                    const int _unlock_statuses = ill::restore_status) -> int;
 
     auto update_replica_size_and_status(rsComm_t& _comm,
                                         const l1desc_t& _l1desc,
@@ -98,7 +98,10 @@ namespace
     auto update_replica_status(rsComm_t& _comm,
                                const l1desc_t& _l1desc,
                                const repl_status_t _new_status,
-                               const bool _send_notifications) -> int;
+                               const bool _send_notifications,
+                               const int _unlock_statuses = ill::restore_status) -> int;
+
+    auto update_replica_status_on_error(rsComm_t& _comm, const l1desc_t& _l1desc) -> int;
 
     auto free_l1_descriptor(int _l1desc_index) -> int;
 
@@ -157,18 +160,17 @@ namespace
         return rsFileClose(&_comm, &input);
     }
 
-    auto unlock_and_publish_replica(
-        rsComm_t& _comm,
-        const ir::replica_proxy_t& _replica,
-        const l1desc& _l1desc,
-        const bool _send_notifications) -> int
+    auto unlock_and_publish_replica(rsComm_t& _comm,
+                                    const ir::replica_proxy_t& _replica,
+                                    const l1desc& _l1desc,
+                                    const bool _send_notifications,
+                                    const int _unlock_statuses) -> int
     {
-        // The sibling replicas are always marked stale because replica_close considers itself to be the new
-        // truth when it is given permission to finalize the replica.
-        constexpr auto unlock_statuses = STALE_REPLICA;
-
         // Unlock the data object but do not publish to catalog because we may want to trigger file_modified.
-        if (const int ec = ill::unlock(_replica.data_id(), _replica.replica_number(), _replica.replica_status(), unlock_statuses); ec < 0) {
+        if (const int ec =
+                ill::unlock(_replica.data_id(), _replica.replica_number(), _replica.replica_status(), _unlock_statuses);
+            ec < 0)
+        {
             irods::log(LOG_ERROR, fmt::format(
                 "[{}:{}] - failed to unlock object [{}]:[{}]",
                 __FUNCTION__, __LINE__, _replica.logical_path(), ec));
@@ -243,7 +245,7 @@ namespace
         // Update the RST with the changes made above to the replica.
         rst::update(repl.data_id(), repl);
 
-        return unlock_and_publish_replica(_comm, repl, _l1desc, _send_notifications);
+        return unlock_and_publish_replica(_comm, repl, _l1desc, _send_notifications, STALE_REPLICA);
     } // update_replica_size_and_status
 
     auto update_replica_size(rsComm_t& _comm, const l1desc_t& _l1desc, const bool _send_notifications) -> int
@@ -273,22 +275,31 @@ namespace
         // Update the RST with the changes made above to the replica.
         rst::update(repl.data_id(), repl);
 
-        return unlock_and_publish_replica(_comm, repl, _l1desc, _send_notifications);
+        return unlock_and_publish_replica(_comm, repl, _l1desc, _send_notifications, STALE_REPLICA);
     } // update_replica_size
 
     auto update_replica_status(rsComm_t& _comm,
                                const l1desc_t& _l1desc,
                                const repl_status_t _new_status,
-                               const bool _send_notifications) -> int
+                               const bool _send_notifications,
+                               const int _unlock_statuses) -> int
     {
-        const auto repl = ir::make_replica_proxy(*_l1desc.dataObjInfo);
+        auto repl = ir::make_replica_proxy(*_l1desc.dataObjInfo);
+
+        repl.replica_status(_new_status);
 
         // Set target replica status in RST as logical locking will not set
         // the status of the target replica.
-        rst::update(repl.data_id(), repl.replica_number(), json{{"data_is_dirty", std::to_string(_new_status)}});
+        rst::update(
+            repl.data_id(), repl.replica_number(), json{{"data_is_dirty", std::to_string(repl.replica_status())}});
 
-        return unlock_and_publish_replica(_comm, repl, _l1desc, _send_notifications);
+        return unlock_and_publish_replica(_comm, repl, _l1desc, _send_notifications, _unlock_statuses);
     } // update_replica_status
+
+    auto update_replica_status_on_error(rsComm_t& _comm, const l1desc_t& _l1desc) -> int
+    {
+        return update_replica_status(_comm, _l1desc, STALE_REPLICA, false);
+    } // update_replica_status_on_error
 
     auto free_l1_descriptor(int _l1desc_index) -> int
     {
@@ -378,14 +389,14 @@ namespace
                 if (update_size && update_status) {
                     if (const auto ec = update_replica_size_and_status(*_comm, l1desc, send_notifications); ec != 0) {
                         rodsLog(LOG_ERROR, "Failed to update the replica size and status in the catalog [error_code=%d].", ec);
-                        update_replica_status(*_comm, l1desc, STALE_REPLICA, false);
+                        update_replica_status_on_error(*_comm, l1desc);
                         return ec;
                     }
                 }
                 else if (update_size) {
                     if (const auto ec = update_replica_size(*_comm, l1desc, send_notifications); ec != 0) {
                         rodsLog(LOG_ERROR, "Failed to update the replica size in the catalog [error_code=%d].", ec);
-                        update_replica_status(*_comm, l1desc, STALE_REPLICA, false);
+                        update_replica_status_on_error(*_comm, l1desc);
                         return ec;
                     }
                 }
@@ -408,9 +419,11 @@ namespace
                         new_status = ill::get_original_replica_status(l1desc.dataObjInfo->dataId, l1desc.dataObjInfo->replNum);
                     }
 
-                    if (const auto ec = update_replica_status(*_comm, l1desc, new_status, send_notifications); ec != 0) {
+                    if (const auto ec =
+                            update_replica_status(*_comm, l1desc, new_status, send_notifications, STALE_REPLICA);
+                        ec != 0) {
                         rodsLog(LOG_ERROR, "Failed to update the replica status in the catalog [error_code=%d].", ec);
-                        update_replica_status(*_comm, l1desc, STALE_REPLICA, false);
+                        update_replica_status_on_error(*_comm, l1desc);
                         return ec;
                     }
                 }
@@ -442,30 +455,30 @@ namespace
             const auto ec = free_l1_descriptor(l1desc_index);
 
             if (ec != 0) {
-                update_replica_status(*_comm, l1desc, STALE_REPLICA, false);
+                update_replica_status_on_error(*_comm, l1desc);
             }
 
             return ec;
         }
         catch (const json::type_error& e) {
             rodsLog(LOG_ERROR, "Failed to extract property from JSON object [error_code=%d]", SYS_INTERNAL_ERR);
-            update_replica_status(*_comm, l1desc, STALE_REPLICA, send_notifications);
+            update_replica_status_on_error(*_comm, l1desc);
             return SYS_INTERNAL_ERR;
         }
         catch (const irods::exception& e) {
             rodsLog(LOG_ERROR, "%s [error_code=%d]", e.what(), e.code());
-            update_replica_status(*_comm, l1desc, STALE_REPLICA, send_notifications);
+            update_replica_status_on_error(*_comm, l1desc);
             return e.code();
         }
         catch (const fs::filesystem_error& e) {
             rodsLog(LOG_ERROR, "%s [error_code=%d]", e.what(), e.code().value());
-            update_replica_status(*_comm, l1desc, STALE_REPLICA, send_notifications);
+            update_replica_status_on_error(*_comm, l1desc);
             return e.code().value();
         }
         catch (const std::exception& e) {
             rodsLog(LOG_ERROR, "An unexpected error occurred while closing the replica. %s [error_code=%d]",
                             e.what(), SYS_INTERNAL_ERR);
-            update_replica_status(*_comm, l1desc, STALE_REPLICA, false);
+            update_replica_status_on_error(*_comm, l1desc);
             return SYS_INTERNAL_ERR;
         }
     } // rs_replica_close

--- a/plugins/resources/compound/libcompound.cpp
+++ b/plugins/resources/compound/libcompound.cpp
@@ -805,8 +805,11 @@ irods::error repl_object(
         const auto free_out = irods::at_scope_exit{[&sync_out] { if (sync_out) std::free(sync_out); }};
         int status = rsFileSyncToArch(_ctx.comm(), &inp, &sync_out );
 
-        // Need to update the physical path with whatever the archive resource came up with
-        if (status >= 0 && CREATE_PATH == dst_create_path) {
+        if (status < 0) {
+            ret = ERROR(status, "rsFileSyncToArch failed");
+        }
+        else if (CREATE_PATH == dst_create_path) {
+            // Need to update the physical path with whatever the archive resource came up with
             rstrcpy( destDataObjInfo->filePath, sync_out->file_name, MAX_NAME_LEN );
         }
     }

--- a/server/api/src/rsDataObjPut.cpp
+++ b/server/api/src/rsDataObjPut.cpp
@@ -328,9 +328,35 @@ namespace
 
             // close the replica, free L1 descriptor
             if (const int ec = irods::close_replica_without_catalog_update(_comm, fd, preserve_rst); ec < 0) {
+                // Closing the replica failed. We need to clean up everything and unlock the data object so that this
+                // data object is left in a workable state.
                 irods::log(LOG_ERROR, fmt::format(
                     "[{}:{}] - error closing replica; ec:[{}]",
                     __FUNCTION__, __LINE__, ec));
+
+                if (const auto l1_desc_ec = freeL1desc(fd); l1_desc_ec != 0) {
+                    irods::log(LOG_ERROR, fmt::format("Failed to release L1 descriptor [error_code={}].", l1_desc_ec));
+                }
+
+                const auto admin_op =
+                    irods::experimental::make_key_value_proxy(l1desc_cache.dataObjInp->condInput).contains(ADMIN_KW);
+                if (const int unlock_ec =
+                        ill::unlock_and_publish(_comm, {final_replica, admin_op}, STALE_REPLICA, ill::restore_status);
+                    unlock_ec < 0)
+                {
+                    irods::log(LOG_ERROR,
+                               fmt::format("[{}:{}] - Failed to unlock data object "
+                                           "[error_code=[{}], path=[{}], hierarchy=[{}]]",
+                                           __func__,
+                                           __LINE__,
+                                           unlock_ec,
+                                           final_replica.logical_path(),
+                                           final_replica.hierarchy()));
+                }
+
+                if (rst::contains(final_replica.data_id())) {
+                    rst::erase(final_replica.data_id());
+                }
 
                 return ec;
             }

--- a/unit_tests/cmake/test_config/irods_key_value_proxy.cmake
+++ b/unit_tests/cmake/test_config/irods_key_value_proxy.cmake
@@ -7,7 +7,11 @@ set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
                             ${CMAKE_SOURCE_DIR}/lib/core/include
                             ${CMAKE_SOURCE_DIR}/lib/api/include
                             ${CMAKE_BINARY_DIR}/lib/api/include
+                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
                             ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
-                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include)
- 
-set(IRODS_TEST_LINK_LIBRARIES irods_common)
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
+
+set(IRODS_TEST_LINK_LIBRARIES
+    irods_common
+    "${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so"
+    )

--- a/unit_tests/cmake/test_config/irods_re_serialization.cmake
+++ b/unit_tests/cmake/test_config/irods_re_serialization.cmake
@@ -16,5 +16,8 @@ set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
                             ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
                             ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
 
-set(IRODS_TEST_LINK_LIBRARIES irods_common
-                              irods_server)
+set(IRODS_TEST_LINK_LIBRARIES
+    irods_common
+    irods_server
+    "${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so"
+    )

--- a/unit_tests/src/test_replica_access_table.cpp
+++ b/unit_tests/src/test_replica_access_table.cpp
@@ -51,6 +51,9 @@ TEST_CASE("replica_access_table")
     REQUIRE(infos[0].token == infos[1].token);
     REQUIRE(infos[0].token != infos[2].token);
 
+    // Erase a PID which does not exist in the replica access table. This should be a no-op.
+    CHECK_NOTHROW(rat::erase_pid(7000));
+
     SECTION("erase and restore entry with single PID")
     {
         auto& info = infos[2];


### PR DESCRIPTION
Addresses https://github.com/irods/irods/issues/6154
Addresses https://github.com/irods/irods/issues/6378
Addresses https://github.com/irods/irods/issues/6479
Addresses https://github.com/irods/irods/issues/6880
Addresses https://github.com/irods/irods/issues/6882
Addresses https://github.com/irods/irods/issues/6886

Companion PR: https://github.com/irods/irods_resource_plugin_s3/pull/2097

Cherry-picked from https://github.com/irods/irods/pull/6884

Core tests are running now. Need to make sure S3 plugin tests pass before merging

There are some differences between this branch and main/4-3-stable. Specifically, the agent cleanup logic is in a completely different file, so the cherry-pick was rather manual in that part. Please review the first (that is, earliest/base) commit carefully.