### PR TITLE
[#6900] Restored specific query, DataObjInCollReCur, for MySQL 8 (main)

### DIFF
--- a/scripts/core_tests_list.json
+++ b/scripts/core_tests_list.json
@@ -81,6 +81,7 @@
     "test_rule_engine_plugin_passthrough",
     "test_rulebase",
     "test_special_collections",
+    "test_specific_queries",
     "test_ssl",
     "test_stacktrace",
     "test_symlink_operations"

--- a/scripts/irods/test/test_specific_queries.py
+++ b/scripts/irods/test/test_specific_queries.py
@@ -1,0 +1,23 @@
+import os
+import unittest
+
+from . import session
+
+class Test_Specific_Queries(session.make_sessions_mixin([], [('alice', 'apass')]), unittest.TestCase):
+
+    def setUp(self):
+        super(Test_Specific_Queries, self).setUp()
+        self.user = self.user_sessions[0]
+
+    def tearDown(self):
+        super(Test_Specific_Queries, self).tearDown()
+
+    def test_DataObjInCollReCur__issue_6900(self):
+        collection = os.path.join(self.user.session_collection, 'test.d')
+        self.user.assert_icommand(['imkdir', 'test.d'])
+
+        data_object_name = 'issue_6900'
+        self.user.assert_icommand(['itouch', os.path.join(collection, data_object_name)])
+
+        expected_output = ['EMPTY_RESC_NAME\n', collection + '\n', data_object_name + '\n']
+        self.user.assert_icommand(['iquest', '--sql', 'DataObjInCollReCur', collection, collection], 'STDOUT', expected_output)

--- a/version.json.dist.in
+++ b/version.json.dist.in
@@ -2,6 +2,6 @@
     "schema_name": "version",
     "schema_version": "v4",
     "irods_version": "@IRODS_VERSION@",
-    "catalog_schema_version": 9,
+    "catalog_schema_version": 10,
     "commit_id": "@IRODS_GIT_SHA1@"
 }


### PR DESCRIPTION
This PR has not been tested.

Notice the bump to the database schema version and the importing of the unittest python module.