### PR TITLE
add test_iqstat to list of core tests (4-2-stable)

### DIFF
--- a/scripts/core_tests_list.json
+++ b/scripts/core_tests_list.json
@@ -32,6 +32,7 @@
     "test_iput_options",
     "test_ipwd",
     "test_iqmod",
+    "test_iqstat",
     "test_iquest",
     "test_ireg",
     "test_irepl",


### PR DESCRIPTION
This was my oversight, which luckily @alanking [caught](https://github.com/irods/irods/pull/6941#pullrequestreview-1317718866), but - as it's after the merge of the [PR](https://github.com/irods/irods/pull/6859) containing the test itself ,  here it is now, as a supplemental PR.  There will be no corresponding pull request for `main` and `4-3-stable`, as the commit contained here will be immediately cherry picked to those branches.