### PR TITLE
[#6912] GenQuery: Add support for || with DATA_RESC_HIER (main)

### DIFF
--- a/scripts/irods/test/test_iquest.py
+++ b/scripts/irods/test/test_iquest.py
@@ -282,3 +282,550 @@ class test_iquest_with_data_resc_hier(unittest.TestCase):
             with self.subTest(op):
                 query = f'select DATA_RESC_HIER where DATA_NAME = \'{self.data_name}\' and DATA_RESC_HIER {op} \'{pattern}\''
                 self.user.assert_icommand(['iquest', '%s', query], 'STDOUT', operations_to_expected_result[op])
+
+
+class test_iquest_logical_or_operator_with_data_resc_hier(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.user = session.mkuser_and_return_session('rodsuser', 'alice', 'apass', lib.get_hostname())
+
+        self.root_resource = 'root'
+        self.mid_resource = 'mid'
+        self.leaf_resource1 = 'leaf1'
+        self.leaf_resource2 = 'leaf2'
+        self.data_name = 'foo'
+        self.logical_path = os.path.join(self.user.session_collection, self.data_name)
+        self.hierarchy1 = ';'.join([self.root_resource, self.mid_resource, self.leaf_resource1])
+        self.hierarchy2 = ';'.join([self.root_resource, self.mid_resource, self.leaf_resource2])
+
+        with session.make_session_for_existing_admin() as admin_session:
+            lib.create_passthru_resource(self.root_resource, admin_session)
+            lib.create_replication_resource(self.mid_resource, admin_session)
+            lib.create_ufs_resource(self.leaf_resource1, admin_session)
+            lib.create_ufs_resource(self.leaf_resource2, admin_session)
+            lib.add_child_resource(self.root_resource, self.mid_resource, admin_session)
+            lib.add_child_resource(self.mid_resource, self.leaf_resource1, admin_session)
+            lib.add_child_resource(self.mid_resource, self.leaf_resource2, admin_session)
+
+        # This should trigger a replication to the other resource.
+        self.user.assert_icommand(['itouch', '-R', self.leaf_resource1, self.logical_path])
+
+        self.base_query = f'select DATA_RESC_HIER where DATA_NAME = \'{self.data_name}\' and DATA_RESC_HIER'
+
+
+    @classmethod
+    def tearDownClass(self):
+        self.user.assert_icommand(['irm', '-f', self.logical_path])
+
+        with session.make_session_for_existing_admin() as admin_session:
+            self.user.__exit__()
+            admin_session.run_icommand(['iadmin', 'rmuser', 'alice'])
+            lib.remove_child_resource(self.mid_resource, self.leaf_resource2, admin_session)
+            lib.remove_child_resource(self.mid_resource, self.leaf_resource1, admin_session)
+            lib.remove_child_resource(self.root_resource, self.mid_resource, admin_session)
+            lib.remove_resource(self.leaf_resource2, admin_session)
+            lib.remove_resource(self.leaf_resource1, admin_session)
+            lib.remove_resource(self.mid_resource, admin_session)
+            lib.remove_resource(self.root_resource, admin_session)
+
+
+    def run_logical_or_query_scenarios(self, scenarios):
+        # Each of the scenarios being tested here is a list of lists of tuples. The tuples consist of an operation, a
+        # condition, and an expected result set:
+        #  - The operation is one of the GenQuery WHERE operations: LIKE, NOT LIKE, =, and !=
+        #  - The condition is a string which will be paired with the operation, e.g. 'root;%'
+        #  - The expected result set is a list of strings representing resource hierarchies which the query will return
+        #
+        # Here is an example scenario:
+        #   [('LIKE', '%;leaf1', [self.hierarchy1]),
+        #    ('NOT LIKE', '%;leaf1', [self.hierarchy2])]
+        #
+        # This will result in a clause for the GenQuery that looks like this:
+        #   LIKE '%;leaf1' || NOT LIKE '%;leaf2'
+        #
+        # The clause will then be put into a GenQuery string run by iquest, which will look like this:
+        #   iquest "%s" "select DATA_RESC_HIER where DATA_NAME = 'foo' and DATA_RESC_HIER LIKE '%;leaf1' || NOT LIKE '%;leaf2'"
+        #
+        # The expected result set is {self.hierarchy1, self.hierarchy2} because the first condition expects
+        # self.hierarchy1 and the second condition expects self.hierarchy2. The || operator combines the expected
+        # result sets.
+        i = 0
+        for scenario in scenarios:
+            i = i + 1
+
+            clauses = []
+            expected_result_set = set()
+            for clause_tuple in scenario:
+                operator = clause_tuple[0]
+                condition = clause_tuple[1]
+                clauses.append(f'{operator} \'{condition}\'')
+
+                for expected_result in clause_tuple[2]:
+                    expected_result_set.add(expected_result)
+
+            query = self.base_query + ' ' + ' || '.join(clauses)
+
+            print("============= (" + query + "): [" + str(i) + "] =============")
+            print(scenario)
+
+            out,err,_ = self.user.run_icommand(['iquest', '%s', query])
+            print(out)
+            print(err)
+
+            if 0 != len(expected_result_set):
+                for result in expected_result_set:
+                    self.assertIn(result, out)
+            else:
+                self.assertIn('CAT_NO_ROWS_FOUND', out)
+
+
+    def test_like_like(self):
+        op1 = 'LIKE'
+        op2 = 'LIKE'
+        scenarios = [
+            [(op1, 'nope;%', []),                                                   (op2, 'nope;%', [])],
+            [(op1, 'nope;%', []),                                                   (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', []),                                                   (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, 'nope;%', []),                                                   (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, 'nope;%', [])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, 'nope;%', [])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, 'nope;%', [])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_like_not_like(self):
+        op1 = 'LIKE'
+        op2 = 'NOT LIKE'
+        scenarios = [
+            [(op1, 'nope;%', []),                                                   (op2, f'{self.root_resource};%', [])],
+            [(op1, 'nope;%', []),                                                   (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', []),                                                   (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, 'nope;%', []),                                                   (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'{self.root_resource};%', [])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, f'{self.root_resource};%', [])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, f'{self.root_resource};%', [])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_like_equals(self):
+        op1 = 'LIKE'
+        op2 = '='
+        # All cases where multiple matches are expected with = have been skipped. These are not valid scenarios for = operator.
+        scenarios = [
+            [(op1, 'nope;%', []),                                                   (op2, 'nope;%', [])],
+        #   [(op1, 'nope;%', []),                                                   (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', []),                                                   (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, 'nope;%', []),                                                   (op2, self.hierarchy2, [self.hierarchy2])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, 'nope;%', [])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, self.hierarchy2, [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, 'nope;%', [])],
+        #   [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, self.hierarchy2, [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, 'nope;%', [])],
+        #   [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, self.hierarchy2, [self.hierarchy2])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_like_not_equals(self):
+        op1 = 'LIKE'
+        op2 = '!='
+        # All cases where no matches are expected with != have been skipped. These are not valid scenarios for != operator.
+        scenarios = [
+        #   [(op1, 'nope;%', []),                                                   (op2, 'nope;%', [])],
+            [(op1, 'nope;%', []),                                                   (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', []),                                                   (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, 'nope;%', []),                                                   (op2, self.hierarchy2, [self.hierarchy1])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, 'nope;%', [])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op1, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, self.hierarchy2, [self.hierarchy1])],
+        #   [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, 'nope;%', [])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy1]),                  (op2, self.hierarchy2, [self.hierarchy1])],
+        #   [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, 'nope;%', [])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy2]),                  (op2, self.hierarchy2, [self.hierarchy1])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_not_like_like(self):
+        op1 = 'NOT LIKE'
+        op2 = 'LIKE'
+        scenarios = [
+            [(op1, f'{self.root_resource};%', []),                  (op2, 'nope;%', [])],
+            [(op1, f'{self.root_resource};%', []),                  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'{self.root_resource};%', []),                  (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, f'{self.root_resource};%', []),                  (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, 'nope;%', [])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, 'nope;%', [])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, 'nope;%', [])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_not_like_not_like(self):
+        op1 = 'NOT LIKE'
+        op2 = 'NOT LIKE'
+        scenarios = [
+            [(op1, f'{self.root_resource};%', []),                  (op2, f'{self.root_resource};%', [])],
+            [(op1, f'{self.root_resource};%', []),                  (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'{self.root_resource};%', []),                  (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, f'{self.root_resource};%', []),                  (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'{self.root_resource};%', [])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, f'{self.root_resource};%', [])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, f'{self.root_resource};%', [])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_not_like_equals(self):
+        op1 = 'NOT LIKE'
+        op2 = '='
+        # All cases where multiple matches are expected with = have been skipped. These are not valid scenarios for = operator.
+        scenarios = [
+            [(op1, f'{self.root_resource};%', []),                  (op2, 'nope;%', [])],
+        #   [(op1, f'{self.root_resource};%', []),                  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'{self.root_resource};%', []),                  (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, f'{self.root_resource};%', []),                  (op2, self.hierarchy2, [self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, 'nope;%', [])],
+        #   [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, self.hierarchy2, [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, 'nope;%', [])],
+        #   [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, self.hierarchy2, [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, 'nope;%', [])],
+        #   [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, self.hierarchy2, [self.hierarchy2])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_not_like_not_equals(self):
+        op1 = 'NOT LIKE'
+        op2 = '!='
+        # All cases where no matches are expected with != have been skipped. These are not valid scenarios for != operator.
+        scenarios = [
+        #   [(op1, f'{self.root_resource};%', []),                  (op2, 'nope;%', [])],
+            [(op1, f'{self.root_resource};%', []),                  (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'{self.root_resource};%', []),                  (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, f'{self.root_resource};%', []),                  (op2, self.hierarchy2, [self.hierarchy1])],
+        #   [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, 'nope;%', [])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, self.hierarchy2, [self.hierarchy1])],
+        #   [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, 'nope;%', [])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource2}', [self.hierarchy1]),  (op2, self.hierarchy2, [self.hierarchy1])],
+        #   [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, 'nope;%', [])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, f'%;{self.leaf_resource1}', [self.hierarchy2]),  (op2, self.hierarchy2, [self.hierarchy1])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_equals_like(self):
+        op1 = '='
+        op2 = 'LIKE'
+        # All cases where multiple matches are expected with = have been skipped. These are not valid scenarios for = operator.
+        scenarios = [
+            [(op1, 'nope;%', []),                                                   (op2, 'nope;%', [])],
+            [(op1, 'nope;%', []),                                                   (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', []),                                                   (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, 'nope;%', []),                                                   (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, 'nope;%', [])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, 'nope;%', [])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, 'nope;%', [])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_equals_not_like(self):
+        op1 = '='
+        op2 = 'NOT LIKE'
+        # All cases where multiple matches are expected with = have been skipped. These are not valid scenarios for = operator.
+        scenarios = [
+            [(op1, 'nope;%', []),                                                   (op2, f'{self.root_resource};%', [])],
+            [(op1, 'nope;%', []),                                                   (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', []),                                                   (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, 'nope;%', []),                                                   (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'{self.root_resource};%', [])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, f'{self.root_resource};%', [])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, f'{self.root_resource};%', [])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_equals_equals(self):
+        op1 = '='
+        op2 = '='
+        # All cases where multiple matches are expected with = have been skipped. These are not valid scenarios for = operator.
+        scenarios = [
+            [(op1, 'nope;%', []),                                                   (op2, 'nope;%', [])],
+        #   [(op1, 'nope;%', []),                                                   (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', []),                                                   (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, 'nope;%', []),                                                   (op2, self.hierarchy2, [self.hierarchy2])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, 'nope;%', [])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, self.hierarchy1, [self.hierarchy1])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, self.hierarchy2, [self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, 'nope;%', [])],
+        #   [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, self.hierarchy2, [self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, 'nope;%', [])],
+        #   [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, self.hierarchy2, [self.hierarchy2])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_equals_not_equals(self):
+        op1 = '='
+        op2 = '!='
+        # All cases where multiple matches are expected with = have been skipped. These are not valid scenarios for = operator.
+        # All cases where no matches are expected with != have been skipped. These are not valid scenarios for != operator.
+        scenarios = [
+        #   [(op1, 'nope;%', []),                                                   (op2, 'nope;%', [])],
+            [(op1, 'nope;%', []),                                                   (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', []),                                                   (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, 'nope;%', []),                                                   (op2, self.hierarchy2, [self.hierarchy1])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, 'nope;%', [])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, self.hierarchy1, [self.hierarchy2])],
+        #   [(op1, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2]),  (op2, self.hierarchy2, [self.hierarchy1])],
+        #   [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, 'nope;%', [])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy1]),                             (op2, self.hierarchy2, [self.hierarchy1])],
+        #   [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, 'nope;%', [])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy2]),                             (op2, self.hierarchy2, [self.hierarchy1])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_not_equals_like(self):
+        op1 = '!='
+        op2 = 'LIKE'
+        # All cases where no matches are expected with != have been skipped. These are not valid scenarios for != operator.
+        scenarios = [
+        #   [(op1, 'nope;%', []),                                   (op2, 'nope;%', [])],
+        #   [(op1, 'nope;%', []),                                   (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+        #   [(op1, 'nope;%', []),                                   (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+        #   [(op1, 'nope;%', []),                                   (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, 'nope;%', [])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, 'nope;%', [])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, 'nope;%', [])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, f'%;{self.leaf_resource1}', [self.hierarchy1])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, f'%;{self.leaf_resource2}', [self.hierarchy2])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_not_equals_not_like(self):
+        op1 = '!='
+        op2 = 'NOT LIKE'
+        # All cases where no matches are expected with != have been skipped. These are not valid scenarios for != operator.
+        scenarios = [
+        #   [(op1, 'nope;%', []),                                   (op2, f'{self.root_resource};%', [])],
+        #   [(op1, 'nope;%', []),                                   (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+        #   [(op1, 'nope;%', []),                                   (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+        #   [(op1, 'nope;%', []),                                   (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'{self.root_resource};%', [])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, f'{self.root_resource};%', [])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, f'{self.root_resource};%', [])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, f'%;{self.leaf_resource2}', [self.hierarchy1])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, f'%;{self.leaf_resource1}', [self.hierarchy2])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_not_equals_equals(self):
+        op1 = '!='
+        op2 = '='
+        # All cases where multiple matches are expected with = have been skipped. These are not valid scenarios for = operator.
+        # All cases where no matches are expected with != have been skipped. These are not valid scenarios for != operator.
+        scenarios = [
+        #   [(op1, 'nope;%', []),                                   (op2, 'nope;%', [])],
+        #   [(op1, 'nope;%', []),                                   (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+        #   [(op1, 'nope;%', []),                                   (op2, self.hierarchy1, [self.hierarchy1])],
+        #   [(op1, 'nope;%', []),                                   (op2, self.hierarchy2, [self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, 'nope;%', [])],
+        #   [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, self.hierarchy2, [self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, 'nope;%', [])],
+        #   [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, self.hierarchy2, [self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, 'nope;%', [])],
+        #   [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, self.hierarchy1, [self.hierarchy1])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, self.hierarchy2, [self.hierarchy2])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_not_equals_not_equals(self):
+        op1 = '!='
+        op2 = '!='
+        # All cases where no matches are expected with != have been skipped. These are not valid scenarios for != operator.
+        scenarios = [
+        #   [(op1, 'nope;%', []),                                   (op2, 'nope;%', [])],
+        #   [(op1, 'nope;%', []),                                   (op2, f'{self.root_resource};%', [self.hierarchy1, self.hierarchy2])],
+        #   [(op1, 'nope;%', []),                                   (op2, self.hierarchy1, [self.hierarchy1])],
+        #   [(op1, 'nope;%', []),                                   (op2, self.hierarchy2, [self.hierarchy2])],
+        #   [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, 'nope;%', [])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, 'nope;%', [self.hierarchy1, self.hierarchy2]),   (op2, self.hierarchy2, [self.hierarchy1])],
+        #   [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, 'nope;%', [])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, self.hierarchy1, [self.hierarchy2]),             (op2, self.hierarchy2, [self.hierarchy1])],
+        #   [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, 'nope;%', [])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, 'nope;%', [self.hierarchy1, self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, self.hierarchy1, [self.hierarchy2])],
+            [(op1, self.hierarchy2, [self.hierarchy1]),             (op2, self.hierarchy2, [self.hierarchy1])],
+        ]
+
+        self.run_logical_or_query_scenarios(scenarios)
+
+
+    def test_invalid_operations(self):
+        pattern = self.hierarchy1
+        valid_operations = [
+            'like',
+            'LIKE',
+            'not like',
+            'not LIKE',
+            'NOT like',
+            'NOT LIKE',
+            '=',
+            '!='
+        ]
+
+        invalid_operations = [
+            '',
+            '==',
+            'lik',
+            'like not like',
+            'not lik',
+            'not like like',
+            'not not like',
+            'not',
+            'notlike',
+            'ot like'
+        ]
+
+        for iop in invalid_operations:
+            with self.subTest(iop):
+                for vop in valid_operations:
+                    # First, with the invalid operation as the first clause of the ||...
+                    query = f'{self.base_query} {iop} \'{pattern}\' || {vop} \'{pattern}\''
+                    self.user.assert_icommand(['iquest', '%s', query], 'STDERR', 'CAT_INVALID_ARGUMENT')
+
+                    # Now, the valid operation as the first clause of the || and the invalid operation as the second.
+                    query = f'{self.base_query} {vop} \'{pattern}\' || {iop} \'{pattern}\''
+                    self.user.assert_icommand(['iquest', '%s', query], 'STDERR', 'CAT_INVALID_ARGUMENT')

--- a/server/api/src/rsGenQuery.cpp
+++ b/server/api/src/rsGenQuery.cpp
@@ -128,21 +128,19 @@ namespace {
         f << '\n';
     }
 
-    auto get_resc_id_cond_for_hier_cond(const std::string_view _cond) -> std::string
+    auto translate_single_data_resc_hier_condition_to_resc_id(const std::string& _cond) -> std::string
     {
         // The default return string will yield 0 results when run in a query because RESC_ID is never '0'.
         constexpr const char* default_condition_str = "='0'";
 
-        const auto cond = std::string{_cond};
-
-        const auto open_quote_pos = cond.find_first_of('\'');
-        const auto close_quote_pos = cond.find_last_of('\'');
+        const auto open_quote_pos = _cond.find_first_of('\'');
+        const auto close_quote_pos = _cond.find_last_of('\'');
         if (close_quote_pos == open_quote_pos) {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-            THROW(SYS_INVALID_INPUT_PARAM, fmt::format("Invalid condition: [{}]", cond));
+            THROW(SYS_INVALID_INPUT_PARAM, fmt::format("Invalid condition: [{}]", _cond));
         }
 
-        const std::string op = cond.substr(0, open_quote_pos);
+        const std::string op = _cond.substr(0, open_quote_pos);
 
         // Only allow =, !=, LIKE, and NOT LIKE to be specified. Check = first because it is used in some
         // critical path operations and will only match 1 result, so it should be quick.
@@ -170,11 +168,11 @@ namespace {
 
         if (!equal_op && !like_op && !not_like_op && !not_equal_op) {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-            THROW(CAT_INVALID_ARGUMENT, fmt::format("Invalid condition: [{}]", cond));
+            THROW(CAT_INVALID_ARGUMENT, fmt::format("Invalid condition: [{}]", _cond));
         }
 
         // Generate a regex by replacing GenQuery wildcards with regex wildcards.
-        std::string hier_regex_str = cond.substr(open_quote_pos + 1, close_quote_pos - open_quote_pos - 1);
+        std::string hier_regex_str = _cond.substr(open_quote_pos + 1, close_quote_pos - open_quote_pos - 1);
         if (!equal_op && !not_equal_op) {
             auto wildcard_pos = hier_regex_str.find_first_of('%');
             while (std::string::npos != wildcard_pos) {
@@ -214,7 +212,33 @@ namespace {
         }
 
         return fmt::format("IN ({})", fmt::join(leaf_ids, ","));
-    } // get_resc_id_cond_for_hier_cond
+    } // translate_single_data_resc_hier_condition_to_resc_id
+
+    auto translate_data_resc_hier_where_clause_to_resc_id(const std::string& _condition) -> std::string
+    {
+        std::string condition_str;
+
+        // For each || operator found, take the condition immediately preceding and translate it from the DATA_RESC_HIER
+        // condition to the equivalent RESC_ID condition.
+        auto previous_or_position = std::string_view::size_type{};
+        for (auto or_position = _condition.find("||", previous_or_position); std::string_view::npos != or_position;
+             or_position = _condition.find("||", previous_or_position))
+        {
+            condition_str += translate_single_data_resc_hier_condition_to_resc_id(
+                _condition.substr(previous_or_position, or_position));
+            condition_str += " || ";
+
+            // Advance the previous position tracker to the current || position, plus 2 so that the next condition to
+            // translate does not include the || itself.
+            previous_or_position = or_position + 2;
+        }
+
+        // There should be one condition found after the last || operator has been found which will need to be
+        // translated because the loop above is translating conditions BEFORE the || operator. || is a binary operation,
+        // so there will necessarily be one left over at the end.
+        return condition_str +=
+               translate_single_data_resc_hier_condition_to_resc_id(_condition.substr(previous_or_position));
+    } // translate_data_resc_hier_where_clause_to_resc_id
 } // anonymous namespace
 
 std::string
@@ -443,7 +467,7 @@ irods::error strip_resc_hier_name_from_query_inp( genQueryInp_t* _inp, int& _pos
             const int inx = inxs[i];
             const char* val = vals[i];
             if (inx == COL_D_RESC_HIER) {
-                const auto new_cond = get_resc_id_cond_for_hier_cond(val);
+                const auto new_cond = translate_data_resc_hier_where_clause_to_resc_id(val);
                 addInxVal(&_inp->sqlCondInp, COL_D_RESC_ID, new_cond.empty() ? "='0'" : new_cond.c_str());
             }
             else {


### PR DESCRIPTION
Addresses #6912 

Unit tests and core tests are passing

Please view this with an eye for optimization. I couldn't come up with any way to avoid some of these copies in a timely fashion :)