### PR TITLE
[#3513] Added use of istream to quota test case (4-2-stable)

### DIFF
--- a/scripts/irods/test/test_quotas.py
+++ b/scripts/irods/test/test_quotas.py
@@ -54,6 +54,8 @@ class Test_Quotas(resource_suite.ResourceBase, unittest.TestCase):
                     lib.make_file(filename_2, 1024, contents='arbitrary')
                     cmd = 'iput -R {0} {1}'.format(self.testresc, filename_2) # should fail
                     self.admin.assert_icommand(cmd.split(), 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
+                    cmd = 'istream write nopes'
+                    self.admin.assert_icommand(cmd.split(), 'STDERR', 'Error: Cannot open data object.', input='some data')
                     cmd = 'iadmin {0} {1} {2} 0'.format(quotatype[0], quotatype[1], quotaresc) # remove quota
                     self.admin.assert_icommand(cmd.split())
                     cmd = 'iadmin cu' # update db


### PR DESCRIPTION
Thinking about this more, I wonder if the call to `rxDataObjOpen` is failing rather than the call to `rxDataObjWrite`.

I'm not sure we can do more for the issue without jumping through hoops because the quota isn't updated as the bytes are written.

To verify if the write operation respects the quota, we'd need to open the data object and then wait for the quota to be exceeded before executing the write operation. Doing that is difficult to do from within the python tests. Doing that from C++ is also difficult due to the lack of tools which allow modifying the server's configuration.

At the very least, we know that this test change increases coverage around quota enforcement.