### PR TITLE
[6495] Improve imkdir inheritance performance (4-2-stable)

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -5057,7 +5057,7 @@ irods::error db_reg_coll_op(
             cllBindVars[cllBindVarCount++] = "1";
             cllBindVars[cllBindVarCount++] = myTime;
             snprintf( tSQL, MAX_SQL_SIZE,
-                      "update R_COLL_MAIN set coll_inheritance=?, modify_ts=? where coll_id=%s",
+                      "update R_COLL_MAIN set coll_inheritance=?, modify_ts=? where coll_id=(select %s)",
                       currStr2 );
             status =  cmlExecuteNoAnswerSql( tSQL, &icss );
 #endif


### PR DESCRIPTION
Improve `imkdir` performance in the case of inheritance by using a subquery in an `UPDATE` statement.
By using a subquery, the planner utilizes an index scan (when optimal) compared to a sequence scan.

The following snippet was produced by creating 10k collections, which has a parent collection with inheritance enabled, before using `EXPLAIN` to estimate the costs of the statements. The first statement is the original, with the second being the new version.

```
ICAT=# EXPLAIN update R_COLL_MAIN set coll_inheritance=12, modify_ts=12 where coll_id=currval('R_ObjectID');
                             QUERY PLAN                              
---------------------------------------------------------------------
 Update on r_coll_main  (cost=0.00..364.79 rows=1 width=713)
   ->  Seq Scan on r_coll_main  (cost=0.00..364.79 rows=1 width=713)
         Filter: (coll_id = currval('r_objectid'::regclass))
(3 rows)

ICAT=# EXPLAIN update R_COLL_MAIN set coll_inheritance=12, modify_ts=12 where coll_id=(SELECT currval('R_ObjectID'));
                                        QUERY PLAN                                        
------------------------------------------------------------------------------------------
 Update on r_coll_main  (cost=0.30..8.31 rows=1 width=713)
   InitPlan 1 (returns $0)
     ->  Result  (cost=0.00..0.01 rows=1 width=8)
   ->  Index Scan using idx_coll_main1 on r_coll_main  (cost=0.29..8.30 rows=1 width=713)
         Index Cond: (coll_id = $0)
(5 rows)
```