### PR TITLE
[#6976] Fix tests for running in topology (4-2-stable)

### DIFF
--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -32,8 +32,15 @@ class Test_AllRules(with_metaclass(metaclass_unittest_test_case_generator.Metacl
     global plugin_name
     plugin_name = IrodsConfig().default_rule_engine_plugin
 
+    # Get the database instance name from the zone report. Test_AllRules does not and shall not run in federation, so
+    # this should be good enough for single machine tests and topology tests for both provider and consumer.
     global database_instance_name
-    database_instance_name = next(iter(IrodsConfig().server_config['plugin_configuration']['database']))
+    database_instance_name = next(
+        iter(
+            json.loads(session.make_session_for_existing_admin().assert_icommand(['izonereport'], 'STDOUT')[1]) \
+                ['zones'][0]['icat_server']['server_config']['plugin_configuration']['database']
+        )
+    )
 
     global rulesdir
     currentdir = os.path.dirname(os.path.realpath(__file__))

--- a/scripts/irods/test/test_iadmin.py
+++ b/scripts/irods/test/test_iadmin.py
@@ -61,6 +61,7 @@ class Test_Iadmin(resource_suite.ResourceBase, unittest.TestCase):
     # iadmin
     ###################
 
+    @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, 'msiDeleteUnusedAVUs does not redirect appropriately. See #6989.')
     @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Applies to the NREP only')
     def test_non_admins_are_not_allowed_to_delete_unused_metadata__issue_6183(self):
         attr_name  = 'issue_6183_attr'
@@ -2140,7 +2141,8 @@ class test_moduser_user(unittest.TestCase):
         """Test downgrading of service account user's type from rodsadmin to other supported types is not allowed."""
         # rodsadmin -> rodsuser
         self.assertEqual('rodsadmin', lib.get_user_type(self.admin, 'rods'))
-        error_msg = 'Cannot downgrade another rodsadmin [rods] running another server [{0}] in this zone.'.format(lib.get_hostname())
+        host = test.settings.ICAT_HOSTNAME
+        error_msg = 'Cannot downgrade another rodsadmin [rods] running another server [{0}] in this zone.'.format(host)
         out, err, ec = self.admin.run_icommand(['iadmin', 'moduser', 'rods', 'type', 'rodsuser'])
         self.assertNotEqual(ec, 0)
         self.assertIn(error_msg, out)

--- a/scripts/irods/test/test_native_rule_engine_plugin.py
+++ b/scripts/irods/test/test_native_rule_engine_plugin.py
@@ -95,6 +95,9 @@ class Test_Native_Rule_Engine_Plugin(resource_suite.ResourceBase, unittest.TestC
             assert_presence_of_attr_value_avu(attr, value, assert_true)
 
     def helper_test_pep(self, rules_to_add, icommand, strings_to_check_for=['THIS IS AN OUT VARIABLE'], number_of_strings_to_look_for=1):
+        # Restart the server here because sometimes the log just stops receiving messages for some unknown reason.
+        IrodsController().restart()
+
         with temporary_core_file() as core:
             time.sleep(1)  # remove once file hash fix is committed #2279
             core.add_rule(rules_to_add)


### PR DESCRIPTION
Addresses #6976 

Running tests:
- [x] Unit tests
- [x] Core tests
- [x] Federation tests
- [x] Topology on provider tests (2h 25m(!))
- [x] Topology on consumer tests (3h 10m(!))

NB: This change is not based on the tip of 4-2-stable at time of writing. My understanding is that tests are failing there, so this change will not be fixing those failing tests (unless I'm instructed otherwise).