### PR TITLE
[#6999] Added unit test for irods::process_stash library (main)

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -58,6 +58,7 @@ set(
   metadata
   packstruct
   parallel_transfer_engine
+  process_stash
   query_builder
   rc_data_obj
   rc_data_obj_repl

--- a/unit_tests/cmake/test_config/irods_process_stash.cmake
+++ b/unit_tests/cmake/test_config/irods_process_stash.cmake
@@ -1,0 +1,11 @@
+set(IRODS_TEST_TARGET irods_process_stash)
+
+set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/src/test_process_stash.cpp)
+
+set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
+                            ${CMAKE_SOURCE_DIR}/lib/core/include
+                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include)
+
+set(IRODS_TEST_LINK_LIBRARIES irods_common)

--- a/unit_tests/src/test_process_stash.cpp
+++ b/unit_tests/src/test_process_stash.cpp
@@ -1,0 +1,67 @@
+#include <catch2/catch.hpp>
+
+#include "irods/process_stash.hpp"
+
+#include <boost/any.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST_CASE("process_stash basic operations")
+{
+    // A POD type which helps to demonstrate the stash's ability to store heterogeneous data.
+    struct pod
+    {
+        int x = 0;
+        int y = 0;
+    };
+
+    // Const data used throughout the test.
+    const int an_integer = 100;
+    const std::string a_string = "some data";
+    const pod a_pod{320, 240};
+
+    // Insert some data into the stash.
+    const auto h1 = irods::process_stash::insert(an_integer);
+    const auto h2 = irods::process_stash::insert(a_string);
+    const auto h3 = irods::process_stash::insert(a_pod);
+
+    // Show that the size of the stash is equivalent to the number of handles.
+    auto handles = irods::process_stash::handles();
+    REQUIRE(handles.size() == 3);
+
+    // Show that the handles returned by the insertion exist in the handles container.
+    const auto handle_exists = [](const auto& _h) noexcept {
+        return [&_h](const auto& _j) noexcept { return _j == _h; };
+    };
+
+    CHECK(std::any_of(std::begin(handles), std::end(handles), handle_exists(h1)));
+    CHECK(std::any_of(std::begin(handles), std::end(handles), handle_exists(h2)));
+    CHECK(std::any_of(std::begin(handles), std::end(handles), handle_exists(h3)));
+
+    // Show that the handles map to the data which generated them.
+    auto* p = irods::process_stash::find(h1);
+    CHECK(boost::any_cast<int&>(*p) == an_integer);
+
+    p = irods::process_stash::find(h2);
+    CHECK(boost::any_cast<std::string&>(*p) == a_string);
+
+    p = irods::process_stash::find(h3);
+    CHECK(boost::any_cast<pod&>(*p).x == a_pod.x);
+    CHECK(boost::any_cast<pod&>(*p).y == a_pod.y);
+
+    // Show that the handles can be used to erase data in the stash.
+    irods::process_stash::erase(h1);
+    CHECK_FALSE(irods::process_stash::find(h1));
+
+    irods::process_stash::erase(h2);
+    CHECK_FALSE(irods::process_stash::find(h2));
+
+    irods::process_stash::erase(h3);
+    CHECK_FALSE(irods::process_stash::find(h3));
+
+    // Show that the stash is now empty.
+    REQUIRE(irods::process_stash::handles().empty());
+}

--- a/unit_tests/unit_tests_list.json
+++ b/unit_tests/unit_tests_list.json
@@ -27,6 +27,7 @@
     "irods_metadata",
     "irods_packstruct",
     "irods_parallel_transfer_engine",
+    "irods_process_stash",
     "irods_query_builder",
     "irods_rc_data_obj",
     "irods_rc_data_obj_repl",


### PR DESCRIPTION
Ported from #7006.

Tweaked the following:
- Header includes for the unit test
- Added clang-tidy NOLINT directive
- Placed files in the correct location
- Applied clang-format

The unit test passed in the testing environment.