### PR TITLE
[#6385] Add DB plugin op for data_object_finalize (4-2-stable)

### DIFF
--- a/plugins/api/src/data_object_finalize.cpp
+++ b/plugins/api/src/data_object_finalize.cpp
@@ -70,8 +70,6 @@ namespace
     using operation = std::function<int(RsComm*, BytesBuf*, BytesBuf**)>;
     // clang-format on
 
-    const auto& cmap = ic::data_objects::column_mapping_operators;
-
     constexpr inline auto database_updated = true;
 
     auto make_error_object(const std::string_view _error_msg = "", const bool _database_updated = false) -> json
@@ -103,165 +101,6 @@ namespace
 
         return {before, after};
     } // split_before_and_after_info
-
-    auto column_is_mutable(const std::string_view _c)
-    {
-        using immutable_columns_list_t = std::vector<const std::string_view>;
-        static const immutable_columns_list_t immutable_columns =
-        {
-            "data_id",
-            "coll_id",
-            "data_name"
-        };
-
-        const auto itr = std::find(
-            std::cbegin(immutable_columns),
-            std::cend(immutable_columns),
-            _c);
-
-        return std::cend(immutable_columns) == itr;
-    } // column_is_mutable
-
-    auto validate_values(json& _obj) -> void
-    {
-        // clang-format off
-        using clock_type    = fs::object_time_type::clock;
-        using duration_type = fs::object_time_type::duration;
-        // clang-format on
-
-        if (std::string_view{SET_TIME_TO_NOW_KW} == _obj.at("modify_ts")) {
-            const auto now = std::chrono::time_point_cast<duration_type>(clock_type::now());
-
-            _obj["modify_ts"] = fmt::format("{:011}", now.time_since_epoch().count());
-        }
-    } // validate_values
-
-    auto generate_sql_update_query() -> std::string
-    {
-        std::string sql{"update R_DATA_MAIN set"};
-
-        for (auto&& c : cmap) {
-            if (!column_is_mutable(c.first)) {
-                continue;
-            }
-
-            sql += fmt::format(" {} = ?,", c.first);
-        }
-        sql.pop_back();
-
-        sql += " where data_id = ? and resc_id = ?";
-
-        return sql;
-    } // generate_sql_update_query
-
-    auto set_replica_state(
-        nanodbc::connection& _db_conn,
-        const std::string_view _db_instance_name,
-        const json& _before,
-        const json& _after) -> void
-    {
-        static const auto sql = generate_sql_update_query();
-
-        irods::log(LOG_DEBUG8, fmt::format("statement:[{}]", sql));
-
-        nanodbc::statement statement{_db_conn};
-        prepare(statement, sql);
-
-        irods::log(LOG_DEBUG9, fmt::format("before:[{}]", _before.dump()));
-        irods::log(LOG_DEBUG9, fmt::format("after:[{}]", _after.dump()));
-
-        // Reserve the size ahead of time to prevent pointer invalidation.
-        // Need to store the bind values in a variable which will outlive
-        // the bind operation scope.
-        std::vector<ic::bind_type> bind_values;
-        bind_values.reserve(cmap.size());
-
-        // Bind values to the statement.
-        std::size_t index = 0;
-        for (auto&& c : cmap) {
-            const auto& key = c.first;
-
-            if (!column_is_mutable(key)) {
-                continue;
-            }
-
-            const auto& bind_fcn = c.second;
-            ic::bind_parameters bp{statement, index, _after, key, bind_values, _db_instance_name};
-
-            bind_fcn(bp);
-
-            index++;
-        }
-
-        // The Oracle ODBC driver will fail on execution of the prepared statement if
-        // a 64-bit integer is bound. To get around this limitation, Oracle allows the
-        // integer to be bound as a string. See the following thread for a little more
-        // information:
-        //
-        //   https://stackoverflow.com/questions/338609/binding-int64-sql-bigint-as-query-parameter-causes-error-during-execution-in-o
-        //
-        if ("oracle" == _db_instance_name) {
-            const auto data_id = _before.at("data_id").get<std::string>();
-            irods::log(LOG_DEBUG9, fmt::format("binding data_id:[{}] at [{}]", data_id, index));
-            statement.bind(index++, data_id.c_str());
-
-            const auto resc_id = _before.at("resc_id").get<std::string>();
-            irods::log(LOG_DEBUG9, fmt::format("binding resc_id:[{}] at [{}]", resc_id, index));
-            statement.bind(index, resc_id.c_str());
-
-            execute(statement);
-        }
-        else {
-            const auto data_id = std::stoull(_before.at("data_id").get<std::string>());
-            irods::log(LOG_DEBUG9, fmt::format("binding data_id:[{}] at [{}]", data_id, index));
-            statement.bind(index++, &data_id);
-
-            const auto resc_id = std::stoull(_before.at("resc_id").get<std::string>());
-            irods::log(LOG_DEBUG9, fmt::format("binding resc_id:[{}] at [{}]", resc_id, index));
-            statement.bind(index, &resc_id);
-
-            execute(statement);
-        }
-    } // set_replica_state
-
-    auto set_data_object_state(
-        nanodbc::connection& _db_conn,
-        const std::string_view _db_instance_name,
-        nanodbc::transaction& _trans,
-        json& _replicas) -> void
-    {
-        try {
-            for (auto& r : _replicas) {
-                auto& after = r.at("after");
-                validate_values(after);
-
-                set_replica_state(_db_conn, _db_instance_name, r.at("before"), after);
-            }
-
-            irods::log(LOG_DEBUG10, "committing transaction");
-            _trans.commit();
-        }
-        catch (const json::exception& e) {
-            THROW(SYS_LIBRARY_ERROR, fmt::format(
-                "[{}:{}] - json exception occurred [{}]",
-                __FUNCTION__, __LINE__, e.what()));
-        }
-        catch (const nanodbc::database_error& e) {
-            THROW(SYS_LIBRARY_ERROR, fmt::format(
-                "[{}:{}] - database error occurred [{}] [{}] [{}]",
-                __FUNCTION__, __LINE__, e.what(), e.state(), e.native()));
-        }
-        catch (const std::exception& e) {
-            THROW(SYS_INTERNAL_ERR, fmt::format(
-                "[{}:{}] - exception occurred [{}]",
-                __FUNCTION__, __LINE__, e.what()));
-        }
-        catch (...) {
-            THROW(SYS_UNKNOWN_ERROR, fmt::format(
-                "[{}:{}] - unknown error occurred",
-                __FUNCTION__, __LINE__));
-        }
-    } // set_data_object_state
 
     auto set_file_object_keywords(const json& _src, irods::file_object_ptr _obj) -> void
     {
@@ -450,30 +289,13 @@ namespace
             return SYS_LIBRARY_ERROR;
         }
 
-        // Actually update the catalog with the information passed in. This is done
-        // transactionally so that the update occurs atomically.
-        try {
-            const auto ec = ic::execute_transaction(db_conn, [&](auto& _trans) -> int
-            {
-                set_data_object_state(db_conn, db_instance_name, _trans, _replicas);
-                return 0;
-            });
+        const auto ec = chl_data_object_finalize(_comm, json{{"replicas", _replicas}}.dump().c_str());
 
-            if (ec < 0) {
-                *_output = irods::to_bytes_buffer(make_error_object("failed to update catalog").dump());
-            }
-
-            return ec;
+        if (ec < 0) {
+            *_output = irods::to_bytes_buffer(make_error_object("failed to update catalog").dump());
         }
-        catch (const irods::exception& e) {
-            const auto msg = e.client_display_what();
 
-            irods::log(LOG_ERROR, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, msg));
-
-            *_output = irods::to_bytes_buffer(make_error_object(msg).dump());
-
-            return e.code();
-        }
+        return ec;
     } // finalize
 
     auto rs_data_object_finalize(

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -40,24 +40,26 @@
 #include "catalog.hpp"
 #include "json_deserialization.hpp"
 
-#include <boost/date_time.hpp>
-#include <boost/regex.hpp>
-#include <boost/lexical_cast.hpp>
-#include <fmt/format.h>
 #include <fmt/chrono.h>
+#include <fmt/format.h>
 #include <nanodbc/nanodbc.h>
+#include <json.hpp>
 
+#include <boost/date_time.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/regex.hpp>
+
+#include <algorithm>
+#include <chrono>
 #include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <locale>
 #include <sstream>
 #include <string>
 #include <string_view>
-#include <iostream>
 #include <type_traits>
 #include <vector>
-#include <algorithm>
-#include <chrono>
-#include <iomanip>
-#include <locale>
 
 using leaf_bundle_t = irods::resource_manager::leaf_bundle_t;
 
@@ -15792,6 +15794,148 @@ auto db_get_delay_rule_info_op(
     }
 } // db_get_delay_info_op
 
+auto db_data_object_finalize_op(irods::plugin_context& _ctx, const char* _json_input) -> irods::error
+{
+    using json = nlohmann::json;
+
+    if (const auto ret = _ctx.valid(); !ret.ok()) {
+        return PASS(ret);
+    }
+
+    constexpr std::array<const char*, 17> column_names = {"data_repl_num",
+                                                          "data_version",
+                                                          "data_type_name",
+                                                          "data_size",
+                                                          "data_path",
+                                                          "data_owner_name",
+                                                          "data_owner_zone",
+                                                          "data_is_dirty",
+                                                          "data_status",
+                                                          "data_checksum",
+                                                          "data_expiry_ts",
+                                                          "data_map_id",
+                                                          "data_mode",
+                                                          "r_comment",
+                                                          "create_ts",
+                                                          "modify_ts",
+                                                          "resc_id"};
+
+    try {
+        auto input = json::parse(_json_input);
+
+        auto& replicas = input.at("replicas");
+        if (replicas.empty()) {
+            return ERROR(JSON_VALIDATION_ERROR, "JSON does not conform to the expected format");
+        }
+
+        const auto get_json_string_value = [](const json& _json, const char* _key) -> const char*
+        {
+            return _json.at(_key).get_ref<const std::string&>().c_str();
+        };
+
+        // Loops over all the replicas and executes an update on that row in R_DATA_MAIN using the replica information
+        // found in the "after" entry for each replica.
+        for (auto& r : replicas) {
+            const auto& before = r.at("before");
+
+            auto& after = r.at("after");
+
+            // SET_TIME_TO_NOW_KW allows the database update to reflect the time of the modification as close as
+            // possible to the actual modification of the replica.
+            {
+                using object_time_type = std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>;
+                using clock_type = object_time_type::clock;
+                using duration_type = object_time_type::duration;
+
+                if (auto& modify_ts = after.at("modify_ts"); modify_ts.get_ref<std::string&>() == SET_TIME_TO_NOW_KW) {
+                    const auto now = std::chrono::time_point_cast<duration_type>(clock_type::now());
+
+                    modify_ts = fmt::format("{:011}", now.time_since_epoch().count());
+                }
+            }
+
+            std::string sql = "update R_DATA_MAIN set";
+
+            for (const auto& c : column_names) {
+                sql += fmt::format(" {} = ?,", c);
+            }
+            sql.pop_back();
+
+            sql += " where data_id = ? and resc_id = ?";
+
+            irods::log(LOG_DEBUG8, fmt::format("statement:[{}]", sql));
+            irods::log(LOG_DEBUG9, fmt::format("before:[{}]", before.dump()));
+            irods::log(LOG_DEBUG9, fmt::format("after:[{}]", after.dump()));
+
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "data_repl_num");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "data_version");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "data_type_name");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "data_size");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "data_path");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "data_owner_name");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "data_owner_zone");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "data_is_dirty");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "data_status");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "data_checksum");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "data_expiry_ts");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "data_map_id");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "data_mode");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "r_comment");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "create_ts");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "modify_ts");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(after, "resc_id");
+
+            cllBindVars[cllBindVarCount++] = get_json_string_value(before, "data_id");
+            cllBindVars[cllBindVarCount++] = get_json_string_value(before, "resc_id");
+
+            // Execute update for this replica. If the update fails, we need to stop immediately because the data object
+            // will not reflect what the caller wanted. In that case, rollback and return an error.
+            if (const auto ec = cmlExecuteNoAnswerSql(sql.c_str(), &icss);
+                0 != ec && CAT_SUCCESS_BUT_WITH_NO_INFO != ec)
+            {
+                _rollback("data_object_finalize");
+
+                std::string msg = fmt::format("cmlExecuteNoAnswerSql failed [ec=[{}]]", ec);
+
+                irods::log(LOG_NOTICE, fmt::format("[{}:{}] - [{}]", __FUNCTION__, __LINE__, msg));
+
+                return ERROR(ec, std::move(msg));
+            }
+        }
+
+        // If everything executed successfully above, we commit all of the changes here, which fulfills the atomicity of
+        // data_object_finalize.
+        if (const auto commit_ec = cmlExecuteNoAnswerSql("commit", &icss); 0 != commit_ec) {
+            const auto& data_id = replicas.front().at("before").at("data_id").get_ref<std::string&>();
+            irods::log(LOG_NOTICE,
+                       fmt::format("[{}:{}] - failure to commit changes [error code=[{}], data_id=[{}]]",
+                                   __func__,
+                                   __LINE__,
+                                   commit_ec,
+                                   data_id));
+
+            return ERROR(commit_ec, "commit failure");
+        }
+    }
+    catch (const json::exception& e) {
+        std::string msg = fmt::format("[{}:{}] - JSON error occurred [{}]", __func__, __LINE__, e.what());
+        irods::log(LOG_ERROR, msg);
+        return ERROR(SYS_LIBRARY_ERROR, std::move(msg));
+    }
+    catch (const std::exception& e) {
+        std::string msg = fmt::format("[{}:{}] - Exception occurred [{}]", __func__, __LINE__, e.what());
+        irods::log(LOG_ERROR, msg);
+        return ERROR(SYS_INTERNAL_ERR, std::move(msg));
+    }
+    catch (...) {
+        std::string msg = fmt::format("[{}:{}] - Unknown error occurred", __func__, __LINE__);
+        irods::log(LOG_ERROR, msg);
+        return ERROR(SYS_UNKNOWN_ERROR, std::move(msg));
+    }
+
+    return SUCCESS();
+} // db_data_object_finalize_op
+
 // =-=-=-=-=-=-=-
 //
 irods::error db_start_operation( irods::plugin_property_map& _props ) {
@@ -16186,6 +16330,9 @@ irods::database* plugin_factory(
         DATABASE_OP_GET_DELAY_RULE_INFO,
         function<error(plugin_context&, const char*, std::vector<std::string>*)>(
             db_get_delay_rule_info_op));
+    pg->add_operation<const char*>(
+        DATABASE_OP_DATA_OBJECT_FINALIZE,
+        function<error(plugin_context&, const char*)>(db_data_object_finalize_op));
 
     return pg;
 

--- a/scripts/irods/test/test_dynamic_peps.py
+++ b/scripts/irods/test/test_dynamic_peps.py
@@ -8,20 +8,22 @@ else:
     import unittest
 
 from . import session
-from .rule_texts_for_tests import rule_texts
-from .. import test
 from .. import lib
 from .. import paths
+from .. import test
 from ..configuration import IrodsConfig
+from ..core_file import temporary_core_file
+from .rule_texts_for_tests import rule_texts
 from textwrap import dedent
 
-class Test_Dynamic_PEPs(session.make_sessions_mixin([('otherrods', 'rods')], []), unittest.TestCase):
+class Test_Dynamic_PEPs(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 'apass')]), unittest.TestCase):
 
     plugin_name = IrodsConfig().default_rule_engine_plugin
 
     def setUp(self):
         super(Test_Dynamic_PEPs, self).setUp()
         self.admin = self.admin_sessions[0]
+        self.user = self.user_sessions[0]
 
     def tearDown(self):
         super(Test_Dynamic_PEPs, self).tearDown()
@@ -199,3 +201,107 @@ class Test_Dynamic_PEPs(session.make_sessions_mixin([('otherrods', 'rods')], [])
                     self.admin.assert_icommand(['irm', '-f', logical_path])
                     self.admin.assert_icommand(['iadmin', 'rum'])
 
+
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'Only implemented for NREP.')
+    @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER , 'Database PEPs only fire on the catalog provider.')
+    def test_pep_database_data_object_finalize__issue_6385(self):
+        other_resource = 'test_pep_database_data_object_finalize_resc'
+        filename = 'test_pep_database_data_object_finalize__issue_6385'
+        contents = 'knock knock'
+        logical_path = os.path.join(self.user.session_collection, filename)
+        expected_attribute = 'latest_replica'
+
+        pep_map = {
+            'irods_rule_engine_plugin-irods_rule_language': dedent('''
+                pep_database_data_object_finalize_post(*instance, *ctx, *out, *replicas) {{
+                    # This PEP annotates an AVU to the target data object indicating the most recently created replica.
+
+                    # Get a JSON handle so we can work with the replicas input.
+                    msiStrlen(*replicas, *size);
+                    msi_json_parse(*replicas, int(*size), *handle);
+
+                    # Get the logical path based on the data ID. (Seems silly that we have to do this.)
+                    msi_json_value(*handle, "/replicas/0/before/data_id", *data_id);
+                    foreach (*result in select COLL_NAME, DATA_NAME where DATA_ID = '*data_id') {{
+                        *logical_path = *result.COLL_NAME ++ '/' ++ *result.DATA_NAME;
+                        break;
+                    }}
+
+                    # Loop over the replicas and find the one which was just created based on "before" replica status.
+                    # We want to get the replica number so we can annotate it as metadata on the data object.
+                    *replica_number = "null";
+
+                    # *replicas is a pure array. Pass an empty string for the JSON pointer to get the size of the array.
+                    msi_json_size(*handle, "/replicas", *array_len);
+                    for (*i = 0; *i < *array_len; *i = *i + 1) {{
+                        msi_json_value(*handle, "/replicas/*i/before/data_is_dirty", *status_before);
+                        # '2' is the intermediate replica status.
+                        if (*status_before == '2') {{
+                            msi_json_value(*handle, "/replicas/*i/after/data_repl_num", *replica_number);
+                            break;
+                        }}
+                    }}
+
+                    # Free the JSON handle because we don't need it anymore.
+                    msi_json_free(*handle);
+
+                    # If replica_number is "null", then no replica was found with replica status of intermediate in its
+                    # "before" object. This database operation is invoked both when locking the data object on open and
+                    # when finalizing the data object on close. In that case, the new replica would not have been
+                    # created yet, so it will not be found in the list of replicas above. We only want to annotate
+                    # metadata when the object was newly created (i.e. its "before" replica status is intermediate) and
+                    # is being closed. Objects opened for appending or overwriting will not have a "before" replica
+                    # status of intermediate.
+                    if (*replica_number != "null") {{
+                        # Annotate the metadata indicating the replica number which was just updated.
+                        msiAddKeyVal(*kvp, "{}", "*replica_number");
+                        msiSetKeyValuePairsToObj(*kvp, "*logical_path", "-d");
+                    }}
+
+                }}''')
+        }
+
+        lib.create_ufs_resource(other_resource, self.admin, hostname=test.settings.HOSTNAME_2)
+
+        try:
+            putfile = os.path.join(self.user.local_session_dir, 'putme')
+            lib.touch(putfile)
+
+            with temporary_core_file() as core:
+                core.add_rule(pep_map[self.plugin_name].format(expected_attribute))
+
+                # Create the first replica with iput. There should be only one replica, it should be good, and it
+                # should annotate metadata indicating that replica 0 as the latest replica.
+                self.user.assert_icommand(['iput', putfile, logical_path])
+                self.assertEqual(str(1), lib.get_replica_status(self.user, os.path.basename(logical_path), 0))
+                self.assertTrue(lib.metadata_attr_with_value_exists(self.user, expected_attribute, str(0)))
+
+                # Create a second replica with istream. There should now be two replicas, one should be good and one
+                # should be stale, and the annotated metadata should indicate that replica 1 is the latest replica.
+                self.user.assert_icommand(['istream', '-R', other_resource, 'write', logical_path], input=contents)
+                self.assertEqual(str(0), lib.get_replica_status(self.user, os.path.basename(logical_path), 0))
+                self.assertEqual(str(1), lib.get_replica_status(self.user, os.path.basename(logical_path), 1))
+                self.assertTrue(lib.metadata_attr_with_value_exists(self.user, expected_attribute, str(1)))
+                self.assertFalse(lib.metadata_attr_with_value_exists(self.user, expected_attribute, str(0)))
+
+                # Overpave the stale replica with irepl. There should still be two replicas, both should be good, and
+                # the annotated metadata should still indicate that replica 1 is the latest replica.
+                self.user.assert_icommand(['irepl', logical_path])
+                self.assertEqual(str(1), lib.get_replica_status(self.user, os.path.basename(logical_path), 0))
+                self.assertEqual(str(1), lib.get_replica_status(self.user, os.path.basename(logical_path), 1))
+                self.assertTrue(lib.metadata_attr_with_value_exists(self.user, expected_attribute, str(1)))
+                self.assertFalse(lib.metadata_attr_with_value_exists(self.user, expected_attribute, str(0)))
+
+        finally:
+            print(self.user.run_icommand(['ils', '-AL', os.path.dirname(logical_path)])[0]) # Debugging
+            print(self.user.run_icommand(['imeta', 'ls', '-d', logical_path])[0]) # Debugging
+
+            for replica_number in [0, 1]:
+                self.admin.run_icommand([
+                    'iadmin', 'modrepl',
+                    'logical_path', logical_path,
+                    'replica_number', str(replica_number),
+                    'DATA_REPL_STATUS', str(0)])
+
+            self.user.run_icommand(['irm', '-f', logical_path])
+            lib.remove_resource(other_resource, self.admin)

--- a/server/core/include/irods_database_constants.hpp
+++ b/server/core/include/irods_database_constants.hpp
@@ -113,6 +113,7 @@ namespace irods {
     const std::string DATABASE_OP_CHECK_PERMISSION_TO_MODIFY_DATA_OBJECT{"database_check_permission_to_modify_data_object"};
     const std::string DATABASE_OP_UPDATE_TICKET_WRITE_BYTE_COUNT{"database_update_ticket_write_byte_count"};
     const std::string DATABASE_OP_GET_DELAY_RULE_INFO{"database_get_delay_rule_info"};
+    const std::string DATABASE_OP_DATA_OBJECT_FINALIZE{"database_data_object_finalize"};
 }; // namespace irods
 
 #endif // __IRODS_DATABASE_CONSTANTS_HPP__

--- a/server/icat/include/icatHighLevelRoutines.hpp
+++ b/server/icat/include/icatHighLevelRoutines.hpp
@@ -288,4 +288,70 @@ auto chl_update_ticket_write_byte_count(RsComm& _comm, const rodsLong_t _data_id
 /// \since 4.2.12
 auto chl_get_delay_rule_info(RsComm& _comm, const char* _rule_id, std::vector<std::string>* _info) -> int;
 
+/// \brief High-level wrapper for atomically updating rows in R_DATA_MAIN for all replicas of a particular data object.
+//
+/// \parblock
+/// \p json_input must have the following JSON structure:
+/// \code{.js}
+/// {
+///     "replicas": [
+///         {
+///             "before": {
+///                 "data_id": <string>,
+///                 "coll_id": <string>,
+///                 "data_repl_num": <string>,
+///                 "data_version": <string>,
+///                 "data_type_name": <string>,
+///                 "data_size": <string>,
+///                 "data_path": <string>,
+///                 "data_owner_name": <string>,
+///                 "data_owner_zone": <string>,
+///                 "data_is_dirty": <string>,
+///                 "data_status": <string>,
+///                 "data_checksum": <string>,
+///                 "data_expiry_ts": <string>,
+///                 "data_map_id": <string>,
+///                 "data_mode": <string>,
+///                 "r_comment": <string>,
+///                 "create_ts": <string>,
+///                 "modify_ts": <string>,
+///                 "resc_id": <string>
+///             },
+///             "after": {
+///                 "data_id": <string>,
+///                 "coll_id": <string>,
+///                 "data_repl_num": <string>,
+///                 "data_version": <string>,
+///                 "data_type_name": <string>,
+///                 "data_size": <string>,
+///                 "data_path": <string>,
+///                 "data_owner_name": <string>,
+///                 "data_owner_zone": <string>,
+///                 "data_is_dirty": <string>,
+///                 "data_status": <string>,
+///                 "data_checksum": <string>,
+///                 "data_expiry_ts": <string>,
+///                 "data_map_id": <string>,
+///                 "data_mode": <string>,
+///                 "r_comment": <string>,
+///                 "create_ts": <string>,
+///                 "modify_ts": <string>,
+///                 "resc_id": <string>
+///             }
+///         },
+///         ...
+///     ]
+/// }
+/// \endcode
+/// \endparblock
+///
+/// \param[in] _comm iRODS comm structure
+/// \param[in] _json_input String holding a JSON object with an array of replicas at key "replicas"
+///
+/// \returns Error code based on whether updating the catalog was successful
+/// \retval 0 Success
+///
+/// \since 4.2.12
+auto chl_data_object_finalize(RsComm& _comm, const char* _replicas) -> int;
+
 #endif // IRODS_ICAT_HIGHLEVEL_ROUTINES_HPP

--- a/server/icat/src/icatHighLevelRoutines.cpp
+++ b/server/icat/src/icatHighLevelRoutines.cpp
@@ -4736,3 +4736,25 @@ auto chl_get_delay_rule_info(RsComm& _comm, const char* _rule_id, std::vector<st
 
     return ret.code();
 } // chl_get_delay_rule_info
+
+auto chl_data_object_finalize(RsComm& _comm, const char* _json_input) -> int
+{
+    irods::database_object_ptr db_obj_ptr;
+    if (const auto ret = irods::database_factory(database_plugin_type, db_obj_ptr); !ret.ok()) {
+        irods::log(PASS(ret));
+        return ret.code();
+    }
+
+    irods::plugin_ptr db_plug_ptr;
+    if (const auto ret = db_obj_ptr->resolve(irods::DATABASE_INTERFACE, db_plug_ptr); !ret.ok()) {
+        irods::log(PASSMSG("failed to resolve database interface", ret));
+        return ret.code();
+    }
+
+    irods::first_class_object_ptr ptr = boost::dynamic_pointer_cast<irods::first_class_object>(db_obj_ptr);
+    irods::database_ptr db = boost::dynamic_pointer_cast<irods::database>(db_plug_ptr);
+
+    const auto ret = db->call(&_comm, irods::DATABASE_OP_DATA_OBJECT_FINALIZE, ptr, _json_input);
+
+    return ret.code();
+} // chl_data_object_finalize


### PR DESCRIPTION
Addresses #6385 

Adapted from and supersedes https://github.com/irods/irods/pull/5664

Still need to do some stuff for this, but putting it up now for discussion purposes. Core tests passed.

- [x] Run unit tests, federation tests, topology tests, etc.
- [x] Investigate and add tests(?) for some scenarios which seem to crash agents (`msi_json_*`?)
- [x] Add more iCommands to PEP test
- [x] Add test for pep_resource_modified_post (see if it's a valid alternative to this and `pep_database_mod_data_obj_meta_post`)