### PR TITLE
Create specific error message on ifsck when file encountered that is not registered. (4-2-stable)

### DIFF
--- a/lib/core/src/fsckUtil.cpp
+++ b/lib/core/src/fsckUtil.cpp
@@ -181,6 +181,9 @@ int chkObjConsistency(rcComm_t* conn,
             status = SYS_INTERNAL_ERR;
         }
     }
+    else if (status == CAT_NO_ROWS_FOUND) {
+        std::printf("WARNING: local file [%s] is not registered in iRODS.\n", inpPath);
+    }
     else {
         std::printf("ERROR chkObjConsistency: rcGenQuery failed: status [%d] genQueryOut [%p] file [%s]\n", status, genQueryOut, inpPath);
     }


### PR DESCRIPTION
All tests (CI and unit) passed.