### PR TITLE
[#6385] Add DB plugin op for data_object_finalize (main)

### DIFF
--- a/server/core/include/irods/irods_database_constants.hpp
+++ b/server/core/include/irods/irods_database_constants.hpp
@@ -114,6 +114,7 @@ namespace irods
     const std::string DATABASE_OP_CHECK_PERMISSION_TO_MODIFY_DATA_OBJECT{"database_check_permission_to_modify_data_object"};
     const std::string DATABASE_OP_UPDATE_TICKET_WRITE_BYTE_COUNT{"database_update_ticket_write_byte_count"};
     const std::string DATABASE_OP_GET_DELAY_RULE_INFO{"database_get_delay_rule_info"};
-} // namespace irods
+    const std::string DATABASE_OP_DATA_OBJECT_FINALIZE{"database_data_object_finalize"};
+}; // namespace irods
 
 #endif // IRODS_DATABASE_CONSTANTS_HPP

--- a/server/icat/include/irods/icatHighLevelRoutines.hpp
+++ b/server/icat/include/irods/icatHighLevelRoutines.hpp
@@ -297,4 +297,70 @@ auto chl_update_ticket_write_byte_count(RsComm& _comm, const rodsLong_t _data_id
 /// \since 4.2.12
 auto chl_get_delay_rule_info(RsComm& _comm, const char* _rule_id, std::vector<std::string>* _info) -> int;
 
+/// \brief High-level wrapper for atomically updating rows in R_DATA_MAIN for all replicas of a particular data object.
+//
+/// \parblock
+/// \p json_input must have the following JSON structure:
+/// \code{.js}
+/// {
+///     "replicas": [
+///         {
+///             "before": {
+///                 "data_id": <string>,
+///                 "coll_id": <string>,
+///                 "data_repl_num": <string>,
+///                 "data_version": <string>,
+///                 "data_type_name": <string>,
+///                 "data_size": <string>,
+///                 "data_path": <string>,
+///                 "data_owner_name": <string>,
+///                 "data_owner_zone": <string>,
+///                 "data_is_dirty": <string>,
+///                 "data_status": <string>,
+///                 "data_checksum": <string>,
+///                 "data_expiry_ts": <string>,
+///                 "data_map_id": <string>,
+///                 "data_mode": <string>,
+///                 "r_comment": <string>,
+///                 "create_ts": <string>,
+///                 "modify_ts": <string>,
+///                 "resc_id": <string>
+///             },
+///             "after": {
+///                 "data_id": <string>,
+///                 "coll_id": <string>,
+///                 "data_repl_num": <string>,
+///                 "data_version": <string>,
+///                 "data_type_name": <string>,
+///                 "data_size": <string>,
+///                 "data_path": <string>,
+///                 "data_owner_name": <string>,
+///                 "data_owner_zone": <string>,
+///                 "data_is_dirty": <string>,
+///                 "data_status": <string>,
+///                 "data_checksum": <string>,
+///                 "data_expiry_ts": <string>,
+///                 "data_map_id": <string>,
+///                 "data_mode": <string>,
+///                 "r_comment": <string>,
+///                 "create_ts": <string>,
+///                 "modify_ts": <string>,
+///                 "resc_id": <string>
+///             }
+///         },
+///         ...
+///     ]
+/// }
+/// \endcode
+/// \endparblock
+///
+/// \param[in] _comm iRODS comm structure
+/// \param[in] _json_input String holding a JSON object with an array of replicas at key "replicas"
+///
+/// \returns Error code based on whether updating the catalog was successful
+/// \retval 0 Success
+///
+/// \since 4.2.12
+auto chl_data_object_finalize(RsComm& _comm, const char* _json_input) -> int;
+
 #endif // IRODS_ICAT_HIGHLEVEL_ROUTINES_HPP

--- a/server/icat/src/icatHighLevelRoutines.cpp
+++ b/server/icat/src/icatHighLevelRoutines.cpp
@@ -4817,3 +4817,28 @@ auto chl_get_delay_rule_info(RsComm& _comm, const char* _rule_id, std::vector<st
 
     return ret.code();
 } // chl_get_delay_rule_info
+
+auto chl_data_object_finalize(RsComm& _comm, const char* _json_input) -> int
+{
+    irods::database_object_ptr db_obj_ptr;
+    if (const auto ret = irods::database_factory(database_plugin_type, db_obj_ptr); !ret.ok()) {
+        irods::log(PASS(ret));
+        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+        return ret.code();
+    }
+
+    irods::plugin_ptr db_plug_ptr;
+    if (const auto ret = db_obj_ptr->resolve(irods::DATABASE_INTERFACE, db_plug_ptr); !ret.ok()) {
+        irods::log(PASSMSG("failed to resolve database interface", ret));
+        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+        return ret.code();
+    }
+
+    irods::first_class_object_ptr ptr = boost::dynamic_pointer_cast<irods::first_class_object>(db_obj_ptr);
+    irods::database_ptr db = boost::dynamic_pointer_cast<irods::database>(db_plug_ptr);
+
+    const auto ret = db->call(&_comm, irods::DATABASE_OP_DATA_OBJECT_FINALIZE, ptr, _json_input);
+
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+    return ret.code();
+} // chl_data_object_finalize


### PR DESCRIPTION
Addresses #6385

Cherry-picked from #7012 

Supersedes #5665

Major difference from 4-2-stable is a hefty application of `NOLINTNEXTLINE` to placate clang-tidy and clang-format had some opinions which were addressed. There is one issue clang-tidy is still upset about that I am not going to address since it has to do with a static constant string in a long list of others like it which have the same issue.

Core tests are running