### PR TITLE
[6918] Correct msiAddKeyVal behavior (4-2-stable)

### DIFF
--- a/lib/core/src/msParam.cpp
+++ b/lib/core/src/msParam.cpp
@@ -1451,60 +1451,61 @@ int
 addKeyValToMspStr( msParam_t * keyStr, msParam_t * valStr,
                    msParam_t * msKeyValStr ) {
 
-    if ( ( keyStr == NULL && valStr == NULL ) || msKeyValStr == NULL ) {
+    if ((keyStr == nullptr && valStr == nullptr) || msKeyValStr == nullptr) {
         return SYS_INTERNAL_NULL_INPUT_ERR;
     }
 
-    if ( msKeyValStr->type == NULL ) {
-        fillStrInMsParam( msKeyValStr, NULL );
+    if (msKeyValStr->type == nullptr) {
+        fillStrInMsParam(msKeyValStr, nullptr);
     }
 
-    char *keyPtr = parseMspForStr( keyStr );
-    int keyLen;
-    if ( keyPtr == NULL || strcmp( keyPtr, MS_NULL_STR ) == 0 ) {
-        keyLen = 0;
-    }
-    else {
-        keyLen = strlen( keyPtr );
-    }
+    auto get_length{[](const char* str) -> std::size_t {
+        if (str == nullptr || std::strcmp(str, MS_NULL_STR) == 0) {
+            return 0;
+        }
+        return std::strlen(str);
+    }};
 
-    char *valPtr = parseMspForStr( valStr );
-    int valLen;
-    if ( valPtr == NULL || strcmp( valPtr, MS_NULL_STR ) == 0 ) {
-        valLen = 0;
-    }
-    else {
-        valLen = strlen( valPtr );
-    }
-    if ( valLen + keyLen <= 0 ) {
+    const char *keyPtr{parseMspForStr(keyStr)};
+    int keyLen{static_cast<int>(get_length(keyPtr))};
+
+    const char *valPtr{parseMspForStr(valStr)};
+    int valLen{static_cast<int>(get_length(valPtr))};
+
+    // Handle case where key and value are empty strings
+    if (valLen + keyLen <= 0) {
         return 0;
     }
 
-    char *oldKeyValPtr = parseMspForStr( msKeyValStr );
-    char *newKeyValPtr, *tmpPtr;
-    if ( oldKeyValPtr == NULL ) {
-        int newLen = valLen + keyLen + 10;
-        newKeyValPtr = ( char * )malloc( newLen );
-        *newKeyValPtr = '\0';
-        tmpPtr = newKeyValPtr;
+    char *oldKeyValPtr{parseMspForStr(msKeyValStr)};
+
+    const int old_len{oldKeyValPtr == nullptr ? 0 : static_cast<int>(std::strlen(oldKeyValPtr))};
+    const int new_len{old_len + valLen + keyLen + 10};
+
+    char *newKeyValPtr{static_cast<char*>(std::malloc(new_len * sizeof(char)))};
+    char *tmpPtr{newKeyValPtr};
+    if (old_len > 0) {
+        std::snprintf(newKeyValPtr, new_len, "%s%s", oldKeyValPtr, MS_INP_SEP_STR);
+
+        constexpr auto separator_length{std::char_traits<char>::length(MS_INP_SEP_STR)};
+        tmpPtr += old_len + separator_length;
     }
     else {
-        int oldLen = strlen( oldKeyValPtr );
-        int newLen = oldLen + valLen + keyLen + 10;
-        newKeyValPtr = ( char * )malloc( newLen );
-        snprintf( newKeyValPtr, newLen, "%s%s", oldKeyValPtr, MS_INP_SEP_STR );
-        tmpPtr = newKeyValPtr + oldLen + 4;
-        free( oldKeyValPtr );
+        *newKeyValPtr = '\0';
     }
+    std::free(oldKeyValPtr);
 
-    if ( keyLen > 0 ) {
-        snprintf( tmpPtr, keyLen + 2, "%s=", keyPtr );
-        tmpPtr += keyLen + 1;
+    constexpr auto null_term_length{1};
+
+    if (keyLen > 0) {
+        constexpr auto null_term_and_kv_separator_length{2};
+        std::snprintf(tmpPtr, keyLen + null_term_and_kv_separator_length, "%s=", keyPtr);
+        tmpPtr += keyLen + null_term_length;
     }
-    if ( valLen > 0 ) {
-        snprintf( tmpPtr, valLen + 2, "%s", valPtr );
+    if (valLen > 0) {
+        std::snprintf(tmpPtr, valLen + null_term_length, "%s", valPtr);
     }
-    msKeyValStr->inOutStruct = ( void * ) newKeyValPtr;
+    msKeyValStr->inOutStruct = newKeyValPtr;
 
     return 0;
 }

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -664,6 +664,110 @@ OUTPUT ruleExecOut
         self.rods_session.assert_icommand("irule -F " + rule_file);
 
     @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for irods_rule_language REP')
+    def test_msiAddKeyValToMspStr_works_with_empty_string__issue_6918(self):
+        rule_file="test_msiAddKeyValToMspStr.r"
+        rule_string= '''
+msiTestAddKeyValToMspStr {{
+    *Flag = "";
+    msiAddKeyValToMspStr("keyOnly", "", *Flag);
+    writeLine("stdout", *Flag);
+
+    *Flag = "";
+    msiAddKeyValToMspStr("", "valueOnly", *Flag);
+    writeLine("stdout", *Flag);
+
+    *Flag = "";
+    msiAddKeyValToMspStr("key", "value", *Flag);
+    writeLine("stdout", *Flag);
+}}
+
+INPUT null
+OUTPUT ruleExecOut
+'''
+
+        with open(rule_file, 'w') as f:
+            f.write(rule_string)
+
+        rep_name = 'irods_rule_engine_plugin-irods_rule_language-instance'
+        self.admin.assert_icommand(['irule', '-r', rep_name, '-F', rule_file], 'STDOUT_MULTILINE', ['keyOnly=', 'valueOnly', 'key=value'])
+
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for irods_rule_language REP')
+    def test_msiRmColl_removes_trash__issue_6918(self):
+        collection_to_free = os.path.join(self.admin.session_collection, 'freeMe')
+
+        # Generate trash
+        self.admin.assert_icommand(['itouch', collection_to_free])
+        self.admin.assert_icommand(['irm', collection_to_free])
+
+        rule_file="test_msiRmCollTrash.r"
+        rule_string= '''
+msiTestRmCollRemovesTrash {{
+    *Flag = "";
+    *Coll = "{trash_col}";
+    msiAddKeyValToMspStr("irodsAdminRmTrash", "", *Flag);
+    msiRmColl(*Coll, *Flag, *result);
+}}
+
+INPUT null
+OUTPUT ruleExecOut
+'''.format(trash_col=os.path.join(self.admin.session_collection_trash))
+
+        with open(rule_file, 'w') as f:
+            f.write(rule_string)
+
+        rep_name = 'irods_rule_engine_plugin-irods_rule_language-instance'
+        self.admin.assert_icommand(['irule', '-r', rep_name, '-F', rule_file])
+
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for irods_rule_language REP')
+    def test_msiRmColl_removes_collection__issue_6918(self):
+        collection_to_free = os.path.join(self.admin.session_collection, 'freeMe')
+
+        self.admin.assert_icommand(['imkdir', collection_to_free])
+
+        rule_file="test_msiRmCollSimple.r"
+        rule_string= '''
+msiTestRmCollSimple {{
+    *Flag = "";
+    *Coll = "{collection}";
+    msiRmColl(*Coll, *Flag, *result);
+}}
+
+INPUT null
+OUTPUT ruleExecOut
+'''.format(collection=collection_to_free)
+
+        with open(rule_file, 'w') as f:
+            f.write(rule_string)
+
+        rep_name = 'irods_rule_engine_plugin-irods_rule_language-instance'
+        self.admin.assert_icommand(['irule', '-r', rep_name, '-F', rule_file])
+
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for irods_rule_language REP')
+    def test_msiRmColl_removes_collection_via_flag__issue_6918(self):
+        collection_to_free = os.path.join(self.admin.session_collection, 'freeMe')
+
+        self.admin.assert_icommand(['imkdir', collection_to_free])
+
+        rule_file="test_msiRmCollViaFlag.r"
+        rule_string= '''
+msiTestRmCollWithFlag {{
+    *Flag = "";
+    *Coll = "";
+    msiAddKeyValToMspStr("collName", "{collection}", *Flag);
+    msiRmColl(*Coll, *Flag, *result);
+}}
+
+INPUT null
+OUTPUT ruleExecOut
+'''.format(collection=collection_to_free)
+
+        with open(rule_file, 'w') as f:
+            f.write(rule_string)
+
+        rep_name = 'irods_rule_engine_plugin-irods_rule_language-instance'
+        self.admin.assert_icommand(['irule', '-r', rep_name, '-F', rule_file])
+
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for irods_rule_language REP')
     def test_msiCheckAccess_3309(self):
 
         data_obj_rule_file="test_msiCheckAccess_data_obj_3309.r"

--- a/server/re/src/reDataObjOpr.cpp
+++ b/server/re/src/reDataObjOpr.cpp
@@ -2074,7 +2074,10 @@ msiCollCreate( msParam_t *inpParam1, msParam_t *inpParam2, msParam_t *outParam, 
  *                      it in the trash. This keyWd has no value. But the
  *                      '=' character is still needed.
  *        \li "irodsAdminRmTrash" - Admin remove trash. This keyWd has no value.
+ *                              inpParam1 must be a path to a trash collection.
  *        \li "irodsRmTrash" - Remove trash. This keyWd has no value.
+ *        \li "collName" - Replaces inpParam1 with value in collName. An alternate
+ *                      method to set the collection to remove.
  * \param[out] outParam - an INT_MS_T containing the status.
  * \param[in,out] rei - The RuleExecInfo structure that is automatically
  *    handled by the rule engine. The user does not include rei as a


### PR DESCRIPTION
`msiAddKeyValToMspStr()` now can handle empty strings/key-value pairs properly.