### PR TITLE
[#6997] Add admin keyword support to purge_cache (4-2-stable)

### DIFF
--- a/plugins/resources/compound/libcompound.cpp
+++ b/plugins/resources/compound/libcompound.cpp
@@ -840,7 +840,8 @@ irods::error repl_object(
 
                 // If we got a REPLICA_IS_BEING_STAGED error, just remove the cache replica.
                 if (REPLICA_IS_BEING_STAGED == error_code_set_to_oprStatus_on_dest_close) {
-                    irods::purge_cache(*_ctx.comm(), *replica.get());
+                    constexpr bool use_admin_kw = true;
+                    irods::trim_replica(*_ctx.comm(), *replica.get(), use_admin_kw);
                 }
             }
             if (source_l1descInx > 0) {

--- a/server/api/src/rsDataObjClose.cpp
+++ b/server/api/src/rsDataObjClose.cpp
@@ -610,7 +610,7 @@ namespace
             apply_static_peps(_comm, _inp, _fd, l1desc.oprStatus);
 
             if (L1desc[_fd].purgeCacheFlag) {
-                irods::purge_cache(_comm, *l1desc.dataObjInfo);
+                irods::trim_replica(_comm, *l1desc.dataObjInfo);
             }
 
             return l1desc.oprStatus;
@@ -630,7 +630,7 @@ namespace
         l1desc.bytesWritten = l1desc.dataObjInfo->dataSize;
 
         if (L1desc[_fd].purgeCacheFlag) {
-            irods::purge_cache(_comm, *l1desc.dataObjInfo);
+            irods::trim_replica(_comm, *l1desc.dataObjInfo);
         }
 
         apply_static_peps(_comm, _inp, _fd, l1desc.oprStatus);
@@ -654,7 +654,7 @@ namespace
 
         if (l1desc.oprStatus >= 0) {
             if (l1desc.purgeCacheFlag) {
-                irods::purge_cache(_comm, *l1desc.dataObjInfo);
+                irods::trim_replica(_comm, *l1desc.dataObjInfo);
             }
 
             irods::apply_metadata_from_cond_input(_comm, *l1desc.dataObjInp);

--- a/server/api/src/rsDataObjPut.cpp
+++ b/server/api/src/rsDataObjPut.cpp
@@ -401,7 +401,7 @@ namespace
             }
 
             if (l1desc_cache.purgeCacheFlag) {
-                irods::purge_cache(_comm, *final_replica.get());
+                irods::trim_replica(_comm, *final_replica.get());
             }
 
             if (status < 0) {

--- a/server/api/src/rsDataObjRepl.cpp
+++ b/server/api/src/rsDataObjRepl.cpp
@@ -668,11 +668,11 @@ namespace
         }
 
         if (source_fd.purgeCacheFlag > 0) {
-            irods::purge_cache(_comm, *source_replica.get());
+            irods::trim_replica(_comm, *source_replica.get());
         }
 
         if (destination_fd.purgeCacheFlag > 0) {
-            irods::purge_cache(_comm, *destination_replica.get());
+            irods::trim_replica(_comm, *destination_replica.get());
         }
 
         if (status >= 0) {

--- a/server/core/include/finalize_utilities.hpp
+++ b/server/core/include/finalize_utilities.hpp
@@ -91,8 +91,14 @@ namespace irods
     /// \since 4.2.9
     auto apply_static_post_pep(RsComm& _comm, l1desc& _l1desc, const int _operation_status, std::string_view _pep_name) -> int;
 
-    // TODO: ...remove this.
-    auto purge_cache(RsComm& _comm, DataObjInfo& _info) -> int;
+    /// \brief Trims the replica referred to by \p _info.
+    ///
+    /// \param[in] _comm The server communication object.
+    /// \param[in] _info DataObjInfo which contains information about the replica to trim.
+    /// \param[in] _admin_operation Adds the admin keyword to the input to the trim API if true.
+    ///
+    /// \returns return code of rsDataObjTrim
+    auto trim_replica(RsComm& _comm, DataObjInfo& _info, bool _admin_operation = false) -> int;
 
     /// \brief Call rs_replica_close without touching the catalog
     ///

--- a/server/core/src/finalize_utilities.cpp
+++ b/server/core/src/finalize_utilities.cpp
@@ -175,7 +175,7 @@ namespace irods
         return size_in_vault;
     } // get_size_in_vault
 
-    auto purge_cache(RsComm& _comm, DataObjInfo& _info) -> int
+    auto trim_replica(RsComm& _comm, DataObjInfo& _info, bool _admin_operation) -> int
     {
         auto replica = irods::experimental::replica::make_replica_proxy(_info);
 
@@ -188,6 +188,10 @@ namespace irods
         cond_input[REPL_NUM_KW] = std::to_string(replica.replica_number());
         cond_input[RESC_HIER_STR_KW] = replica.hierarchy();
 
+        if (_admin_operation) {
+            cond_input[ADMIN_KW] = "";
+        }
+
         int status = rsDataObjTrim(&_comm, &inp);
         if (status < 0) {
             irods::log(LOG_ERROR, fmt::format(
@@ -195,7 +199,7 @@ namespace irods
                 __FUNCTION__, replica.hierarchy(), replica.logical_path()));
         }
         return status;
-    } // purge_cache
+    } // trim_replica
 
     auto duplicate_l1_descriptor(const l1desc& _src) -> l1desc
     {

--- a/server/re/src/reDataObjOpr.cpp
+++ b/server/re/src/reDataObjOpr.cpp
@@ -1516,7 +1516,7 @@ msiDataObjGet( msParam_t *inpParam1, msParam_t *msKeyValStr,
 }
 
 /**
-* \fn msiDataObjChksum (msParam_t *inpParam1, msParam_t *msKeyValStr, msParam_t *outParam, ruleExecInfo_t *rei)
+ * \fn msiDataObjChksum (msParam_t *inpParam1, msParam_t *msKeyValStr, msParam_t *outParam, ruleExecInfo_t *rei)
  *
  * \brief This microservice calls rsDataObjChksum to chksum the iput data object as part of a workflow execution.
  *
@@ -1558,7 +1558,7 @@ msiDataObjGet( msParam_t *inpParam1, msParam_t *msKeyValStr,
  * \pre none
  * \post none
  * \sa none
-**/
+ **/
 int
 msiDataObjChksum( msParam_t *inpParam1, msParam_t *msKeyValStr,
                   msParam_t *outParam, ruleExecInfo_t *rei ) {
@@ -1594,8 +1594,8 @@ msiDataObjChksum( msParam_t *inpParam1, msParam_t *msKeyValStr,
         return rei->status;
     }
 
-    validKwFlags = CHKSUM_ALL_FLAG | FORCE_CHKSUM_FLAG | REPL_NUM_FLAG |
-                   OBJ_PATH_FLAG | VERIFY_CHKSUM_FLAG | ADMIN_FLAG;
+    validKwFlags =
+        CHKSUM_ALL_FLAG | FORCE_CHKSUM_FLAG | REPL_NUM_FLAG | OBJ_PATH_FLAG | VERIFY_CHKSUM_FLAG | ADMIN_FLAG;
     if ( ( rei->status = parseMsKeyValStrForDataObjInp( msKeyValStr,
                          myDataObjInp, KEY_WORD_KW, validKwFlags, &outBadKeyWd ) ) < 0 ) {
         if ( outBadKeyWd != NULL ) {


### PR DESCRIPTION
Once again, and perhaps finally, addresses #6997 

Tests exist in companion PR: https://github.com/irods/irods_resource_plugin_s3/pull/2106

One thing you may notice is that `purge_cache` is a bit of a misnomer... The function actually just trims whatever replica you specify with the passed in `DataObjInfo&`. This makes it a pretty handy replacement to calling trim API directly. I renamed it to `trim_replica` since it's a server-only function. I left this in a separate commit so it can be easily reverted.

Unit tests passed. Running regular test suite to make sure nothing fell over. Working with @JustinKyleJames to check the Glacier tests.