### PR TITLE
[#5411] Skip iinit test when SSL is enabled (4-2-stable)

### DIFF
--- a/scripts/irods/test/test_misc.py
+++ b/scripts/irods/test/test_misc.py
@@ -220,6 +220,7 @@ class Test_Misc(session.make_sessions_mixin([('otherrods', 'rods')], []), unitte
     def test_scoped_permission__issue_7032(self):
         self.admin.assert_icommand(['irule', '-r', 'irods_rule_engine_plugin-irods_rule_language-instance', 'msi_test_scoped_permission', 'null', 'ruleExecOut'])
 
+    @unittest.skipIf(test.settings.USE_SSL, 'iinit does not correctly create irods_environment.json with SSL enabled.')
     def test_iinit_does_not_crash_from_long_home_directory__issue_5411(self):
         # Create a temp directory
         temp_dir_name = tempfile.mkdtemp()


### PR DESCRIPTION
Addresses #5411 

Found while running tests in topology on consumer with SSL enabled