### PR TITLE
[7048, 7161] Use error stack for `clientLogin` (main)

### DIFF
--- a/lib/core/include/irods/rodsError.h
+++ b/lib/core/include/irods/rodsError.h
@@ -2,7 +2,10 @@
 #define RODS_ERROR_H__
 
 #ifdef __cplusplus
-#include <string>
+#  include <cstdio>
+#  include <string>
+#else
+#  include <stdio.h>
 #endif
 
 #define ERR_MSG_LEN             1024
@@ -33,6 +36,20 @@ typedef struct ErrorStack {
     struct ErrorMessage **errMsg;
 } rError_t;
 
+/// \brief Allocate memory for the ErrorStack struct if the dereferenced pointer is null.
+///
+/// Below is an example demonstrating the usage.
+/// \code{.cpp}
+/// struct ErrorStack* p = NULL;
+/// allocate_error_stack_if_necessary(&p);
+/// assert(p != NULL);
+/// \endcode
+///
+/// \param[in,out] _stack the ErrorStack to be allocated
+///
+/// \since 4.3.1
+void allocate_error_stack_if_necessary(struct ErrorStack** _stack);
+
 /// \brief Add an error msg to the ErrorStack struct up to MAX_ERROR_MESSAGES.
 ///
 /// \param[in/out] myError the ErrorStack struct for the error msg.
@@ -43,6 +60,25 @@ typedef struct ErrorStack {
 /// \retval 0 on success
 /// \retval USER__NULL_INPUT_ERR if myError is NULL
 int addRErrorMsg(struct ErrorStack *myError, const int status, const char *msg);
+
+/// \brief Add an error msg to the ErrorStack struct up to MAX_ERROR_MESSAGES. Allocates ErrorStack if necessary.
+///
+/// Below is an example demonstrating the usage.
+/// \code{.cpp}
+/// struct ErrorStack* p = NULL;
+/// allocate_if_necessary_and_add_rError_msg(&p, 0, "Error Message");
+/// assert(p != NULL);
+/// \endcode
+///
+/// \param[in,out] _stack the ErrorStack struct for the error msg. Will be allocated if necessary.
+/// \param[in] _status the input error status.
+/// \param[in] _msg the error msg string. This string will be copied to myError.
+///
+/// \returns error code
+/// \retval 0 on success
+///
+/// \since 4.3.1
+int allocate_if_necessary_and_add_rError_msg(struct ErrorStack** _stack, const int _status, const char* _msg);
 
 /// \brief Frees the ErrorStack and its contents
 ///
@@ -72,7 +108,7 @@ int replErrorStack(struct ErrorStack *srcRError, struct ErrorStack *destRError);
 /// \retval USER__NULL_INPUT_ERR if myError is NULL
 int freeRErrorContent(struct ErrorStack *myError);
 
-/// \brief Print the contents of the provided ErrorStack
+/// \brief Print the contents of the provided ErrorStack to stdout
 ///
 /// \parblock
 /// The output takes the following form:
@@ -91,6 +127,28 @@ int freeRErrorContent(struct ErrorStack *myError);
 /// \retval 0 always
 /// \retval USER__NULL_INPUT_ERR if rError is NULL
 int printErrorStack(struct ErrorStack *rError);
+
+/// \brief Print the contents of the provided ErrorStack to given file
+///
+/// \parblock
+/// The output takes the following form:
+///
+/// Level 0: <error message>
+/// Level 1: <error message>
+/// ...
+/// Level 99: <error message>
+///
+/// If the error status for a particular ErrorMessage is STDOUT_STATUS, "Level <int>: " is not printed.
+/// \endparblock
+///
+/// \param[in,out] rError the ErrorStack which is to have its contents printed
+/// \param[in,out] stream the stream where the ErrorStack will be printed to
+///
+/// \returns error code
+/// \retval 0 always
+/// \retval USER__NULL_INPUT_ERR if rError is NULL
+/// \retval FILE_WRITE_ERROR if std::fprintf fails
+int print_error_stack_to_file(const struct ErrorStack* rError, FILE* stream);
 
 #ifdef __cplusplus
 }

--- a/lib/core/src/clientLogin.cpp
+++ b/lib/core/src/clientLogin.cpp
@@ -55,7 +55,8 @@ namespace
 
             log_auth::info(msg);
 
-            printError(&_comm, ec, const_cast<char*>(msg.data()));
+            // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+            allocate_if_necessary_and_add_rError_msg(&_comm.rError, ec, msg.c_str());
 
             return ec;
         }
@@ -68,7 +69,7 @@ namespace
 
             log_auth::info(msg);
 
-            printError(&_comm, ec, const_cast<char*>(msg.data()));
+            allocate_if_necessary_and_add_rError_msg(&_comm.rError, ec, msg.c_str());
 
             return ec;
         }
@@ -81,7 +82,7 @@ namespace
 
             log_auth::info(msg);
 
-            printError(&_comm, ec, const_cast<char*>(msg.data()));
+            allocate_if_necessary_and_add_rError_msg(&_comm.rError, ec, msg.c_str());
 
             return ec;
         }
@@ -94,7 +95,7 @@ namespace
 
             log_auth::info(msg);
 
-            printError(&_comm, ec, const_cast<char*>(msg.data()));
+            allocate_if_necessary_and_add_rError_msg(&_comm.rError, ec, msg.c_str());
 
             return ec;
         }
@@ -130,29 +131,6 @@ void setSessionSignatureClientside( char* _sig ) {
         ( unsigned char )_sig[15] );
 
 } // setSessionSignatureClientside
-
-int printError( rcComm_t *Conn, int status, char *routineName ) {
-    rError_t *Err;
-    rErrMsg_t *ErrMsg;
-    int i, len;
-    if ( Conn ) {
-        if ( Conn->rError ) {
-            Err = Conn->rError;
-            len = Err->len;
-            for ( i = 0; i < len; i++ ) {
-                ErrMsg = Err->errMsg[i];
-                fprintf( stderr, "Level %d: %s\n", i, ErrMsg->msg );
-            }
-        }
-    }
-    char *mySubName = NULL;
-    const char *myName = rodsErrorName( status, &mySubName );
-    fprintf( stderr, "%s failed with error %d %s %s\n", routineName,
-             status, myName, mySubName );
-    free( mySubName );
-
-    return 0;
-}
 
 int clientLoginPam( rcComm_t* Conn,
                     char*     password,
@@ -199,7 +177,7 @@ int clientLoginPam( rcComm_t* Conn,
        communication socket. */
     status = sslStart( Conn );
     if ( status ) {
-        printError( Conn, status, "sslStart" );
+        allocate_if_necessary_and_add_rError_msg(&Conn->rError, status, "sslStart");
         return status;
     }
 
@@ -209,7 +187,7 @@ int clientLoginPam( rcComm_t* Conn,
     pamAuthReqInp.timeToLive = ttl;
     status = rcPamAuthRequest( Conn, &pamAuthReqInp, &pamAuthReqOut );
     if ( status ) {
-        printError( Conn, status, "rcPamAuthRequest" );
+        allocate_if_necessary_and_add_rError_msg(&Conn->rError, status, "rcPamAuthRequest");
         sslEnd( Conn );
         return status;
     }
@@ -247,7 +225,7 @@ int clientLoginTTL( rcComm_t *Conn, int ttl ) {
     if ( int status = rcGetLimitedPassword( Conn,
                 &getLimitedPasswordInp,
                 &getLimitedPasswordOut ) ) {
-        printError( Conn, status, "rcGetLimitedPassword" );
+        allocate_if_necessary_and_add_rError_msg(&Conn->rError, status, "rcGetLimitedPassword");
         memset( userPassword, 0, sizeof( userPassword ) );
         return status;
     }
@@ -299,7 +277,8 @@ int clientLogin(rcComm_t* _comm, const char* _context, const char* _scheme_overr
 
         log_auth::info(msg);
 
-        printError(_comm, ec, const_cast<char*>(msg.data()));
+        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+        allocate_if_necessary_and_add_rError_msg(&_comm->rError, ec, msg.c_str());
 
         return ec;
     }
@@ -369,7 +348,8 @@ int clientLogin(rcComm_t* _comm, const char* _context, const char* _scheme_overr
 
             log_auth::info(msg);
 
-            printError(_comm, ec, const_cast<char*>(msg.data()));
+            // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+            allocate_if_necessary_and_add_rError_msg(&_comm->rError, ec, msg.c_str());
 
             return ec;
         }
@@ -379,7 +359,7 @@ int clientLogin(rcComm_t* _comm, const char* _context, const char* _scheme_overr
 
             log_auth::info(msg);
 
-            printError(_comm, ec, const_cast<char*>(msg.data()));
+            allocate_if_necessary_and_add_rError_msg(&_comm->rError, ec, msg.c_str());
 
             return ec;
         }
@@ -416,10 +396,8 @@ int clientLogin(rcComm_t* _comm, const char* _context, const char* _scheme_overr
     // send an authentication request to the server
     ret = auth_plugin->call <rcComm_t* > ( NULL, irods::AUTH_CLIENT_AUTH_REQUEST, auth_obj, _comm );
     if ( !ret.ok() ) {
-        printError(
-            _comm,
-            ret.code(),
-            ( char* )ret.result().c_str() );
+        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+        allocate_if_necessary_and_add_rError_msg(&_comm->rError, ret.code(), ret.result().c_str());
         return ret.code();
     }
 
@@ -435,10 +413,8 @@ int clientLogin(rcComm_t* _comm, const char* _context, const char* _scheme_overr
     // send the auth response to the agent
     ret = auth_plugin->call <rcComm_t* > ( NULL, irods::AUTH_CLIENT_AUTH_RESPONSE, auth_obj, _comm );
     if ( !ret.ok() ) {
-        printError(
-            _comm,
-            ret.code(),
-            ( char* )ret.result().c_str() );
+        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+        allocate_if_necessary_and_add_rError_msg(&_comm->rError, ret.code(), ret.result().c_str());
         return ret.code();
     }
 
@@ -462,7 +438,7 @@ clientLoginWithPassword( rcComm_t *Conn, char* password ) {
     char userNameAndZone[NAME_LEN * 2 + 1];
     MD5_CTX context;
     if ( !password ) {
-        printError( Conn, -1, "null password pointer" );
+        allocate_if_necessary_and_add_rError_msg(&Conn->rError, -1, "null password pointer");
         return -1;
     }
 
@@ -472,7 +448,7 @@ clientLoginWithPassword( rcComm_t *Conn, char* password ) {
     }
     status = rcAuthRequest( Conn, &authReqOut );
     if ( status || NULL == authReqOut ) { // JMC cppcheck - nullptr
-        printError( Conn, status, "rcAuthRequest" );
+        allocate_if_necessary_and_add_rError_msg(&Conn->rError, status, "rcAuthRequest");
         return status;
     }
 
@@ -512,7 +488,7 @@ clientLoginWithPassword( rcComm_t *Conn, char* password ) {
     status = rcAuthResponse( Conn, &authRespIn );
 
     if ( status ) {
-        printError( Conn, status, "rcAuthResponse" );
+        allocate_if_necessary_and_add_rError_msg(&Conn->rError, status, "rcAuthResponse");
         return status;
     }
     Conn->loggedIn = 1;

--- a/lib/core/src/rcConnect.cpp
+++ b/lib/core/src/rcConnect.cpp
@@ -65,6 +65,8 @@ rcComm_t* _rcConnect(
     conn->thread_ctx = ( thread_context* ) malloc( sizeof( thread_context ) );
     memset( conn->thread_ctx, 0, sizeof( thread_context ) );
 
+    allocate_error_stack_if_necessary(&conn->rError);
+
     if ( errMsg != NULL ) {
         memset( errMsg, 0, sizeof( rErrMsg_t ) );
     }
@@ -96,6 +98,7 @@ rcComm_t* _rcConnect(
             delete  conn->thread_ctx->cond;
             free( conn->thread_ctx );
         }
+        freeRError(conn->rError);
         free( conn );
         return NULL;
     }
@@ -116,6 +119,7 @@ rcComm_t* _rcConnect(
             delete  conn->thread_ctx->cond;
             free( conn->thread_ctx );
         }
+        freeRError(conn->rError);
         free( conn );
         return NULL;
     }
@@ -145,6 +149,7 @@ rcComm_t* _rcConnect(
             delete  conn->thread_ctx->cond;
             free( conn->thread_ctx );
         }
+        freeRError(conn->rError);
         free( conn );
         return NULL;
     }

--- a/lib/core/src/rcMisc.cpp
+++ b/lib/core/src/rcMisc.cpp
@@ -58,8 +58,8 @@
 #endif
 
 #include <cstdlib>
+#include <cstdio>
 #include <cstring>
-#include <cstdlib>
 #include <iostream>
 #include <iomanip>
 #include <algorithm>
@@ -5040,3 +5040,31 @@ int may_contain_sensitive_data(const char* _buffer, size_t _buffer_size)
         return std::search(_buffer, end, std::begin(_s), std::end(_s)) != end;
     });
 } // may_contain_sensitive_data
+
+int printError(rcComm_t* Conn, int status, char* routineName)
+{
+    rError_t* Err{};
+    rErrMsg_t* ErrMsg{};
+    int i{};
+    int len{};
+    if (Conn != nullptr) {
+        if (Conn->rError != nullptr) {
+            Err = Conn->rError;
+            len = Err->len;
+            for (i = 0; i < len; i++) {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                ErrMsg = Err->errMsg[i];
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                std::fprintf(stderr, "Level %d: %s\n", i, ErrMsg->msg);
+            }
+        }
+    }
+    char* mySubName = nullptr;
+    const char* myName = rodsErrorName(status, &mySubName);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    std::fprintf(stderr, "%s failed with error %d %s %s\n", routineName, status, myName, mySubName);
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+    std::free(mySubName);
+
+    return 0;
+}

--- a/scripts/irods/test/test_ipasswd.py
+++ b/scripts/irods/test/test_ipasswd.py
@@ -139,7 +139,7 @@ class Test_Ipasswd(resource_suite.ResourceBase, unittest.TestCase):
         #
         expected_lines = [
                             'CAT_INVALID_AUTHENTICATION',
-                            '826000 CAT_INVALID_AUTHENTICATION'
+                            '826000'
                          ]
         self.user0.assert_icommand('ipasswd BAD_PASSWD', 'STDERR_MULTILINE', expected_lines, input='apass\napass\n', desired_rc=7)
 
@@ -222,11 +222,6 @@ class Test_Ipasswd(resource_suite.ResourceBase, unittest.TestCase):
         # and...
 
         str1 = "CAT_INVALID_AUTHENTICATION: failed to perform request"
-        self.assertIn(str1, stderr, "ipasswd: Expected stderr: \"...{0}...\", got: \"{1}\"".format(str1, stderr))
-
-        # and...
-
-        str1 = "failed with error -826000 CAT_INVALID_AUTHENTICATION"
         self.assertIn(str1, stderr, "ipasswd: Expected stderr: \"...{0}...\", got: \"{1}\"".format(str1, stderr))
 
     # ==========================================================================================================
@@ -321,7 +316,7 @@ class Test_Ipasswd(resource_suite.ResourceBase, unittest.TestCase):
         #
         expected_lines = [
                             'CAT_INVALID_AUTHENTICATION',
-                            '826000 CAT_INVALID_AUTHENTICATION'
+                            '826000'
                          ]
         self.admin.assert_icommand('ipasswd BAD_PASSWD', 'STDERR_MULTILINE', expected_lines, input='rods\nrods\n', desired_rc=7)
 
@@ -404,9 +399,4 @@ class Test_Ipasswd(resource_suite.ResourceBase, unittest.TestCase):
         # and...
 
         str1 = "CAT_INVALID_AUTHENTICATION: failed to perform request"
-        self.assertIn(str1, stderr, "ipasswd: Expected stderr: \"...{0}...\", got: \"{1}\"".format(str1, stderr))
-
-        # and...
-
-        str1 = "failed with error -826000 CAT_INVALID_AUTHENTICATION"
         self.assertIn(str1, stderr, "ipasswd: Expected stderr: \"...{0}...\", got: \"{1}\"".format(str1, stderr))


### PR DESCRIPTION
Removed calls to printError in clientLogin.cpp
Moved printError function to rcMisc.cpp

Addresses https://github.com/irods/irods/issues/7048