### PR TITLE
Client connection libraries allow deferring/changing the auth logic (4-3-stable)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -28,6 +28,7 @@ Checks:
     hicpp-signed-bitwise,
     misc-*,
     modernize-*,
+    -modernize-use-trailing-return-type,
     performance-*,
     portability-std-allocator-const,
     portability-simd-intrinsics,
@@ -36,6 +37,7 @@ Checks:
 WarningsAsErrors:
     boost-*,
     bugprone-*,
+    -bugprone-easily-swappable-parameters,
     clang-diagnostic-*,
     clang-analyzer-*,
     cert-dcl*,
@@ -43,10 +45,12 @@ WarningsAsErrors:
     cert-env33-c,
     cert-err34-c,
     cert-err*-cpp,
+    -cert-err58-cpp,
     cert-flp30-c,
     cert-oop*,
     cppcoreguidelines-*,
-    -cppcoreguidelines-pro-bounds-array-to-pointer-decay
+    -cppcoreguidelines-avoid-magic-numbers,
+    -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
     concurrency-thread-canceltype-asynchronous,
     google-build-namespaces,
     google-build-using-namespace,
@@ -60,11 +64,14 @@ WarningsAsErrors:
     hicpp-signed-bitwise,
     misc-*,
     modernize-*,
+    -modernize-use-trailing-return-type,
     performance-*,
     portability-std-allocator-const,
     readability-*,
     -readability-avoid-const-params-in-decls,
-    -readability-implicit-bool-conversion
+    -readability-function-cognitive-complexity,
+    -readability-implicit-bool-conversion,
+    -readability-named-parameter
 FormatStyle:     none
 CheckOptions:
   - key:             llvm-else-after-return.WarnOnConditionVariables

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -305,6 +305,7 @@ install(
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/experimental_plugin_framework.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/fixed_buffer_resource.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/fsckUtil.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/fully_qualified_username.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/future.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/getRodsEnv.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/getUtil.h"

--- a/lib/core/include/irods/connection_pool.hpp
+++ b/lib/core/include/irods/connection_pool.hpp
@@ -1,66 +1,197 @@
 #ifndef IRODS_CONNECTION_POOL_HPP
 #define IRODS_CONNECTION_POOL_HPP
 
+#include "irods/fully_qualified_username.hpp"
 #include "irods/rcConnect.h"
 
-#include <memory>
-#include <vector>
-#include <mutex>
 #include <atomic>
-#include <string>
 #include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
 
 namespace irods
 {
-    class connection_pool
+    /// Manages multiple iRODS connections for one or more users.
+    ///
+    /// Instances of this class are not copyable or moveable.
+    ///
+    /// \since 4.2.5
+    class connection_pool // NOLINT(cppcoreguidelines-special-member-functions)
     {
-    public:
-        // A wrapper around a connection in the pool.
-        // On destruction, the underlying connection is immediately returned
-        // to the pool.
-        class connection_proxy
+      public:
+        /// Manages a single connection within a connection_pool.
+        ///
+        /// On destruction, the underlying connection is immediately returned to the pool.
+        ///
+        /// Instances of this class are not copyable.
+        ///
+        /// \since 4.2.5
+        class connection_proxy // NOLINT(cppcoreguidelines-special-member-functions)
         {
-        public:
+          public:
             friend class connection_pool;
 
+            /// Constructs an empty connection_proxy.
+            ///
+            /// On success, the following assertions will be true:
+            /// - static_cast<RcComm*>(instance) will return a nullptr
+            /// - static_cast<RcComm&>(instance) will throw an irods::exception
+            ///
+            /// \since 4.2.9
             connection_proxy();
 
-            connection_proxy(connection_proxy&&);
-            connection_proxy& operator=(connection_proxy&&);
+            connection_proxy(connection_proxy&&) noexcept;
+            connection_proxy& operator=(connection_proxy&&) noexcept;
 
+            /// Destructs the connection_proxy and returns the underlying RcComm to the pool.
+            ///
+            /// \since 4.2.5
             ~connection_proxy();
 
-            operator bool() const noexcept;
+            /// Returns a boolean indicating whether the connection_proxy holds a valid RcComm.
+            ///
+            /// \retval true  If the underlying RcComm is valid.
+            /// \retval false Otherwise.
+            ///
+            /// \since 4.2.7
+            operator bool() const noexcept; // NOLINT(google-explicit-constructor)
 
-            operator rcComm_t&() const;
-            explicit operator rcComm_t*() const noexcept;
+            /// Returns a reference to the underlying RcComm.
+            ///
+            /// \throws irods::exception If the underlying RcComm is not valid (i.e. nullptr).
+            ///
+            /// \since 4.2.5
+            operator RcComm&() const; // NOLINT(google-explicit-constructor)
 
-            rcComm_t* release();
+            /// Returns a pointer to the underlying RcComm.
+            ///
+            /// If the underlying RcComm is not valid, a \p nullptr is returned.
+            ///
+            /// \since 4.2.7
+            explicit operator RcComm*() const noexcept;
 
-        private:
-            connection_proxy(connection_pool& _pool, rcComm_t& _conn, int _index) noexcept;
+            /// Transfers ownership of the underlying RcComm from the connection_proxy and
+            /// connection_pool to the caller.
+            ///
+            /// \since 4.2.7
+            RcComm* release();
+
+          private:
+            connection_proxy(connection_pool& _pool, RcComm& _conn, int _index) noexcept;
 
             static constexpr int uninitialized_index = -1;
 
             connection_pool* pool_;
-            rcComm_t* conn_;
+            RcComm* conn_;
             int index_;
-        };
+        }; // class connection_proxy
 
+        /// Constructs a connection_pool.
+        ///
+        /// Each connection in the pool is authenticated as \p _name (pound) _zone.
+        ///
+        /// \param[in] _size         The number of connections to create.
+        /// \param[in] _host         The hostname of the iRODS server.
+        /// \param[in] _port         The port to connect to.
+        /// \param[in] _name         The name of the user to connect as.
+        /// \param[in] _zone         The zone of the user to connect as.
+        /// \param[in] _refresh_time The number of seconds before a connection is refreshed.
+        ///
+        /// \throws irods::exception If an error occurs.
+        ///
+        /// \since 4.2.5
+        [[deprecated]] connection_pool(int _size,
+                                       const std::string& _host,
+                                       const int _port,
+                                       const std::string& _name,
+                                       const std::string& _zone,
+                                       const int _refresh_time);
+
+        /// Constructs a connection_pool.
+        ///
+        /// Each connection in the pool is authenticated as \p _username.
+        ///
+        /// \param[in] _size         The number of connections to create.
+        /// \param[in] _host         The hostname of the iRODS server.
+        /// \param[in] _port         The port to connect to.
+        /// \param[in] _username     The name of the user to connect as.
+        /// \param[in] _refresh_time The number of seconds before a connection is refreshed.
+        ///
+        /// \throws irods::exception If an error occurs.
+        ///
+        /// \since 4.3.1
         connection_pool(int _size,
                         const std::string& _host,
                         const int _port,
-                        const std::string& _username,
-                        const std::string& _zone,
+                        experimental::fully_qualified_username _username,
                         const int _refresh_time);
+
+        /// Constructs a connection_pool.
+        ///
+        /// Each connection in the pool is authenticated as \p _username.
+        ///
+        /// This constructor allows use of non-native authentication schemes (e.g. PAM, Kerberos, etc).
+        ///
+        /// \param[in] _size         The number of connections to create.
+        /// \param[in] _host         The hostname of the iRODS server.
+        /// \param[in] _port         The port to connect to.
+        /// \param[in] _username     The name of the user to connect as.
+        /// \param[in] _refresh_time The number of seconds before a connection is refreshed.
+        /// \param[in] _auth_func    The callback used for authenticating each connection.
+        ///
+        /// \throws irods::exception If an error occurs.
+        ///
+        /// \since 4.3.1
+        connection_pool(int _size,
+                        const std::string& _host,
+                        const int _port,
+                        experimental::fully_qualified_username _username,
+                        const int _refresh_time,
+                        std::function<void(RcComm&)> _auth_func);
+
+        /// Constructs a connection_pool.
+        ///
+        /// Each connection in the pool is authenticated as \p _proxy_username if provided.
+        /// Otherwise, the connections are authenticated as \p _username. API oeprations are
+        /// always executed as \p _username.
+        ///
+        /// This constructor allows use of non-native authentication schemes (e.g. PAM, Kerberos, etc).
+        ///
+        /// \param[in] _size           The number of connections to create.
+        /// \param[in] _host           The hostname of the iRODS server.
+        /// \param[in] _port           The port to connect to.
+        /// \param[in] _proxy_username The name of the user acting as the proxy.
+        /// \param[in] _username       The name of the user being proxied.
+        /// \param[in] _auth_func      The callback used for authenticating each connection.
+        /// \param[in] _refresh_time   The number of seconds before a connection is refreshed.
+        ///
+        /// \throws irods::exception If an error occurs.
+        ///
+        /// \since 4.3.1
+        connection_pool(int _size,
+                        std::string_view _host,
+                        const int _port,
+                        std::optional<experimental::fully_qualified_username> _proxy_username,
+                        experimental::fully_qualified_username _username,
+                        const int _refresh_time,
+                        std::function<void(RcComm&)> _auth_func);
 
         connection_pool(const connection_pool&) = delete;
         connection_pool& operator=(const connection_pool&) = delete;
 
+        /// Returns a connection from the pool.
+        ///
+        /// This function will block if all connections are in use.
+        ///
+        /// \since 4.2.5
         connection_proxy get_connection();
 
-    private:
-        using connection_pointer = std::unique_ptr<rcComm_t, int(*)(rcComm_t*)>;
+      private:
+        using connection_pointer = std::unique_ptr<RcComm, int (*)(RcComm*)>;
 
         struct connection_context
         {
@@ -70,13 +201,13 @@ namespace irods
             connection_pointer conn{nullptr, rcDisconnect};
             rErrMsg_t error{};
             std::time_t creation_time{};
-        };
+        }; // struct connection_context
 
         void create_connection(int _index,
-                               std::function<void()> _on_connect_error,
-                               std::function<void()> _on_login_error);
+                               const std::function<void()>& _on_connect_error,
+                               const std::function<void()>& _on_login_error);
 
-        rcComm_t* refresh_connection(int _index);
+        RcComm* refresh_connection(int _index);
 
         bool verify_connection(int _index);
 
@@ -86,14 +217,24 @@ namespace irods
 
         const std::string host_;
         const int port_;
-        const std::string username_;
-        const std::string zone_;
+        const std::optional<experimental::fully_qualified_username> proxy_username_;
+        const experimental::fully_qualified_username username_;
         const int refresh_time_;
+        std::function<void(RcComm&)> auth_func_;
         std::vector<connection_context> conn_ctxs_;
-    };
+    }; // class connection_pool
 
-    std::shared_ptr<connection_pool> make_connection_pool(int size = 1);
+    /// Constructs a connection_pool on the heap.
+    ///
+    /// The connection_pool is constructed using client credentials defined in
+    /// irods_environment.json.
+    ///
+    /// \param[in] _size The number of connections to create.
+    ///
+    /// \returns A shared pointer to a connection_pool.
+    ///
+    /// \since 4.2.8
+    std::shared_ptr<connection_pool> make_connection_pool(int _size = 1);
 } // namespace irods
 
 #endif // IRODS_CONNECTION_POOL_HPP
-

--- a/lib/core/include/irods/fully_qualified_username.hpp
+++ b/lib/core/include/irods/fully_qualified_username.hpp
@@ -1,0 +1,94 @@
+#ifndef IRODS_FULLY_QUALIFIED_USERNAME_HPP
+#define IRODS_FULLY_QUALIFIED_USERNAME_HPP
+
+/// \file
+
+#include "irods/irods_exception.hpp"
+#include "irods/rodsErrorTable.h"
+
+#include <string_view>
+
+namespace irods::experimental
+{
+    /// A class which is designed to enforce use of fully-qualified iRODS usernames.
+    ///
+    /// This class should be used as a building block for other libraries and utilities.
+    ///
+    /// Instances of this class are readonly.
+    ///
+    /// \since 4.3.1
+    class fully_qualified_username
+    {
+      public:
+        /// Constructs a fully_qualified_username.
+        ///
+        /// \param[in] _name The part of the username preceding the pound sign.
+        ///                  The string pased must be non-empty.
+        /// \param[in] _zone The part of the username following the pound sign.
+        ///                  The string pased must be non-empty.
+        ///
+        /// \throws irods::exception If an error occurs or a constraint is violated.
+        ///
+        /// \since 4.3.1
+        fully_qualified_username(const std::string_view _name, const std::string_view _zone)
+        {
+            if (_name.empty()) {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                THROW(SYS_INVALID_INPUT_PARAM, "Empty name not allowed.");
+            }
+
+            if (_zone.empty()) {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                THROW(SYS_INVALID_INPUT_PARAM, "Empty zone not allowed.");
+            }
+
+            name_.assign(_name.data(), _name.size());
+            zone_.assign(_zone.data(), _zone.size());
+        } // constructor
+
+        fully_qualified_username(const fully_qualified_username& _other) = default;
+        auto operator=(const fully_qualified_username& _other) -> fully_qualified_username& = default;
+
+        fully_qualified_username(fully_qualified_username&& _other) = default;
+        auto operator=(fully_qualified_username&& _other) -> fully_qualified_username& = default;
+
+        ~fully_qualified_username() = default;
+
+        /// Returns the part of the username preceding the pound sign.
+        ///
+        /// \since 4.3.1
+        [[nodiscard]] auto name() const noexcept -> const std::string&
+        {
+            return name_;
+        } // name
+
+        /// Returns the part of the username following the pound sign.
+        ///
+        /// \since 4.3.1
+        [[nodiscard]] auto zone() const noexcept -> const std::string&
+        {
+            return zone_;
+        } // zone
+
+        /// Returns the fully-qualified username.
+        ///
+        /// \since 4.3.1
+        [[nodiscard]] auto full_name() const -> std::string
+        {
+            std::string fn;
+
+            fn.reserve(name_.size() + zone_.size() + 1);
+            fn += name_;
+            fn += '#';
+            fn += zone_;
+
+            return fn;
+        } // full_name
+
+      private:
+        std::string name_;
+        std::string zone_;
+    }; // class fully_qualified_username
+} // namespace irods::experimental
+
+#endif // IRODS_FULLY_QUALIFIED_USERNAME_HPP

--- a/lib/core/include/irods/library_features.h
+++ b/lib/core/include/irods/library_features.h
@@ -1,6 +1,12 @@
 #ifndef IRODS_LIBRARY_FEATURES_H
 #define IRODS_LIBRARY_FEATURES_H
 
+// This file SHOULD NOT be processed by clang-tidy because it is required to define
+// preprocessor macros for compile-time decision making, hence the use of the following
+// clang-tidy directive.
+//
+// NOLINTBEGIN
+
 /// \file
 ///
 /// \brief iRODS Feature Test Macros
@@ -27,5 +33,10 @@
 ///
 /// \since 4.3.1
 #define IRODS_HAS_LIBRARY_SYSTEM_ERROR        202301L
+
+/// Defined if the C++ client connection libraries support proxy users.
+///
+/// \since 4.3.1
+#define IRODS_HAS_FEATURE_PROXY_USER_SUPPORT_FOR_CLIENT_CONNECTION_LIBRARIES 202306L
 
 #endif // IRODS_LIBRARY_FEATURES_H

--- a/lib/core/include/irods/rodsErrorTable.h
+++ b/lib/core/include/irods/rodsErrorTable.h
@@ -243,6 +243,7 @@ NEW_ERROR(RESOLUTION_ERROR,                            -174000)
 NEW_ERROR(INVALID_HANDLE,                              -175000)
 NEW_ERROR(DOES_NOT_EXIST,                              -176000)
 NEW_ERROR(TYPE_NOT_SUPPORTED,                          -177000)
+NEW_ERROR(AUTHENTICATION_ERROR,                        -178000)
 
 /** @} */
 

--- a/lib/core/src/client_connection.cpp
+++ b/lib/core/src/client_connection.cpp
@@ -12,138 +12,202 @@ namespace irods::experimental
         rodsEnv env{};
         _getRodsEnv(env);
 
-        connect_and_login(env.rodsHost, env.rodsPort, env.rodsUserName, env.rodsZone);
-    }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+        connect_and_login(env.rodsHost, env.rodsPort, {env.rodsUserName, env.rodsZone});
+    } // default constructor
+
+    client_connection::client_connection(struct defer_authentication) // NOLINT(readability-named-parameter)
+        : conn_{nullptr, rcDisconnect}
+    {
+        rodsEnv env{};
+        _getRodsEnv(env);
+
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+        only_connect(env.rodsHost, env.rodsPort, {env.rodsUserName, env.rodsZone});
+    } // constructor
 
     client_connection::client_connection(const std::string_view _host,
                                          const int _port,
-                                         const std::string_view _username,
-                                         const std::string_view _zone)
+                                         const fully_qualified_username& _username)
         : conn_{nullptr, rcDisconnect}
     {
-        connect_and_login(_host, _port, _username, _zone);
-    }
+        connect_and_login(std::string{_host}, _port, _username);
+    } // constructor
+
+    client_connection::client_connection(struct defer_authentication, // NOLINT(readability-named-parameter)
+                                         const std::string_view _host,
+                                         const int _port,
+                                         const fully_qualified_username& _username)
+        : conn_{nullptr, rcDisconnect}
+    {
+        only_connect(std::string{_host}, _port, _username);
+    } // constructor
 
     client_connection::client_connection(const std::string_view _host,
                                          const int _port,
-                                         const std::string_view _proxy_user,
-                                         const std::string_view _proxy_zone,
-                                         const std::string_view _username,
-                                         const std::string_view _zone)
+                                         const fully_qualified_username& _proxy_username,
+                                         const fully_qualified_username& _username)
         : conn_{nullptr, rcDisconnect}
     {
-        connect_and_login(_host, _port, _proxy_user,
-                          _proxy_zone, _username,
-                          _zone);
-    }
+        connect_and_login(std::string{_host}, _port, _proxy_username, _username);
+    } // constructor
+
+    client_connection::client_connection(struct defer_authentication, // NOLINT(readability-named-parameter)
+                                         const std::string_view _host,
+                                         const int _port,
+                                         const fully_qualified_username& _proxy_username,
+                                         const fully_qualified_username& _username)
+        : conn_{nullptr, rcDisconnect}
+    {
+        only_connect(std::string{_host}, _port, _proxy_username, _username);
+    } // constructor
 
     client_connection::client_connection(RcComm& _conn)
         : conn_{&_conn, rcDisconnect}
     {
-    }
+    } // constructor
 
-    client_connection::client_connection(struct defer_connection)
+    client_connection::client_connection(struct defer_connection) // NOLINT(readability-named-parameter)
         : conn_{nullptr, rcDisconnect}
     {
-    }
+    } // constructor
 
     auto client_connection::connect() -> void
     {
         rodsEnv env{};
         _getRodsEnv(env);
 
-        connect_and_login(env.rodsHost, env.rodsPort, env.rodsUserName, env.rodsZone);
-    }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+        connect_and_login(env.rodsHost, env.rodsPort, {env.rodsUserName, env.rodsZone});
+    } // connect
 
-    auto client_connection::connect(const std::string_view _host,
-                                    const int _port,
-                                    const std::string_view _username,
-                                    const std::string_view _zone) -> void
-    {
-        connect_and_login(_host, _port, _username, _zone);
-    }
-
-    auto client_connection::connect(const std::string_view _proxy_user,
-                                    const std::string_view _proxy_zone) -> void
+    auto client_connection::connect(struct defer_authentication) -> void // NOLINT(readability-named-parameter)
     {
         rodsEnv env{};
         _getRodsEnv(env);
 
-        connect_and_login(env.rodsHost, env.rodsPort, _proxy_user, _proxy_zone,
-                          env.rodsUserName, env.rodsZone);
-    }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+        only_connect(env.rodsHost, env.rodsPort, {env.rodsUserName, env.rodsZone});
+    } // connect
+
+    auto client_connection::connect(const std::string_view _host,
+                                    const int _port,
+                                    const fully_qualified_username& _username) -> void
+    {
+        connect_and_login(std::string{_host}, _port, _username);
+    } // connect
+
+    auto client_connection::connect(struct defer_authentication, // NOLINT(readability-named-parameter)
+                                    const std::string_view _host,
+                                    const int _port,
+                                    const fully_qualified_username& _username) -> void
+    {
+        only_connect(std::string{_host}, _port, _username);
+    } // connect
+
+    auto client_connection::connect(struct defer_authentication, // NOLINT(readability-named-parameter)
+                                    const std::string_view _host,
+                                    const int _port,
+                                    const fully_qualified_username& _proxy_username,
+                                    const fully_qualified_username& _username) -> void
+    {
+        only_connect(std::string{_host}, _port, _proxy_username, _username);
+    } // connect
+
+    // NOLINTNEXTLINE(readability-named-parameter)
+    auto client_connection::connect(struct defer_authentication, const fully_qualified_username& _proxy_username)
+        -> void
+    {
+        rodsEnv env{};
+        _getRodsEnv(env);
+
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+        only_connect(env.rodsHost, env.rodsPort, _proxy_username, {env.rodsUserName, env.rodsZone});
+    } // connect
 
     auto client_connection::disconnect() noexcept -> void
     {
         conn_.reset();
-    }
+    } // disconnect
 
     client_connection::operator bool() const noexcept
     {
         return static_cast<bool>(conn_);
-    }
+    } // operator bool
 
     client_connection::operator RcComm&() const
     {
         if (!conn_) {
-            THROW(USER_SOCK_CONNECT_ERR, "invalid client_connection object");
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(USER_SOCK_CONNECT_ERR, "Invalid client_connection object");
         }
 
         return *conn_;
-    }
+    } // operator RcComm&
 
     client_connection::operator RcComm*() const noexcept
     {
         return conn_.get();
-    }
+    } // operator RcComm*
 
-    auto client_connection::connect_and_login(const std::string_view _host,
+    auto client_connection::connect_and_login(const std::string& _host,
                                               const int _port,
-                                              const std::string_view _username,
-                                              const std::string_view _zone) -> void
+                                              const fully_qualified_username& _username) -> void
     {
-        rErrMsg_t error{};
-        conn_.reset(rcConnect(_host.data(),
-                              _port,
-                              _username.data(),
-                              _zone.data(),
-                              NO_RECONN,
-                              &error));
-
-        if (!conn_) {
-            THROW(USER_SOCK_CONNECT_ERR, "connect error");
-        }
+        only_connect(_host, _port, _username);
 
         if (clientLogin(conn_.get()) != 0) {
-            THROW(USER_SOCK_CONNECT_ERR, "client login error");
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(USER_SOCK_CONNECT_ERR, "Client login error");
         }
-    }
+    } // connect_and_login
 
-    auto client_connection::connect_and_login(const std::string_view _host,
+    auto client_connection::connect_and_login(const std::string& _host,
                                               const int _port,
-                                              const std::string_view _proxy_user,
-                                              const std::string_view _proxy_zone,
-                                              const std::string_view _username,
-                                              const std::string_view _zone) -> void
+                                              const fully_qualified_username& _proxy_username,
+                                              const fully_qualified_username& _username) -> void
+    {
+        only_connect(_host, _port, _proxy_username, _username);
+
+        if (clientLogin(conn_.get()) != 0) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(USER_SOCK_CONNECT_ERR, "Client login error");
+        }
+    } // connect_and_login
+
+    auto client_connection::only_connect(const std::string& _host,
+                                         const int _port,
+                                         const fully_qualified_username& _username) -> void
     {
         rErrMsg_t error{};
-        conn_.reset(_rcConnect(_host.data(),
+        conn_.reset(
+            rcConnect(_host.c_str(), _port, _username.name().c_str(), _username.zone().c_str(), NO_RECONN, &error));
+
+        if (!conn_) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(USER_SOCK_CONNECT_ERR, "Connect error");
+        }
+    } // only_connect
+
+    auto client_connection::only_connect(const std::string& _host,
+                                         const int _port,
+                                         const fully_qualified_username& _proxy_username,
+                                         const fully_qualified_username& _username) -> void
+    {
+        rErrMsg_t error{};
+        conn_.reset(_rcConnect(_host.c_str(),
                                _port,
-                               _proxy_user.data(),
-                               _proxy_zone.data(),
-                               _username.data(),
-                               _zone.data(),
+                               _proxy_username.name().c_str(),
+                               _proxy_username.zone().c_str(),
+                               _username.name().c_str(),
+                               _username.zone().c_str(),
                                &error,
                                1,
                                NO_RECONN));
-        
+
         if (!conn_) {
-            THROW(USER_SOCK_CONNECT_ERR, "connect error");
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            THROW(USER_SOCK_CONNECT_ERR, "Connect error");
         }
-
-        if (clientLogin(conn_.get()) != 0) {
-            THROW(USER_SOCK_CONNECT_ERR, "client login error");
-        }
-    }
+    } // only_connect
 } // namespace irods::experimental
-

--- a/lib/core/src/client_connection.cpp
+++ b/lib/core/src/client_connection.cpp
@@ -139,7 +139,7 @@ namespace irods::experimental
     {
         if (!conn_) {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-            THROW(USER_SOCK_CONNECT_ERR, "Invalid client_connection object");
+            THROW(SYS_LIBRARY_ERROR, "Invalid connection object");
         }
 
         return *conn_;
@@ -158,7 +158,7 @@ namespace irods::experimental
 
         if (clientLogin(conn_.get()) != 0) {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-            THROW(USER_SOCK_CONNECT_ERR, "Client login error");
+            THROW(AUTHENTICATION_ERROR, "Client login error");
         }
     } // connect_and_login
 
@@ -171,7 +171,7 @@ namespace irods::experimental
 
         if (clientLogin(conn_.get()) != 0) {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-            THROW(USER_SOCK_CONNECT_ERR, "Client login error");
+            THROW(AUTHENTICATION_ERROR, "Client login error");
         }
     } // connect_and_login
 

--- a/lib/core/src/connection_pool.cpp
+++ b/lib/core/src/connection_pool.cpp
@@ -5,17 +5,22 @@
 
 #include <stdexcept>
 #include <thread>
+#include <tuple> // For std::ignore.
 
 namespace irods
 {
+    //
+    // Connection Proxy Implementation
+    //
+
     connection_pool::connection_proxy::connection_proxy()
         : pool_{}
         , conn_{}
         , index_{uninitialized_index}
     {
-    }
+    } // default constructor
 
-    connection_pool::connection_proxy::connection_proxy(connection_proxy&& _other)
+    connection_pool::connection_proxy::connection_proxy(connection_proxy&& _other) noexcept
         : pool_{_other.pool_}
         , conn_{_other.conn_}
         , index_{_other.index_}
@@ -23,9 +28,9 @@ namespace irods
         _other.pool_ = nullptr;
         _other.conn_ = nullptr;
         _other.index_ = uninitialized_index;
-    }
+    } // move constructor
 
-    connection_pool::connection_proxy& connection_pool::connection_proxy::operator=(connection_proxy&& _other)
+    connection_pool::connection_proxy& connection_pool::connection_proxy::operator=(connection_proxy&& _other) noexcept
     {
         pool_ = _other.pool_;
         conn_ = _other.conn_;
@@ -36,74 +41,109 @@ namespace irods
         _other.index_ = uninitialized_index;
 
         return *this;
-    }
+    } // operator=
 
     connection_pool::connection_proxy::~connection_proxy()
     {
+        // NOLINTNEXTLINE(readability-implicit-bool-conversion)
         if (pool_ && uninitialized_index != index_) {
             pool_->return_connection(index_);
         }
-    }
+    } // destructor
 
     connection_pool::connection_proxy::operator bool() const noexcept
     {
         return nullptr != conn_;
-    }
+    } // operator bool
 
-    connection_pool::connection_proxy::operator rcComm_t&() const
+    connection_pool::connection_proxy::operator RcComm&() const
     {
-        if (!conn_) {
+        if (!conn_) { // NOLINT(readability-implicit-bool-conversion)
             throw std::runtime_error{"Invalid connection object"};
         }
 
         return *conn_;
-    }
+    } // operator RcComm&
 
-    connection_pool::connection_proxy::operator rcComm_t*() const noexcept
+    connection_pool::connection_proxy::operator RcComm*() const noexcept
     {
         return conn_;
-    }
+    } // operator RcComm*
 
-    rcComm_t* connection_pool::connection_proxy::release()
+    RcComm* connection_pool::connection_proxy::release()
     {
         pool_->release_connection(index_);
         auto* conn = conn_;
         conn_ = nullptr;
         return conn;
-    }
+    } // release
 
-    connection_pool::connection_proxy::connection_proxy(connection_pool& _pool,
-                                                        rcComm_t& _conn,
-                                                        int _index) noexcept
+    connection_pool::connection_proxy::connection_proxy(connection_pool& _pool, RcComm& _conn, int _index) noexcept
         : pool_{&_pool}
         , conn_{&_conn}
         , index_{_index}
     {
-    }
+    } // constructor
+
+    //
+    // Connection Pool Implementation
+    //
 
     connection_pool::connection_pool(int _size,
                                      const std::string& _host,
                                      const int _port,
-                                     const std::string& _username,
+                                     const std::string& _name,
                                      const std::string& _zone,
                                      const int _refresh_time)
+        : connection_pool{_size, _host, _port, std::nullopt, {_name, _zone}, _refresh_time, {}}
+    {
+    } // constructor
+
+    connection_pool::connection_pool(int _size,
+                                     const std::string& _host,
+                                     const int _port,
+                                     experimental::fully_qualified_username _username,
+                                     const int _refresh_time)
+        : connection_pool{_size, _host, _port, std::nullopt, std::move(_username), _refresh_time, {}}
+    {
+    } // constructor
+
+    connection_pool::connection_pool(int _size,
+                                     const std::string& _host,
+                                     const int _port,
+                                     experimental::fully_qualified_username _username,
+                                     const int _refresh_time,
+                                     std::function<void(RcComm&)> _auth_func)
+        : connection_pool{_size, _host, _port, std::nullopt, std::move(_username), _refresh_time, std::move(_auth_func)}
+    {
+    } // constructor
+
+    connection_pool::connection_pool(int _size,
+                                     std::string_view _host,
+                                     const int _port,
+                                     std::optional<experimental::fully_qualified_username> _proxy_username,
+                                     experimental::fully_qualified_username _username,
+                                     const int _refresh_time,
+                                     std::function<void(RcComm&)> _auth_func)
         : host_{_host}
         , port_{_port}
-        , username_{_username}
-        , zone_{_zone}
+        , proxy_username_{std::move(_proxy_username)}
+        , username_{std::move(_username)}
         , refresh_time_(_refresh_time)
+        , auth_func_{std::move(_auth_func)}
         , conn_ctxs_(_size)
     {
         if (_size < 1) {
-            throw std::runtime_error{"invalid connection pool size"};
+            throw std::runtime_error{"Invalid connection pool size"}; // TODO These should be irods::exceptions.
         }
 
         // Always initialize the first connection to guarantee that the
         // network plugin is loaded. This guarantees that asynchronous calls
         // to rcConnect do not cause a segfault.
-        create_connection(0,
-                          [] { throw std::runtime_error{"connect error"}; },
-                          [] { throw std::runtime_error{"client login error"}; });
+        create_connection(
+            0,
+            [] { throw std::runtime_error{"Connect error"}; },
+            [] { throw std::runtime_error{"Client login error"}; });
 
         // If the size of the pool is one, then return immediately.
         if (_size == 1) {
@@ -117,51 +157,68 @@ namespace irods
         std::atomic<bool> connect_error{};
         std::atomic<bool> login_error{};
 
-        for (int i = 1; i < _size; ++i) {
-            irods::thread_pool::post(thread_pool, [this, i, &connect_error, &login_error] {
-                if (connect_error.load() || login_error.load()) {
-                    return;
-                }
+        const auto on_connect_error = [&connect_error] { connect_error.store(true); };
+        const auto on_login_error = [&login_error] { login_error.store(true); };
 
-                create_connection(i,
-                                  [&connect_error] { connect_error.store(true); },
-                                  [&login_error] { login_error.store(true); });
-            });
+        for (int i = 1; i < _size; ++i) {
+            irods::thread_pool::post(
+                thread_pool, [this, i, &connect_error, &login_error, &on_connect_error, &on_login_error] {
+                    if (connect_error.load() || login_error.load()) {
+                        return;
+                    }
+
+                    create_connection(i, on_connect_error, on_login_error);
+                });
         }
 
         thread_pool.join();
 
         if (connect_error.load()) {
-            throw std::runtime_error{"connect error"};
+            throw std::runtime_error{"Connect error"};
         }
 
         if (login_error.load()) {
-            throw std::runtime_error{"client login error"};
+            throw std::runtime_error{"Client login error"};
         }
-    }
+    } // constructor
 
     void connection_pool::create_connection(int _index,
-                                            std::function<void()> _on_connect_error,
-                                            std::function<void()> _on_login_error)
+                                            const std::function<void()>& _on_connect_error,
+                                            const std::function<void()>& _on_login_error)
     {
         auto& ctx = conn_ctxs_[_index];
         ctx.creation_time = std::time(nullptr);
-        ctx.conn.reset(rcConnect(host_.c_str(),
-                                 port_,
-                                 username_.c_str(),
-                                 zone_.c_str(),
-                                 NO_RECONN,
-                                 &ctx.error));
+
+        if (proxy_username_.has_value()) {
+            ctx.conn.reset(_rcConnect(host_.c_str(),
+                                      port_,
+                                      proxy_username_->name().c_str(),
+                                      proxy_username_->zone().c_str(),
+                                      username_.name().c_str(),
+                                      username_.zone().c_str(),
+                                      &ctx.error,
+                                      1,
+                                      NO_RECONN));
+        }
+        else {
+            ctx.conn.reset(rcConnect(
+                host_.c_str(), port_, username_.name().c_str(), username_.zone().c_str(), NO_RECONN, &ctx.error));
+        }
 
         if (!ctx.conn) {
             _on_connect_error();
             return;
         }
 
+        if (auth_func_) {
+            auth_func_(*ctx.conn);
+            return;
+        }
+
         if (clientLogin(ctx.conn.get()) != 0) {
             _on_login_error();
         }
-    }
+    } // create_connection
 
     bool connection_pool::verify_connection(int _index)
     {
@@ -172,7 +229,8 @@ namespace irods
         }
 
         try {
-            query<rcComm_t>{ctx.conn.get(), "select ZONE_NAME where ZONE_TYPE = 'local'"};
+            // NOLINTNEXTLINE(bugprone-unused-raii)
+            query<RcComm>{ctx.conn.get(), "select ZONE_NAME where ZONE_TYPE = 'local'"};
             if (std::time(nullptr) - ctx.creation_time > refresh_time_) {
                 return false;
             }
@@ -182,30 +240,30 @@ namespace irods
         }
 
         return true;
-    }
+    } // verify_connection
 
-    rcComm_t* connection_pool::refresh_connection(int _index)
+    RcComm* connection_pool::refresh_connection(int _index)
     {
         auto& ctx = conn_ctxs_[_index];
         ctx.error = {};
 
         if (ctx.refresh) {
             ctx.refresh = false;
-            ctx.conn.release();
         }
 
         if (!verify_connection(_index)) {
-            create_connection(_index,
-                              [] { throw std::runtime_error{"connect error"}; },
-                              [] { throw std::runtime_error{"client login error"}; });
+            create_connection(
+                _index,
+                [] { throw std::runtime_error{"Connect error"}; },
+                [] { throw std::runtime_error{"Client login error"}; });
         }
 
         return ctx.conn.get();
-    }
+    } // refresh_connection
 
     connection_pool::connection_proxy connection_pool::get_connection()
     {
-        for (int i = 0;; i = ++i % conn_ctxs_.size()) {
+        for (int i = 0;; i = (i + 1) % static_cast<int>(conn_ctxs_.size())) {
             std::unique_lock<std::mutex> lock{conn_ctxs_[i].mutex, std::defer_lock};
 
             if (lock.try_lock()) {
@@ -215,30 +273,24 @@ namespace irods
                 }
             }
         }
-    }
+    } // get_connection
 
     void connection_pool::return_connection(int _index)
     {
         conn_ctxs_[_index].in_use.store(false);
-    }
+    } // return_connection
 
     void connection_pool::release_connection(int _index)
     {
         conn_ctxs_[_index].refresh = true;
-        conn_ctxs_[_index].conn.release();
-    }
+        std::ignore = conn_ctxs_[_index].conn.release();
+    } // release_connection
 
-    std::shared_ptr<connection_pool> make_connection_pool(int size)
+    std::shared_ptr<connection_pool> make_connection_pool(int _size)
     {
         rodsEnv env{};
         _getRodsEnv(env);
         return std::make_shared<irods::connection_pool>(
-            size,
-            env.rodsHost,
-            env.rodsPort,
-            env.rodsUserName,
-            env.rodsZone,
-            env.irodsConnectionPoolRefreshTime);
-    }
+            _size, env.rodsHost, env.rodsPort, env.rodsUserName, env.rodsZone, env.irodsConnectionPoolRefreshTime);
+    } // make_connection_pool
 } // namespace irods
-

--- a/plugins/microservices/src/test_issue_6829.cpp
+++ b/plugins/microservices/src/test_issue_6829.cpp
@@ -62,7 +62,7 @@ namespace
         const auto& env = _rei->rsComm->myEnv;
 
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-        irods::experimental::client_connection conn{env.rodsHost, env.rodsPort, username, env.rodsZone};
+        irods::experimental::client_connection conn{env.rodsHost, env.rodsPort, {username, env.rodsZone}};
         IRODS_MSI_ASSERT(conn);
 
         io::client::native_transport tp{conn};

--- a/server/api/src/rsModAccessControl.cpp
+++ b/server/api/src/rsModAccessControl.cpp
@@ -3,6 +3,7 @@
 #include "irods/catalog_utilities.hpp"
 #include "irods/client_connection.hpp"
 #include "irods/filesystem/path.hpp"
+#include "irods/fully_qualified_username.hpp"
 #include "irods/icatHighLevelRoutines.hpp"
 #include "irods/irods_configuration_keywords.hpp"
 #include "irods/irods_logger.hpp"
@@ -68,10 +69,11 @@ int rsModAccessControl(rsComm_t* rsComm, modAccessControlInp_t* modAccessControl
             const auto client_user_type =
                 *ua::server::type(*rsComm, ua::user{rsComm->clientUser.userName, rsComm->clientUser.rodsZone});
             if (ua::user_type::rodsadmin != client_user_type) {
-                auto conn = irods::experimental::client_connection{catalog_provider_host.hostName->name,
-                                                                   rsComm->myEnv.rodsPort,
-                                                                   static_cast<char*>(rsComm->myEnv.rodsUserName),
-                                                                   static_cast<char*>(rsComm->myEnv.rodsZone)};
+                auto local_admin =
+                    irods::experimental::fully_qualified_username{rsComm->myEnv.rodsUserName, rsComm->myEnv.rodsZone};
+
+                auto conn = irods::experimental::client_connection{
+                    catalog_provider_host.hostName->name, rsComm->myEnv.rodsPort, local_admin};
 
                 return rcModAccessControl(static_cast<RcComm*>(conn), &newModAccessControlInp);
             }

--- a/server/api/src/rsModColl.cpp
+++ b/server/api/src/rsModColl.cpp
@@ -3,6 +3,7 @@
 #include "irods/catalog_utilities.hpp"
 #include "irods/client_connection.hpp"
 #include "irods/filesystem/path.hpp"
+#include "irods/fully_qualified_username.hpp"
 #include "irods/icatHighLevelRoutines.hpp"
 #include "irods/irods_configuration_keywords.hpp"
 #include "irods/irods_rs_comm_query.hpp"
@@ -117,10 +118,11 @@ auto rsModColl(rsComm_t* rsComm, collInp_t* modCollInp) -> int
             const auto client_user_type =
                 *ua::server::type(*rsComm, ua::user{rsComm->clientUser.userName, rsComm->clientUser.rodsZone});
             if (ua::user_type::rodsadmin != client_user_type) {
-                auto conn = irods::experimental::client_connection{catalog_provider_host.hostName->name,
-                                                                   rsComm->myEnv.rodsPort,
-                                                                   static_cast<char*>(rsComm->myEnv.rodsUserName),
-                                                                   static_cast<char*>(rsComm->myEnv.rodsZone)};
+                auto local_admin =
+                    irods::experimental::fully_qualified_username{rsComm->myEnv.rodsUserName, rsComm->myEnv.rodsZone};
+
+                auto conn = irods::experimental::client_connection{
+                    catalog_provider_host.hostName->name, rsComm->myEnv.rodsPort, local_admin};
 
                 return rcModColl(static_cast<RcComm*>(conn), modCollInp);
             }

--- a/server/delay_server/src/irodsDelayServer.cpp
+++ b/server/delay_server/src/irodsDelayServer.cpp
@@ -2,6 +2,7 @@
 
 #include "irods/client_connection.hpp"
 #include "irods/connection_pool.hpp"
+#include "irods/fully_qualified_username.hpp"
 #include "irods/get_delay_rule_info.h"
 #include "irods/initServer.hpp"
 #include "irods/irods_at_scope_exit.hpp"
@@ -167,7 +168,10 @@ namespace
                     logger::delay_server::debug("Connecting to host [{}] as proxy user [{}] on behalf of user [{}] ...",
                                                 *executor, env.rodsUserName, *_client_user);
 
-                    return {*executor, env.rodsPort, env.rodsUserName, env.rodsZone, *_client_user, env.rodsZone};
+                    irods::experimental::fully_qualified_username local_admin{env.rodsUserName, env.rodsZone};
+                    irods::experimental::fully_qualified_username user{*_client_user, env.rodsZone};
+
+                    return {*executor, env.rodsPort, local_admin, user};
                 }
             }
         }

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -43,6 +43,7 @@ set(
   dstream
   filesystem
   fixed_buffer_resource
+  fully_qualified_username
   get_delay_rule_info
   get_file_descriptor_info
   hierarchy_parser

--- a/unit_tests/cmake/test_config/irods_client_connection.cmake
+++ b/unit_tests/cmake/test_config/irods_client_connection.cmake
@@ -7,4 +7,5 @@ set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
                             ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
 
 set(IRODS_TEST_LINK_LIBRARIES irods_common
-                              irods_client)
+                              irods_client
+                              ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)

--- a/unit_tests/cmake/test_config/irods_connection_pool.cmake
+++ b/unit_tests/cmake/test_config/irods_connection_pool.cmake
@@ -3,5 +3,9 @@ set(IRODS_TEST_TARGET irods_connection_pool)
 set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
                             ${CMAKE_CURRENT_SOURCE_DIR}/src/test_connection_pool.cpp)
  
+set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
+
 set(IRODS_TEST_LINK_LIBRARIES irods_common
-                              irods_client)
+                              irods_client
+                              ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)

--- a/unit_tests/cmake/test_config/irods_fully_qualified_username.cmake
+++ b/unit_tests/cmake/test_config/irods_fully_qualified_username.cmake
@@ -1,0 +1,6 @@
+set(IRODS_TEST_TARGET irods_fully_qualified_username)
+
+set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/src/test_fully_qualified_username.cpp)
+
+set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include)

--- a/unit_tests/src/test_atomic_apply_acl_operations.cpp
+++ b/unit_tests/src/test_atomic_apply_acl_operations.cpp
@@ -285,7 +285,7 @@ TEST_CASE("Non-admin users are not allowed to use the admin_mode option")
     conn.disconnect();
     rodsEnv env;
     _getRodsEnv(env);
-    conn.connect(env.rodsHost, env.rodsPort, test_user.name.c_str(), env.rodsZone);
+    conn.connect(env.rodsHost, env.rodsPort, {test_user.name.c_str(), env.rodsZone});
 
     // Capture the home collection of the test user.
     const auto test_user_home = fs::path{"/"} / env.rodsZone / "home" / test_user.name;

--- a/unit_tests/src/test_client_connection.cpp
+++ b/unit_tests/src/test_client_connection.cpp
@@ -2,9 +2,14 @@
 
 #include "irods/client_connection.hpp"
 #include "irods/filesystem.hpp"
+#include "irods/fully_qualified_username.hpp"
 #include "irods/getRodsEnv.h"
+#include "irods/irods_at_scope_exit.hpp"
 #include "irods/rcConnect.h"
 #include "irods/rodsClient.h"
+#include "irods/user_administration.hpp"
+
+#include <array>
 
 namespace ix = irods::experimental;
 
@@ -24,10 +29,7 @@ TEST_CASE("connect using multi-argument constructor", "client_connection")
     _getRodsEnv(env);
 
     load_client_api_plugins();
-    ix::client_connection conn{env.rodsHost,
-                               env.rodsPort,
-                               env.rodsUserName,
-                               env.rodsZone};
+    ix::client_connection conn{env.rodsHost, env.rodsPort, {env.rodsUserName, env.rodsZone}};
 
     REQUIRE(conn);
 
@@ -59,6 +61,7 @@ TEST_CASE("take ownership of raw connection", "client_connection")
     REQUIRE(ix::filesystem::client::exists(conn, "/"));
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE("defer connection", "client_connection")
 {
     load_client_api_plugins();
@@ -76,10 +79,7 @@ TEST_CASE("defer connection", "client_connection")
         rodsEnv env;
         _getRodsEnv(env);
 
-        conn.connect(env.rodsHost,
-                     env.rodsPort,
-                     env.rodsUserName,
-                     env.rodsZone);
+        conn.connect(env.rodsHost, env.rodsPort, {env.rodsUserName, env.rodsZone});
 
         REQUIRE(conn);
     }
@@ -105,6 +105,7 @@ TEST_CASE("supports move semantics", "client_connection")
     REQUIRE(ix::filesystem::client::exists(new_owner, "/"));
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE("supports implicit and explicit casts to underlying type", "client_connection")
 {
     load_client_api_plugins();
@@ -118,9 +119,9 @@ TEST_CASE("supports implicit and explicit casts to underlying type", "client_con
 
         // Test the connection.
         REQUIRE(ix::filesystem::client::exists(conn_ref, "/"));
-    });
+    }());
 
-    RcComm* conn_ptr = static_cast<RcComm*>(conn);
+    auto* conn_ptr = static_cast<RcComm*>(conn);
     REQUIRE(conn_ptr);
     REQUIRE(conn);
 
@@ -128,3 +129,126 @@ TEST_CASE("supports implicit and explicit casts to underlying type", "client_con
     REQUIRE(ix::filesystem::client::exists(*conn_ptr, "/"));
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST_CASE("defer authentication", "client_connection")
+{
+    load_client_api_plugins();
+
+    const auto test_deferred_authentication = [](ix::client_connection& _conn, const std::string& _path) {
+        // Show that "conn" holds a valid RcComm.
+        REQUIRE(_conn);
+
+        // Show that even though the connection is valid, the user cannot execute any
+        // operations because they haven't completed authentication.
+        REQUIRE_THROWS(ix::filesystem::client::exists(_conn, _path));
+
+        // Show that the previous operation is allowed once the user is authenticated.
+        REQUIRE(clientLogin(static_cast<RcComm*>(_conn)) == 0);
+        REQUIRE(ix::filesystem::client::exists(_conn, _path));
+    };
+
+    namespace ia = irods::experimental::administration;
+
+    ix::client_connection admin_conn;
+
+    const ia::user defer_user{"defer_user"};
+    REQUIRE_NOTHROW(ia::client::add_user(admin_conn, defer_user));
+
+    irods::at_scope_exit remove_defer_user{
+        [&admin_conn, defer_user] { ia::client::remove_user(admin_conn, defer_user); }};
+
+    SECTION("construct using irods_environment.json")
+    {
+        ix::client_connection conn{ix::defer_authentication};
+        test_deferred_authentication(conn, "/");
+    }
+
+    SECTION("construct with user-provided arguments")
+    {
+        rodsEnv env;
+        _getRodsEnv(env);
+
+        ix::fully_qualified_username user{env.rodsUserName, env.rodsZone};
+        ix::client_connection conn{ix::defer_authentication, env.rodsHost, env.rodsPort, user};
+
+        test_deferred_authentication(conn, "/");
+    }
+
+    SECTION("construct with proxy and user-provided arguments")
+    {
+        rodsEnv env;
+        _getRodsEnv(env);
+
+        ix::fully_qualified_username proxy_user{env.rodsUserName, env.rodsZone};
+        ix::fully_qualified_username user{defer_user.name, env.rodsZone};
+
+        ix::client_connection conn{ix::defer_authentication, env.rodsHost, env.rodsPort, proxy_user, user};
+
+        test_deferred_authentication(conn, fmt::format("/{}/home/{}", env.rodsZone, defer_user.name));
+    }
+
+    SECTION("connect using irods_environment.json")
+    {
+        ix::client_connection conn{ix::defer_connection};
+        conn.connect(ix::defer_authentication);
+        test_deferred_authentication(conn, "/");
+    }
+
+    SECTION("connect with user-provided arguments")
+    {
+        rodsEnv env;
+        _getRodsEnv(env);
+
+        ix::client_connection conn{ix::defer_connection};
+        conn.connect(ix::defer_authentication, env.rodsHost, env.rodsPort, {env.rodsUserName, env.rodsZone});
+
+        test_deferred_authentication(conn, "/");
+    }
+
+    SECTION("connect with proxy and user-provided arguments")
+    {
+        rodsEnv env;
+        _getRodsEnv(env);
+
+        ix::fully_qualified_username proxy_user{env.rodsUserName, env.rodsZone};
+        ix::fully_qualified_username user{defer_user.name, env.rodsZone};
+
+        ix::client_connection conn{ix::defer_connection};
+        conn.connect(ix::defer_authentication, env.rodsHost, env.rodsPort, proxy_user, user);
+
+        test_deferred_authentication(conn, fmt::format("/{}/home/{}", env.rodsZone, defer_user.name));
+    }
+
+    SECTION("connect with proxy using irods_environment.json")
+    {
+        const ia::user proxy_admin{"proxy_admin"};
+        REQUIRE_NOTHROW(ia::client::add_user(admin_conn, proxy_admin, ia::user_type::rodsadmin));
+
+        irods::at_scope_exit remove_proxy_admin{
+            [&admin_conn, proxy_admin] { ia::client::remove_user(admin_conn, proxy_admin); }};
+
+        // The property is mutable so that we can use it for clientLoginWithPassword()
+        // later in the test.
+        auto password = std::to_array("ppass");
+        const ia::user_password_property pwd_property{password.data()};
+        REQUIRE_NOTHROW(ia::client::modify_user(admin_conn, proxy_admin, pwd_property));
+
+        rodsEnv env;
+        _getRodsEnv(env);
+
+        ix::client_connection conn{ix::defer_connection};
+        conn.connect(ix::defer_authentication, {proxy_admin.name, env.rodsZone});
+
+        // Show that "conn" holds a valid RcComm.
+        REQUIRE(conn);
+
+        // Show that even though the connection is valid, the user cannot execute any
+        // operations because they haven't completed authentication.
+        const auto path = fmt::format("/{}/home/{}", env.rodsZone, env.rodsUserName);
+        REQUIRE_THROWS(ix::filesystem::client::exists(conn, path));
+
+        // Show that the previous operation is allowed once the user is authenticated.
+        REQUIRE(clientLoginWithPassword(static_cast<RcComm*>(conn), password.data()) == 0);
+        REQUIRE(ix::filesystem::client::exists(conn, path));
+    }
+}

--- a/unit_tests/src/test_connection_pool.cpp
+++ b/unit_tests/src/test_connection_pool.cpp
@@ -1,17 +1,27 @@
 #include <catch2/catch.hpp>
 
+#include "irods/client_connection.hpp"
 #include "irods/connection_pool.hpp"
 #include "irods/filesystem.hpp"
+#include "irods/fully_qualified_username.hpp"
 #include "irods/getRodsEnv.h"
 #include "irods/irods_at_scope_exit.hpp"
+#include "irods/irods_exception.hpp"
+#include "irods/rcConnect.h"
 #include "irods/rodsClient.h"
+#include "irods/rodsErrorTable.h"
+#include "irods/user_administration.hpp"
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE("connection pool")
 {
     rodsEnv env;
     _getRodsEnv(env);
 
     load_client_api_plugins();
+
+    constexpr int cp_size = 1;
+    constexpr int cp_refresh_time = 600;
 
     SECTION("connections are detachable")
     {
@@ -21,15 +31,15 @@ TEST_CASE("connection pool")
             REQUIRE(rcDisconnect(released_conn_ptr) == 0);
         }};
 
-        const int cp_size = 1;
-        const int cp_refresh_time = 600;
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         irods::connection_pool conn_pool{cp_size,
                                          env.rodsHost,
                                          env.rodsPort,
                                          env.rodsUserName,
                                          env.rodsZone,
                                          cp_refresh_time};
+#pragma clang diagnostic pop
 
         namespace fs = irods::experimental::filesystem;
 
@@ -61,7 +71,46 @@ TEST_CASE("connection pool")
         REQUIRE(released_conn_ptr != static_cast<rcComm_t*>(conn));
     }
 
-    SECTION("connection_proxies are default constructible")
+    SECTION("connections are detachable (updated interface)")
+    {
+        rcComm_t* released_conn_ptr = nullptr;
+
+        irods::at_scope_exit at_scope_exit{[&released_conn_ptr] { REQUIRE(rcDisconnect(released_conn_ptr) == 0); }};
+
+        irods::experimental::fully_qualified_username user{env.rodsUserName, env.rodsZone};
+        irods::connection_pool conn_pool{cp_size, env.rodsHost, env.rodsPort, user, cp_refresh_time};
+
+        namespace fs = irods::experimental::filesystem;
+
+        {
+            auto conn = conn_pool.get_connection();
+            REQUIRE(static_cast<rcComm_t*>(conn) != nullptr);
+            REQUIRE(fs::client::exists(conn, env.rodsHome));
+
+            // Show that the connection is no longer being managed by the pool.
+            released_conn_ptr = conn.release();
+            REQUIRE(released_conn_ptr != nullptr);
+            REQUIRE_FALSE(conn);
+            REQUIRE(static_cast<rcComm_t*>(conn) == nullptr);
+            REQUIRE_THROWS((void) static_cast<rcComm_t&>(conn), "Invalid connection object");
+        } //namespace irods::experimental::filesystem;
+
+        // Show that the released connection is no longer managed by the
+        // connection pool, but is still usable.
+        REQUIRE(fs::client::exists(*released_conn_ptr, env.rodsHome));
+
+        // Given that the connection pool contained only one connection.
+        // Show that requesting a connection will cause the connection pool
+        // to construct a new connection in place of the released connection.
+        auto conn = conn_pool.get_connection();
+        REQUIRE(static_cast<rcComm_t*>(conn) != nullptr);
+
+        // Show that the released connection and the connection recently
+        // created by the connection pool are indeed different connections.
+        REQUIRE(released_conn_ptr != static_cast<rcComm_t*>(conn));
+    }
+
+    SECTION("connection_proxy is default constructible")
     {
         // This will not compile if the connection proxy class is not
         // default constructible. This allows connection proxies to be
@@ -107,5 +156,109 @@ TEST_CASE("connection pool")
 
         REQUIRE(released_conn_ptr);
     }
-}
 
+    SECTION("connection pools allow the default authentication method to be overridden")
+    {
+        REQUIRE_NOTHROW([&env] {
+            const auto auth_func = [](auto& _comm) {
+                if (clientLogin(&_comm) != 0) {
+                    THROW(SYS_SOCK_CONNECT_ERR, ".irodsA authentication error");
+                }
+            };
+
+            irods::experimental::fully_qualified_username user{env.rodsUserName, env.rodsZone};
+            irods::connection_pool conn_pool{cp_size, env.rodsHost, env.rodsPort, user, cp_refresh_time, auth_func};
+        }());
+    }
+
+    SECTION("connection pools support proxied connections")
+    {
+        irods::experimental::client_connection admin_conn;
+
+        namespace ia = irods::experimental::administration;
+
+        const ia::user proxy_admin{"proxy_admin"};
+        REQUIRE_NOTHROW(ia::client::add_user(admin_conn, proxy_admin, ia::user_type::rodsadmin));
+
+        irods::at_scope_exit remove_proxy_admin{
+            [&admin_conn, proxy_admin] { ia::client::remove_user(admin_conn, proxy_admin); }};
+
+        auto password = std::to_array("ppass");
+        const ia::user_password_property pwd_property{password.data()};
+        REQUIRE_NOTHROW(ia::client::modify_user(admin_conn, proxy_admin, pwd_property));
+
+        const auto auth_func = [&password](auto& _comm) {
+            if (clientLoginWithPassword(&_comm, password.data()) != 0) {
+                THROW(SYS_SOCK_CONNECT_ERR, "Password authentication error");
+            }
+        };
+
+        irods::experimental::fully_qualified_username proxy_user{proxy_admin.name, env.rodsZone};
+        irods::experimental::fully_qualified_username user{env.rodsUserName, env.rodsZone};
+
+        irods::connection_pool conn_pool{
+            cp_size, env.rodsHost, env.rodsPort, proxy_user, user, cp_refresh_time, auth_func};
+
+        auto conn = conn_pool.get_connection();
+
+        // Show that the proxied connection works by accessing the home collection of
+        // the proxied user.
+        namespace fs = irods::experimental::filesystem;
+        REQUIRE(fs::client::exists(conn, fmt::format("/{}/home/{}", env.rodsZone, env.rodsUserName)));
+    }
+
+    SECTION("connection pool throws exception on incorrect alternative authentication method")
+    {
+        const auto auth_func = [](auto& _comm) {
+            // This will cause the connection pool to throw an exception on construction.
+            if (clientLoginWithPassword(&_comm, "nope") != 0) {
+                THROW(SYS_SOCK_CONNECT_ERR, "Password authentication error");
+            }
+        };
+
+        try {
+            irods::experimental::fully_qualified_username user{env.rodsUserName, env.rodsZone};
+            irods::connection_pool conn_pool{cp_size, env.rodsHost, env.rodsPort, user, cp_refresh_time, auth_func};
+        }
+        catch (const irods::exception& e) {
+            REQUIRE(e.code() == SYS_SOCK_CONNECT_ERR);
+        }
+    }
+
+    SECTION("connection pool with proxy throws exception on incorrect alternative authentication method")
+    {
+        irods::experimental::client_connection admin_conn;
+
+        namespace ia = irods::experimental::administration;
+
+        const ia::user proxy_admin{"proxy_admin"};
+        REQUIRE_NOTHROW(ia::client::add_user(admin_conn, proxy_admin, ia::user_type::rodsadmin));
+
+        irods::at_scope_exit remove_proxy_admin{
+            [&admin_conn, proxy_admin] { ia::client::remove_user(admin_conn, proxy_admin); }};
+
+        // The property is mutable so that we can use it for clientLoginWithPassword()
+        // later in the test.
+        auto password = std::to_array("ppass");
+        const ia::user_password_property pwd_property{password.data()};
+        REQUIRE_NOTHROW(ia::client::modify_user(admin_conn, proxy_admin, pwd_property));
+
+        const auto auth_func = [](auto& _comm) {
+            // This will cause the connection pool to throw an exception on construction.
+            if (clientLoginWithPassword(&_comm, "nope") != 0) {
+                THROW(SYS_SOCK_CONNECT_ERR, "Password authentication error");
+            }
+        };
+
+        try {
+            irods::experimental::fully_qualified_username proxy_user{proxy_admin.name, env.rodsZone};
+            irods::experimental::fully_qualified_username user{env.rodsUserName, env.rodsZone};
+
+            irods::connection_pool conn_pool{
+                cp_size, env.rodsHost, env.rodsPort, proxy_user, user, cp_refresh_time, auth_func};
+        }
+        catch (const irods::exception& e) {
+            REQUIRE(e.code() == SYS_SOCK_CONNECT_ERR);
+        }
+    }
+}

--- a/unit_tests/src/test_fully_qualified_username.cpp
+++ b/unit_tests/src/test_fully_qualified_username.cpp
@@ -1,0 +1,35 @@
+#include <catch2/catch.hpp>
+
+#include "irods/fully_qualified_username.hpp"
+#include "irods/rodsErrorTable.h"
+
+TEST_CASE("fully_qualified_username")
+{
+    irods::experimental::fully_qualified_username fqun{"rods", "tempZone"};
+
+    CHECK(fqun.name() == "rods");
+    CHECK(fqun.zone() == "tempZone");
+    CHECK(fqun.full_name() == "rods#tempZone");
+}
+
+TEST_CASE("fully_qualified_username throws exception on empty name")
+{
+    try {
+        irods::experimental::fully_qualified_username{"", "tempZone"};
+    }
+    catch (const irods::exception& e) {
+        CHECK(e.code() == SYS_INVALID_INPUT_PARAM);
+        CHECK_THAT(e.client_display_what(), Catch::Matchers::Contains("Empty name not allowed."));
+    }
+}
+
+TEST_CASE("fully_qualified_username throws exception on empty zone")
+{
+    try {
+        irods::experimental::fully_qualified_username{"rods", ""};
+    }
+    catch (const irods::exception& e) {
+        CHECK(e.code() == SYS_INVALID_INPUT_PARAM);
+        CHECK_THAT(e.client_display_what(), Catch::Matchers::Contains("Empty zone not allowed."));
+    }
+}

--- a/unit_tests/src/test_get_delay_rule_info.cpp
+++ b/unit_tests/src/test_get_delay_rule_info.cpp
@@ -105,7 +105,8 @@ TEST_CASE("rc_get_delay_rule_info")
 
                 // Connect to the server as the test user.
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-                irods::experimental::client_connection alice_conn{env.rodsHost, env.rodsPort, alice.name, env.rodsZone};
+                irods::experimental::client_connection alice_conn{
+                    env.rodsHost, env.rodsPort, {alice.name, env.rodsZone}};
                 REQUIRE(alice_conn);
 
                 // Show that the non-admin user is not allowed to invoke the API endpoint.

--- a/unit_tests/src/test_json_apis_from_client.cpp
+++ b/unit_tests/src/test_json_apis_from_client.cpp
@@ -72,10 +72,7 @@ TEST_CASE("test atomic metadata with BinBytesBuf", "[xml]")
 
     const auto sandbox = fs::path{env.rodsHome} / "unit_testing_sandbox";
 
-    ix::client_connection conn{env.rodsHost,
-                               env.rodsPort,
-                               env.rodsUserName,
-                               env.rodsZone};
+    ix::client_connection conn{env.rodsHost, env.rodsPort, {env.rodsUserName, env.rodsZone}};
 
     REQUIRE(fs::client::create_collection(conn, sandbox));
 

--- a/unit_tests/src/test_metadata.cpp
+++ b/unit_tests/src/test_metadata.cpp
@@ -1,12 +1,13 @@
 #include <catch2/catch.hpp>
 #include <fmt/format.h>
 
-#include "irods/getRodsEnv.h"
-#include "irods/rodsClient.h"
-#include "irods/rcConnect.h"
 #include "irods/connection_pool.hpp"
 #include "irods/filesystem.hpp"
+#include "irods/fully_qualified_username.hpp"
+#include "irods/getRodsEnv.h"
 #include "irods/metadata.hpp"
+#include "irods/rcConnect.h"
+#include "irods/rodsClient.h"
 
 #include "irods/irods_at_scope_exit.hpp"
 #include "irods/dstream.hpp"
@@ -29,12 +30,8 @@ TEST_CASE("metadata")
     const int cp_size = 1;
     const int cp_refresh_time = 600;
 
-    irods::connection_pool conn_pool{cp_size,
-                                     env.rodsHost,
-                                     env.rodsPort,
-                                     env.rodsUserName,
-                                     env.rodsZone,
-                                     cp_refresh_time};
+    irods::experimental::fully_qualified_username user{env.rodsUserName, env.rodsZone};
+    irods::connection_pool conn_pool{cp_size, env.rodsHost, env.rodsPort, user, cp_refresh_time};
 
     auto conn = conn_pool.get_connection();
 

--- a/unit_tests/src/test_query_builder.cpp
+++ b/unit_tests/src/test_query_builder.cpp
@@ -23,10 +23,7 @@ TEST_CASE("query builder")
 
     load_client_api_plugins();
 
-    ix::client_connection conn{env.rodsHost,
-                               env.rodsPort,
-                               env.rodsUserName,
-                               env.rodsZone};
+    ix::client_connection conn{env.rodsHost, env.rodsPort, {env.rodsUserName, env.rodsZone}};
 
     const fs::path user_home = env.rodsHome;
 

--- a/unit_tests/unit_tests_list.json
+++ b/unit_tests/unit_tests_list.json
@@ -13,6 +13,7 @@
     "irods_dstream",
     "irods_filesystem",
     "irods_fixed_buffer_resource",
+    "irods_fully_qualified_username",
     "irods_get_delay_rule_info",
     "irods_get_file_descriptor_info",
     "irods_hierarchy_parser",


### PR DESCRIPTION
Cherry-picked from #7047.