### PR TITLE
[7101] Include missing headers (4-3-stable)

### DIFF
--- a/lib/core/include/irods/guiProgressCallback.h
+++ b/lib/core/include/irods/guiProgressCallback.h
@@ -1,6 +1,9 @@
 #ifndef _GUI_PROGRESS_CALLBACK_H__
 #define _GUI_PROGRESS_CALLBACK_H__
 
+#include "irods/rodsDef.h" // For MAX_NAME_LEN
+#include "irods/rodsType.h" // For rodsLong_t
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Include missing headers that define rodsLong_t and MAX_NAME_LEN