### PR TITLE
[#2533,#3824] Add TCP keepalive option configs (main)

### DIFF
--- a/lib/core/include/irods/getRodsEnv.h
+++ b/lib/core/include/irods/getRodsEnv.h
@@ -56,6 +56,12 @@ typedef struct RodsEnvironment {
     // =-=-=-=-=-=-=-
     // override of plugin installation directory
     char irodsPluginHome[MAX_NAME_LEN];
+
+    // =-=-=-=-=-=-=-
+    // TCP keepalive configurations
+    int tcp_keepalive_intvl;
+    int tcp_keepalive_probes;
+    int tcp_keepalive_time;
 } rodsEnv;
 
 #ifdef __cplusplus

--- a/lib/core/include/irods/irods_configuration_keywords.hpp
+++ b/lib/core/include/irods/irods_configuration_keywords.hpp
@@ -98,6 +98,10 @@ namespace irods
     extern const char* const KW_CFG_EVICTION_AGE_IN_SECONDS;
     extern const char* const KW_CFG_CACHE_CLEARER_SLEEP_TIME_IN_SECONDS;
 
+    extern const char* const KW_CFG_IRODS_TCP_KEEPALIVE_PROBES;
+    extern const char* const KW_CFG_IRODS_TCP_KEEPALIVE_TIME_IN_SECONDS;
+    extern const char* const KW_CFG_IRODS_TCP_KEEPALIVE_INTVL_IN_SECONDS;
+
     // service_account_environment.json keywords
     extern const char* const KW_CFG_IRODS_USER_NAME;
     extern const char* const KW_CFG_IRODS_HOST;

--- a/lib/core/include/irods/rodsErrorTable.h
+++ b/lib/core/include/irods/rodsErrorTable.h
@@ -244,6 +244,7 @@ NEW_ERROR(INVALID_HANDLE,                              -175000)
 NEW_ERROR(DOES_NOT_EXIST,                              -176000)
 NEW_ERROR(TYPE_NOT_SUPPORTED,                          -177000)
 NEW_ERROR(AUTHENTICATION_ERROR,                        -178000)
+NEW_ERROR(SOCKET_ERROR,                                -179000)
 
 /** @} */
 

--- a/lib/core/include/irods/sockComm.h
+++ b/lib/core/include/irods/sockComm.h
@@ -1,5 +1,7 @@
-#ifndef SOCK_COMM_H__
-#define SOCK_COMM_H__
+#ifndef IRODS_SOCK_COMM_H
+#define IRODS_SOCK_COMM_H
+
+/// \file
 
 #include "irods/rodsDef.h"
 #include "irods/rodsPackInstruct.h"
@@ -92,9 +94,19 @@ int rcReconnect(struct RcComm **comm, char *newHost, struct RodsEnvironment *myE
 
 int mySockClose(int sock); // server stop fcn <==> rsAccept?
 
+/// \brief Set the TCP_KEEPALIVE options for the specified socket.
+///
+/// param[in] _sfd Socket file descriptor on which options are being set.
+///
+/// \return An integer
+/// \retval 0 on success
+/// \retval <0 on failure
+///
+/// \since 4.3.1
+int set_socket_tcp_keepalive_options(int _sfd); // NOLINT(modernize-use-trailing-return-type)
+
 #ifdef __cplusplus
 }
 #endif
 
-#endif // SOCK_COMM_H__ 
-
+#endif // IRODS_SOCK_COMM_H

--- a/lib/core/src/getRodsEnv.cpp
+++ b/lib/core/src/getRodsEnv.cpp
@@ -354,6 +354,25 @@ extern "C" {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         capture_string_property(irods::KW_CFG_IRODS_PLUGINS_HOME, _env->irodsPluginHome, MAX_NAME_LEN);
 
+        // If the configuration is not set for the TCP keepalive options, set the value to something invalid. This
+        // indicates that we should not set the option on the socket, which will allow the socket to use the kernel
+        // configuration.
+        status =
+            capture_integer_property(irods::KW_CFG_IRODS_TCP_KEEPALIVE_INTVL_IN_SECONDS, _env->tcp_keepalive_intvl);
+        if (status < 0) {
+            _env->tcp_keepalive_intvl = -1;
+        }
+
+        status = capture_integer_property(irods::KW_CFG_IRODS_TCP_KEEPALIVE_PROBES, _env->tcp_keepalive_probes);
+        if (status < 0) {
+            _env->tcp_keepalive_probes = -1;
+        }
+
+        status = capture_integer_property(irods::KW_CFG_IRODS_TCP_KEEPALIVE_TIME_IN_SECONDS, _env->tcp_keepalive_time);
+        if (status < 0) {
+            _env->tcp_keepalive_time = -1;
+        }
+
         return 0;
     }
 
@@ -630,6 +649,10 @@ extern "C" {
         capture_string_env_var(
             env_var,
             _env->irodsPluginHome );
+
+        capture_integer_env_var(irods::KW_CFG_IRODS_TCP_KEEPALIVE_INTVL_IN_SECONDS, _env->tcp_keepalive_intvl);
+        capture_integer_env_var(irods::KW_CFG_IRODS_TCP_KEEPALIVE_PROBES, _env->tcp_keepalive_probes);
+        capture_integer_env_var(irods::KW_CFG_IRODS_TCP_KEEPALIVE_TIME_IN_SECONDS, _env->tcp_keepalive_time);
 
         return 0;
     }

--- a/lib/core/src/irods_configuration_keywords.cpp
+++ b/lib/core/src/irods_configuration_keywords.cpp
@@ -130,6 +130,10 @@ namespace irods
     const char* const KW_CFG_IRODS_TRANS_BUFFER_SIZE_FOR_PARA_TRANS{"irods_transfer_buffer_size_for_parallel_transfer_in_megabytes"};
     const char* const KW_CFG_IRODS_CONNECTION_POOL_REFRESH_TIME{"irods_connection_pool_refresh_time_in_seconds"};
 
+    const char* const KW_CFG_IRODS_TCP_KEEPALIVE_PROBES{"irods_tcp_keepalive_probes"};
+    const char* const KW_CFG_IRODS_TCP_KEEPALIVE_TIME_IN_SECONDS{"irods_tcp_keepalive_time_in_seconds"};
+    const char* const KW_CFG_IRODS_TCP_KEEPALIVE_INTVL_IN_SECONDS{"irods_tcp_keepalive_intvl_in_seconds"};
+
     // legacy ssl environment variables
     const char* const KW_CFG_IRODS_SSL_CA_CERTIFICATE_PATH{"irods_ssl_ca_certificate_path"};
     const char* const KW_CFG_IRODS_SSL_CA_CERTIFICATE_FILE{"irods_ssl_ca_certificate_file"};

--- a/schemas/configuration/v4/service_account_environment.json.in
+++ b/schemas/configuration/v4/service_account_environment.json.in
@@ -38,6 +38,9 @@
         "irods_ssl_certificate_key_file": {"type": "string"},
         "irods_ssl_dh_params_file": {"type": "string"},
         "irods_ssl_verify_server": {"enum": ["cert","hostname","none"]},
+        "irods_tcp_keepalive_intvl_in_seconds": {"type": "integer"},
+        "irods_tcp_keepalive_probes": {"type": "integer"},
+        "irods_tcp_keepalive_time_in_seconds": {"type": "integer"},
         "irods_transfer_buffer_size_for_parallel_transfer_in_megabytes": {"type": "integer"},
         "schema_name": {"type": "string"},
         "schema_version": {"type": "string"}

--- a/scripts/irods/test/test_misc.py
+++ b/scripts/irods/test/test_misc.py
@@ -373,3 +373,93 @@ class Test_Misc(session.make_sessions_mixin([('otherrods', 'rods')], []), unitte
             error_string = ' ERROR: environment_properties::capture: missing environment file. should be at [{}/.irods/irods_environment.json]\n'.format(
                 temp_home)
             self.assertEqual(stderr, error_string)
+
+
+    def test_tcp_keepalive_time__issue_2533_3824(self):
+        # This test sets the iRODS TCP keepalive time to various values. Due to the nature of TCP socket timeouts, this
+        # does not test the behavior of the TCP keepalive options on the sockets. It mainly demonstrates the range of
+        # values allowed by the system.
+        self.env = os.environ.copy()
+
+        # Test with tcp_keepalive_time unset.
+        self.admin.assert_icommand('ils', 'STDOUT', self.admin.session_collection, env=self.env)
+
+        # Test with tcp_keepalive_time set to 1. This is the smallest valid value and should not affect behavior.
+        self.env['IRODS_TCP_KEEPALIVE_TIME_IN_SECONDS'] = str(1)
+        self.admin.assert_icommand('ils', 'STDOUT', self.admin.session_collection, env=self.env)
+
+        # Test with tcp_keepalive_time set to 0. This value is invalid, but is detected by the socket-creating function
+        # and ignored, effectively leaving it unset.
+        self.env['IRODS_TCP_KEEPALIVE_TIME_IN_SECONDS'] = str(0)
+        self.admin.assert_icommand('ils', 'STDOUT', self.admin.session_collection, env=self.env)
+
+        # Test with tcp_keepalive_time set to 0. This value is invalid, but is detected by the socket-creating function
+        # and ignored, effectively leaving it unset.
+        self.env['IRODS_TCP_KEEPALIVE_TIME_IN_SECONDS'] = str(-1)
+        self.admin.assert_icommand('ils', 'STDOUT', self.admin.session_collection, env=self.env)
+
+        # Test with tcp_keepalive_time set to INT32_MAX. This value is invalid and is not detected by the
+        # socket-creating function, so it attempts to set the socket option and fails because the value is invalid.
+        # Check for SOCKET_ERROR (-179000) with an errno of 22 (Invalid argument).
+        self.env['IRODS_TCP_KEEPALIVE_TIME_IN_SECONDS'] = str(2147483647)
+        self.admin.assert_icommand('ils', 'STDERR', '-179022 SOCKET_ERROR, Invalid argument', env=self.env)
+
+
+    def test_tcp_keepalive_intvl__issue_2533_3824(self):
+        # This test sets the iRODS TCP keepalive interval to various values. Due to the nature of TCP socket timeouts,
+        # this does not test the behavior of the TCP keepalive options on the sockets. It mainly demonstrates the range
+        # of values allowed by the system.
+        self.env = os.environ.copy()
+
+        # Test with tcp_keepalive_intvl unset.
+        self.admin.assert_icommand('ils', 'STDOUT', self.admin.session_collection, env=self.env)
+
+        # Test with tcp_keepalive_intvl set to 1. This is the smallest valid value and should not affect behavior.
+        self.env['IRODS_TCP_KEEPALIVE_INTVL_IN_SECONDS'] = str(1)
+        self.admin.assert_icommand('ils', 'STDOUT', self.admin.session_collection, env=self.env)
+
+        # Test with tcp_keepalive_intvl set to 0. This value is invalid, but is detected by the socket-creating function
+        # and ignored, effectively leaving it unset.
+        self.env['IRODS_TCP_KEEPALIVE_INTVL_IN_SECONDS'] = str(0)
+        self.admin.assert_icommand('ils', 'STDOUT', self.admin.session_collection, env=self.env)
+
+        # Test with tcp_keepalive_intvl set to 0. This value is invalid, but is detected by the socket-creating function
+        # and ignored, effectively leaving it unset.
+        self.env['IRODS_TCP_KEEPALIVE_INTVL_IN_SECONDS'] = str(-1)
+        self.admin.assert_icommand('ils', 'STDOUT', self.admin.session_collection, env=self.env)
+
+        # Test with tcp_keepalive_intvl set to INT32_MAX. This value is invalid and is not detected by the
+        # socket-creating function, so it attempts to set the socket option and fails because the value is invalid.
+        # Check for SOCKET_ERROR (-179000) with an errno of 22 (Invalid argument).
+        self.env['IRODS_TCP_KEEPALIVE_INTVL_IN_SECONDS'] = str(2147483647)
+        self.admin.assert_icommand('ils', 'STDERR', '-179022 SOCKET_ERROR, Invalid argument', env=self.env)
+
+
+    def test_tcp_keepalive_probes__issue_2533_3824(self):
+        # This test sets the iRODS TCP keepalive probes to various values. Due to the nature of TCP socket timeouts,
+        # this does not test the behavior of the TCP keepalive options on the sockets. It mainly demonstrates the range
+        # of values allowed by the system.
+        self.env = os.environ.copy()
+
+        # Test with tcp_keepalive_probes unset.
+        self.admin.assert_icommand('ils', 'STDOUT', self.admin.session_collection, env=self.env)
+
+        # Test with tcp_keepalive_probes set to 1. This is the smallest valid value and should not affect behavior.
+        self.env['IRODS_TCP_KEEPALIVE_PROBES'] = str(1)
+        self.admin.assert_icommand('ils', 'STDOUT', self.admin.session_collection, env=self.env)
+
+        # Test with tcp_keepalive_probes set to 0. This value is invalid, but is detected by the socket-creating
+        # function and ignored, effectively leaving it unset.
+        self.env['IRODS_TCP_KEEPALIVE_PROBES'] = str(0)
+        self.admin.assert_icommand('ils', 'STDOUT', self.admin.session_collection, env=self.env)
+
+        # Test with tcp_keepalive_probes set to 0. This value is invalid, but is detected by the socket-creating
+        # function and ignored, effectively leaving it unset.
+        self.env['IRODS_TCP_KEEPALIVE_PROBES'] = str(-1)
+        self.admin.assert_icommand('ils', 'STDOUT', self.admin.session_collection, env=self.env)
+
+        # Test with tcp_keepalive_probes set to INT32_MAX. This value is invalid and is not detected by the
+        # socket-creating function, so it attempts to set the socket option and fails because the value is invalid.
+        # Check for SOCKET_ERROR (-179000) with an errno of 22 (Invalid argument).
+        self.env['IRODS_TCP_KEEPALIVE_PROBES'] = str(2147483647)
+        self.admin.assert_icommand('ils', 'STDERR', '-179022 SOCKET_ERROR, Invalid argument', env=self.env)

--- a/server/core/src/miscServerFunct.cpp
+++ b/server/core/src/miscServerFunct.cpp
@@ -2371,13 +2371,15 @@ svrChkReconnAtReadEnd( rsComm_t *rsComm ) {
     return 0;
 }
 
-int
-svrSockOpenForInConn( rsComm_t *rsComm, int *portNum, char **addr, int proto ) {
-    int status;
+int svrSockOpenForInConn(rsComm_t* rsComm, int* portNum, char** addr, int proto)
+{
+    int sfd = sockOpenForInConn(rsComm, portNum, addr, proto);
+    if (sfd < 0) {
+        return sfd;
+    }
 
-    status = sockOpenForInConn( rsComm, portNum, addr, proto );
-    if ( status < 0 ) {
-        return status;
+    if (const int ec = set_socket_tcp_keepalive_options(sfd); ec < 0) {
+        return ec;
     }
 
     if ( addr != NULL && *addr != NULL &&
@@ -2397,8 +2399,8 @@ svrSockOpenForInConn( rsComm_t *rsComm, int *portNum, char **addr, int proto ) {
                      *addr );
         }
     }
-    return status;
-}
+    return sfd;
+} // svrSockOpenForInConn
 
 char *
 getLocalSvrAddr() {


### PR DESCRIPTION
Addresses #2533, #3824

Unit tests passed, running core tests.

I will be playing with `tc` tomorrow to see if I can demonstrate any effect from changing these values. I have demonstrated that setting `tcp_keepalive_time` to 0 results in an `errno` of 22, which is "Invalid argument". Not very useful. :)