### PR TITLE
Added single quote escaping to general_query

### DIFF
--- a/plugins/database/src/general_query.cpp
+++ b/plugins/database/src/general_query.cpp
@@ -1525,6 +1525,9 @@ insertWhere( char *condition, int option ) {
     }
 
     for ( cp1 = cpFirstQuote + 1; cp1 < cpSecondQuote; cp1++ ) {
+        if ( *cp1 == '\'' && *(cp1 + 1) == '\'' ) {
+            cp1++;
+        }
         bindVars[bindIx++] = *cp1;
     }
     bindVars[bindIx++] = '\0';


### PR DESCRIPTION
Potentially scary PR that allows for embedded single quote stuff to be used in genQuery1.

Pros:
- Fixes the embedded single quote issue (embedded quotes parsed by general_query should now be in doubles, so the where clause WHERE DATA_NAME = 'test''in' -> WHERE DATA_NAME = 'test'in' in the SQL query)

Cons:
- Any client code using existing genQuery1 queries has potential points of failure and need to be rewritten (includes stuff like ils, iput, etc...)

e.g. of an issue with iput if no fixes are implemented and this change is merged in: any file with double embedded quotes will be treated as if they only had a single quote, and passing it with -f could clobber a file unexpectedly.


With genQuery2 on the horizon, this potentially breaking change is questionably worth merging. However, I will leave it here as a point of discussion or for posterity.

EDIT: Relevant issues appear to be #7169 #7164 (Verified this fix works for the latter, haven't checked the former)