### PR TITLE
Overwrites for bulk puts (main)

### DIFF
--- a/scripts/irods/test/test_icommands_file_operations.py
+++ b/scripts/irods/test/test_icommands_file_operations.py
@@ -823,6 +823,7 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
         # prepare test directory
         number_of_files = 5
         dirname = self.admin.local_session_dir + '/files'
+        collection = os.path.join(self.admin.session_collection, 'files')
         # files less than 4200000 were failing to trigger the writeLine
         for filesize in range(5000, 6000000, 500000):
             lib.make_large_local_tmp_dir(dirname, number_of_files, filesize)
@@ -831,13 +832,14 @@ class Test_ICommands_File_Operations(resource_suite.ResourceBase, unittest.TestC
                 core.add_rule(pep_map[self.plugin_name])
 
                 initial_size_of_server_log = lib.get_file_size_by_path(paths.server_log_path())
-                self.admin.assert_icommand(['iput', '-frb', dirname], "STDOUT_SINGLELINE", ustrings.recurse_ok_string())
+                self.admin.assert_icommand(['iput', '-rb', dirname], "STDOUT_SINGLELINE", ustrings.recurse_ok_string())
                 lib.delayAssert(
                     lambda: lib.log_message_occurrences_equals_count(
                         msg='writeLine: inString = acPostProcForPut called for',
                         count=number_of_files,
                         start_index=initial_size_of_server_log))
                 shutil.rmtree(dirname)
+            self.admin.assert_icommand(['irm', '-rf', collection])
 
     def test_large_irods_maximum_size_for_single_buffer_in_megabytes_2880(self):
         self.admin.environment_file_contents['irods_maximum_size_for_single_buffer_in_megabytes'] = 2000

--- a/scripts/irods/test/test_iput_options.py
+++ b/scripts/irods/test/test_iput_options.py
@@ -203,6 +203,10 @@ class Test_iPut_Options(ResourceBase, unittest.TestCase):
         tempfile.mkstemp(dir=source_path)
         try:
             _,out,_ = self.admin.assert_icommand(
+                ['iput', '-v', '-r', '-b', '-f', source_path, 'v-r-b-f'],
+                'STDERR', '-402000 USER_INCOMPATIBLE_PARAMS')
+
+            _,out,_ = self.admin.assert_icommand(
                 ['iput', '-v', '-r', source_path, 'v-r'],
                 'STDOUT', ustrings.recurse_ok_string())
             self.assertNotIn(bulk_str, out, 'Bulk upload performed with no bulk flag')
@@ -217,10 +221,6 @@ class Test_iPut_Options(ResourceBase, unittest.TestCase):
                 'STDOUT', ustrings.recurse_ok_string())
             self.assertIn(bulk_str, out, 'Bulk upload not performed when requested')
 
-            _,out,_ = self.admin.assert_icommand(
-                ['iput', '-v', '-r', '-b', '-f', source_path, 'v-r-b-f'],
-                'STDOUT', ustrings.recurse_ok_string())
-            self.assertIn(bulk_str, out, 'Bulk upload not performed when requested')
         finally:
             shutil.rmtree(source_path, ignore_errors=True)
 

--- a/server/api/src/rsBulkDataObjPut.cpp
+++ b/server/api/src/rsBulkDataObjPut.cpp
@@ -88,6 +88,15 @@ postProcRenamedPhyFiles(
 int
 rsBulkDataObjPut( rsComm_t *rsComm, bulkOprInp_t *bulkOprInp,
                   bytesBuf_t *bulkOprInpBBuf ) {
+    if (!rsComm || !bulkOprInp) {
+        return USER__NULL_INPUT_ERR;
+    }
+
+    if (getValByKey(&bulkOprInp->condInput, FORCE_FLAG_KW)) {
+        addRErrorMsg(&rsComm->rError, USER_INCOMPATIBLE_PARAMS, "Force flag keyword is not allowed for bulk puts.");
+        return USER_INCOMPATIBLE_PARAMS;
+    }
+
     int status;
     int remoteFlag;
     rodsServerHost_t *rodsServerHost;


### PR DESCRIPTION
There are two and a half solutions presented here, as discussed in #7110. The "half" is whether to use `SYS_NOT_ALLOWED` or `USER_INCOMPATIBLE_PARAMS` in the case where we do not allow overwrites with bulk puts.

Please provide input on which solution seems more palatable.