### PR TITLE
Remove password_length configuration (main)

### DIFF
--- a/plugins/auth_legacy/src/pam.cpp
+++ b/plugins/auth_legacy/src/pam.cpp
@@ -402,18 +402,18 @@ irods::error pam_auth_agent_request(
         return ERROR( status, "pam auth check failed" );
     }
 
-    // =-=-=-=-=-=-=-
-    // request the resulting irods password after the handshake
-    char password_out[ MAX_NAME_LEN ];
-    char* pw_ptr = &password_out[0];
-    status = chlUpdateIrodsPamPassword( _ctx.comm(), const_cast< char* >( user_name.c_str() ), ttl, NULL, &pw_ptr );
+    // Request the resulting irods password after the handshake. Plus 1 for null terminator.
+    std::array<char, MAX_PASSWORD_LEN + 1> password_out{};
+    char* password_ptr = password_out.data();
+    status =
+        chlUpdateIrodsPamPassword(_ctx.comm(), user_name.c_str(), ttl, nullptr, &password_ptr, password_out.size());
     if (status < 0) {
         return ERROR(status, "failed updating iRODS pam password");
     }
 
     // =-=-=-=-=-=-=-
     // set the result for communication back to the client
-    ptr->request_result( password_out );
+    ptr->request_result(password_out.data());
 
     // =-=-=-=-=-=-=-
     // win!

--- a/server/icat/include/irods/icatHighLevelRoutines.hpp
+++ b/server/icat/include/irods/icatHighLevelRoutines.hpp
@@ -194,9 +194,12 @@ int chlVersionFnmBase( rsComm_t *rsComm,
 int chlModTicket( rsComm_t *rsComm, const char *opName, const char *ticket,
                   const char *arg1, const char *arg2, const char *arg3,
                   const KeyValPair *condInput);
-int chlUpdateIrodsPamPassword( rsComm_t *rsComm, const char *userName,
-                               int timeToLive, const char *testTime,
-                               char **irodsPassword );
+auto chlUpdateIrodsPamPassword(rsComm_t* _comm,
+                               const char* _user_name,
+                               int _ttl,
+                               const char* _test_time,
+                               char** _password_buffer,
+                               std::size_t _password_buffer_size) -> int;
 
 /// =-=-=-=-=-=-=-
 /// @brief typedefs and prototype for query used for rebalancing operation

--- a/server/icat/src/icatHighLevelRoutines.cpp
+++ b/server/icat/src/icatHighLevelRoutines.cpp
@@ -2038,12 +2038,13 @@ chlMakeLimitedPw(
 // If one already exists, the expire time is updated, and it's value is returned.
 // Passwords created are pseudo-random strings, unrelated to the PAM password.
 // If testTime is non-null, use that as the create-time, as a testing aid.
-int chlUpdateIrodsPamPassword(
-    rsComm_t* _comm,
-    const char*     _user_name,
-    int             _ttl,
-    const char*     _test_time,
-    char**    _irods_password ) {
+auto chlUpdateIrodsPamPassword(rsComm_t* _comm,
+                               const char* _user_name,
+                               int _ttl,
+                               const char* _test_time,
+                               char** _password_buffer,
+                               std::size_t _password_buffer_size) -> int
+{
     // =-=-=-=-=-=-=-
     // call factory for database object
     irods::database_object_ptr db_obj_ptr;
@@ -2078,18 +2079,14 @@ int chlUpdateIrodsPamPassword(
 
     // =-=-=-=-=-=-=-
     // call the operation on the plugin
-    ret = db->call <
-          const char*,
-          int,
-          const char*,
-          char** > (
-              _comm,
-              irods::DATABASE_OP_UPDATE_PAM_PASSWORD,
-              ptr,
-              _user_name,
-              _ttl,
-              _test_time,
-              _irods_password );
+    ret = db->call(_comm,
+                   irods::DATABASE_OP_UPDATE_PAM_PASSWORD,
+                   ptr,
+                   _user_name,
+                   _ttl,
+                   _test_time,
+                   _password_buffer,
+                   _password_buffer_size);
 
     return ret.code();
 


### PR DESCRIPTION
This presents two solutions to the pam_password length enforcement problem presented in #7098.

In one, the length restriction is increased from 50 (`MAX_PASSWORD_LEN`) to `PAM_MAX_RESP_SIZE` (on my system, this value is 512). This is the solution discussed in https://github.com/linux-pam/linux-pam/issues/118.

In the other, the length restriction is removed entirely on the client side and the entire password entered by the user is copied into the JSON input and passed to the server. I have tested a password of length 6000 and experienced no problems with this solution.

The question is... which of these is what we want, if either?

Bonus question: Should the `password_length` be signed or unsigned?

A test has been added to ensure that the configured `password_length` is being enforced by the server-side configuration. However, by this point, a password of very long length may have been passed over the wire, which may or may not have been the purpose of the limited password buffer in the first place.

No automated test was added for a PAM password of length greater than 50 because this would require a change to the testing infrastructure. I am willing to do this as well, but wasn't sure.