### PR TITLE
[7023] fix swapping of provider/consumer in setup_irods.py (main)

### DIFF
--- a/scripts/irods/lib.py
+++ b/scripts/irods/lib.py
@@ -450,6 +450,7 @@ def default_prompt(*args, **kwargs):
     l = logging.getLogger(__name__)
     default = kwargs.pop('default', [])
     input_filter = kwargs.pop('input_filter', lambda x: x)
+    previous = kwargs.pop('previous', [])
 
     while True:
         if default:
@@ -465,7 +466,9 @@ def default_prompt(*args, **kwargs):
                     args[0] % tuple(args[1:]), ':\n',
                     '\n'.join(['%d. %s' % (i + 1, default[i]) for i in range(0, len(default))]),
                     '\nPlease select a number or choose 0 to enter a new value'])
-                user_input = default_prompt(message, default=[1], **kwargs)
+
+                user_input = default_prompt(message, default=[previous if previous else 1], **kwargs)
+
                 try:
                     i = int(user_input) - 1
                 except (TypeError, ValueError):

--- a/scripts/setup_irods.py
+++ b/scripts/setup_irods.py
@@ -198,7 +198,8 @@ def determine_server_role(irods_config):
     default_catalog_service_role = irods_config.server_config.get('catalog_service_role', 'provider')
     irods_config.server_config['catalog_service_role'] = irods.lib.default_prompt(
         'iRODS server\'s role',
-        default=[default_catalog_service_role] + list(catalog_service_roles - set([default_catalog_service_role])),
+        default=catalog_service_roles,
+        previous=catalog_service_roles.index(default_catalog_service_role) + 1,
         input_filter=irods.lib.set_filter(catalog_service_roles, field='Server role'))
     irods_config.commit(irods_config.server_config, irods_config.server_config_path, clear_cache=False)
 


### PR DESCRIPTION
I will clean it up a bit but the three ideas are included / commented out.

The problem/limitation of default_prompt is that we overloaded the 'default' kwarg to be more than a single value (a list, used as the numbered options), and then always selected the first list value as the actual default from that set of options.

I created a newly named 'previous' kwarg, populated it with any detected value, and then set the default value based on 'previous'.   I preserved the earlier behavior when not passing a previous value.

I think this is sufficient - we can refactor again later to not use a 'list of defaults' at all... later.

This current PR presents the list of options, in the same order across multiple runs, and remembers a previous selection.   I think those are the full list of criteria for success.