### PR TITLE
[#7296] Make erase_if and erase return indication of change (4-3-stable)

### DIFF
--- a/lib/core/include/irods/process_stash.hpp
+++ b/lib/core/include/irods/process_stash.hpp
@@ -50,8 +50,10 @@ namespace irods::process_stash
     ///
     /// \param[in] _key The string which maps to the value of interest.
     ///
+    /// \returns A boolean indicating if an element is removed.
+    ///
     /// \since 4.2.12
-    auto erase(const std::string& _key) -> void;
+    auto erase(const std::string& _key) -> bool;
 
     /// Removes all entries satisfying the predicate.
     ///
@@ -70,8 +72,10 @@ namespace irods::process_stash
     /// If \p _pred returns \p true, the entry is removed.
     /// \endparblock
     ///
+    /// \returns The number of elements removed.
+    ///
     /// \since 4.3.1
-    auto erase_if(const std::function<bool(const std::string&, const boost::any&)>& _pred) -> void;
+    auto erase_if(const std::function<bool(const std::string&, const boost::any&)>& _pred) -> std::size_t;
 
     /// Returns all handles in the process stash.
     ///

--- a/lib/core/src/process_stash.cpp
+++ b/lib/core/src/process_stash.cpp
@@ -50,16 +50,16 @@ namespace irods::process_stash
         return nullptr;
     } // find
 
-    auto erase(const std::string& _key) -> void
+    auto erase(const std::string& _key) -> bool
     {
         std::lock_guard lock{g_mtx};
-        g_stash.erase(_key);
+        return g_stash.erase(_key);
     } // erase
 
-    auto erase_if(const std::function<bool(const std::string&, const boost::any&)>& _pred) -> void
+    auto erase_if(const std::function<bool(const std::string&, const boost::any&)>& _pred) -> std::size_t
     {
         std::lock_guard lock{g_mtx};
-        std::erase_if(g_stash, [&_pred](const auto& _item) {
+        return std::erase_if(g_stash, [&_pred](const auto& _item) {
             const auto& [k, v] = _item;
             return _pred(k, v);
         });

--- a/unit_tests/src/test_process_stash.cpp
+++ b/unit_tests/src/test_process_stash.cpp
@@ -53,14 +53,17 @@ TEST_CASE("process_stash basic operations")
     CHECK(boost::any_cast<pod&>(*p).y == a_pod.y);
 
     // Show that the handles can be used to erase data in the stash.
-    irods::process_stash::erase(h1);
+    CHECK(irods::process_stash::erase(h1));
     CHECK_FALSE(irods::process_stash::find(h1));
 
-    irods::process_stash::erase(h2);
+    CHECK(irods::process_stash::erase(h2));
     CHECK_FALSE(irods::process_stash::find(h2));
 
-    irods::process_stash::erase(h3);
+    CHECK(irods::process_stash::erase(h3));
     CHECK_FALSE(irods::process_stash::find(h3));
+
+    // Try to erase something not there
+    CHECK_FALSE(irods::process_stash::erase(h3));
 
     // Show that the stash is now empty.
     REQUIRE(irods::process_stash::handles().empty());
@@ -91,7 +94,7 @@ TEST_CASE("process_stash::erase_if")
     REQUIRE(handles.size() == 3);
 
     // Show that the handles can be erased using a predicate.
-    irods::process_stash::erase_if([&h1, &h3](auto&& _k, auto&&) { return _k == h1 || _k == h3; });
+    CHECK(irods::process_stash::erase_if([&h1, &h3](auto&& _k, auto&&) { return _k == h1 || _k == h3; }) == 2);
     CHECK_FALSE(irods::process_stash::find(h1));
     CHECK_FALSE(irods::process_stash::find(h3));
 


### PR DESCRIPTION
Cherrypick of #7301. Ran unit-tests, all except `irods_parallel_transfer_engine` passed.