### PR TITLE
[#7364] Relax version matching for find_package (main)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,7 @@ install(
 write_basic_package_version_file(
   "${CMAKE_IRODS_BINARY_DIR}/IRODSConfigVersion.cmake"
   VERSION ${IRODS_VERSION}
-  COMPATIBILITY ExactVersion
+  COMPATIBILITY SameMinorVersion
 )
 
 install(


### PR DESCRIPTION
Addresses #7364 for main

With this change, `find_pacakge` can be used with a minimum version of iRODS.

`SameMinorVersion` is used over `AnyNewerVersion` so that a project looking for iRODS 4.2 won't match an installation of 4.3.