### PR TITLE
[7293] Changed mail microservice to use boost::process instead of system() (main)

### DIFF
--- a/lib/core/src/stringOpr.cpp
+++ b/lib/core/src/stringOpr.cpp
@@ -316,6 +316,8 @@ checkStringForSystem( const char * inString ) {
     if ( inString == NULL ) {
         return 0;
     }
+    // Now that boost::process is being used, no need to check for shell injections
+    // Disallowing \r and \n is by spec
     if (boost::regex_match(inString, boost::regex("[^\r\n]*"))) {
         return 0;
     }

--- a/lib/core/src/stringOpr.cpp
+++ b/lib/core/src/stringOpr.cpp
@@ -316,7 +316,7 @@ checkStringForSystem( const char * inString ) {
     if ( inString == NULL ) {
         return 0;
     }
-    if ( boost::regex_match( inString, boost::regex( "[a-zA-Z0-9,./ ]*" ) ) ) {
+    if (boost::regex_match(inString, boost::regex("[^\r\n]*"))) {
         return 0;
     }
     return USER_INPUT_STRING_ERR;

--- a/server/re/src/mailMS.cpp
+++ b/server/re/src/mailMS.cpp
@@ -1,4 +1,4 @@
-// \file
+/// \file
 
 #include "irods/icatHighLevelRoutines.hpp"
 
@@ -10,6 +10,10 @@
 #include <sys/types.h>
 #include <pwd.h>
 
+namespace
+{
+    using log_re = irods::experimental::log::rule_engine;
+} // anonymous namespace
 /**
  * \fn msiSendMail(msParam_t* xtoAddr, msParam_t* xsubjectLine, msParam_t* xbody, ruleExecInfo_t *)
  *
@@ -20,7 +24,8 @@
  * \since pre-2.1
  *
  *
- * \note   This microservice sends e-mail using the mail command in the unix system. No attachments are supported. The sender of the e-mail is the unix user-id running the irodsServer.
+ * \note   This microservice sends e-mail using the mail command in the unix system. No attachments are supported. The
+ *sender of the e-mail is the unix user-id running the irodsServer.
  *
  * \usage See clients/icommands/test/rules/
  *
@@ -42,7 +47,7 @@
  * \pre none
  * \post none
  * \sa none
-**/
+ **/
 int msiSendMail( msParam_t* xtoAddr, msParam_t* xsubjectLine, msParam_t* xbody, ruleExecInfo_t* ) {
 
     const char * toAddr = ( char * ) xtoAddr->inOutStruct;
@@ -88,11 +93,10 @@ int msiSendMail( msParam_t* xtoAddr, msParam_t* xsubjectLine, msParam_t* xbody, 
         return SYS_MALLOC_ERR;
     }
 
-    int ret = 0;
     namespace bp = boost::process;
-    ret = bp::system(bp::search_path("mail"), "-s", subjectLine, toAddr, bp::std_in < fName);
+    int ret = bp::system(bp::search_path("mail"), "-s", subjectLine, toAddr, bp::std_in < fName);
     if ( ret ) {
-        irods::log(ERROR(ret, "boost::process::system command returned non-zero status"));
+        log_re::error("{}: error code: {}", __func__, ret);
     }
     sprintf( mailStr, "rm %s", fName );
     ret = system( mailStr );

--- a/server/re/src/mailMS.cpp
+++ b/server/re/src/mailMS.cpp
@@ -94,9 +94,10 @@ int msiSendMail( msParam_t* xtoAddr, msParam_t* xsubjectLine, msParam_t* xbody, 
     }
 
     namespace bp = boost::process;
-    int ret = bp::system(bp::search_path("mail"), "-s", subjectLine, toAddr, bp::std_in < fName);
-    if ( ret ) {
-        log_re::error("{}: error code: {}", __func__, ret);
+    std::error_code ec{0, std::system_category()};
+    int ret = bp::system(bp::search_path("mail"), "-s", subjectLine, toAddr, bp::std_in < fName, ec);
+    if (ret || ec) {
+        log_re::error("{}: mail command return code: {}, error code: {}", __func__, ret, ec.value());
     }
     sprintf( mailStr, "rm %s", fName );
     ret = system( mailStr );


### PR DESCRIPTION
Tested by hand to check functionality is as expected, but haven't run test suites yet.
A few questions:
I deleted the block with the solaris_platform stuff; is that okay? ...do we even support Solaris?
I also deleted the block for empty subjects, since in my testing, an empty subject still sent properly, but with no subject line.
Finally, not sure if checkStringForSystem() is the best name anymore for that function. I did a recursive grep and couldn't find anything else using it, but maybe we need to keep it for other peoples' clients? Should I write a new function with a better name and leave it as-is?