### PR TITLE
[irods/irods_rule_engine_plugin_python#183] PREP tests: update references to global_vars (4-3-stable)

### DIFF
--- a/scripts/irods/test/test_prep_genquery_iterator.py
+++ b/scripts/irods/test/test_prep_genquery_iterator.py
@@ -356,7 +356,7 @@ class Test_Genquery_Iterator(resource_suite.ResourceBase, unittest.TestCase):
                 rule_file = f.name
                 print(dedent('''\
                 def main(rule_args,callback,rei):
-                    TestCollection = global_vars['*testcollection'][1:-1]
+                    TestCollection = irods_rule_vars['*testcollection'][1:-1]
                     retval = callback.my_rule_256(TestCollection);
                     result = retval['arguments'][0]
                     callback.writeLine("stdout", "multiples of 256 test: {}".format(result))
@@ -451,7 +451,7 @@ class Test_Genquery_Iterator(resource_suite.ResourceBase, unittest.TestCase):
                 rule_file = f.name
                 print(dedent('''\
                 def main(rule_args,callback,rei):
-                    TestCollection = global_vars['*testcollection'][1:-1]
+                    TestCollection = irods_rule_vars['*testcollection'][1:-1]
                     retval = callback.my_rule_256_nonnested(TestCollection);
                     result = retval['arguments'][0]
                     callback.writeLine("stdout", "nonnested repeats test: {}".format(result))
@@ -514,7 +514,7 @@ class Test_Genquery_Iterator(resource_suite.ResourceBase, unittest.TestCase):
                 rule_file = f.name
                 print(dedent('''\
                 def main(rule_args,callback,rei):
-                    TestCollection = global_vars['*testcollection'][1:-1]
+                    TestCollection = irods_rule_vars['*testcollection'][1:-1]
                     retval = callback.my_rule_256_nested(TestCollection);
                     result = retval['arguments'][0]
                     # import os
@@ -573,7 +573,7 @@ class Test_Genquery_Iterator(resource_suite.ResourceBase, unittest.TestCase):
             rule_file = f.name
             print(dedent('''\
             def main(rule_args,callback,rei):
-                collect = global_vars['*testcollection'][1:-1]
+                collect = irods_rule_vars['*testcollection'][1:-1]
                 from genquery import row_iterator, paged_iterator, AS_LIST
 
                 condString1 = "COLL_NAME = '" + collect + "' and {cond1}"
@@ -695,10 +695,10 @@ class Test_Genquery_Iterator(resource_suite.ResourceBase, unittest.TestCase):
                 rule_string = dedent('''\
                                  def main(rule_args,callback,rei):
                                      a = "%s/%%" # collection  plus Sql match pattern
-                                     b = global_vars['*rpi'][1:-1]  # rows_per_iter
+                                     b = irods_rule_vars['*rpi'][1:-1]  # rows_per_iter
                                      c = ""      # empty string (no verbose log dump)
-                                     rpi = global_vars['*rpi'][1:-1]
-                                     nobj = global_vars['*nobj'][1:-1]
+                                     rpi = irods_rule_vars['*rpi'][1:-1]
+                                     nobj = irods_rule_vars['*nobj'][1:-1]
                                      #callback.writeLine('serverLog', '*nobj = {}'.format(nobj))
                                      predicted = validate_output( nobj , rpi , "" )
                                      if b == "0": b = ""

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -2191,7 +2191,7 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
             '''),
             'irods_rule_engine_plugin-python': textwrap.dedent('''
                 def main(rule_args, callback, rei):
-                    out_dict = callback.msiDataObjRsync(global_vars['*SourceFile'][1:-1], 'IRODS_TO_IRODS', global_vars['*Resource'][1:-1], global_vars['*DestFile'][1:-1], 0)
+                    out_dict = callback.msiDataObjRsync(irods_rule_vars['*SourceFile'][1:-1], 'IRODS_TO_IRODS', global_vars['*Resource'][1:-1], global_vars['*DestFile'][1:-1], 0)
                     if not out_dict['status']:
                         callback.writeLine('stdout', 'ERROR: ' + str(out_dict['code']))
 
@@ -2253,7 +2253,7 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
             '''),
             'irods_rule_engine_plugin-python': textwrap.dedent('''
                 def main(rule_args, callback, rei):
-                    out_dict = callback.msiCollRsync(global_vars['*SourceColl'][1:-1], global_vars['*DestColl'][1:-1], global_vars['*Resource'][1:-1], 'IRODS_TO_IRODS', 0)
+                    out_dict = callback.msiCollRsync(irods_rule_vars['*SourceColl'][1:-1], global_vars['*DestColl'][1:-1], global_vars['*Resource'][1:-1], 'IRODS_TO_IRODS', 0)
                     if not out_dict['status']:
                         callback.writeLine('stdout', 'ERROR: ' + str(out_dict['code']))
 
@@ -2322,7 +2322,7 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
             '''),
             'irods_rule_engine_plugin-python': textwrap.dedent('''
                 def main(rule_args, callback, rei):
-                    out_dict = callback.msiDataObjUnlink('objPath=' + global_vars['*SourceFile'][1:-1] + '++++unreg=', 0)
+                    out_dict = callback.msiDataObjUnlink('objPath=' + irods_rule_vars['*SourceFile'][1:-1] + '++++unreg=', 0)
                     if not out_dict['status']:
                         callback.writeLine('stdout', 'ERROR: ' + str(out_dict['code']))
 
@@ -2366,7 +2366,7 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
             '''),
             'irods_rule_engine_plugin-python': textwrap.dedent('''
                 def main(rule_args, callback, rei):
-                    out_dict = callback.msiDataObjRepl(global_vars['*SourceFile'][1:-1], 'destRescName=' + global_vars['*Resource'][1:-1] + '++++irodsAdmin=', 0)
+                    out_dict = callback.msiDataObjRepl(irods_rule_vars['*SourceFile'][1:-1], 'destRescName=' + global_vars['*Resource'][1:-1] + '++++irodsAdmin=', 0)
                     if not out_dict['status']:
                         callback.writeLine('stdout', 'ERROR: ' + str(out_dict['code']))
 
@@ -2420,7 +2420,7 @@ class Test_Resource_Compound(ChunkyDevTest, ResourceSuite, unittest.TestCase):
             '''),
             'irods_rule_engine_plugin-python': textwrap.dedent('''
                 def main(rule_args, callback, rei):
-                    out_dict = callback.msisync_to_archive(global_vars['*RescHier'][1:-1], global_vars['*PhysicalPath'][1:-1], global_vars['*LogicalPath'][1:-1])
+                    out_dict = callback.msisync_to_archive(irods_rule_vars['*RescHier'][1:-1], global_vars['*PhysicalPath'][1:-1], global_vars['*LogicalPath'][1:-1])
                     if not out_dict['status']:
                         callback.writeLine('stdout', 'ERROR: ' + str(out_dict['code']))
 

--- a/scripts/irods/test/test_rulebase.py
+++ b/scripts/irods/test/test_rulebase.py
@@ -77,7 +77,7 @@ class Test_Rulebase(ResourceBase, unittest.TestCase):
             '''),
             'irods_rule_engine_plugin-python': textwrap.dedent(f'''
                 def main(rule_args, callback, rei):
-                    out_dict = callback.msiDataObjCreate(global_vars['*TEST_ROOT'][1:-1] + '/' + '{filename}', 'null', 0)
+                    out_dict = callback.msiDataObjCreate(irods_rule_vars['*TEST_ROOT'][1:-1] + '/' + '{filename}', 'null', 0)
                     file_desc = out_dict['arguments'][2]
 
                     out_dict = callback.msiDataObjWrite(file_desc, 'this_is_a_test_string', 0)


### PR DESCRIPTION
In service of irods/irods_rule_engine_plugin_python#183
Companion to irods/irods_rule_engine_plugin_python#185