### PR TITLE
[#7104] Honor logical locking in rsDataObjTruncate (main)

### DIFF
--- a/server/api/src/rsDataObjTruncate.cpp
+++ b/server/api/src/rsDataObjTruncate.cpp
@@ -1,29 +1,23 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-/* This is script-generated code (for the most part).  */
-/* See dataObjTruncate.h for a description of this API call.*/
-
-#include "irods/rcMisc.h"
-#include "irods/dataObjTruncate.h"
-#include "irods/rodsLog.h"
-#include "irods/icatDefines.h"
-#include "irods/fileTruncate.h"
-#include "irods/unregDataObj.h"
-#include "irods/objMetaOpr.hpp"
-#include "irods/dataObjOpr.hpp"
-#include "irods/rsGlobalExtern.hpp"
-#include "irods/rcGlobalExtern.h"
 #include "irods/rsDataObjTruncate.hpp"
-#include "irods/rmColl.h"
-#include "irods/modDataObjMeta.h"
-#include "irods/subStructFileTruncate.h"
+
+#include "irods/dataObjOpr.hpp"
+#include "irods/dataObjTruncate.h"
+#include "irods/fileTruncate.h"
 #include "irods/getRemoteZoneResc.h"
+#include "irods/icatDefines.h"
+#include "irods/irods_resource_backport.hpp"
+#include "irods/modDataObjMeta.h"
+#include "irods/objMetaOpr.hpp"
+#include "irods/rcGlobalExtern.h"
+#include "irods/rcMisc.h"
+#include "irods/rmColl.h"
+#include "irods/rodsLog.h"
+#include "irods/rsFileTruncate.hpp"
+#include "irods/rsGlobalExtern.hpp"
 #include "irods/rsModDataObjMeta.hpp"
 #include "irods/rsSubStructFileTruncate.hpp"
-#include "irods/rsFileTruncate.hpp"
-
-#include "irods/irods_resource_backport.hpp"
-
+#include "irods/subStructFileTruncate.h"
+#include "irods/unregDataObj.h"
 
 
 int

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -70,6 +70,7 @@ set(
   rc_check_auth_credentials
   rc_data_obj
   rc_data_obj_repl
+  rc_data_obj_truncate
   rc_get_library_features
   rc_switch_user
   re_serialization

--- a/unit_tests/cmake/test_config/irods_rc_data_obj_truncate.cmake
+++ b/unit_tests/cmake/test_config/irods_rc_data_obj_truncate.cmake
@@ -1,0 +1,14 @@
+set(IRODS_TEST_TARGET irods_rc_data_obj_truncate)
+
+set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/src/test_rc_data_obj_truncate.cpp)
+
+set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_FMT}/include)
+
+set(IRODS_TEST_LINK_LIBRARIES irods_common
+                              irods_client
+                              irods_plugin_dependencies
+                              ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so
+                              ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
+                              ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)

--- a/unit_tests/src/test_rc_data_obj_truncate.cpp
+++ b/unit_tests/src/test_rc_data_obj_truncate.cpp
@@ -1,0 +1,142 @@
+#include <catch2/catch.hpp>
+
+#include "irods/client_connection.hpp"
+#include "irods/dataObjInpOut.h"
+#include "irods/dstream.hpp"
+#include "irods/filesystem.hpp"
+#include "irods/irods_at_scope_exit.hpp"
+#include "irods/irods_exception.hpp"
+#include "irods/key_value_proxy.hpp"
+#include "irods/objInfo.h"
+#include "irods/rcMisc.h"
+#include "irods/replica.hpp"
+#include "irods/replica_proxy.hpp"
+#include "irods/resource_administration.hpp"
+#include "irods/rodsClient.h"
+#include "irods/rodsDef.h"
+#include "irods/rodsErrorTable.h"
+#include "irods/transport/default_transport.hpp"
+#include "unit_test_utils.hpp"
+
+#include <fmt/format.h>
+
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+// clang-format off
+namespace adm	 = irods::experimental::administration;
+namespace fs	  = irods::experimental::filesystem;
+namespace replica = irods::experimental::replica;
+// clang-format on
+
+TEST_CASE("truncate_locked_data_object__issue_7104")
+{
+    try {
+        load_client_api_plugins();
+
+        const std::string test_resc = "test_resc";
+        const std::string vault_name = "test_resc_vault";
+
+        // Create a new resource
+        {
+            irods::experimental::client_connection conn;
+            RcComm& comm = static_cast<RcComm&>(conn);
+            unit_test_utils::add_ufs_resource(comm, test_resc, vault_name);
+        }
+
+        irods::experimental::client_connection conn;
+        RcComm& comm = static_cast<RcComm&>(conn);
+
+        rodsEnv env;
+        _getRodsEnv(env);
+
+        const auto sandbox = fs::path{env.rodsHome} / "test_rc_data_obj_truncate";
+        if (!fs::client::exists(comm, sandbox)) {
+            REQUIRE(fs::client::create_collection(comm, sandbox));
+        }
+
+        irods::at_scope_exit remove_sandbox{[&sandbox, &test_resc] {
+            irods::experimental::client_connection conn;
+            RcComm& comm = static_cast<RcComm&>(conn);
+
+            REQUIRE(fs::client::remove_all(comm, sandbox, fs::remove_options::no_trash));
+
+            adm::client::remove_resource(comm, test_resc);
+        }};
+
+        const auto target_object = sandbox / "target_object";
+
+        static constexpr auto contents = std::string_view{"content!"};
+
+        // Create a new data object.
+        {
+            irods::experimental::io::client::native_transport tp{conn};
+            irods::experimental::io::odstream{tp, target_object} << contents;
+        }
+
+        // Show that the replica is in a good state.
+        REQUIRE(GOOD_REPLICA == replica::replica_status(comm, target_object, 0));
+        REQUIRE(contents.size() == replica::replica_size(comm, target_object, 0));
+
+        SECTION("single replica")
+        {
+            // Sleep here so that the mtime on the replica we open CAN be different (but we don't expect it to be).
+            const auto original_mtime = replica::last_write_time(comm, target_object, 0);
+            std::this_thread::sleep_for(2s);
+
+            // Open the object in read-write mode in order to lock the object.
+            DataObjInp doi{};
+            std::strncpy(doi.objPath, target_object.c_str(), MAX_NAME_LEN);
+            doi.openFlags = O_RDWR;
+
+            // Open the replica and ensure that the status is updated appropriately.
+            const auto fd = rcDataObjOpen(&comm, &doi);
+            REQUIRE(fd > 2);
+            REQUIRE(INTERMEDIATE_REPLICA == replica::replica_status(comm, target_object, 0));
+
+            irods::experimental::client_connection conn2;
+            RcComm& comm2 = static_cast<RcComm&>(conn2);
+
+            DataObjInp truncate_doi{};
+            std::strncpy(truncate_doi.objPath, target_object.c_str(), MAX_NAME_LEN);
+
+            SECTION("same size")
+            {
+                truncate_doi.dataSize = contents.size();
+            }
+
+            SECTION("larger size")
+            {
+                truncate_doi.dataSize = contents.size() + 1;
+            }
+
+            SECTION("smaller size")
+            {
+                truncate_doi.dataSize = contents.size() - 1;
+            }
+
+            // Attempt to truncate the object using the size specified for each section, and fail.
+            CHECK(LOCKED_DATA_OBJECT_ACCESS == rcDataObjTruncate(&comm2, &truncate_doi));
+
+            // Close the open data object so that it is back at rest.
+            OpenedDataObjInp close_inp{};
+            close_inp.l1descInx = fd;
+            REQUIRE(0 == rcDataObjClose(&comm, &close_inp));
+
+            // Ensure that the object (single replica) was not updated.
+            CHECK(GOOD_REPLICA == replica::replica_status(comm, target_object, 0));
+            CHECK(contents.size() == replica::replica_size(comm, target_object, 0));
+            CHECK(original_mtime == replica::last_write_time(comm, target_object, 0));
+        }
+    }
+    catch (const irods::exception& e) {
+        fmt::print(stderr, "irods::exception occurred: [{}]", e.what());
+    }
+    catch (const std::exception& e) {
+        fmt::print(stderr, "std::exception occurred: [{}]", e.what());
+    }
+} // truncate_locked_data_object__issue_7104

--- a/unit_tests/unit_tests_list.json
+++ b/unit_tests/unit_tests_list.json
@@ -39,6 +39,7 @@
     "irods_rc_check_auth_credentials",
     "irods_rc_data_obj",
     "irods_rc_data_obj_repl",
+    "irods_rc_data_obj_truncate",
     "irods_rc_get_library_features",
     "irods_rc_switch_user",
     "irods_re_serialization",


### PR DESCRIPTION
Addresses #7104...?

I'm opening the PR for eyeballs. The new unit test fails appropriately before the C++ changes and passes appropriately after the C++ changes. Still need to run all the other tests.

I have a few questions that we can discuss here or offline:
1. As has been discussed elsewhere, the expectation was to implement a new API endpoint. I figured it would be just as well to modify the existing endpoint. Do we want to introduce a new API over modifying the existing one? Why?
2. If we make a new API, should we deprecate the existing one?
3. Do we want to expand testing for truncate as part of this effort? Currently, there are no tests for this API.