### PR TITLE
[#7554] Deprecate `rxGeneralUpdate` API endpoint (main)

### DIFF
--- a/lib/api/include/irods/apiNumberData.h
+++ b/lib/api/include/irods/apiNumberData.h
@@ -129,6 +129,7 @@ API_NUMBER(MOD_AVU_METADATA_AN,                     706)
 API_NUMBER(MOD_ACCESS_CONTROL_AN,                   707)
 API_NUMBER(RULE_EXEC_MOD_AN,                        708)
 API_NUMBER(GET_TEMP_PASSWORD_AN,                    709)
+// DEPRECATED: GeneralUpdate is deprecated. Its use should be avoided.
 API_NUMBER(GENERAL_UPDATE_AN,                       710)
 API_NUMBER(READ_COLLECTION_AN,                      713)
 API_NUMBER(USER_ADMIN_AN,                           714)

--- a/lib/api/include/irods/apiTable.hpp
+++ b/lib/api/include/irods/apiTable.hpp
@@ -754,6 +754,8 @@ static irods::apidef_t client_api_table_inp[] = {
         "api_get_temp_password", irods::clearInStruct_noop, irods::clearOutStruct_noop,
         (funcPtr)CALL_GETTEMPPASSWORDOUT
     },
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     {
         GENERAL_UPDATE_AN, RODS_API_VERSION,
         LOCAL_PRIV_USER_AUTH, LOCAL_PRIV_USER_AUTH,
@@ -762,6 +764,7 @@ static irods::apidef_t client_api_table_inp[] = {
         "api_general_update", irods::clearInStruct_noop, irods::clearOutStruct_noop,
         (funcPtr)CALL_GENERALUPDATEINP
     },
+#pragma clang diagnostic pop
     {
         MOD_DATA_OBJ_META_AN, RODS_API_VERSION, REMOTE_USER_AUTH, REMOTE_USER_AUTH,
         "ModDataObjMeta_PI", 0, NULL, 0,

--- a/lib/api/include/irods/generalUpdate.h
+++ b/lib/api/include/irods/generalUpdate.h
@@ -1,12 +1,18 @@
-#ifndef GENERAL_UPDATE_H__
-#define GENERAL_UPDATE_H__
+#ifndef IRODS_GENERAL_UPDATE_H
+#define IRODS_GENERAL_UPDATE_H
 
 #include "irods/rcConnect.h"
 #include "irods/rodsGeneralUpdate.h"
 
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
-int rcGeneralUpdate( rcComm_t *conn, generalUpdateInp_t *generalUpdateInp );
 
+int rcGeneralUpdate(rcComm_t* conn, generalUpdateInp_t* generalUpdateInp)
+    __attribute__((deprecated("GeneralUpdate is deprecated. Its use should be avoided.")));
+
+#ifdef __cplusplus
+} // extern "C"
 #endif
+
+#endif // IRODS_GENERAL_UPDATE_H

--- a/lib/core/include/irods/rodsGeneralUpdate.h
+++ b/lib/core/include/irods/rodsGeneralUpdate.h
@@ -24,10 +24,13 @@
 #define UPDATE_NOW_TIME "update_now_time"
 
 #define GeneralUpdateInp_PI "int type; struct InxValPair_PI;"
-typedef struct GeneralUpdateInp {
+
+// NOLINTNEXTLINE(modernize-use-using)
+__attribute__((deprecated("GeneralUpdate is deprecated. Its use should be avoided."))) typedef struct __attribute__((
+    deprecated("GeneralUpdate is deprecated. Its use should be avoided."))) GeneralUpdateInp
+{
     int type;  /* GEN_UPDATE_INSERT or DELETE */
     inxValPair_t values;  /* Column IDs (from rodsGenQuery.h) and values */
 } generalUpdateInp_t;
-
 
 #endif	// RODS_GENERAL_UPDATE_H__

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -15406,11 +15406,17 @@ irods::error db_gen_query_ticket_setup_op(
 
 // =-=-=-=-=-=-=-
 // from general_query.cpp ::
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 int chl_general_update_impl( generalUpdateInp_t );
+#pragma clang diagnostic pop
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 irods::error db_general_update_op(
     irods::plugin_context& _ctx,
     generalUpdateInp_t*    _update_inp ) {
+#pragma clang diagnostic pop
     // =-=-=-=-=-=-=-
     // check the context
     irods::error ret = _ctx.valid();
@@ -16178,10 +16184,13 @@ irods::database* plugin_factory(
         DATABASE_OP_GEN_QUERY,
         function<error(plugin_context&,genQueryInp_t*,genQueryOut_t*)>(
             db_gen_query_op ) );
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     pg->add_operation(
         DATABASE_OP_GENERAL_UPDATE,
         function<error(plugin_context&,generalUpdateInp_t*)>(
             db_general_update_op ) );
+#pragma clang diagnostic pop
     pg->add_operation(
         DATABASE_OP_GEN_QUERY_ACCESS_CONTROL_SETUP,
         function<error(plugin_context&,const char*,const char*,const char*,int,int)>(

--- a/plugins/database/src/general_update.cpp
+++ b/plugins/database/src/general_update.cpp
@@ -28,8 +28,11 @@ int updateDebug = 0;
 extern int logSQLGenUpdate;
 char tSQL[MAX_SQL_SIZE];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 int
 generalInsert( generalUpdateInp_t generalUpdateInp ) {
+#pragma clang diagnostic pop
     int i, j;
     char *tableName, *columnName;
     char *firstTableName;
@@ -127,8 +130,11 @@ generalInsert( generalUpdateInp_t generalUpdateInp ) {
     return 0;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 int
 generalDelete( generalUpdateInp_t generalUpdateInp ) {
+#pragma clang diagnostic pop
     int i, j;
     char *tableName, *columnName;
     char *firstTableName;
@@ -179,10 +185,12 @@ generalDelete( generalUpdateInp_t generalUpdateInp ) {
     return 0;
 }
 
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 /* General Update */
 int chl_general_update_impl(
     generalUpdateInp_t generalUpdateInp ) {
+#pragma clang diagnostic pop
     int status;
     static int firstCall = 1;
     icatSessionStruct *icss;

--- a/server/api/include/irods/rsGeneralUpdate.hpp
+++ b/server/api/include/irods/rsGeneralUpdate.hpp
@@ -1,10 +1,15 @@
-#ifndef RS_GENERAL_UPDATE_HPP
-#define RS_GENERAL_UPDATE_HPP
+#ifndef IRODS_RS_GENERAL_UPDATE_HPP
+#define IRODS_RS_GENERAL_UPDATE_HPP
 
 #include "irods/rcConnect.h"
 #include "irods/rodsGeneralUpdate.h"
 
-int rsGeneralUpdate( rsComm_t *rsComm, generalUpdateInp_t *generalUpdateInp );
-int _rsGeneralUpdate( generalUpdateInp_t *generalUpdateInp );
+int rsGeneralUpdate(rsComm_t* rsComm, generalUpdateInp_t* generalUpdateInp)
+    __attribute__((deprecated("GeneralUpdate is deprecated. Its use should be avoided.")));
 
-#endif
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+int _rsGeneralUpdate( generalUpdateInp_t *generalUpdateInp );
+#pragma clang diagnostic pop
+
+#endif // IRODS_RS_GENERAL_UPDATE_HPP

--- a/server/api/src/rsGeneralUpdate.cpp
+++ b/server/api/src/rsGeneralUpdate.cpp
@@ -54,11 +54,10 @@ rsGeneralUpdate( rsComm_t *rsComm, generalUpdateInp_t *generalUpdateInp ) {
     return status;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 int
 _rsGeneralUpdate( generalUpdateInp_t *generalUpdateInp ) {
-    int status;
-
-    status  = chlGeneralUpdate( *generalUpdateInp );
-
-    return status;
+    return chlGeneralUpdate(*generalUpdateInp);
 }
+#pragma clang diagnostic pop

--- a/server/core/include/irods/irods_api_calling_functions.hpp
+++ b/server/core/include/irods/irods_api_calling_functions.hpp
@@ -601,11 +601,9 @@ int call_getTempPasswordOut(
 #endif
 
 #ifdef CREATE_API_TABLE_FOR_SERVER
-int call_generalUpdateInp(
-    irods::api_entry*,
-    rsComm_t*,
-    generalUpdateInp_t*);
-#define CALL_GENERALUPDATEINP call_generalUpdateInp
+[[deprecated("GeneralUpdate is deprecated. Its use should be avoided.")]] int
+call_generalUpdateInp(irods::api_entry*, rsComm_t*, generalUpdateInp_t*);
+#  define CALL_GENERALUPDATEINP call_generalUpdateInp
 #else
 #define CALL_GENERALUPDATEINP nullptr
 #endif

--- a/server/core/include/irods/irods_database_constants.hpp
+++ b/server/core/include/irods/irods_database_constants.hpp
@@ -37,7 +37,8 @@ namespace irods
     const std::string DATABASE_OP_GEN_QUERY_ACCESS_CONTROL_SETUP( "database_gen_query_access_control_setup" );
     const std::string DATABASE_OP_GEN_QUERY_TICKET_SETUP( "database_gen_query_ticket_setup" );
     const std::string DATABASE_OP_SPECIFIC_QUERY( "database_specific_query" );
-    const std::string DATABASE_OP_GENERAL_UPDATE( "database_general_update" );
+    [[deprecated("GeneralUpdate is deprecated. Its use should be avoided.")]] const std::string
+        DATABASE_OP_GENERAL_UPDATE("database_general_update");
     const std::string DATABASE_OP_DEL_COLL_BY_ADMIN( "database_del_coll_by_admin" );
     const std::string DATABASE_OP_DEL_COLL( "database_del_coll" );
     const std::string DATABASE_OP_CHECK_AUTH( "database_check_auth" );

--- a/server/core/src/irods_api_calling_functions.cpp
+++ b/server/core/src/irods_api_calling_functions.cpp
@@ -647,6 +647,8 @@ int call_ruleExecModInp(
                    _inp);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 int call_generalUpdateInp(
     irods::api_entry*    _api,
     rsComm_t*            _comm,
@@ -656,6 +658,7 @@ int call_generalUpdateInp(
                    _comm,
                    _inp);
 }
+#pragma clang diagnostic pop
 
 int call_modDataObjMetaInp(
     irods::api_entry*    _api,

--- a/server/icat/include/irods/icatHighLevelRoutines.hpp
+++ b/server/icat/include/irods/icatHighLevelRoutines.hpp
@@ -61,7 +61,8 @@ int chlGenQueryTicketSetup( const char *ticket, const char *clientAddr );
 int chlSpecificQuery( specificQueryInp_t specificQueryInp,
                       genQueryOut_t *genQueryOut );
 
-int chlGeneralUpdate( generalUpdateInp_t generalUpdateInp );
+int chlGeneralUpdate(generalUpdateInp_t generalUpdateInp)
+    __attribute__((deprecated("GeneralUpdate is deprecated. Its use should be avoided.")));
 
 int chlDelCollByAdmin( rsComm_t *rsComm, collInfo_t *collInfo );
 int chlDelColl( rsComm_t *rsComm, collInfo_t *collInfo );


### PR DESCRIPTION
Not yet tested.

Depending on how things go, I may expand this to `rxGeneralRowInsert` and `rxGeneralRowPurge`.