### PR TITLE
[#7537] Add `--ignore-symlinks` alias for `--link` option (4-3-stable)

### DIFF
--- a/lib/core/src/irods_parse_command_line_options.cpp
+++ b/lib/core/src/irods_parse_command_line_options.cpp
@@ -26,38 +26,41 @@ static int parse_program_options(
     path_list_t&     _paths ) {
     namespace po = boost::program_options;
 
-    po::options_description opt_desc( "options" );
+    po::options_description opt_desc("options");
+    // clang-format off
     opt_desc.add_options()
-    ( "help,h", "show command usage" )
-    ( "all,a", "all - update all existing copies" )
-    ( "bulk,b", "bulk upload to reduce overhead" )
-    ( "force,f", "force - write data-object even it exists already; overwrite it" )
-    ( "redirect,I", "redirect connection - redirect the connection to connect directly to the resource server." )
-    ( "checksum,k", "checksum - calculate a checksum on the data server-side, and store it in the catalog" )
-    ( "verify_checksum,K", "verify checksum - calculate and verify the checksum on the data, both client-side and server-side, without storing in the catalog." )
-    ( "repl_num,n", po::value<std::string>(), "replNum  - the replica to be replaced, typically not needed" )
-    ( "num_threads,N", po::value<int>(), "numThreads - the number of threads to use for the transfer. A value of 0 means no threading. By default (-N option not used) the server decides the number of threads to use." )
-    ( "physical_path,p", po::value<std::string>(), "physicalPath - the absolute physical path of the uploaded file on the server" )
-    ( "progress,P", "output the progress of the upload." )
-    ( "rbudp,Q", "use RBUDP (datagram) protocol for the data transfer" )
-    ( "recursive,r", "recursive - store the whole subdirectory" )
-    ( "dest_resc,R", po::value<std::string>(), "resource - specifies the resource to store to. This can also be specified in your environment or via a rule set up by the administrator" )
-    ( "ticket,t", po::value<std::string>(), "ticket - ticket (string) to use for ticket-based access" )
-    ( "renew_socket,T", "renew socket connection after 10 minutes" )
-    ( "verbose,v", "verbose" )
-    ( "very_verbose,V", "very verbose" )
-    ( "data_type,D", po::value<std::string>(), "dataType - the data type string" )
-    ( "restart_file,X", po::value<std::string>(), "restartFile - specifies that the restart option is on and the restartFile input specifies a local file that contains the restart information." )
-    ( "link", "ignore symlink." )
-    ( "lfrestart", po::value<std::string>(), "lfRestartFile - specifies that the large file restart option is on and the lfRestartFile input specifies a local file that contains the restart information." )
-    ( "retries", po::value<int>(), "count - Retry the iput in case of error. The 'count' input specifies the number of times to retry. It must be used with the -X option" )
-    ( "wlock", "use advisory write (exclusive) lock for the upload" )
-    ( "rlock", "use advisory read lock for the download" )
-    ( "purgec", "Purge the staged cache copy after uploading an object to a" )
-    ( "kv_pass", po::value<std::string>(), "pass key-value strings through to the plugin infrastructure" )
-    ( "metadata", po::value<std::string>(), "atomically assign metadata after a data object is put" )
-    ( "acl", po::value<std::string>(), "atomically apply an access control list after a data object is put" )
-    ( "path_args", po::value<path_list_t>( &_paths )->composing(), "some files and stuffs" );
+        ("help,h", "show command usage")
+        ("all,a", "all - update all existing copies")
+        ("bulk,b", "bulk upload to reduce overhead")
+        ("force,f", "force - write data-object even it exists already; overwrite it")
+        ("redirect,I", "redirect connection - redirect the connection to connect directly to the resource server.")
+        ("checksum,k", "checksum - calculate a checksum on the data server-side, and store it in the catalog")
+        ("verify_checksum,K", "verify checksum - calculate and verify the checksum on the data, both client-side and server-side, without storing in the catalog.")
+        ("repl_num,n", po::value<std::string>(), "replNum  - the replica to be replaced, typically not needed")
+        ("num_threads,N", po::value<int>(), "numThreads - the number of threads to use for the transfer. A value of 0 means no threading. By default (-N option not used) the server decides the number of threads to use.")
+        ("physical_path,p", po::value<std::string>(), "physicalPath - the absolute physical path of the uploaded file on the server")
+        ("progress,P", "output the progress of the upload.")
+        ("rbudp,Q", "use RBUDP (datagram) protocol for the data transfer")
+        ("recursive,r", "recursive - store the whole subdirectory")
+        ("dest_resc,R", po::value<std::string>(), "resource - specifies the resource to store to. This can also be specified in your environment or via a rule set up by the administrator")
+        ("ticket,t", po::value<std::string>(), "ticket - ticket (string) to use for ticket-based access")
+        ("renew_socket,T", "renew socket connection after 10 minutes")
+        ("verbose,v", "verbose")
+        ("very_verbose,V", "very verbose")
+        ("data_type,D", po::value<std::string>(), "dataType - the data type string")
+        ("restart_file,X", po::value<std::string>(), "restartFile - specifies that the restart option is on and the restartFile input specifies a local file that contains the restart information.")
+        ("link", "[Deprecated] ignore symlinks. Use --ignore-symlinks.")
+        ("ignore-symlinks", "ignore symlinks.")
+        ("lfrestart", po::value<std::string>(), "lfRestartFile - specifies that the large file restart option is on and the lfRestartFile input specifies a local file that contains the restart information.")
+        ("retries", po::value<int>(), "count - Retry the iput in case of error. The 'count' input specifies the number of times to retry. It must be used with the -X option")
+        ("wlock", "use advisory write (exclusive) lock for the upload")
+        ("rlock", "use advisory read lock for the download")
+        ("purgec", "Purge the staged cache copy after uploading an object to a")
+        ("kv_pass", po::value<std::string>(), "pass key-value strings through to the plugin infrastructure")
+        ("metadata", po::value<std::string>(), "atomically assign metadata after a data object is put")
+        ("acl", po::value<std::string>(), "atomically apply an access control list after a data object is put")
+        ("path_args", po::value<path_list_t>(&_paths)->composing(), "some files and stuffs");
+    // clang-format on
 
     po::positional_options_description pos_desc;
     pos_desc.add( "path_args", -1 );
@@ -200,7 +203,7 @@ static int parse_program_options(
             return INVALID_ANY_CAST;
         }
     }
-    if ( global_prog_ops_var_map.count( "link" ) ) {
+    if (global_prog_ops_var_map.count("ignore-symlinks") || global_prog_ops_var_map.count("link")) {
         _rods_args.link = 1;
     }
     if ( global_prog_ops_var_map.count( "lfrestart" ) ) {

--- a/lib/core/src/parseCommandLine.cpp
+++ b/lib/core/src/parseCommandLine.cpp
@@ -18,6 +18,7 @@ CommandLineOptions document so we can keep it all consistent.
 #include "irodsntutil.hpp"
 #endif
 
+#include <cstring>
 
 /*
  Input:
@@ -51,7 +52,7 @@ parseCmdLineOpt( int argc, char **argv, const char *optString, int includeLong,
     /* handle the long options first */
     if ( includeLong ) {
         for ( int i = 0; i < argc; i++ ) {
-            if ( strcmp( "--link", argv[i] ) == 0 ) {
+            if (std::strcmp("--ignore-symlinks", argv[i]) == 0 || std::strcmp("--link", argv[i]) == 0) {
                 rodsArgs->link = True;
                 argv[i] = "-Z"; /* ignore symlink */
             }


### PR DESCRIPTION
Cherry-picked from #7567 