### PR TITLE
[#6953] Deprecate BACKUP_RESC_NAME_KW (main)

### DIFF
--- a/lib/api/include/irods/dataObjRepl.h
+++ b/lib/api/include/irods/dataObjRepl.h
@@ -21,7 +21,7 @@
  *          DEST_RESC_NAME_KW - "value" = The destination Resource.
  *          ADMIN_KW - Admin removing other users' files. Only files
  *              in trash can be removed.
- *          BACKUP_RESC_NAME_KW - backup resource (backup mode).
+ *          BACKUP_RESC_NAME_KW - (Deprecated) backup resource (backup mode).
  *   return value - The status of the operation.
  */
 #ifdef __cplusplus

--- a/lib/api/src/rcDataObjRepl.cpp
+++ b/lib/api/src/rcDataObjRepl.cpp
@@ -46,7 +46,7 @@
  *    \n REPL_NUM_KW - The replica number of the copy to be used as source.
  *    \n RESC_NAME_KW - The copy stored in this resource to be used as source.
  *    \n DEST_RESC_NAME_KW - The resource to store the new replica.
- *    \n BACKUP_RESC_NAME_KW - The resource to store the new replica.
+ *    \n BACKUP_RESC_NAME_KW - (Deprecated) The resource to store the new replica.
  *             In backup mode. If a good copy already exists in this
  *             resource, don't make another one.
  *    \n ADMIN_KW - admin user backup/replicate other user's files.

--- a/lib/core/include/irods/msParam.h
+++ b/lib/core/include/irods/msParam.h
@@ -94,6 +94,7 @@ typedef struct ValidKeyWd {
 
 #define RESC_NAME_FLAG          0x1
 #define DEST_RESC_NAME_FLAG     0x2
+// BACKUP_RESC_NAME has been deprecated.
 #define BACKUP_RESC_NAME_FLAG   0x4
 #define FORCE_FLAG_FLAG         0x8
 #define ALL_FLAG                0x10

--- a/lib/core/include/irods/objInfo.h
+++ b/lib/core/include/irods/objInfo.h
@@ -151,6 +151,8 @@ typedef struct DataObjInfo {
     int  dataAccessInx;
     int  writeFlag;
     char destRescName[NAME_LEN];
+    // The backupResc feature has been deprecated and will be removed in a future release. It is not being marked as
+    // deprecated for compilation purposes because we cannot change this struct and it is used everywhere.
     char backupRescName[NAME_LEN];
     char subPath[MAX_NAME_LEN];
     specColl_t *specColl;

--- a/lib/core/include/irods/parseCommandLine.h
+++ b/lib/core/include/irods/parseCommandLine.h
@@ -20,6 +20,7 @@ typedef struct RodsArguments {
     int noattr;
     char *attrStr;
     int bulk;
+    // backupMode has been deprecated and will be removed in a future release.
     int backupMode;
     int condition;
     char *conditionString;

--- a/lib/core/include/irods/rodsKeyWdDef.h
+++ b/lib/core/include/irods/rodsKeyWdDef.h
@@ -17,6 +17,7 @@
 #define RESC_NAME_KW                                "rescName"      /* resource name */
 #define DEST_RESC_NAME_KW                           "destRescName"  /* destination resource name */
 #define DEF_RESC_NAME_KW                            "defRescName"   /* default resource name */
+// BACKUP_RESC_NAME has been deprecated.
 #define BACKUP_RESC_NAME_KW                         "backupRescName" /* destination resource name */
 #define LEAF_RESOURCE_NAME_KW                       "leafRescName"
 #define DATA_TYPE_KW                                "dataType"      /* data type */

--- a/lib/core/src/replUtil.cpp
+++ b/lib/core/src/replUtil.cpp
@@ -201,6 +201,7 @@ initCondForRepl( rodsEnv *myRodsEnv, rodsArguments_t *rodsArgs,
                    myRodsEnv->rodsDefResource );
     }
 
+    // The BACKUP_RESC_NAME feature has been deprecated and will be removed in a future release.
     if ( myResc != NULL && rodsArgs->backupMode == True ) {
         addKeyVal( &dataObjInp->condInput, BACKUP_RESC_NAME_KW,
                    myResc );

--- a/packaging/core.dvm.template
+++ b/packaging/core.dvm.template
@@ -33,6 +33,7 @@ collId||rei->doi->collId
 statusString||rei->doi->statusString
 # dataMapId||rei->doi->dataMapId
 destRescName||rei->doi->destRescName
+# The backupRescName feature has been deprecated and will be removed in a future release.
 backupRescName||rei->doi->backupRescName
 rescName||rei->doi->rescName
 # user info coming directly

--- a/plugins/rule_engines/irods_rule_language/src/reVariableMap.gen.cpp
+++ b/plugins/rule_engines/irods_rule_language/src/reVariableMap.gen.cpp
@@ -735,7 +735,7 @@ int getValFromDataObjInfo( char *varMap, dataObjInfo_t *rei, Res **varValue, Reg
         return i;
     }
 
-
+    // The backupResc feature has been deprecated and will be removed in a future release.
     if ( strcmp( varName, "backupRescName" ) == 0 ) {
 
         i = getStrLeafValue( varValue, rei->backupRescName, r );
@@ -991,6 +991,7 @@ int setValFromDataObjInfo( char *varMap, dataObjInfo_t **inrei, Res *newVarValue
         return i;
     }
 
+    // The backupResc feature has been deprecated and will be removed in a future release.
     if ( strcmp( varName, "backupRescName" ) == 0 ) {
 
         i = setStrLeafValue( rei->backupRescName, NAME_LEN, newVarValue );
@@ -1233,7 +1234,7 @@ ExprType *getVarTypeFromDataObjInfo( char *varMap, Region *r ) {
 
     }
 
-
+    // The backupResc feature has been deprecated and will be removed in a future release.
     if ( strcmp( varName, "backupRescName" ) == 0 ) {
 
         return newSimpType( T_STRING, r );

--- a/server/api/src/rsChkObjPermAndStat.cpp
+++ b/server/api/src/rsChkObjPermAndStat.cpp
@@ -202,6 +202,7 @@ chkCollForBundleOpr( rsComm_t *rsComm,
                             auto cond_input = irods::experimental::make_key_value_proxy(data_obj_inp.condInput);
                             irods::at_scope_exit free_kvp{ [&data_obj_inp] { clearKeyVal(&data_obj_inp.condInput); } };
 
+                            // The BACKUP_RESC_NAME feature has been deprecated and will be removed in a future release.
                             cond_input[BACKUP_RESC_NAME_KW] = resource;
                             cond_input[RESC_HIER_STR_KW] = curCollEnt->resc_hier;
                             cond_input[DEST_RESC_HIER_STR_KW] = resc_hier;
@@ -261,6 +262,7 @@ chkCollForBundleOpr( rsComm_t *rsComm,
                 auto cond_input = irods::experimental::make_key_value_proxy(data_obj_inp.condInput);
                 irods::at_scope_exit free_kvp{ [&data_obj_inp] { clearKeyVal(&data_obj_inp.condInput); } };
 
+                // The BACKUP_RESC_NAME feature has been deprecated and will be removed in a future release.
                 cond_input[BACKUP_RESC_NAME_KW] = resource;
                 cond_input[RESC_HIER_STR_KW] = curCollEnt->resc_hier;
                 cond_input[DEST_RESC_HIER_STR_KW] = resc_hier;

--- a/server/core/src/irods_resource_backport.cpp
+++ b/server/core/src/irods_resource_backport.cpp
@@ -320,6 +320,7 @@ namespace irods {
         }
         else if ( _cond_input ) {
             char* name = NULL;
+            // The BACKUP_RESC_NAME feature has been deprecated and will be removed in a future release.
             if ( ( name = getValByKey( _cond_input, BACKUP_RESC_NAME_KW ) ) == NULL &&
                     ( name = getValByKey( _cond_input, DEST_RESC_NAME_KW ) ) == NULL &&
                     ( name = getValByKey( _cond_input, DEF_RESC_NAME_KW ) ) == NULL &&
@@ -435,6 +436,7 @@ namespace irods {
         std::string& _out ) {
         if ( _resc_name.empty() ) {
             char* name = 0;
+            // The BACKUP_RESC_NAME feature has been deprecated and will be removed in a future release.
             name = getValByKey( _cond_input, BACKUP_RESC_NAME_KW );
             if ( name ) {
                 _out = std::string( name );

--- a/server/core/src/irods_resource_redirect.cpp
+++ b/server/core/src/irods_resource_redirect.cpp
@@ -30,6 +30,7 @@ namespace
         if (dest_resc_name) {
             key_word = dest_resc_name;
         }
+        // The BACKUP_RESC_NAME feature has been deprecated and will be removed in a future release.
         char* backup_resc_name = getValByKey(&_data_obj_inp.condInput, BACKUP_RESC_NAME_KW);
         if (backup_resc_name) {
             key_word = backup_resc_name;

--- a/server/re/src/reDataObjOpr.cpp
+++ b/server/re/src/reDataObjOpr.cpp
@@ -912,7 +912,7 @@ msiDataObjUnlink( msParam_t *inpParam, msParam_t *outParam,
  *      compatibility.
  *    Valid keyWds are:
  *          \li "destRescName" - the target resource to replicate to.
- *          \li "backupRescName" - the target resource to backup
+ *          \li "backupRescName" - (Deprecated) the target resource to backup
  *                the data. If this keyWd is used, the backup mode
  *                will be switched on.
  *          \li "rescName" - the resource of the source copy.
@@ -957,7 +957,7 @@ msiDataObjUnlink( msParam_t *inpParam, msParam_t *outParam,
  * \pre none
  * \post none
  * \sa none
-**/
+ **/
 int
 msiDataObjRepl( msParam_t *inpParam1, msParam_t *msKeyValStr,
                 msParam_t *outParam, ruleExecInfo_t *rei ) {
@@ -993,11 +993,11 @@ msiDataObjRepl( msParam_t *inpParam1, msParam_t *msKeyValStr,
         return rei->status;
     }
 
-    validKwFlags = OBJ_PATH_FLAG | DEST_RESC_NAME_FLAG | NUM_THREADS_FLAG |
-                   BACKUP_RESC_NAME_FLAG | RESC_NAME_FLAG | UPDATE_REPL_FLAG |
-                   REPL_NUM_FLAG | ALL_FLAG | ADMIN_FLAG | VERIFY_CHKSUM_FLAG |
-                   RBUDP_TRANSFER_FLAG | RBUDP_SEND_RATE_FLAG | RBUDP_PACK_SIZE_FLAG |
-                   FORCE_CHKSUM_FLAG;
+    validKwFlags = OBJ_PATH_FLAG | DEST_RESC_NAME_FLAG | NUM_THREADS_FLAG | RESC_NAME_FLAG | UPDATE_REPL_FLAG |
+                   REPL_NUM_FLAG | ALL_FLAG | ADMIN_FLAG | VERIFY_CHKSUM_FLAG | RBUDP_TRANSFER_FLAG |
+                   RBUDP_SEND_RATE_FLAG | RBUDP_PACK_SIZE_FLAG | FORCE_CHKSUM_FLAG;
+    // The BACKUP_RESC_NAME feature has been deprecated and will be removed in a future version.
+    validKwFlags |= BACKUP_RESC_NAME_FLAG;
     rei->status = parseMsKeyValStrForDataObjInp( msKeyValStr, myDataObjInp,
                   DEST_RESC_NAME_KW, validKwFlags, &outBadKeyWd );
 
@@ -2834,7 +2834,6 @@ msiExecCmd( msParam_t *inpParam1, msParam_t *inpParam2, msParam_t *inpParam3,
     return rei->status;
 }
 
-
 /**
  * \fn msiCollRepl (msParam_t *collection, msParam_t *msKeyValStr, msParam_t *status,
  * ruleExecInfo_t *rei)
@@ -2860,7 +2859,7 @@ msiExecCmd( msParam_t *inpParam1, msParam_t *inpParam2, msParam_t *inpParam3,
  *      compatibility.
  *      Valid keyWds are:
  *        \li "destRescName" - the target resource to replicate to.
- *        \li "backupRescName" - the target resource to backup
+ *        \li "backupRescName" - (Deprecated) the target resource to backup
  *              the data. If this keyWd is used, the backup mode
  *              will be switched on.
  *        \li "rescName" - the resource of the source copy.
@@ -2899,7 +2898,7 @@ msiExecCmd( msParam_t *inpParam1, msParam_t *inpParam2, msParam_t *inpParam3,
  * \pre none
  * \post none
  * \sa none
-**/
+ **/
 int
 msiCollRepl( msParam_t *collection, msParam_t *msKeyValStr, msParam_t *status,
              ruleExecInfo_t *rei ) {
@@ -2939,10 +2938,10 @@ msiCollRepl( msParam_t *collection, msParam_t *msKeyValStr, msParam_t *status,
 
 
     /* Parse resource name and directly write to collReplInp */
-    validKwFlags = COLL_NAME_FLAG | DEST_RESC_NAME_FLAG |
-                   BACKUP_RESC_NAME_FLAG | RESC_NAME_FLAG | UPDATE_REPL_FLAG |
-                   REPL_NUM_FLAG | ALL_FLAG | ADMIN_FLAG | VERIFY_CHKSUM_FLAG |
-                   FORCE_CHKSUM_FLAG;
+    validKwFlags = COLL_NAME_FLAG | DEST_RESC_NAME_FLAG | RESC_NAME_FLAG | UPDATE_REPL_FLAG | REPL_NUM_FLAG | ALL_FLAG |
+                   ADMIN_FLAG | VERIFY_CHKSUM_FLAG | FORCE_CHKSUM_FLAG;
+    // The BACKUP_RESC_NAME feature has been deprecated and will be removed in a future version.
+    validKwFlags |= BACKUP_RESC_NAME_FLAG;
     rei->status = parseMsKeyValStrForCollInp( msKeyValStr, collInp,
                   DEST_RESC_NAME_KW, validKwFlags, &outBadKeyWd );
 


### PR DESCRIPTION
Addresses #6953 

Companion PR: https://github.com/irods/irods_client_icommands/pull/456

I have not run any tests because this test is almost exclusively comments and documentation changes. The one code change is separating the deprecated `BACKUP_RESC_NAME_FLAG` from the other flags in a couple of microservices so that it can be singled out as deprecated in a comment, but it is still available for use.