### PR TITLE
[6610] Deprecated RBUDP (4-3-stable)

### DIFF
--- a/lib/api/src/rcDataObjCopy.cpp
+++ b/lib/api/src/rcDataObjCopy.cpp
@@ -59,11 +59,11 @@
  *    \n DEST_RESC_NAME_KW - The resource to store this data object
  *    \n FILE_PATH_KW - The physical file path for this data object if the
  *             normal resource vault is not used.
- *    \n RBUDP_TRANSFER_KW - use RBUDP for data transfer. This keyWd has no
+ *    \n RBUDP_TRANSFER_KW - (Deprecated) use RBUDP for data transfer. This keyWd has no
  *             value
- *    \n RBUDP_SEND_RATE_KW - the number of RBUDP packet to send per second
+ *    \n RBUDP_SEND_RATE_KW - (Deprecated) the number of RBUDP packet to send per second
  *	    The default is 600000
- *    \n RBUDP_PACK_SIZE_KW - the size of RBUDP packet. The default is 8192
+ *    \n RBUDP_PACK_SIZE_KW - (Deprecated) the size of RBUDP packet. The default is 8192
  *
  * \return integer
  * \retval 0 on success

--- a/lib/api/src/rcDataObjGet.cpp
+++ b/lib/api/src/rcDataObjGet.cpp
@@ -58,11 +58,11 @@
  *    \n FORCE_FLAG_KW - overwrite existing local copy. This keyWd has no value.
  *    \n VERIFY_CHKSUM_KW - verify the checksum value of the local file after
  *           the download. This keyWd has no value.
- *    \n RBUDP_TRANSFER_KW - use RBUDP for data transfer. This keyWd has no
+ *    \n RBUDP_TRANSFER_KW - (Deprecated) use RBUDP for data transfer. This keyWd has no
  *             value
- *    \n RBUDP_SEND_RATE_KW - the number of RBUDP packet to send per second
+ *    \n RBUDP_SEND_RATE_KW - (Deprecated) the number of RBUDP packet to send per second
  *          The default is 600000.
- *    \n RBUDP_PACK_SIZE_KW - the size of RBUDP packet. The default is 8192.
+ *    \n RBUDP_PACK_SIZE_KW - (Deprecated) the size of RBUDP packet. The default is 8192.
  *    \n LOCK_TYPE_KW - set advisory lock type. valid value - WRITE_LOCK_TYPE.
  * \param[in] locFilePath - the path of the local file to download. This path
  *           can be a relative path.

--- a/lib/api/src/rcDataObjPut.cpp
+++ b/lib/api/src/rcDataObjPut.cpp
@@ -65,11 +65,11 @@
  *    \n VERIFY_CHKSUM_KW - verify and register the target checksum value
  *            after the copy. The value is the md5 checksum value of the
  *            local file.
- *    \n RBUDP_TRANSFER_KW - use RBUDP for data transfer. This keyWd has no
+ *    \n RBUDP_TRANSFER_KW - (Deprecated) use RBUDP for data transfer. This keyWd has no
  *             value.
- *    \n RBUDP_SEND_RATE_KW - the number of RBUDP packet to send per second
+ *    \n RBUDP_SEND_RATE_KW - (Deprecated) the number of RBUDP packet to send per second
  *          The default is 600000.
- *    \n RBUDP_PACK_SIZE_KW - the size of RBUDP packet. The default is 8192.
+ *    \n RBUDP_PACK_SIZE_KW - (Deprecated) the size of RBUDP packet. The default is 8192.
  *    \n LOCK_TYPE_KW - set advisory lock type. valid value - WRITE_LOCK_TYPE.
  * \param[in] locFilePath - the path of the local file to upload. This path
  *           can be a relative path.

--- a/lib/api/src/rcDataObjRepl.cpp
+++ b/lib/api/src/rcDataObjRepl.cpp
@@ -53,11 +53,11 @@
  *            This keyWd has no value.
  *    \n FILE_PATH_KW - The physical file path for this data object if the
  *             normal resource vault is not used.
- *    \n RBUDP_TRANSFER_KW - use RBUDP for data transfer. This keyWd has no
+ *    \n RBUDP_TRANSFER_KW - (Deprecated) use RBUDP for data transfer. This keyWd has no
  *             value.
- *    \n RBUDP_SEND_RATE_KW - the number of RBUDP packet to send per second
+ *    \n RBUDP_SEND_RATE_KW - (Deprecated) the number of RBUDP packet to send per second
  *          The default is 600000.
- *    \n RBUDP_PACK_SIZE_KW - the size of RBUDP packet. The default is 8192.
+ *    \n RBUDP_PACK_SIZE_KW - (Deprecated) the size of RBUDP packet. The default is 8192.
  *    \n LOCK_TYPE_KW - set advisory lock type. valid value - READ_LOCK_TYPE.
  *
  * \return integer

--- a/lib/core/include/irods/rodsKeyWdDef.h
+++ b/lib/core/include/irods/rodsKeyWdDef.h
@@ -72,9 +72,12 @@
 #define ALL_MS_PARAM_KW                             "allMsParam"
 #define UNREG_COLL_KW                               "unregColl"
 #define UPDATE_REPL_KW                              "updateRepl"
+// RBUDP_TRANSFER_KW has been deprecated
 #define RBUDP_TRANSFER_KW                           "rbudpTransfer"
 #define VERY_VERBOSE_KW                             "veryVerbose"
+// RBUDP_SEND_RATE_KW has been deprecated
 #define RBUDP_SEND_RATE_KW                          "rbudpSendRate"
+// RBUDP_PACK_SIZE_KW has been deprecated
 #define RBUDP_PACK_SIZE_KW                          "rbudpPackSize"
 #define ZONE_KW                                     "zone"
 #define REMOTE_ZONE_OPR_KW                          "remoteZoneOpr"

--- a/lib/core/src/irods_parse_command_line_options.cpp
+++ b/lib/core/src/irods_parse_command_line_options.cpp
@@ -40,7 +40,7 @@ static int parse_program_options(
         ("num_threads,N", po::value<int>(), "numThreads - the number of threads to use for the transfer. A value of 0 means no threading. By default (-N option not used) the server decides the number of threads to use.")
         ("physical_path,p", po::value<std::string>(), "physicalPath - the absolute physical path of the uploaded file on the server")
         ("progress,P", "output the progress of the upload.")
-        ("rbudp,Q", "use RBUDP (datagram) protocol for the data transfer")
+        ("rbudp,Q", "[Deprecated] use RBUDP (datagram) protocol for the data transfer")
         ("recursive,r", "recursive - store the whole subdirectory")
         ("dest_resc,R", po::value<std::string>(), "resource - specifies the resource to store to. This can also be specified in your environment or via a rule set up by the administrator")
         ("ticket,t", po::value<std::string>(), "ticket - ticket (string) to use for ticket-based access")

--- a/lib/core/src/rcPortalOpr.cpp
+++ b/lib/core/src/rcPortalOpr.cpp
@@ -1282,7 +1282,6 @@ int getFileToPortalRbudp(
     int             veryVerbose,
     int             packetSize ) {
 
-
     portList_t *myPortList;
     int status;
     rbudpReceiver_t rbudpReceiver;

--- a/server/core/include/irods/miscServerFunct.hpp
+++ b/server/core/include/irods/miscServerFunct.hpp
@@ -71,8 +71,7 @@ int
 sameHostCopy( rsComm_t *rsComm, dataCopyInp_t *dataCopyInp );
 void
 sameHostPartialCopy( portalTransferInp_t *myInput );
-int
-rbudpRemLocCopy( dataCopyInp_t *dataCopyInp );
+[[deprecated("RBUDP is deprecated. Its use should be avoided.")]] int rbudpRemLocCopy(dataCopyInp_t* dataCopyInp);
 int
 remLocCopy( rsComm_t *rsComm, dataCopyInp_t *dataCopyInp );
 void
@@ -90,8 +89,7 @@ isUserPrivileged( rsComm_t *rsComm );
 int intNoSupport( ... );
 rodsLong_t longNoSupport( ... );
 void getZoneServerId( char *zoneName, char *zoneSID );
-int
-svrPortalPutGetRbudp( rsComm_t *rsComm );
+[[deprecated("RBUDP is deprecated. Its use should be avoided.")]] int svrPortalPutGetRbudp(rsComm_t* rsComm);
 void
 reconnManager( rsComm_t *rsComm );
 int

--- a/server/core/src/miscServerFunct.cpp
+++ b/server/core/src/miscServerFunct.cpp
@@ -439,7 +439,10 @@ svrPortalPutGet( rsComm_t *rsComm ) {
 
     if ( getUdpPortFromPortList( thisPortList ) != 0 ) {
         /* rbudp transfer */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         retVal = svrPortalPutGetRbudp( rsComm );
+#pragma clang diagnostic pop
         return retVal;
     }
 
@@ -1319,7 +1322,6 @@ rbudpRemLocCopy( dataCopyInp_t *dataCopyInp ) {
         status = getFileToPortalRbudp( portalOprOut, NULL,
                                        FileDesc[destL3descInx].fd,
                                        veryVerbose, packetSize );
-
     }
     else {
         int srcL3descInx = dataOprInp->srcL3descInx;
@@ -1361,7 +1363,10 @@ int remLocCopy(rsComm_t *rsComm, dataCopyInp_t *dataCopyInp)
 
     if ( getUdpPortFromPortList( &portalOprOut->portList ) != 0 ) {
         /* rbudp transfer */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         return rbudpRemLocCopy( dataCopyInp );
+#pragma clang diagnostic pop
     }
 
     if ( numThreads > MAX_NUM_CONFIG_TRAN_THR || numThreads <= 0 ) {


### PR DESCRIPTION
I am opening this so that everyone can take a look.  I am not sure if I did this correctly or not.  When someone calls the various -Q options via icommands (iput, iget, icp, irepl), they will get a warning message that states the following:

```
Warning: RBUDP (-Q) is deprecated. Its use should be avoided.
```
The following will show up in the server log:

```
Warning: RBUDP transfer option was called.  This has been deprecated.
```
I am not sure I implemented the client side the correct way.  Furthermore, I am not sure that this code has any effect.

```
    const irods::at_scope_exit add_deprecated_api_warning_message{[&] {
        addRErrorMsg(&rsComm->rError, DEPRECATED_API, "RBUDP has been deprecated.");
    }};
```

I was hoping this would make it back to the client so that this warning could be seen by non-icommands.

Finally, there are many methods that are called by the ones deprecated here that could also be deprecated.  Not sure how far I should go with that.
