### PR TITLE
[7388] Documenting the writeLine() function/microservice (4-3-stable)

### DIFF
--- a/doxygen/microservices.cpp
+++ b/doxygen/microservices.cpp
@@ -38,6 +38,7 @@
   - #msiSplitPath - Splits a pathname into parent and child values
   - #msiGetSessionVarValue - Gets the value of a session variable in the rei
   - #msiExit - Add a user message to the error stack
+  - #writeLine - Writes a message to the iRODS log, stdout, stderr, or a data object
 
  \subsection mainmsilowlevel Data Object Low-level Microservices
   Can be called by client through irule.

--- a/plugins/rule_engines/irods_rule_language/src/functions.cpp
+++ b/plugins/rule_engines/irods_rule_language/src/functions.cpp
@@ -1970,6 +1970,30 @@ Res *smsi_remoteExec( Node** paramsr, int, Node* node, ruleExecInfo_t* rei, int,
 #endif
 }
 
+#ifdef IRODS_FOR_DOXYGEN 
+/// \brief  Writes a message to either the iRODS log, stdout, stderr, or a data object.
+/// 
+/// \module core
+/// 
+/// \param[in] where a msParam of type STR_MS_T which is either "stdout", "stderr", "serverLog", or a full path to a data object.
+/// \param[in] inString a msParam of type STR_MS_T which is a string to be logged. 
+/// \param[in,out] rei The RuleExecInfo structure that is automatically
+///    handled by the rule engine. The user does not include rei as a
+///    parameter in the rule invocation.
+/// 
+/// \return integer
+/// \retval 0 upon success
+///
+/// \b Example
+/// \code{.py}
+/// writeLine("stdout", "This shows up on stdout");
+/// writeLine("stderr", "This shows up on stderr");
+/// writeLine("serverLog", "This shows up in the server log");
+/// writeLine("/tempZone/home/alice/foo", "This is written to the data object /tempZone/home/alice/foo");
+/// \endcode
+int writeLine(msParam_t *where, msParam_t *inString, ruleExecInfo_t *rei);
+#endif // IRODS_FOR_DOXYGEN
+
 Res *smsi_writeLine( Node** paramsr, int, Node*, ruleExecInfo_t* rei, int, Env* env, rError_t*, Region* r ) {
     char *inString = convertResToString( paramsr[1] );
     Res *where = ( Res * )paramsr[0];


### PR DESCRIPTION
This is to document writeLine().  I am not 100% sure if this is done as expected.

1. Will the link in doxygen/microservices.cpp be tied to the doxygen comments in plugins/rule_engines/irods_rule_language/src/functions.cpp?
2. Is this how we want this done where documentation for writeLine() is preceding the implementation for smsi_writeLine()?