### PR TITLE
[#7390] Auth tests: Loosen error message assertions (main)

### DIFF
--- a/scripts/irods/test/test_native_authentication.py
+++ b/scripts/irods/test/test_native_authentication.py
@@ -340,8 +340,14 @@ class test_configurations(unittest.TestCase):
 
             # Password should be expired for both sessions despite one having re-authenticated past the
             # expiry time.
-            temp_auth_session.assert_icommand(
-                ["ils"], 'STDERR', 'CAT_PASSWORD_EXPIRED: failed to perform request')
+            out, err, rc = temp_auth_session.run_icommand('ils')
+            self.assertEqual('', out)
+            # #7344 - This should always return CAT_PASSWORD_EXPIRED, but sometimes it returns
+            # CAT_INVALID_AUTHENTICATION. This should be made more consistent.
+            self.assertTrue(
+                'CAT_PASSWORD_EXPIRED: failed to perform request' in err or
+                'CAT_INVALID_AUTHENTICATION: failed to perform request' in err)
+            self.assertNotEqual(0, rc)
             # The sessions are using the same password, so the second response will be different
             # TODO: irods/irods#7344 - This should emit a better error message.
             self.auth_session.assert_icommand(

--- a/scripts/irods/test/test_pam_password_authentication.py
+++ b/scripts/irods/test/test_pam_password_authentication.py
@@ -564,8 +564,14 @@ class test_configurations(unittest.TestCase):
 
                     # Password should be expired for both sessions despite one having re-authenticated past the
                     # expiry time.
-                    temp_auth_session.assert_icommand(
-                        ["ils"], 'STDERR', 'CAT_PASSWORD_EXPIRED: failed to perform request')
+                    out, err, rc = temp_auth_session.run_icommand('ils')
+                    self.assertEqual('', out)
+                    # #7344 - This should always return CAT_PASSWORD_EXPIRED, but sometimes it returns
+                    # CAT_INVALID_AUTHENTICATION. This should be made more consistent.
+                    self.assertTrue(
+                        'CAT_PASSWORD_EXPIRED: failed to perform request' in err or
+                        'CAT_INVALID_AUTHENTICATION: failed to perform request' in err)
+                    self.assertNotEqual(0, rc)
                     # The sessions are using the same password, so the second response will be different
                     # TODO: irods/irods#7344 - This should emit a better error message.
                     self.auth_session.assert_icommand(


### PR DESCRIPTION
Addresses https://github.com/irods/irods/issues/7390

Just ran the updated pam_password test and it passed like 20 times in a row, so probably okay. The native auth version was updated but the test is being skipped right now as the feature in question is not supported for that auth scheme.