### PR TITLE
[#7319] Make `msiSetResource` not crash agent

### DIFF
--- a/scripts/irods/test/test_native_rule_engine_plugin.py
+++ b/scripts/irods/test/test_native_rule_engine_plugin.py
@@ -831,6 +831,30 @@ OUTPUT ruleExecOut
         finally:
             os.unlink(rule_file)
 
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'rule language only')
+    def test_msiSetResource__issue_7319(self):
+        rule_map = {
+            'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent('''
+                test_msiSetResource {{
+                    msiSetResource("testResc");
+                }}
+                OUTPUT ruleExecOut
+                ''')
+        }
+
+        rule_file = 'test_msiSetResource.r'
+        with open(rule_file, 'w') as f:
+            f.write(rule_map[self.plugin_name])
+
+        try:
+            rep_name = 'irods_rule_engine_plugin-irods_rule_language-instance'
+
+            self.admin.assert_icommand(['irule', '-r', rep_name, '-F', rule_file], 'STDERR', 'SYS_INTERNAL_NULL_INPUT_ERR', desired_rc=4)
+            self.user0.assert_icommand(['irule', '-r', rep_name, '-F', rule_file], 'STDERR', 'SYS_INTERNAL_NULL_INPUT_ERR', desired_rc=4)
+
+        finally:
+            os.remove(rule_file)
+
     def test_re_serialization_for_RsComm_ptr__issue_5950(self):
         pep_map = {
             'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent('''

--- a/server/re/src/icatGeneralMS.cpp
+++ b/server/re/src/icatGeneralMS.cpp
@@ -6,8 +6,14 @@
 #include "irods/miscServerFunct.hpp"
 #include "irods/modAccessControl.h"
 #include "irods/irods_configuration_keywords.hpp"
+#include "irods/irods_logger.hpp"
 #include "irods/rsModAccessControl.hpp"
 #include "irods/irods_re_structs.hpp"
+
+namespace
+{
+    using log_msi = irods::experimental::log::microservice;
+} // anonymous namespace
 
 /**
  * \fn msiGetIcatTime (msParam_t *timeOutParam, msParam_t *typeInParam, ruleExecInfo_t *)
@@ -138,11 +144,14 @@ msiQuota( ruleExecInfo_t *rei ) {
  * \sa none
 **/
 int  msiSetResource( msParam_t* xrescName, ruleExecInfo_t *rei ) {
-    char *rescName;
+    char* rescName{static_cast<char*>(xrescName->inOutStruct)};
 
-    rescName = ( char * ) xrescName->inOutStruct;
+    if (nullptr == rei->doi) {
+        log_msi::error("{}: Cannot set resource, no DOI (DataObjInfo) attached to REI (RuleExecInfo).", __func__);
+        return SYS_INTERNAL_NULL_INPUT_ERR;
+    }
 
-    snprintf( rei->doi->rescName, sizeof( rei->doi->rescName ), "%s", rescName );
+    std::snprintf(rei->doi->rescName, sizeof(rei->doi->rescName), "%s", rescName);
     return 0;
 }
 


### PR DESCRIPTION
This provides a simple fix to `msiSetResource(...)` by adding a null check before dereference.