### PR TITLE
[#7618] Document process for reporting security vulnerabilities (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Funders have included DARPA, NSF, DOD, DOE, LC, NARA, NASA, NOAA, USPTO, and LLN
 
 iRODS is released under a 3-clause BSD License.
 
+## Reporting Security Vulnerabilities
+
+See [SECURITY.md](SECURITY.md) for details.
+
 ## Links to elsewhere...
 
  - [https://github.com/irods](https://github.com/irods)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporting Security Vulnerabilities
+
+The iRODS Consortium takes security very seriously. If you feel you've discovered a vulnerability, please send an email to [security@irods.org](mailto:security@irods.org).
+
+The iRODS Consortium and the community greatly appreciate you taking the time to submit your findings.


### PR DESCRIPTION
This results in a **Security tab** appearing on the front page.

The README also includes a link to the new markdown file for easier access.

This can be applied to the organization as well, but I need to investigate that more. Also, can happen later.

The idea to handle this via a SECURITY.md file was proposed by @MartinFlores751 _(good stuff)_.

Visit the branch to see how it looks live.