### PR TITLE
[7540] Fix double-free in rsCollRepl (main)

### DIFF
--- a/server/api/src/rsCollRepl.cpp
+++ b/server/api/src/rsCollRepl.cpp
@@ -138,7 +138,7 @@ rsCollRepl( rsComm_t *rsComm, collInp_t *collReplInp,
         collEnt = NULL;
     }
     rsCloseCollection( rsComm, &handleInx );
-    freeCollEnt( collEnt );
+    free(collEnt);
 
     return savedStatus;
 }


### PR DESCRIPTION
Funny-looking PR. Debugged with asan.

`rsCloseCollection` calls `freeCollHandle` calls `clearCollHandle` calls `clearCollSqlResult`, which frees the `collSqlResult_t`'s members. 

However, `rsReadCollection` calls `readCollection` calls `getNextCollMetaInfo`/`getNextDataObjMetaInfo`, and pointers from the `collSqlResult_t` are assigned to the `collEnt_t`'s members (no copying!), so freeing the members of the `collEnt_t` results in a double-free (since `clearCollSqlResult` should have already freed it).

The only reason this worked before (but not in error cases) was because the double-free was evaded by `collEnt` being set to `NULL` a few lines above (as the final operation of the `while` loop). This means `freeCollEnt` effectively becomes a no-op, since it instantly returns if `NULL` (and doesn't call `clearCollEnt`, the offending function). 

However, in error cases, like when `rsDataObjRepl` fails, the `break` immediately breaks out of the loop. This means `collEnt` is not null, so `clearCollEnt` is called.

Finally, my suggested change doesn't double-free on normal operation because after the while-loop terminates, `collEnt` is freed and set to `NULL` in `rsReadCollection` when `status < 0`. Per the [C standard](https://www.open-std.org/JTC1/SC22/wg14/www/docs/n1124.pdf) (7.20.3.2/2), `free(NULL);` does nothing.

Additionally, I have confirmed with asan that not freeing `collEnt` here (or somewhere) will cause a leak in error cases.

Will run tests shortly.

Whew, I think that's all of it. A lot of words for a one line commit.