### PR TITLE
[#7619] irodsctl stop: Fix orphan agent cleanup (main)

### DIFF
--- a/scripts/irods/controller.py
+++ b/scripts/irods/controller.py
@@ -293,7 +293,7 @@ def capture_process_tree(server_proc, server_descendants, candidate_binaries=Non
 
     if server_proc.is_running():
         try:
-            cur_descendants = filter(should_return_proc, server_proc.children(recursive=True))
+            cur_descendants = set(filter(should_return_proc, server_proc.children(recursive=True)))
             orphaned_descendants = server_descendants.difference(cur_descendants)
             server_descendants.update(cur_descendants)
         except (psutil.NoSuchProcess):

--- a/scripts/irods/test/test_irodsctl.py
+++ b/scripts/irods/test/test_irodsctl.py
@@ -1,21 +1,20 @@
+import unittest
+
+from subprocess import PIPE
 import json
 import os
 import shutil
 import sys
 import tempfile
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
-from .. import test
+from . import session
 from . import settings
-from ..test.command import assert_command
 from .. import lib
 from .. import paths
-from ..controller import IrodsController
+from .. import test
 from ..configuration import IrodsConfig
+from ..controller import IrodsController, capture_process_tree
+from ..test.command import assert_command
 
 class Test_Irodsctl(unittest.TestCase):
     def test_re_shm_creation(self):
@@ -43,6 +42,68 @@ class Test_Irodsctl(unittest.TestCase):
             else:
                 assert_command([irodsctl_fullpath, 'restart', '-v'], 'STDERR_SINGLELINE', 'jsonschema not installed', desired_rc=0)
 
+    def test_agents_kept_alive_by_connected_clients_are_cleaned_up_after_failed_graceful_shutdown__issue_7619(self):
+        # Get the server process so that we can monitor the child processes.
+        server_proc = IrodsController().get_server_proc()
+        self.assertIsNotNone(server_proc)
+
+        with session.make_session_for_existing_admin() as admin_session:
+            user = session.mkuser_and_return_session('rodsuser', 'bilbo', 'bpass', lib.get_hostname())
+            logical_path = f'{user.session_collection}/the_replica_that_never_should_have_been'
+
+            try:
+                # Create a session and kick off a client call that will never return. In this case, a call to
+                # istream write with no input.
+                istream_command = ['istream', 'write', logical_path]
+                kwargs = dict()
+                user._prepare_run_icommand(istream_command, kwargs)
+                istream_proc = lib.execute_command_nonblocking(
+                    istream_command, stdout=PIPE, stderr=PIPE, stdin=PIPE, **kwargs)
+                self.assertIsNone(istream_proc.poll())
+                # Wait until the data object is created in the catalog before proceeding. This is how we confirm that
+                # an agent exists for the istream call.
+                lib.delayAssert(lambda: lib.replica_exists(user, logical_path, 0))
+
+                # Collect all the server processes. Should be 3-4 depending on whether the delay server is querying.
+                # capture_process_tree does not count the grandpa process.
+                server_descendants_before_shutdown = set()
+                self.assertTrue(
+                    capture_process_tree(
+                        server_proc, server_descendants_before_shutdown, IrodsController().server_binaries))
+                print(server_descendants_before_shutdown) # debugging
+                self.assertGreaterEqual(len(server_descendants_before_shutdown), 3)
+
+                # Shut down the server - this will take a while as it will need to time out first.
+                assert_command(
+                    [os.path.join(IrodsConfig().irods_directory, 'irodsctl'), 'stop', '-v'],
+                    'STDERR', 'Killing forcefully...')
+
+                # Ensure that the server shut down but the client process did not.
+                self.assertFalse(server_proc.is_running())
+                self.assertIsNone(istream_proc.poll())
+
+                # Now for the most important part... Confirm that all the server processes from before are gone.
+                # Pass None for server_proc because it should not be running anymore. get_binary_to_procs_dict()
+                # defaults to searching for processes with the server binary names.
+                self.assertEqual(0, len(IrodsController().get_binary_to_procs_dict(server_proc=None)))
+
+            finally:
+                # Restart the server.
+                IrodsController().restart()
+
+                # Set the replica to stale (it will be in the intermediate status - this is not a bug) and remove.
+                admin_session.run_icommand(
+                    ['iadmin', 'modrepl', 'logical_path', logical_path, 'replica_number', '0', 'DATA_REPL_STATUS', '0'])
+                user.run_icommand(['irm', '-f', logical_path])
+
+                # Exit the session created from before and remove the user.
+                user.__exit__()
+                admin_session.run_icommand(['iadmin', 'rmuser', user.username])
+
+                # Kill the client process spawned above, if applicable.
+                istream_proc.terminate()
+
+
 def stop_irods_server():
     assert_command([os.path.join(IrodsConfig().irods_directory, 'irodsctl'), 'stop', '-v'],
                    'STDOUT_SINGLELINE', 'Success')
@@ -61,7 +122,7 @@ def start_irods_server(env=None):
     else:
         assert_command('{0} graceful_start -v'.format(os.path.join(IrodsConfig().irods_directory, 'irodsctl')),
                        'STDERR_SINGLELINE', 'jsonschema not installed', desired_rc=0, env=env)
-    with make_session_for_existing_admin() as admin_session:
+    with session.make_session_for_existing_admin() as admin_session:
         admin_session.assert_icommand('ils', 'STDOUT_SINGLELINE', admin_session.zone_name)
 
 def restart_irods_server(env=None):


### PR DESCRIPTION
Addresses #7619

I've confirmed the fix and test validity on Ubuntu 22.04. I would like to test on Centos 7, too, because we will be releasing for that platform for 4.3.2 and it uses python2 by default.

Need to run core tests as well.