### PR TITLE
[_7319] Correct nullptr dereference in `msiSetDefaultResc(...)` (main)

### DIFF
--- a/scripts/irods/test/test_native_rule_engine_plugin.py
+++ b/scripts/irods/test/test_native_rule_engine_plugin.py
@@ -855,6 +855,30 @@ OUTPUT ruleExecOut
         finally:
             os.remove(rule_file)
 
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'rule language only')
+    def test_msiSetDefaultResc__issue_7319(self):
+        rule_map = {
+            'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent('''
+                test_msiSetDefaultResc {{
+                    msiSetDefaultResc('TestResc', 'preferred');
+                }}
+                OUTPUT ruleExecOut
+                ''')
+        }
+
+        rule_file = 'test_msiSetDefaultResc.r'
+        with open(rule_file, 'w') as f:
+            f.write(rule_map[self.plugin_name])
+
+        try:
+            rep_name = 'irods_rule_engine_plugin-irods_rule_language-instance'
+
+            self.admin.assert_icommand(['irule', '-r', rep_name, '-F', rule_file], desired_rc=0)
+            self.user0.assert_icommand(['irule', '-r', rep_name, '-F', rule_file], desired_rc=0)
+
+        finally:
+            os.remove(rule_file)
+
     def test_re_serialization_for_RsComm_ptr__issue_5950(self):
         pep_map = {
             'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent('''

--- a/server/re/src/reSysDataObjOpr.cpp
+++ b/server/re/src/reSysDataObjOpr.cpp
@@ -65,9 +65,11 @@ msiSetDefaultResc( msParam_t *xdefaultRescList, msParam_t *xoptionStr, ruleExecI
 
     optionStr = ( char * ) xoptionStr->inOutStruct;
 
+    auto* cond_input{nullptr == rei->doinp ? nullptr : &rei->doinp->condInput};
+
     RE_TEST_MACRO( "    Calling msiSetDefaultResc" )
 
-    irods::error err = irods::set_default_resource( rei->rsComm, defaultRescList, optionStr, &rei->doinp->condInput, default_resc );
+    irods::error err = irods::set_default_resource( rei->rsComm, defaultRescList, optionStr, cond_input, default_resc );
     rei->status = err.code();
 
     if ( rei->status >= 0 ) {


### PR DESCRIPTION
This PR fixes a bug in `msiSetDefaultResc(...)` where a `nullptr` may be dereferenced, causing the agent to crash.