### PR TITLE
[#7651] Make use of msiSendMail an opt-in (main)

### DIFF
--- a/doxygen/microservices.cpp
+++ b/doxygen/microservices.cpp
@@ -114,7 +114,7 @@
   - #msiSubstr   - Returns a substring of the given string
 
  \subsection msiemail Email Microservices
-  - #msiSendMail   - (Deprecated) Sends email
+  - #msiSendMail - (Deprecated) Sends email
 
  \subsection msikv Key-Value (Attr-Value) Microservices
   - #writeKeyValPairs - Writes key-value pairs to stdout or stderr and with given separator

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -265,6 +265,10 @@ class Test_AllRules(resource_suite.ResourceBase, unittest.TestCase):
                 # print("skipping " + rulefile + " ----- tested separately")
                 return False
 
+            # msiSendMail is deprecated and disabled by default as of 4.3.2.
+            if "rulemsiSendMail" in rulefile:
+                return False
+
             return True
 
         for rulefile in filter(filter_rulefiles, sorted(os.listdir(rulesdir))):
@@ -275,6 +279,26 @@ class Test_AllRules(resource_suite.ResourceBase, unittest.TestCase):
                                                      ,'STDOUT_SINGLELINE', "completed successfully")
                 return test
 
+            # Returns a test with the following name:
+            #
+            #     test_<filename>_r
+            #
+            # Dots (.) are replaced with underscores (_).
+            #
+            # The rule files which are used to generate the tests normally follow
+            # the naming scheme below (following the scheme is not required):
+            #
+            #     rule<microservice_name>.r.
+            #
+            # So, given a file named rulemsiSendMail.r, the line below will
+            # generate the following test name:
+            #
+            #     test_rulemsiSendMail_r
+            #
+            # Individual tests can be run using the generated name like so:
+            #
+            #     test_all_rules.Test_AllRules.test_<filename>_r
+            #
             yield 'test_' + rulefile.replace('.', '_'), make_test(rulefile)
 
     def test_rulemsiDataObjRsync(self):

--- a/scripts/irods/test/test_misc.py
+++ b/scripts/irods/test/test_misc.py
@@ -16,13 +16,14 @@ from ..configuration import IrodsConfig
 from ..controller import IrodsController
 from ..core_file import temporary_core_file
 
-class Test_Misc(session.make_sessions_mixin([('otherrods', 'rods')], []), unittest.TestCase):
+class Test_Misc(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 'apass')]), unittest.TestCase):
 
     plugin_name = IrodsConfig().default_rule_engine_plugin
 
     def setUp(self):
         super(Test_Misc, self).setUp()
         self.admin = self.admin_sessions[0]
+        self.user = self.user_sessions[0]
 
     def tearDown(self):
         super(Test_Misc, self).tearDown()
@@ -471,3 +472,39 @@ class Test_Misc(session.make_sessions_mixin([('otherrods', 'rods')], []), unitte
         # Check for SOCKET_ERROR (-179000) with an errno of 22 (Invalid argument).
         self.env['IRODS_TCP_KEEPALIVE_PROBES'] = str(2147483647)
         self.admin.assert_icommand('ils', 'STDERR', '-179022 SOCKET_ERROR, Invalid argument', env=self.env)
+
+
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', "Designed for the NREP")
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing")
+    def test_enabling_and_disabling_of_msiSendMail__issue_7651(self):
+        config = IrodsConfig()
+        rep_name = f'{self.plugin_name}-instance'
+        rule = 'msiSendMail("x", "y", "z")'
+
+        # Show use of msiSendMail is blocked when the configuration option is not defined.
+        self.assertNotIn('enable_deprecated_msiSendMail', config.server_config['advanced_settings'])
+        self.user.assert_icommand(['irule', '-r', rep_name, rule, 'null', 'ruleExecOut'], 'STDERR', ['-169000 SYS_NOT_ALLOWED'])
+
+        # Show use of msiSendMail is blocked when the configuration option is set to false.
+        with lib.file_backed_up(config.server_config_path):
+            config.server_config['advanced_settings']['enable_deprecated_msiSendMail'] = False
+            lib.update_json_file_from_dict(config.server_config_path, config.server_config)
+            self.assertIn('enable_deprecated_msiSendMail', config.server_config['advanced_settings'])
+            self.user.assert_icommand(['irule', '-r', rep_name, rule, 'null', 'ruleExecOut'], 'STDERR', ['-169000 SYS_NOT_ALLOWED'])
+
+        # Show use of msiSendMail is blocked when the configuration option is set to something
+        # other than a boolean.
+        with lib.file_backed_up(config.server_config_path):
+            config.server_config['advanced_settings']['enable_deprecated_msiSendMail'] = 'not_a_boolean'
+            lib.update_json_file_from_dict(config.server_config_path, config.server_config)
+            self.assertIn('enable_deprecated_msiSendMail', config.server_config['advanced_settings'])
+            self.user.assert_icommand(['irule', '-r', rep_name, rule, 'null', 'ruleExecOut'], 'STDERR', ['-169000 SYS_NOT_ALLOWED'])
+
+        # Show use of msiSendMail is allowed when the configuration option is set to true.
+        with lib.file_backed_up(config.server_config_path):
+            config.server_config['advanced_settings']['enable_deprecated_msiSendMail'] = True
+            lib.update_json_file_from_dict(config.server_config_path, config.server_config)
+            self.assertIn('enable_deprecated_msiSendMail', config.server_config['advanced_settings'])
+            # irule will not report an error even if the underlying mail command isn't installed.
+            # This behavior is expected.
+            self.user.assert_icommand(['irule', '-r', rep_name, rule, 'null', 'ruleExecOut'])


### PR DESCRIPTION
The design may be a little weird. That's due to different ideas on how to go about exposing this functionality.

I'm leaning towards the following:
- Making `msiSendMail` always reset the internal variable upon use
- Making the new MSI always set the internal variable to true
    - Removes the need for an input argument

Those changes disallow putting the agent in a state where anyone can invoke the MSI. I'm thinking about long-running agents here. It also forces all calls to `msiSendMail` to be addressed/reviewed.

Thoughts?