### PR TITLE
Add replica_truncate microservice, fix Doxygen (main)

### DIFF
--- a/doxygen/microservices.cpp
+++ b/doxygen/microservices.cpp
@@ -67,6 +67,7 @@
   - #msiCheckPermission - Check if a data object permission is the same as the one given
   - #msiCheckOwner - Check if the user is the owner of the data object
   - #msiSetReplComment - Sets the data_comments attribute of a data object
+  - #msi_replica_truncate - Truncate a replica to the desired size
 
  \subsection msicollection Collection Microservices
   - #msiCollCreate - Create a collection

--- a/lib/api/include/irods/replica_truncate.h
+++ b/lib/api/include/irods/replica_truncate.h
@@ -21,15 +21,15 @@ extern "C" {
 /// \param[in] _comm A pointer to a RcComm.
 /// \param[in] _inp \parblock
 /// DataObjInp structure which requires the following inputs:
-///     objPath - The full logical path to the target data object.
-///     dataSize - The desired size of the replica after truncating.
+///     - objPath: The full logical path to the target data object.
+///     - dataSize: The desired size of the replica after truncating.
 ///
 /// The condInput supports the following keywords:
-///     REPL_NUM_KW - The replica number of the replica to truncate.
-///     RESC_NAME_KW - The name of the resource with the replica to truncate. Must be a root resource.
-///     DEF_RESC_NAME_KW - The default resource to target in the absence of any other inputs or policy.
-///     RESC_HIER_STR_KW - Full resource hierarchy to the replica to truncate. Use with caution.
-///     ADMIN_KW - Flag indicating that the operation is to be performed with elevated privileges. No value required.
+///     - REPL_NUM_KW: The replica number of the replica to truncate.
+///     - RESC_NAME_KW: The name of the resource with the replica to truncate. Must be a root resource.
+///     - DEF_RESC_NAME_KW: The default resource to target in the absence of any other inputs or policy.
+///     - RESC_HIER_STR_KW: Full resource hierarchy to the replica to truncate. Use with caution.
+///     - ADMIN_KW: Flag indicating that the operation is to be performed with elevated privileges. No value required.
 /// \endparblock
 /// \param[out] _out \parblock
 /// Character string representing a JSON structure with the following form:

--- a/scripts/core_tests_list.json
+++ b/scripts/core_tests_list.json
@@ -2,6 +2,7 @@
     "test_all_rules.Test_AllRules",
     "test_all_rules.Test_JSON_microservices",
     "test_all_rules.Test_msiDataObjRepl_checksum_keywords",
+    "test_all_rules.test_msi_replica_truncate",
     "test_auth.Test_Auth",
     "test_auth.test_iinit",
     "test_catalog",

--- a/server/api/include/irods/rs_replica_truncate.hpp
+++ b/server/api/include/irods/rs_replica_truncate.hpp
@@ -21,15 +21,15 @@ extern "C" {
 /// \param[in] _comm A pointer to a RsComm.
 /// \param[in] _inp \parblock
 /// DataObjInp structure which requires the following inputs:
-///     objPath - The full logical path to the target data object.
-///     dataSize - The desired size of the replica after truncating.
+///     - objPath: The full logical path to the target data object.
+///     - dataSize: The desired size of the replica after truncating.
 ///
 /// The condInput supports the following keywords:
-///     REPL_NUM_KW - The replica number of the replica to truncate.
-///     RESC_NAME_KW - The name of the resource with the replica to truncate. Must be a root resource.
-///     DEF_RESC_NAME_KW - The default resource to target in the absence of any other inputs or policy.
-///     RESC_HIER_STR_KW - Full resource hierarchy to the replica to truncate. Use with caution.
-///     ADMIN_KW - Flag indicating that the operation is to be performed with elevated privileges. No value required.
+///     - REPL_NUM_KW: The replica number of the replica to truncate.
+///     - RESC_NAME_KW: The name of the resource with the replica to truncate. Must be a root resource.
+///     - DEF_RESC_NAME_KW: The default resource to target in the absence of any other inputs or policy.
+///     - RESC_HIER_STR_KW: Full resource hierarchy to the replica to truncate. Use with caution.
+///     - ADMIN_KW: Flag indicating that the operation is to be performed with elevated privileges. No value required.
 /// \endparblock
 /// \param[out] _out \parblock
 /// Character string representing a JSON structure with the following form:

--- a/server/re/include/irods/reAction.hpp
+++ b/server/re/include/irods/reAction.hpp
@@ -183,6 +183,8 @@ namespace irods
         table_[ "msiDataObjPhymv" ] = new irods::ms_table_entry( "msiDataObjPhymv", 6, std::function<int(msParam_t*,msParam_t*,msParam_t*,msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiDataObjPhymv ) );
         table_[ "msiDataObjRename" ] = new irods::ms_table_entry( "msiDataObjRename", 4, std::function<int(msParam_t*,msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiDataObjRename ) );
         table_[ "msiDataObjTrim" ] = new irods::ms_table_entry( "msiDataObjTrim", 6, std::function<int(msParam_t*,msParam_t*,msParam_t*,msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiDataObjTrim ) );
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        table_[ "msi_replica_truncate" ] = new irods::ms_table_entry( "msi_replica_truncate", 2, std::function<int(msParam_t*,msParam_t*,ruleExecInfo_t*)>( msi_replica_truncate ) );
         table_[ "msiCollCreate" ] = new irods::ms_table_entry( "msiCollCreate", 3, std::function<int(msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiCollCreate ) );
         table_[ "msiRmColl" ] = new irods::ms_table_entry( "msiRmColl", 3, std::function<int(msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiRmColl ) );
         table_[ "msiCollRepl" ] = new irods::ms_table_entry( "msiCollRepl", 3, std::function<int(msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiCollRepl ) );

--- a/server/re/include/irods/reDataObjOpr.hpp
+++ b/server/re/include/irods/reDataObjOpr.hpp
@@ -96,4 +96,6 @@ msiCollRsync( msParam_t *inpParam1, msParam_t *inpParam2,
 int
 _rsCollRsync( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
               char *srcColl, char *destColl );
+
+auto msi_replica_truncate(MsParam* _inp, MsParam* _out, RuleExecInfo* _rei) -> int;
 #endif	/* RE_DATA_OBJ_OPR_H */


### PR DESCRIPTION
Addresses #7577 
Addresses #7650

A few notes...

1. The only code changes are for the new microservice, which is not used by anything else. Therefore, I did not run the whole test suite as I do not see it as necessary.
2. I put the tests for the new microservice in the same commit as the microservice implementation itself this time because there is no benefit to separating them in this instance. It is testing a microservice that did not exist before, so of course the test will fail. That being said, make sure the returned error codes make sense and are expected. I think they are fine.
3. As noted in the docstring, the new tests are not meant to be comprehensive tests for truncate but just the various inputs for the microservice itself. The inputs for the API have been fleshed out in the Catch2 tests.
4. I can move the microservice to some other file. I just put it with the other "data object" microservices because I didn't want to create a new category.