### PR TITLE
[#7570] Bump server_config.json schema version for GenQuery2 log category (main)

### DIFF
--- a/packaging/server_config.json.template
+++ b/packaging/server_config.json.template
@@ -1,6 +1,6 @@
 {
     "schema_name": "server_config",
-    "schema_version": "v4",
+    "schema_version": "v5",
     "advanced_settings": {
         "agent_factory_watcher_sleep_time_in_seconds": 5,
         "default_number_of_transfer_threads": 4,
@@ -49,6 +49,7 @@
         "authentication": "info",
         "database": "info",
         "delay_server": "info",
+        "genquery2": "info",
         "legacy": "info",
         "microservice": "info",
         "network": "info",

--- a/schemas/configuration/v4/server_config.json.in
+++ b/schemas/configuration/v4/server_config.json.in
@@ -114,6 +114,7 @@
                     "authentication": {"enum": ["trace", "debug", "info", "warn", "error", "critical"], "maxItems": 1},
                     "database": {"enum": ["trace", "debug", "info", "warn", "error", "critical"], "maxItems": 1},
                     "delay_server": {"enum": ["trace", "debug", "info", "warn", "error", "critical"], "maxItems": 1},
+                    "genquery2": {"enum": ["trace", "debug", "info", "warn", "error", "critical"], "maxItems": 1},
                     "legacy": {"enum": ["trace", "debug", "info", "warn", "error", "critical"], "maxItems": 1},
                     "microservice": {"enum": ["trace", "debug", "info", "warn", "error", "critical"], "maxItems": 1},
                     "network": {"enum": ["trace", "debug", "info", "warn", "error", "critical"], "maxItems": 1},

--- a/scripts/irods/upgrade_configuration.py
+++ b/scripts/irods/upgrade_configuration.py
@@ -316,6 +316,13 @@ def run_schema_update(config_dict, schema_name, next_schema_version):
             merge_hosts_config_into_server_config(config_dict)
             merge_host_access_control_config_into_server_config(config_dict)
 
+    if next_schema_version == 5:
+        if schema_name == 'server_config':
+            # Build a new server_config.json file using server_config.json.template as a base.
+            # Overwrite all configuration properties in the template with the properties from
+            # "config_dict" (i.e. the local server's server_config.json).
+            config_dict = convert_to_v4_schema_and_add_missing_properties(config_dict)
+
     config_dict['schema_version'] = 'v%d' % (next_schema_version)
 
     return config_dict


### PR DESCRIPTION
This is necessary to keep the server log from printing a warning every time the GenQuery2 parser is invoked due to the genquery2 log category not being defined in server_config.json.

Now ...
- Are all references to "v4" supposed to be changed to "v5"?
- Are schema versions allowed to differ if nothing is changed in the file?

Something tells me all schema files must be updated.

Hmm, definitely need to write down the rules around schema bumps, etc.

Alternatively, we bump the log message from warn to trace. Then the genquery2 log category isn't needed. The server already defaults missing categories to info.