### PR TITLE
[#7704] Ensure `trimPrefix(...)` doesn't go past end of string (main)

### DIFF
--- a/lib/core/include/irods/rcMisc.h
+++ b/lib/core/include/irods/rcMisc.h
@@ -360,9 +360,15 @@ int getAttriInAttriArray(const char* objPath,
                          int* outDataMode,
                          char** outChksum);
 
+// clang-format off
+__attribute__((deprecated))
 char* trimSpaces(char* str);
+// clang-format on
 
+// clang-format off
+__attribute__((deprecated))
 char* trimPrefix(char* str);
+// clang-format on
 
 int convertListToMultiString(char* strInput, int input);
 

--- a/scripts/irods/test/test_irule.py
+++ b/scripts/irods/test/test_irule.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import os
 import sys
 if sys.version_info >= (2, 7):
     import unittest
@@ -53,3 +54,18 @@ class Test_Irule(ResourceBase, unittest.TestCase):
         self.assertNotIn( "[1]", stdout )
         self.assertIn( "badInput format error", stderr )
         self.assertNotEqual( rc, 0 )
+
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for irods_rule_language REP')
+    def test_irule_does_not_crash_on_bad_rule_file__issue_7740(self):
+        bad_rule = '''
+        test_irule_does_not_crash_on_bad_rule_file__issue_7740 {
+            writeLine("Did I do this right?");
+        }
+        OUTPUT
+        '''
+        path_to_file = os.path.join(self.admin.local_session_dir, 'issue_7740.r')
+
+        with open(path_to_file, 'w') as f:
+            f.write(bad_rule)
+
+        self.admin.assert_icommand_fail(['irule', '-F', path_to_file, '-r', 'irods_rule_engine_plugin-irods_rule_language-instance'], desired_rc=2)


### PR DESCRIPTION
Minimal patch to fix going past the end of the string.

Can't switch to using `std::isspace(...)` or others, as they would expand what this function originally did, I believe.
Table for reference:
https://en.cppreference.com/w/cpp/string/byte/isspace