### PR TITLE
[5210] Rewrite make_copy so it stores rule files in memory

### DIFF
--- a/plugins/rule_engines/irods_rule_language/include/irods/private/re/configuration.hpp
+++ b/plugins/rule_engines/irods_rule_language/include/irods/private/re/configuration.hpp
@@ -141,6 +141,7 @@ int clearResources( int resources );
 int clearCoreRuleIndex( );
 int clearAppRuleIndex( );
 int readRuleStructAndRuleSetFromFile( const char *ruleBaseName, const char *rulesFileName );
+int readRuleStructAndRuleSetFromBuffer(const char* ruleBaseName, char* ruleBase);
 int loadRuleFromCacheOrFile( const char*, const char *irbSet );
 int createCoreRuleIndex( );
 int createAppRuleIndex( );

--- a/plugins/rule_engines/irods_rule_language/include/irods/private/re/rules.hpp
+++ b/plugins/rule_engines/irods_rule_language/include/irods/private/re/rules.hpp
@@ -13,6 +13,13 @@
 
 int readRuleSetFromFile( const char *ruleBaseName, RuleSet *ruleSet, Env *funcDesc, int* errloc, rError_t *errmsg, Region *r );
 int readRuleSetFromLocalFile( const char *ruleBaseName, const char *fileName, RuleSet *ruleSet, Env *funcDesc, int *errloc, rError_t *errmsg, Region *r );
+int readRuleSetFromBuffer(const char* ruleBaseName,
+                          char* ruleBody,
+                          RuleSet* ruleSet,
+                          Env* funcDesc,
+                          int* errloc,
+                          rError_t* errmsg,
+                          Region* r);
 int parseAndComputeMsParamArrayToEnv( msParamArray_t *msParamArray, Env *global, ruleExecInfo_t *rei, int reiSaveFlag, rError_t *errmsg, Region *r );
 int parseAndComputeRule( char *expr, Env *env, ruleExecInfo_t *rei, int reiSaveFlag, rError_t *errmsg, Region *r );
 int parseAndComputeRuleNewEnv( char *expr, ruleExecInfo_t *rei, int reiSaveFlag, msParamArray_t *msParamArray, rError_t *errmsg, Region *r );


### PR DESCRIPTION
Instead of what `make_copy` used to do, it stores copies of rule files in-memory with an `unordered_map` mapping `irb` to the content.
`make_copy`'s copies seem to be accessed in two ways:
1. `readRuleSetFromLocalFile` uses `fopen` and friends. Copied the function, except with `fmemopen` for the new version.
2. `hash_rules` uses `std::ifstream` and friends. Copied the function, except with a `std::stringstream`

Seems to work ok at first blush. Taking suggestions on anything.