### PR TITLE
[#7859] Convert null pointer to empty string for checksum output parameter of msiDataObjChksum (4-3-stable)

### DIFF
--- a/server/re/src/reDataObjOpr.cpp
+++ b/server/re/src/reDataObjOpr.cpp
@@ -1621,7 +1621,7 @@ msiDataObjChksum( msParam_t *inpParam1, msParam_t *msKeyValStr,
     }
 
     if ( rei->status >= 0 ) {
-        fillStrInMsParam( outParam, chksum );
+        fillStrInMsParam(outParam, chksum ? chksum : "");
         free( chksum );
     }
     else {


### PR DESCRIPTION
Tested manually at the bench.

Just need to confirm the test is good and run the full test suite.