### PR TITLE
[7947] make checksum buffer size configurable (4-3-stable)

### DIFF
--- a/packaging/server_config.json.template
+++ b/packaging/server_config.json.template
@@ -3,6 +3,7 @@
     "schema_version": "v4",
     "advanced_settings": {
         "agent_factory_watcher_sleep_time_in_seconds": 5,
+        "checksum_read_buffer_size_in_bytes": 1048576,
         "default_number_of_transfer_threads": 4,
         "default_temporary_password_lifetime_in_seconds": 120,
         "delay_rule_executors": [],


### PR DESCRIPTION
This is a change to allow the setting of the read buffer size for checksum in server_config.json.

- The test case simply puts a file in iRODS, reads the checksum, removed the data object, updates the buffer size in the configuration, restarts the server, puts the same file, reads the checksum, compares the two, then cleans up.  I don't know of any way to verify that the buffer size is actually updated at runtime although I have manually tested and verified this with extra logging.

-  I updated the configuration template to add `checksum_read_buffer_size_in_bytes` with the same default that was originally hardcoded.  I started up a server to verify that a new installation has this configuration.  I also verified that during the execution of the test the configuration was in fact updated.