### PR TITLE
[7947] make checksum buffer size configurable (main)

### DIFF
--- a/packaging/server_config.json.template
+++ b/packaging/server_config.json.template
@@ -3,6 +3,7 @@
     "schema_version": "v4",
     "advanced_settings": {
         "agent_factory_watcher_sleep_time_in_seconds": 5,
+        "checksum_read_buffer_size_in_bytes": 1048576,
         "default_number_of_transfer_threads": 4,
         "default_temporary_password_lifetime_in_seconds": 120,
         "delay_rule_executors": [],


### PR DESCRIPTION
This is a cherry-pick from the 4-3-stable commit.

- Added test case for checksum buffer size update
- Updated server_config.json template to include checksum_read_buffer_size_in_bytes