### PR TITLE
[#7410] Use default value for `CMAKE_INSTALL_LIBDIR` (main)

### DIFF
--- a/cmake/InstallDirs.cmake
+++ b/cmake/InstallDirs.cmake
@@ -14,13 +14,6 @@ if(CMAKE_HOST_UNIX)
   endif()
 endif()
 
-# We don't do multiarch triples on debian, nor do we use the lib64 dir on centos and
-# opensuse (though we probably should). We can revisit this later; for now let's just
-# set our own default for CMAKE_INSTALL_LIBDIR
-if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
-  set(CMAKE_INSTALL_LIBDIR "lib" CACHE PATH "Object code libraries (lib)")
-endif()
-
 include(GNUInstallDirs)
 
 if(NOT DEFINED IRODS_INCLUDE_DIRS)


### PR DESCRIPTION
With this PR, `InstallDirs.cmake` no longer overrides the default value for `CMAKE_INSTALL_LIBDIR`, which means the by default, our libraries and plugins will now be installed in the proper locations depending on distribution directory structure.

Since `CMAKE_INSTALL_LIBDIR` is a cache variable on which other variables depend, a clean cmake build directory is recommended.

So far testing hasn't revealed anything surprising, but I've got more tests to run, so I'm leaving this in draft mode for now.