### PR TITLE
 [7599,7440] Rework logic in _cllExecSqlNoResult to return proper error codes (4-3-stable)

### DIFF
--- a/scripts/irods/test/test_iadmin.py
+++ b/scripts/irods/test/test_iadmin.py
@@ -1669,6 +1669,22 @@ class Test_Iadmin(resource_suite.ResourceBase, unittest.TestCase):
     def test_non_admins_are_not_allowed_to_invoke_iadmin_get_delay_server_info__issue_5249(self):
         self.user0.assert_icommand(['iadmin', 'get_delay_server_info'], 'STDERR', ['-830000 CAT_INSUFFICIENT_PRIVILEGE_LEVEL'])
 
+    def test_iadmin_mkuser_returns_correct_error_on_duplicate_user__issue_7599(self):
+        test_user_name = 'duplicate_user_issue_7599'
+        try:
+            self.admin.assert_icommand(['iadmin', 'mkuser', test_user_name, 'rodsuser'])
+            self.admin.assert_icommand(['iadmin', 'mkuser', test_user_name, 'rodsuser'], 'STDERR', ['-809000 CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME'])
+        finally:
+            self.admin.run_icommand(['iadmin', 'rmuser', test_user_name])
+
+    def test_iadmin_mkgroup_returns_correct_error_on_duplicate_group__issue_7599(self):
+        test_group_name = 'duplicate_group_issue_7599'
+        try:
+            self.admin.assert_icommand(['iadmin', 'mkgroup', test_group_name])
+            self.admin.assert_icommand(['iadmin', 'mkgroup', test_group_name], 'STDERR', ['-809000 CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME'])
+        finally:
+            self.admin.run_icommand(['iadmin', 'rmgroup', test_group_name])
+
 class Test_Iadmin_Resources(resource_suite.ResourceBase, unittest.TestCase):
 
     def setUp(self):

--- a/scripts/irods/test/test_imeta_error_handling.py
+++ b/scripts/irods/test/test_imeta_error_handling.py
@@ -71,10 +71,7 @@ class Test_Imeta_Error_Handling(unittest.TestCase):
         self.admin.assert_icommand(['imeta', 'addw', '-d', self.test_data_paths_wildcard, attr, val], 'STDOUT', desired_rc=0)
         _, err, ec = self.admin.run_icommand(['imeta', 'addw', '-d', self.test_data_paths_wildcard, attr, val])
         self.assertEqual(4, ec)
-        # In unixODBC versions > 2.3.5, the database plugin does not return CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME
-        # but instead it returns CAT_SQL_ERR. We support platforms that use both 2.3.4 and 2.3.6, so either error
-        # code is acceptable for this test.
-        self.assertTrue('CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME' in err or 'CAT_SQL_ERR' in err)
+        self.assertIn('CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME', err)
 
     def test_imeta_add_return_code(self):
         data_path = f'{self.test_data_path_base}0'
@@ -83,10 +80,7 @@ class Test_Imeta_Error_Handling(unittest.TestCase):
         self.admin.assert_icommand(['imeta', 'add', '-d', data_path, attr, val], 'STDOUT', desired_rc=0)
         _, err, ec = self.admin.run_icommand(['imeta', 'add', '-d', data_path, attr, val])
         self.assertEqual(4, ec)
-        # In unixODBC versions > 2.3.5, the database plugin does not return CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME
-        # but instead it returns CAT_SQL_ERR. We support platforms that use both 2.3.4 and 2.3.6, so either error
-        # code is acceptable for this test.
-        self.assertTrue('CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME' in err or 'CAT_SQL_ERR' in err)
+        self.assertIn('CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME', err)
 
     def test_imeta_addw_stderr_5184(self):
         self.admin.assert_icommand(['imeta', 'addw', '-d', self.test_data_paths_wildcard, '5184_attr', '5184_attr'], 'STDOUT')

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -786,8 +786,12 @@ OUTPUT ruleExecOut
             lib.make_file(file1, 100)
 
             # put small file
-            self.admin.assert_icommand("iput -R %s %s" % (resource_name, file1), 'STDERR', 'USER_SOCK_CONNECT_ERR')  # iput
-            self.admin.assert_icommand("ils -L %s" % file1, 'STDERR_SINGLELINE', "does not exist")  # should not be listed
+            _, err, ec = self.admin.run_icommand("iput -R %s %s" % (resource_name, file1))
+            self.assertNotEqual(ec, 0)
+
+            # Both are okay, since either case is possible when connecting to an invalid host.
+            # It depends on if the host rejects the connection or ignores it (i.e. a "stealth" port).
+            self.assertTrue('-347000 USER_SOCK_CONNECT_TIMEDOUT' in err or '-305000 USER_SOCK_CONNECT_ERR' in err)
         finally:
             if os.path.exists(file1):
                 os.unlink(file1)
@@ -807,8 +811,12 @@ OUTPUT ruleExecOut
             lib.make_file(file1, 100)
 
             # put small file
-            self.admin.assert_icommand("iput -R %s %s" % (resource_name, file1), 'STDERR', 'USER_SOCK_CONNECT_ERR')  # iput
-            self.admin.assert_icommand("ils -L %s" % file1, 'STDERR_SINGLELINE', "does not exist")  # should not be listed
+            _, err, ec = self.admin.run_icommand("iput -R %s %s" % (resource_name, file1))
+            self.assertNotEqual(ec, 0)
+
+            # Both are okay, since either case is possible when connecting to an invalid host.
+            # It depends on if the host rejects the connection or ignores it (i.e. a "stealth" port).
+            self.assertTrue('-347000 USER_SOCK_CONNECT_TIMEDOUT' in err or '-305000 USER_SOCK_CONNECT_ERR' in err)
         finally:
             if os.path.exists(file1):
                 os.unlink(file1)
@@ -831,8 +839,12 @@ OUTPUT ruleExecOut
             lib.make_file(file1, 100)
 
             # put small file
-            self.admin.assert_icommand("iput -R %s %s" % (resource_name, file1), 'STDERR', 'USER_SOCK_CONNECT_ERR')  # iput
-            self.admin.assert_icommand("ils -L %s" % file1, 'STDERR_SINGLELINE', "does not exist")  # should not be listed
+            _, err, ec = self.admin.run_icommand("iput -R %s %s" % (resource_name, file1))
+            self.assertNotEqual(ec, 0)
+
+            # Both are okay, since either case is possible when connecting to an invalid host.
+            # It depends on if the host rejects the connection or ignores it (i.e. a "stealth" port).
+            self.assertTrue('-347000 USER_SOCK_CONNECT_TIMEDOUT' in err or '-305000 USER_SOCK_CONNECT_ERR' in err)
         finally:
             if os.path.exists(file1):
                 os.unlink(file1)


### PR DESCRIPTION
Cherry-pick of https://github.com/irods/irods/pull/7987