### PR TITLE
[#7410] Provide CMake cache variable for package configuration directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,10 +286,12 @@ add_subdirectory(unit_tests)
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/packaging.cmake")
 
 include(CMakePackageConfigHelpers)
+set(IRODS_INSTALL_CMAKECONFDIR "${IRODS_INSTALL_CMAKEDIR}/irods-${IRODS_VERSION_MAJOR}.${IRODS_VERSION_MINOR}")
+
 configure_package_config_file(
   "${CMAKE_IRODS_SOURCE_DIR}/cmake/IRODSConfig.cmake.not_yet_installed.in"
   "${CMAKE_IRODS_BINARY_DIR}/IRODSConfig.cmake.not_yet_installed" # suffix prevents cmake's find_package() from using this copy of the file
-  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/irods/cmake"
+  INSTALL_DESTINATION "${IRODS_INSTALL_CMAKECONFDIR}"
   PATH_VARS IRODS_INCLUDE_DIRS
 )
 configure_file(
@@ -301,7 +303,7 @@ configure_file(
 install(
   FILES
   "${CMAKE_IRODS_BINARY_DIR}/IRODSConfig.cmake.not_yet_installed"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/irods/cmake"
+  DESTINATION "${IRODS_INSTALL_CMAKECONFDIR}"
   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
   RENAME IRODSConfig.cmake
 )
@@ -310,7 +312,7 @@ install(
   FILES
   "${CMAKE_IRODS_BINARY_DIR}/IRODSConfigVersion.cmake"
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/IRODSTargetsWrapper.cmake"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/irods/cmake"
+  DESTINATION "${IRODS_INSTALL_CMAKECONFDIR}"
   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
 )
 
@@ -331,14 +333,14 @@ install(
   "${CMAKE_IRODS_SOURCE_DIR}/cmake/Modules/IrodsCPackPlatform.cmake"
   "${CMAKE_IRODS_SOURCE_DIR}/cmake/Modules/IrodsCPackCommon.cmake"
   "${CMAKE_IRODS_SOURCE_DIR}/cmake/Modules/IrodsRunpathDefaults.cmake"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/irods/cmake/Modules"
+  DESTINATION "${IRODS_INSTALL_CMAKECONFDIR}/Modules"
   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
 )
 
 install(
   EXPORT
   IRODSTargets
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/irods/cmake"
+  DESTINATION "${IRODS_INSTALL_CMAKECONFDIR}"
   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
 )
 

--- a/cmake/InstallDirs.cmake
+++ b/cmake/InstallDirs.cmake
@@ -34,6 +34,17 @@ warn_for_old_libdir_cache()
 
 include(GNUInstallDirs)
 
+# Despite what the CMake documentation says, find_package has a hard time finding our
+# package configuration if it's in lib64.
+if(CMAKE_INSTALL_LIBDIR MATCHES "^lib[^/]+.*")
+  set(IRODS_INSTALL_CMAKEDIR_default "lib/cmake")
+elseif(CMAKE_INSTALL_LIBDIR MATCHES "^usr/lib[^/]+.*")
+  set(IRODS_INSTALL_CMAKEDIR_default "usr/lib/cmake")
+else()
+  set(IRODS_INSTALL_CMAKEDIR_default "${CMAKE_INSTALL_LIBDIR}/cmake")
+endif()
+set(IRODS_INSTALL_CMAKEDIR "${IRODS_INSTALL_CMAKEDIR_default}" CACHE PATH "CMake package configuration directory (lib/cmake)")
+
 if(NOT DEFINED IRODS_INCLUDE_DIRS)
 	set(IRODS_INCLUDE_DIRS "${CMAKE_INSTALL_INCLUDEDIR}")
 endif()


### PR DESCRIPTION
Despite what CMake's documentation might say, getting `find_package` to look in `lib64` for CMake package configuration files is a very ugly business that we would rather try to avoid. This PR puts our CMake package configuration back in `lib` for EL and provides a cache variable `IRODS_INSTALL_CMAKEDIR` should the builder need to tweak things.

Part of #7410, as this work should've been in the PR for changing where our libraries end up.

Still testing, so draft for now.