### PR TITLE
[#8047] Guarantee test users are removed if rc_switch_user test fails (main)

### DIFF
--- a/unit_tests/src/test_rc_switch_user.cpp
+++ b/unit_tests/src/test_rc_switch_user.cpp
@@ -395,8 +395,8 @@ TEST_CASE("rc_switch_user can be called multiple times when KW_SWITCH_PROXY_USER
     // Create a groupadmin.
     const adm::user bob{"test_user_bob", env.rodsZone};
     REQUIRE_NOTHROW(adm::client::add_user(conn, bob));
-    REQUIRE_NOTHROW(adm::client::modify_user(conn, bob, adm::user_password_property{"rods"}));
     irods::at_scope_exit remove_test_user_bob{[&conn, &bob] { REQUIRE_NOTHROW(adm::client::remove_user(conn, bob)); }};
+    REQUIRE_NOTHROW(adm::client::modify_user(conn, bob, adm::user_password_property{"rods"}));
     REQUIRE_NOTHROW(adm::client::modify_user(conn, bob, adm::user_type_property{adm::user_type::groupadmin}));
 
     //


### PR DESCRIPTION
Small tweak to make unit test match changes in #8060.