### PR TITLE
[#8001] Write client and proxy user info to ips data file in correct order (4-3-stable)

### DIFF
--- a/server/core/src/procLog.cpp
+++ b/server/core/src/procLog.cpp
@@ -9,6 +9,8 @@
 
 #include <boost/lexical_cast.hpp>
 
+#include <cstdio>
+#include <ctime>
 #include <charconv>
 #include <fstream>
 
@@ -89,10 +91,16 @@ logAgentProc( rsComm_t *rsComm ) {
         return UNIX_FILE_OPEN_ERR - errno;
     }
 
-    fprintf( fptr, "%s %s %s %s %s %s %u\n",
-             rsComm->proxyUser.userName, clientZone,
-             rsComm->clientUser.userName, proxyZone,
-             progName, remoteAddr, ( unsigned int ) time( 0 ) );
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    std::fprintf(fptr,
+                 "%s %s %s %s %s %s %u\n",
+                 rsComm->clientUser.userName,
+                 clientZone,
+                 rsComm->proxyUser.userName,
+                 proxyZone,
+                 progName,
+                 remoteAddr,
+                 static_cast<unsigned int>(std::time(nullptr)));
 
     rsComm->procLogFlag = PROC_LOG_DONE;
     fclose( fptr );


### PR DESCRIPTION
I'll confirm at the bench whether this works.

This doesn't require running the full suite since the same data is being presented, just in a different order.