### PR TITLE
[#7823] Update GitHub workflows for Ubuntu 24.04 (4-3-stable)

### DIFF
--- a/.github/workflows/linter-irods-clang-format.yml
+++ b/.github/workflows/linter-irods-clang-format.yml
@@ -5,7 +5,7 @@ defaults:
         shell: bash
 jobs:
     clang-format:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout Repository
               uses: actions/checkout@v3
@@ -17,7 +17,7 @@ jobs:
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -qq apt-transport-https ca-certificates
-                  sudo apt-get install -qq wget
+                  sudo apt-get install -qq wget lsb-release
             - name: Install Clang Compiler
               run: |
                   wget -qO - https://unstable.irods.org/irods-unstable-signing-key.asc | sudo apt-key add -
@@ -32,7 +32,7 @@ jobs:
                   # Configure Git so that "git clang-format" can be run.
                   git config --global clangFormat.binary clang-format
                   git config --global clangFormat.style file
-                  git config --global clangFormat.extensions 'h,c,hpp,cpp,tpp'
+                  git config --global clangFormat.extensions 'h,h.in,c,c.in,hpp,hpp.in,cpp,cpp.in'
 
                   # Diff the target branch with all changes made within the pull request.
                   diff_output=$(git clang-format --diff origin/$GITHUB_BASE_REF)

--- a/.github/workflows/linter-irods-clang-tidy.yml
+++ b/.github/workflows/linter-irods-clang-tidy.yml
@@ -5,7 +5,7 @@ defaults:
         shell: bash
 jobs:
     clang-tidy:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout Repository
               uses: actions/checkout@v3
@@ -22,7 +22,8 @@ jobs:
                     curl \
                     g++ \
                     make \
-                    python-dev \
+                    cmake \
+                    python3-dev \
                     unixodbc \
                     libcurl4-gnutls-dev \
                     libbz2-dev \
@@ -31,18 +32,13 @@ jobs:
                     libssl-dev \
                     libxml2-dev \
                     unixodbc-dev \
-                    python-psutil \
+                    python3-psutil \
                     odbc-postgresql \
                     libkrb5-dev \
                     python3-distro \
                     flex \
-                    bison
-            - name: Install libstdc++6
-              run: |
-                  sudo apt-get install -qq software-properties-common
-                  sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-                  sudo apt-get update -qq
-                  sudo apt-get install -qq libstdc++6
+                    bison \
+                    lsb-release
             - name: Install iRODS Externals
               run: |
                   wget -qO - https://unstable.irods.org/irods-unstable-signing-key.asc | sudo apt-key add -
@@ -54,7 +50,6 @@ jobs:
                     irods-externals-catch22.13.8-0 \
                     irods-externals-clang-runtime13.0.1-0 \
                     irods-externals-clang13.0.1-0 \
-                    irods-externals-cmake3.21.4-0 \
                     irods-externals-cppzmq4.8.1-1 \
                     irods-externals-fmt-libcxx8.1.1-1 \
                     irods-externals-json3.10.4-0 \
@@ -64,7 +59,6 @@ jobs:
                     irods-externals-zeromq4-1-libcxx4.1.8-1
             - name: Configure CMake
               run: |
-                  export PATH=/opt/irods-externals/cmake3.21.4-0/bin:$PATH
                   mkdir build
                   cd build
                   cmake -DIRODS_DISABLE_COMPILER_OPTIMIZATIONS=YES -DIRODS_UNIT_TESTS_BUILD=YES ..


### PR DESCRIPTION
In service of #7823

Also adds [.h,.c.,.hpp,.cpp].in files to clang-format extension list