### PR TITLE
[WIP] [#8036] Communicate server status to service manager

### DIFF
--- a/packaging/irods.service.template
+++ b/packaging/irods.service.template
@@ -3,11 +3,9 @@ Description=iRODS
 After=network.target
 
 [Service]
-Type=forking
-PIDFile=/var/run/irods/irods-server.pid
-ExecStart=/usr/sbin/irodsServer -d
-ExecReload=/bin/kill -HUP $MAINPID
-ExecStop=/bin/kill -TERM $MAINPID
+Type=notify-reload
+ExecStart=/usr/sbin/irodsServer
+KillMode=mixed
 Restart=on-failure
 User=irods
 Group=irods

--- a/server/core/CMakeLists.txt
+++ b/server/core/CMakeLists.txt
@@ -142,6 +142,7 @@ install(
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/irods_oracle_object.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/irods_physical_object.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/irods_postgres_object.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/irods_notify_service_manager.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/irods_report_plugins_in_json.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/irods_resource_backport.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/irods_resource_constants.hpp"

--- a/server/core/include/irods/irods_notify_service_manager.hpp
+++ b/server/core/include/irods/irods_notify_service_manager.hpp
@@ -1,0 +1,195 @@
+#include "irods/irods_error.hpp"
+#include "irods/rodsErrorTable.h"
+
+#include <fmt/format.h>
+#include <fmt/compile.h>
+
+#include <cstdint>
+#include <ctime>
+#include <string>
+#include <utility>
+
+namespace irods
+{
+    // systemd requires that some status messages contain a monotonic timestamp in microseconds.
+    static inline std::uint64_t get_monotonic_usec()
+    {
+        // we want CLOCK_MONOTONIC.
+        // std::chrono::steady_clock is supposed to be CLOCK_MONOTONIC, but might not be, and might
+        // not even be present.
+        // boost::chrono::steady_clock may also be absent.
+        // therefore, we do it the old fashioned way.
+
+        std::timespec ts; // NOLINT(cppcoreguidelines-pro-type-member-init)
+        // TODO: check for error, fall back to another implementation
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        const std::uint64_t mt_s = static_cast<std::uint64_t>(ts.tv_sec);
+        const std::uint64_t mt_ns = static_cast<std::uint64_t>(ts.tv_nsec);
+        const std::uint64_t usec = (mt_s * 1000000) + (mt_ns / 1000);
+        return usec;
+    }
+}
+
+#ifdef IRODS_USE_SD_NOTIFY
+
+#include <systemd/sd-daemon.h>
+
+namespace irods
+{
+
+    namespace
+    {
+        static inline irods::error notify_service_manager_impl(const char *_msg)
+        {
+            int ret = sd_notify(0, _msg);
+            if (ret < 0) {
+                return ERROR(SYS_LIBRARY_ERROR + ret, "sd_notify error");
+            }
+            return SUCCESS();
+        }
+    }
+
+    static inline irods::error notify_service_manager(const std::string& _msg)
+    {
+        return notify_service_manager_impl(_msg.data());
+    }
+
+    template <typename... Args>
+    static inline irods::error notify_service_manager(const fmt::format_string<Args...>& _format, Args&&... _args)
+    {
+        // early check to avoid unneeded fmt evaluation
+        const char *sm_socket_path = std::getenv("NOTIFY_SOCKET");
+        if (!sm_socket_path) {
+            // if NOTIFY_SOCKET is not set, we're done
+            return SUCCESS();
+        }
+
+        auto msg = fmt::format(_format, std::forward<Args>(_args)...);
+        return notify_service_manager_impl(msg.data());
+    }
+
+    template <typename CompiledFormat, typename... Args>
+        requires fmt::detail::is_compiled_string<CompiledFormat>::value || fmt::detail::is_compiled_format<CompiledFormat>::value || std::is_same_v<CompiledFormat, fmt::format_string<Args...>>
+    static inline irods::error notify_service_manager(const CompiledFormat& _format, Args&&... _args)
+    {
+        // early check to avoid unneeded fmt evaluation
+        const char *sm_socket_path = std::getenv("NOTIFY_SOCKET");
+        if (!sm_socket_path) {
+            // if NOTIFY_SOCKET is not set, we're done
+            return SUCCESS();
+        }
+
+        auto msg = fmt::format(_format, std::forward<Args>(_args)...);
+        return notify_service_manager_impl(msg.data());
+    }
+}
+
+#else
+
+#include <cstdlib>
+#include <cstring>
+
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include <boost/asio.hpp>
+
+namespace irods
+{
+    namespace
+    {
+        // We have to reimplement boost::asio::local::datagram_protocol to add SOCK_CLOEXEC
+        class sm_socket_protocol
+        {
+        public:
+
+            int type() const noexcept
+            {
+                return (SOCK_DGRAM | SOCK_CLOEXEC);
+            }
+
+            int protocol() const noexcept
+            {
+                return 0;
+            }
+
+            int family() const noexcept
+            {
+                return AF_UNIX;
+            }
+
+            typedef boost::asio::local::basic_endpoint<sm_socket_protocol> endpoint;
+            typedef boost::asio::basic_datagram_socket<sm_socket_protocol> socket;
+        };
+
+        static inline irods::error notify_service_manager_impl(const char *_msg, const std::size_t _msg_length, const char *_sm_socket_path)
+        {
+            if (!_msg) {
+                return ERROR(SYS_INTERNAL_NULL_INPUT_ERR, "_msg is not a valid pointer");
+            }
+            if (_msg_length == 0) {
+                return ERROR(SYS_INTERNAL_NULL_INPUT_ERR, "_msg is empty");
+            }
+
+            if (_sm_socket_path[0] != '/' && _sm_socket_path[0] != '@') {
+                // Only AF_UNIX is supported, with path or abstract sockets
+                return ERROR(SYS_NOT_SUPPORTED, "Socket in NOTIFY_SOCKET not supported");
+            }
+
+            boost::asio::io_context io_context;
+            const sm_socket_protocol::endpoint sm_socket_path(_sm_socket_path);
+            sm_socket_protocol::socket sm_socket(io_context);
+
+            sm_socket.open();
+            std::size_t written = sm_socket.send_to(boost::asio::buffer(_msg, _msg_length), sm_socket_path);
+            if (written < _msg_length) {
+                return ERROR(SYS_SOCK_WRITE_ERR, "could not write entire message to socket");
+            }
+
+            return SUCCESS();
+        }
+    }
+
+    static inline irods::error notify_service_manager(const std::string& _msg)
+    {
+        const char *sm_socket_path = std::getenv("NOTIFY_SOCKET");
+        if (!sm_socket_path) {
+            // if NOTIFY_SOCKET is not set, we're done
+            return SUCCESS();
+        }
+
+        return notify_service_manager_impl(_msg.data(), _msg.size(), sm_socket_path);
+    }
+
+    template <typename... Args>
+    static inline irods::error notify_service_manager(const fmt::format_string<Args...>& _format, Args&&... _args)
+    {
+        const char *sm_socket_path = std::getenv("NOTIFY_SOCKET");
+        if (!sm_socket_path) {
+            // if NOTIFY_SOCKET is not set, we're done
+            return SUCCESS();
+        }
+
+        auto msg = fmt::format(_format, std::forward<Args>(_args)...);
+
+        return notify_service_manager_impl(msg.data(), msg.size(), sm_socket_path);
+    }
+
+    template <typename CompiledFormat, typename... Args>
+        requires fmt::detail::is_compiled_string<CompiledFormat>::value || fmt::detail::is_compiled_format<CompiledFormat>::value
+    static inline irods::error notify_service_manager(const CompiledFormat& _format, Args&&... _args)
+    {
+        const char *sm_socket_path = std::getenv("NOTIFY_SOCKET");
+        if (!sm_socket_path) {
+            // if NOTIFY_SOCKET is not set, we're done
+            return SUCCESS();
+        }
+
+        auto msg = fmt::format(_format, std::forward<Args>(_args)...);
+
+        return notify_service_manager_impl(msg.data(), msg.size(), sm_socket_path);
+    }
+
+}
+
+#endif

--- a/server/main_server/src/main.cpp
+++ b/server/main_server/src/main.cpp
@@ -9,6 +9,7 @@
 #include "irods/irods_default_paths.hpp"
 #include "irods/irods_environment_properties.hpp"
 #include "irods/irods_logger.hpp"
+#include "irods/irods_notify_service_manager.hpp"
 #include "irods/irods_server_api_table.hpp"
 #include "irods/irods_server_properties.hpp"
 #include "irods/irods_signal.hpp"
@@ -30,6 +31,7 @@
 #include <boost/stacktrace.hpp>
 
 #include <fmt/format.h>
+#include <fmt/compile.h>
 #include <nlohmann/json.hpp>
 
 #include <jsoncons/json.hpp>
@@ -284,6 +286,8 @@ auto main(int _argc, char* _argv[]) -> int
             return 1;
         }
 
+        irods::notify_service_manager("READY=1");
+
         // Enter parent process main loop.
         //
         // This process should never introduce threads. Everything it cares about must be handled
@@ -493,16 +497,24 @@ Signals:
         return false;
     } // validate_configuration
 
+    inline auto daemonize_fork() -> void
+    {
+        pid_t child_pid = fork();
+
+        if (child_pid > 0) {
+            irods::notify_service_manager(FMT_COMPILE("MAINPID={}"), child_pid);
+            _exit(0);
+        }
+
+        if (child_pid < 0) {
+            _exit(1);
+        }
+    }
+
     auto daemonize() -> void
     {
         // Become a background process.
-        // clang-format off
-        switch (fork()) {
-            case -1: _exit(1);
-            case  0: break;
-            default: _exit(0);
-        }
-        // clang-format on
+        daemonize_fork();
 
         // Become session leader.
         if (setsid() == -1) {
@@ -510,13 +522,7 @@ Signals:
         }
 
         // Make sure we aren't the session leader.
-        // clang-format off
-        switch (fork()) {
-            case -1: _exit(1);
-            case  0: break;
-            default: _exit(0);
-        }
-        // clang-format on
+        daemonize_fork();
 
         umask(0);
 
@@ -819,6 +825,8 @@ Signals:
 
     auto handle_shutdown() -> void
     {
+        irods::notify_service_manager("STOPPING=1");
+
         kill(g_pid_af, SIGTERM);
 
         if (g_pid_ds > 0) {
@@ -836,6 +844,8 @@ Signals:
 
     auto handle_shutdown_graceful() -> void
     {
+        irods::notify_service_manager("STOPPING=1");
+
         kill(g_pid_af, SIGQUIT);
 
         if (g_pid_ds > 0) {
@@ -973,10 +983,13 @@ Signals:
     {
         irods::at_scope_exit reset_reload_flag{[] { g_reload_config = 0; }};
 
+        irods::notify_service_manager(FMT_COMPILE("RELOADING=1\nMONOTONIC_USEC={}"), irods::get_monotonic_usec());
+
         log_server::info("{}: Received configuration reload instruction. Reloading configuration.", __func__);
 
         if (!validate_configuration()) {
             log_server::error("{}: Invalid configuration. Server will continue with existing configuration.", __func__);
+            irods::notify_service_manager("READY=1\nSTATUS=Reload failed due to invalid configuration");
             return;
         }
 
@@ -990,11 +1003,13 @@ Signals:
             log_server::error("{}: Reload error: {}. Server will continue with existing configuration.",
                               __func__,
                               e.client_display_what());
+            irods::notify_service_manager("READY=1\nSTATUS=Reload failed");
             return;
         }
         catch (const std::exception& e) {
             log_server::error(
                 "{}: Reload error: {}. Server will continue with existing configuration.", __func__, e.what());
+            irods::notify_service_manager("READY=1\nSTATUS=Reload failed");
             return;
         }
 
@@ -1007,12 +1022,14 @@ Signals:
                               __func__,
                               e.client_display_what());
             irods::server_properties::instance().set_configuration(std::move(previous_server_config));
+            irods::notify_service_manager("READY=1\nSTATUS=Reload failed");
             return;
         }
         catch (const std::exception& e) {
             log_server::error(
                 "{}: Reload error: {}. Server will continue with existing configuration.", __func__, e.what());
             irods::server_properties::instance().set_configuration(std::move(previous_server_config));
+            irods::notify_service_manager("READY=1\nSTATUS=Reload failed");
             return;
         }
 
@@ -1056,10 +1073,12 @@ Signals:
         }
         catch (const irods::exception& e) {
             log_server::error("{}: Reload error: {}", __func__, e.client_display_what());
+            irods::notify_service_manager("READY=1\nSTATUS=Reload error");
             return;
         }
         catch (const std::exception& e) {
             log_server::error("{}: Reload error: {}", __func__, e.what());
+            irods::notify_service_manager("READY=1\nSTATUS=Reload error");
             return;
         }
 
@@ -1114,6 +1133,8 @@ Signals:
 
         // We do not need to manually launch the delay server because the delay server migration
         // logic will handle that for us.
+
+        irods::notify_service_manager("READY=1\nSTATUS=Configuration reloaded");
     } // handle_configuration_reload
 
     auto launch_delay_server(bool _write_to_stdout, bool _enable_test_mode) -> void


### PR DESCRIPTION
Addresses #8036 

TODO:
- Consider moving implementation to a `.cpp` file
- Implement fallbacks for `get_monotonic_usec`
- Implement CMake logic for libsystemd
- Consider fleshing out our `sd_notify` implementation
- Test compiling with multiple compilers (we're using `requires`)
- Log errors instead of returning error objects (best practice is generally to ignore service manager communication errors and continue operation)
- Testing