### PR TITLE
[#8109] Deprecate `forkAndExec(...)` (4-3-stable)

### DIFF
--- a/server/core/include/irods/miscServerFunct.hpp
+++ b/server/core/include/irods/miscServerFunct.hpp
@@ -110,8 +110,7 @@ char *
 getSvrAddr( rodsServerHost_t *rodsServerHost );
 int
 setLocalSrvAddr( char *outLocalAddr );
-int
-forkAndExec( char *av[] );
+[[deprecated]] int forkAndExec(char* av[]);
 int
 setupSrvPortalForParaOpr( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
                           int oprType, portalOprOut_t **portalOprOut );


### PR DESCRIPTION
Builds without warnings. No tests ran, as the issues should come up at build time.