### PR TITLE
[#8090] Add Undefined Behavior Sanitizer to Build Options (4-3-stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ include(RequireOutOfSourceBuild)
 
 option(IRODS_DISABLE_COMPILER_OPTIMIZATIONS "Disables compiler optimizations by setting -O0." OFF)
 option(IRODS_ENABLE_ADDRESS_SANITIZER "Enables detection of memory leaks and other features provided by Address Sanitizer." OFF)
+option(IRODS_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER "Enables detection of undefined behavior provided by Undefined Behavior Sanitizer." OFF)
+option(IRODS_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER_IMPLICIT_CONVERSION_CHECK "Enables detection of implicit conversions by Undefined Behavior Sanitizer." OFF)
 option(IRODS_ENABLE_ALL_TESTS "Enables all tests (e.g. C/C++ unit tests, microservices specifically designed for testing)." OFF)
 
 if (NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
@@ -41,18 +43,46 @@ if (IRODS_ENABLE_ADDRESS_SANITIZER)
   #     export ASAN_SYMBOLIZER_PATH=/opt/irods-externals/clang13.0.0-0/bin/llvm-symbolizer
   #
   add_compile_definitions(IRODS_ADDRESS_SANITIZER_DEFAULT_OPTIONS="log_path=/tmp/irods_asan_output:detect_odr_violation=1")
+  add_compile_options(-fsanitize=address)
+  add_link_options(-fsanitize=address)
+endif()
+
+if (IRODS_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER)
+  # Make sure the correct llvm-symbolizer binary is available to Undefined Behavior Sanitizer. This binary
+  # allows debug symbols to be reported appropriately. Additionally, set options for logging.
+  #
+  #     export PATH=/opt/irods-externals/clang13.0.1-0/bin:$PATH
+  add_compile_definitions(IRODS_UNDEFINED_BEHAVIOR_SANITIZER_DEFAULT_OPTIONS="log_path=/tmp/irods_ubsan_output")
+
   add_compile_options(
-    -fsanitize=address
-    -fno-omit-frame-pointer
-    -fno-optimize-sibling-calls
-    -O1
-  )
+    -fsanitize=undefined
+    -fsanitize=float-divide-by-zero
+    -fsanitize=unsigned-integer-overflow
+    -fsanitize=local-bounds
+    -fsanitize=nullability
+    -fsanitize-ignorelist=${CMAKE_CURRENT_SOURCE_DIR}/ub-sanitizer-ignorelist.txt)
   add_link_options(
-    -fsanitize=address
+    -fsanitize=undefined
+    -fsanitize=float-divide-by-zero
+    -fsanitize=unsigned-integer-overflow
+    -fsanitize=local-bounds
+    -fsanitize=nullability)
+
+  if (IRODS_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER_IMPLICIT_CONVERSION_CHECK)
+     add_compile_options(-fsanitize=implicit-conversion)
+     add_link_options(-fsanitize=implicit-conversion)
+  endif()
+endif()
+
+if (IRODS_ENABLE_ADDRESS_SANITIZER OR IRODS_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER)
+  add_compile_options(
     -fno-omit-frame-pointer
     -fno-optimize-sibling-calls
-    -O1
-  )
+    -O1)
+  add_link_options(
+    -fno-omit-frame-pointer
+    -fno-optimize-sibling-calls
+    -O1)
 else()
   set(CMAKE_EXE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS_INIT} -Wl,-z,defs")
   set(CMAKE_MODULE_LINKER_FLAGS_INIT "${CMAKE_MODULE_LINKER_FLAGS_INIT} -Wl,-z,defs")

--- a/lib/core/src/msParam.cpp
+++ b/lib/core/src/msParam.cpp
@@ -1189,9 +1189,18 @@ namespace
 
         const auto& bbuf = _func(*execCmdOut);
 
-        *_out = static_cast<char*>(std::malloc(bbuf.len + 1));
-        std::memcpy(*_out, static_cast<char*>(bbuf.buf), bbuf.len);
-        (*_out)[bbuf.len] = '\0';
+        const auto out_len{bbuf.len + 1};
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+        *_out = static_cast<char*>(std::malloc(out_len));
+
+        if (nullptr != bbuf.buf) {
+            std::memcpy(*_out, static_cast<char*>(bbuf.buf), bbuf.len);
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            (*_out)[bbuf.len] = '\0';
+        }
+        else {
+            std::memset(*_out, 0, out_len);
+        }
 
         return 0;
     }

--- a/lib/filesystem/src/path.cpp
+++ b/lib/filesystem/src/path.cpp
@@ -368,7 +368,7 @@ namespace irods::experimental::filesystem
             return *this;
         }
 
-        if (is_separator(fp[pos_ - 1])) {
+        if (pos_ > 0 && is_separator(fp[pos_ - 1])) {
             // We've reached the root separator of the path.
             if (0 == pos_ - 1)
             {

--- a/server/delay_server/src/irodsDelayServer.cpp
+++ b/server/delay_server/src/irodsDelayServer.cpp
@@ -72,6 +72,14 @@ extern "C" const char* __asan_default_options()
 } // __asan_default_options
 #endif
 
+#if __has_feature(undefined_behavior_sanitizer)
+extern "C" const char* __ubsan_default_options()
+{
+    // See root CMakeLists.txt file for definition.
+    return IRODS_UNDEFINED_BEHAVIOR_SANITIZER_DEFAULT_OPTIONS;
+} // __ubsan_default_options
+#endif
+
 // clang-format off
 namespace ix = irods::experimental;
 

--- a/server/main_server/src/rodsServer.cpp
+++ b/server/main_server/src/rodsServer.cpp
@@ -103,6 +103,14 @@ extern "C" const char* __asan_default_options()
 } // __asan_default_options
 #endif
 
+#if __has_feature(undefined_behavior_sanitizer)
+extern "C" const char* __ubsan_default_options()
+{
+    // See root CMakeLists.txt file for definition.
+    return IRODS_UNDEFINED_BEHAVIOR_SANITIZER_DEFAULT_OPTIONS;
+} // __ubsan_default_options
+#endif
+
 #define LOCK_FILE_PURGE_TIME 7200 // Purge lock files every 2 hr.
 
 // clang-format off

--- a/server/re/src/printMS.cpp
+++ b/server/re/src/printMS.cpp
@@ -171,10 +171,18 @@ int writeBytesBuf( msParam_t* where, msParam_t* inBuf, ruleExecInfo_t *rei ) {
     }
 
     if ( inBuf->inpOutBuf ) {
+        const auto writeStr_len{inBuf->inpOutBuf->len + 1};
         /* Buffer might no be null-terminated */
-        writeStr = ( char* )malloc( inBuf->inpOutBuf->len + 1 );
-        strncpy( writeStr, ( char* )inBuf->inpOutBuf->buf, inBuf->inpOutBuf->len );
-        writeStr[inBuf->inpOutBuf->len] = '\0';
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+        writeStr = static_cast<char*>(malloc(writeStr_len));
+        if (nullptr != inBuf->inpOutBuf->buf) {
+            strncpy(writeStr, static_cast<char*>(inBuf->inpOutBuf->buf), inBuf->inpOutBuf->len);
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            writeStr[inBuf->inpOutBuf->len] = '\0';
+        }
+        else {
+            std::memset(writeStr, 0, writeStr_len);
+        }
     }
     else {
         writeStr = strdup( inBuf->label );

--- a/ub-sanitizer-ignorelist.txt
+++ b/ub-sanitizer-ignorelist.txt
@@ -1,0 +1,1 @@
+src:/opt/irods-externals/*


### PR DESCRIPTION
Still need to improve the ignore list (e.g. hashing functions have expected overflow behavior.)

Found some issues, planning to address easy fixes in this PR too.

I do have a question. Based on the current configuration, files like ssl.cpp, sockComm.cpp, and packStruct.cpp produce a lot of errors on implicit conversions. These conversions are not undefined behavior, but a reminder to check "is this is what you really want".

Do we want to make these conversions explicit? If we don't, do we make an ignore for these?