### PR TITLE
[#2600] Doxygen: Add replica_open.h (4-3-stable)

### DIFF
--- a/lib/api/include/irods/replica_open.h
+++ b/lib/api/include/irods/replica_open.h
@@ -1,6 +1,8 @@
 #ifndef IRODS_REPLICA_OPEN_H
 #define IRODS_REPLICA_OPEN_H
 
+/// \file
+
 struct RcComm;
 struct DataObjInp;
 


### PR DESCRIPTION
In service of #2600

Noticed that `replica_close` had documentation but not `replica_open`.