### PR TITLE
[#8106] Fix memory leaks found in irsync tests (4-3-stable)

### DIFF
--- a/lib/core/include/irods/rodsPath.h
+++ b/lib/core/include/irods/rodsPath.h
@@ -69,6 +69,7 @@ int
 getFileType( rodsPath_t *rodsPath );
 void
 clearRodsPath( rodsPath_t *rodsPath );
+void freeRodsPathInpMembers(rodsPathInp_t* path);
 
 // Returns a new path with the following special characters escaped:
 //   - '\f'

--- a/lib/core/src/chksumUtil.cpp
+++ b/lib/core/src/chksumUtil.cpp
@@ -5,6 +5,7 @@
 #include "irods/rodsLog.h"
 #include "irods/chksumUtil.h"
 #include "irods/rcGlobalExtern.h"
+#include "irods/irods_at_scope_exit.hpp"
 
 #include <sys/time.h>
 
@@ -25,8 +26,10 @@ int chksumUtil(rcComm_t* conn,
         return USER__NULL_INPUT_ERR;
     }
 
-    collInp_t collInp;
-    dataObjInp_t dataObjInp;
+    collInp_t collInp{};
+    irods::at_scope_exit clearColl{[&collInp] { clearCollInp(&collInp); }};
+    dataObjInp_t dataObjInp{};
+    irods::at_scope_exit clearData{[&dataObjInp] { clearDataObjInp(&dataObjInp); }};
     int savedStatus = initCondForChksum( myRodsArgs, &dataObjInp, &collInp );
 
     if ( savedStatus < 0 ) {

--- a/lib/core/src/irods_parse_command_line_options.cpp
+++ b/lib/core/src/irods_parse_command_line_options.cpp
@@ -277,7 +277,7 @@ static int build_irods_path_structure(const path_list_t& _path_list,
         return USER__NULL_INPUT_ERR;
     }
 
-    memset( _rods_paths, 0, sizeof( rodsPathInp_t ) );
+    freeRodsPathInpMembers(_rods_paths);
 
     if ( _path_list.size() <= 0 ) {
         if ( ( _flag & ALLOW_NO_SRC_FLAG ) == 0 ) {

--- a/lib/core/src/miscUtil.cpp
+++ b/lib/core/src/miscUtil.cpp
@@ -199,16 +199,17 @@ rmdirR( char *startDir, char *destDir ) {
 int
 getRodsObjType( rcComm_t *conn, rodsPath_t *rodsPath ) {
     int status;
-    dataObjInp_t dataObjInp;
-    rodsObjStat_t *rodsObjStatOut = NULL;
 
     if ( rodsPath == NULL ) {
         return USER__NULL_INPUT_ERR;
     }
 
-    memset( &dataObjInp, 0, sizeof( dataObjInp ) );
+    dataObjInp_t dataObjInp{};
+    irods::at_scope_exit clearData{[&dataObjInp] { clearDataObjInp(&dataObjInp); }};
 
     rstrcpy( dataObjInp.objPath, rodsPath->outPath, MAX_NAME_LEN );
+
+    rodsObjStat_t* rodsObjStatOut{};
     status = rcObjStat( conn, &dataObjInp, &rodsObjStatOut );
 
     if ( status < 0 ) {
@@ -248,6 +249,8 @@ getRodsObjType( rcComm_t *conn, rodsPath_t *rodsPath ) {
             rstrcpy( rodsPath->chksum, rodsObjStatOut->chksum, NAME_LEN );
         }
     }
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+    std::free(rodsPath->rodsObjStat);
     rodsPath->rodsObjStat = rodsObjStatOut;
 
     return rodsPath->objState;

--- a/lib/core/src/msParam.cpp
+++ b/lib/core/src/msParam.cpp
@@ -570,6 +570,14 @@ int clearMsParam(msParam_t* msParam, int freeInOutStruct)
                 clearExecCmdOut(msParam->inOutStruct);
                 std::free(msParam->inOutStruct);
             }
+            // Do not free KeyValPair_MS_T unconditionally as this will lead
+            // to a use-after-free error. Additionally, this behavior matches the default
+            // of checking freeInOutStruct before freeing the data.
+            else if (std::strcmp(msParam->type, KeyValPair_MS_T) == 0 && freeInOutStruct > 0) {
+                clearKeyVal(static_cast<keyValPair_t*>(msParam->inOutStruct));
+                // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+                std::free(msParam->inOutStruct);
+            }
             // This else-block must always be the final block in this if-ladder.
             // Changing the order of these if-blocks can result in memory leaks.
             else if (freeInOutStruct > 0) {

--- a/lib/core/src/rodsPath.cpp
+++ b/lib/core/src/rodsPath.cpp
@@ -555,6 +555,30 @@ clearRodsPath( rodsPath_t *rodsPath ) {
     return;
 }
 
+auto freeRodsPathInpMembers(rodsPathInp_t* path) -> void
+{
+    if (nullptr == path) {
+        return;
+    }
+
+    for (int i{}; i < path->numSrc; i++) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        clearRodsPath(&path->srcPath[i]);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        clearRodsPath(&path->targPath[i]);
+    }
+    clearRodsPath(path->destPath);
+
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+    std::free(path->srcPath);
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+    std::free(path->destPath);
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+    std::free(path->targPath);
+
+    std::memset(path, 0, sizeof(rodsPathInp_t));
+} // freeRodsPathInpMembers
+
 char* escape_path(const char* _path)
 {
     static const std::map<char, std::string> special_char_mappings{

--- a/lib/core/src/rsyncUtil.cpp
+++ b/lib/core/src/rsyncUtil.cpp
@@ -6,6 +6,7 @@
 #include "irods/miscUtil.h"
 #include "irods/checksum.h"
 #include "irods/rcGlobalExtern.h"
+#include "irods/irods_at_scope_exit.hpp"
 #include "irods/irods_log.hpp"
 #include "irods/irods_hasher_factory.hpp"
 #include "irods/irods_path_recursion.hpp"
@@ -49,8 +50,10 @@ rsyncUtil( rcComm_t *conn, rodsEnv *myRodsEnv, rodsArguments_t *myRodsArgs,
         return savedStatus;
     }
 
-    dataObjInp_t dataObjOprInp;
-    dataObjCopyInp_t dataObjCopyInp;
+    dataObjInp_t dataObjOprInp{};
+    irods::at_scope_exit clearDataObj{[&dataObjOprInp] { clearDataObjInp(&dataObjOprInp); }};
+    dataObjCopyInp_t dataObjCopyInp{};
+    irods::at_scope_exit clearDataObjCopy{[&dataObjCopyInp] { clearDataObjCopyInp(&dataObjCopyInp); }};
 
     if ( rodsPathInp->srcPath[0].objType <= COLL_OBJ_T &&
             rodsPathInp->targPath[0].objType <= COLL_OBJ_T ) {

--- a/server/api/src/rsDataObjChksum.cpp
+++ b/server/api/src/rsDataObjChksum.cpp
@@ -223,6 +223,8 @@ namespace
                                                   json& _verification_results)
     {
         char* ignore_checksum{};
+        // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+        irods::at_scope_exit free_c_str{[&ignore_checksum] { std::free(ignore_checksum); }};
 
         if (const auto ec = verifyDataObjChksum(&_comm, &_replica, &ignore_checksum); ec < 0) {
             std::string msg;


### PR DESCRIPTION
This PR has a companion fix in icommands. The icommands fix are optional, as in there is no real growing memory leak, but it does address ASAN comments.