### PR TITLE
[#7164] Add test showing "ils -A" handling embedded single quotes (main)

### DIFF
--- a/scripts/irods/test/test_ils.py
+++ b/scripts/irods/test/test_ils.py
@@ -158,3 +158,8 @@ class Test_Ils(resource_suite.ResourceBase, unittest.TestCase):
         expected_output = [os.path.join(self.admin.session_collection, coll_name)]
         self.admin.assert_icommand(['ils'], 'STDOUT', expected_output)
         self.admin.assert_icommand(['ils', coll_name], 'STDOUT', expected_output)
+
+    def test_ils_prints_acls_when_data_object_contains_single_quotation_mark_in_name__issue_7164(self):
+        data_object = "just testin'"
+        self.admin.assert_icommand(['itouch', data_object])
+        self.admin.assert_icommand(['ils', '-A', data_object], 'STDOUT', [f'ACL - {self.admin.qualified_username}:own'])


### PR DESCRIPTION
Rebased on tip of main.

Ran test in isolation as this doesn't change the behavior of the server.

```
 --- IrodsSession: icommand executed by [otherrods#tempZone] [ils -A just testin'] ---         
Assert Command: ils -A just testin'                                                  
Expecting STDOUT: ['ACL - otherrods#tempZone:own']                 
  stdout:            
    |   /tempZone/home/otherrods/2025-02-05Z22:09:43--irods-testing-3w9c7ypy/just testin'      
    |         ACL - otherrods#tempZone:own                                        
  stderr:                                                                                      
    |                                                                                      
Output found                                
```

I think we're all good here.