### PR TITLE
[#8133] Remove duplicate macro definition for GenQuery1 (main)

### DIFF
--- a/lib/core/include/irods/rodsGenQuery.h
+++ b/lib/core/include/irods/rodsGenQuery.h
@@ -362,7 +362,6 @@ primary ordering column.
 #define COL_SL_DISK_SPACE     1406
 #define COL_SL_NET_INPUT      1407
 #define COL_SL_NET_OUTPUT     1408
-#define COL_SL_NET_OUTPUT     1408
 #define COL_SL_CREATE_TIME    1409
 
 /* R_SERVER_LOAD_DIGEST */


### PR DESCRIPTION
Cherry-pick of #8169.