### PR TITLE
[#7685] Fix flex warning for GenQuery2 lexer rules (4-3-stable)

### DIFF
--- a/server/genquery2/dsl/lexer.l
+++ b/server/genquery2/dsl/lexer.l
@@ -57,7 +57,7 @@
     .|\n               { string_literal += YYText(); }
     <<EOF>>            { throw yy::parser::syntax_error{loc, fmt::format("missing closing single quote: [{}]", string_literal)}; }
 }
-[ \t\n]                ;
+[ \t\n]+               ;
 (?i:select)            return yy::parser::make_SELECT(loc);
 (?i:where)             return yy::parser::make_WHERE(loc);
 (?i:like)              return yy::parser::make_LIKE(loc);

--- a/server/genquery2/dsl/lexer.l
+++ b/server/genquery2/dsl/lexer.l
@@ -54,7 +54,7 @@
                             string_literal.push_back(value);
                        }
     '                  { BEGIN(INITIAL); return yy::parser::make_STRING_LITERAL(string_literal, loc); }
-    .                  { string_literal += YYText(); }
+    .|\n               { string_literal += YYText(); }
     <<EOF>>            { throw yy::parser::syntax_error{loc, fmt::format("missing closing single quote: [{}]", string_literal)}; }
 }
 [ \t\n]                ;

--- a/unit_tests/src/test_rc_genquery2.cpp
+++ b/unit_tests/src/test_rc_genquery2.cpp
@@ -32,6 +32,10 @@ TEST_CASE("rc_genquery2")
         input.zone = nullptr;
 
         char* output{};
+        irods::at_scope_exit_unsafe free_output{[&output] {
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+            std::free(output);
+        }};
         REQUIRE(rc_genquery2(static_cast<RcComm*>(conn), &input, &output) == 0);
         REQUIRE_FALSE(output == nullptr);
 
@@ -67,6 +71,10 @@ TEST_CASE("rc_genquery2")
         input.query_string = query_string.data();
 
         char* output{};
+        irods::at_scope_exit_unsafe free_output{[&output] {
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+            std::free(output);
+        }};
         REQUIRE(rc_genquery2(static_cast<RcComm*>(conn), &input, &output) == 0);
         REQUIRE_FALSE(output == nullptr);
 
@@ -89,6 +97,10 @@ TEST_CASE("rc_genquery2")
         input.query_string = query_string.data();
 
         char* output{};
+        irods::at_scope_exit_unsafe free_output{[&output] {
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+            std::free(output);
+        }};
         REQUIRE(rc_genquery2(static_cast<RcComm*>(conn), &input, &output) == 0);
         REQUIRE_FALSE(output == nullptr);
 
@@ -109,6 +121,10 @@ TEST_CASE("rc_genquery2")
         input.query_string = query_string.data();
 
         char* output{};
+        irods::at_scope_exit_unsafe free_output{[&output] {
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+            std::free(output);
+        }};
         REQUIRE(rc_genquery2(static_cast<RcComm*>(conn), &input, &output) == 0);
         REQUIRE_FALSE(output == nullptr);
 


### PR DESCRIPTION
All unit/core tests pass.