### PR TITLE
[#8134,#8135] GenQuery2: Fix column mappings and table aliasing for permissions (main)

### DIFF
--- a/server/genquery2/include/irods/private/genquery2_table_column_mappings.hpp
+++ b/server/genquery2/include/irods/private/genquery2_table_column_mappings.hpp
@@ -184,7 +184,7 @@ namespace irods::experimental::genquery2
         {"DATA_ACCESS_PERM_NAME", {"R_TOKN_MAIN", "token_name"}},
         {"DATA_ACCESS_USER_ID", {"R_OBJT_ACCESS", "user_id"}},
         {"DATA_ACCESS_USER_NAME", {"R_USER_MAIN", "user_name"}}, // What about groups?
-        {"DATA_ACCESS_USER_ZONE", {"R_USER_MAIN", "user_zone"}},
+        {"DATA_ACCESS_USER_ZONE", {"R_USER_MAIN", "zone_name"}},
         //{"DATA_ACCESS_DATA_ID",  {"R_OBJT_ACCESS", "object_id"}},
         //{"DATA_ACCESS_NAME",     {"R_TOKN_MAIN", "token_name"}}, // special?
         //{"DATA_TOKEN_NAMESPACE", {"R_TOKN_MAIN", "token_namespace"}}, // special?
@@ -192,8 +192,8 @@ namespace irods::experimental::genquery2
         {"COLL_ACCESS_PERM_ID", {"R_OBJT_ACCESS", "access_type_id"}},
         {"COLL_ACCESS_PERM_NAME", {"R_TOKN_MAIN", "token_name"}},
         {"COLL_ACCESS_USER_ID", {"R_OBJT_ACCESS", "user_id"}},
-        {"COLL_ACCESS_USER_NAME", {"R_USER_NAME", "user_name"}},
-        {"COLL_ACCESS_USER_ZONE", {"R_USER_NAME", "user_zone"}},
+        {"COLL_ACCESS_USER_NAME", {"R_USER_MAIN", "user_name"}},
+        {"COLL_ACCESS_USER_ZONE", {"R_USER_MAIN", "zone_name"}},
         //{"COLL_ACCESS_COLL_ID",  {"R_OBJT_ACCESS", "object_id"}},
         //{"COLL_ACCESS_NAME",     {"R_TOKN_MAIN", "token_name"}}, // special?
         //{"COLL_TOKEN_NAMESPACE", {"R_TOKN_MAIN", "token_namespace"}}, // special?

--- a/server/genquery2/src/genquery2_sql.cpp
+++ b/server/genquery2/src/genquery2_sql.cpp
@@ -524,7 +524,7 @@ namespace
             }
 
             // The alias for R_USER_MAIN as it relates to data objects.
-            if (tail == "USER_NAME") {
+            if (tail == "USER_NAME" || tail == "USER_ZONE") {
                 return "pdu";
             }
 
@@ -542,7 +542,7 @@ namespace
             }
 
             // The alias for R_USER_MAIN as it relates to collections.
-            if (tail == "USER_NAME") {
+            if (tail == "USER_NAME" || tail == "USER_ZONE") {
                 return "pcu";
             }
 
@@ -853,7 +853,7 @@ namespace irods::experimental::genquery2
                 add_r_data_main = true;
                 table_alias = "pdt"; // The alias for R_TOKN_MAIN as it relates to data objects.
             }
-            else if (_column.name == "DATA_ACCESS_USER_NAME") {
+            else if (_column.name == "DATA_ACCESS_USER_NAME" || _column.name == "DATA_ACCESS_USER_ZONE") {
                 add_r_data_main = true;
                 table_alias = "pdu"; // The alias for R_USER_MAIN as it relates to data objects.
             }
@@ -870,7 +870,7 @@ namespace irods::experimental::genquery2
                 add_r_coll_main = true;
                 table_alias = "pct"; // The alias for R_TOKN_MAIN as it relates to collections.
             }
-            else if (_column.name == "COLL_ACCESS_USER_NAME") {
+            else if (_column.name == "COLL_ACCESS_USER_NAME" || _column.name == "COLL_ACCESS_USER_ZONE") {
                 add_r_coll_main = true;
                 table_alias = "pcu"; // The alias for R_USER_MAIN as it relates to collections.
             }


### PR DESCRIPTION
Cherry-pick of #8171.

Will verify the changes pass at the bench.