### PR TITLE
Fix unencrypted parallel transfer with server encryption enabled, test iget over federation (4-3-stable)

### DIFF
--- a/scripts/irods/test/test_federation.py
+++ b/scripts/irods/test/test_federation.py
@@ -2393,6 +2393,89 @@ class test_irepl_all_permission_levels__issue_7444_7465(unittest.TestCase):
 					self.user0.assert_icommand(['irm', '-f', logical_path])
 
 
+class test_iget_data_in_remote_zone(unittest.TestCase):
+	@classmethod
+	def setUpClass(self):
+		# Create a session as the administrator for the remote zone so we can do things in the remote zone.
+		self.remote_admin = session.make_session_for_existing_user(
+			test.settings.PREEXISTING_ADMIN_USERNAME,
+			test.settings.PREEXISTING_ADMIN_PASSWORD,
+			test.settings.FEDERATION.REMOTE_HOST,
+			test.settings.FEDERATION.REMOTE_ZONE)
+
+		# Create two users in the local zone and accompanying users in the remote zone.
+		local_user_name0 = 'smeagol'
+		local_user_name1 = 'bilbo'
+		self.user0 = session.mkuser_and_return_session(
+			'rodsuser', local_user_name0, 'spass', lib.get_hostname())
+		self.user1 = session.mkuser_and_return_session(
+			'rodsuser', local_user_name1, 'bpass', lib.get_hostname())
+
+		# Create a user in the remote zone for each local zone's test users. Don't give the user a password.
+		self.local_user0_remote_name = '#'.join([self.user0.username, self.user0.zone_name])
+		self.local_user1_remote_name = '#'.join([self.user1.username, self.user1.zone_name])
+		self.remote_admin.assert_icommand(['iadmin', 'mkuser', self.local_user0_remote_name, 'rodsuser'])
+		self.remote_admin.assert_icommand(['iadmin', 'mkuser', self.local_user1_remote_name, 'rodsuser'])
+
+	@classmethod
+	def tearDownClass(self):
+		# Clean up remote users and sessions.
+		self.remote_admin.run_icommand(['iadmin', 'rmuser', self.local_user0_remote_name])
+		self.remote_admin.run_icommand(['iadmin', 'rmuser', self.local_user1_remote_name])
+		self.remote_admin.__exit__()
+
+		# Clean up local users and sessions.
+		self.user0.__exit__()
+		self.user1.__exit__()
+		with session.make_session_for_existing_admin() as admin_session:
+			admin_session.run_icommand(['iadmin', 'rmuser', self.user0.username])
+			admin_session.run_icommand(['iadmin', 'rmuser', self.user1.username])
+
+	def test_iget_object_in_zoneB_as_user_in_zoneA_that_has_no_remote_user_in_zoneB_fails_correctly__issue_6421(self):
+		remote_zone = test.settings.FEDERATION.REMOTE_ZONE
+		logical_path = os.path.join(self.user0.remote_home_collection(remote_zone), "get_this_object")
+
+		try:
+			# Remove the user1 remote user so that it does not exist.
+			self.remote_admin.assert_icommand(['iadmin', 'rmuser', self.local_user1_remote_name])
+
+			# Create a data object in the remote zone in the remote user0's home collection.
+			content = "we hates it"
+			self.user0.assert_icommand(["istream", "write", logical_path], input=content)
+			self.user0.assert_icommand(["istream", "read", logical_path], "STDOUT", content)
+
+			# Try to get the data as user1 even though there is no remote user for user1. This should fail.
+			self.user1.assert_icommand(["iget", logical_path], "STDERR", "-317000 USER_INPUT_PATH_ERR")
+
+		finally:
+			self.remote_admin.run_icommand(['iadmin', 'mkuser', self.local_user1_remote_name, 'rodsuser'])
+			self.user0.run_icommand(["irm", "-f", logical_path])
+
+	def test_iget_object_in_zoneB_as_user_in_zoneA_that_has_no_permissions_fails_correctly__issue_6421(self):
+		remote_zone = test.settings.FEDERATION.REMOTE_ZONE
+		parent_collection = self.user0.remote_home_collection(remote_zone)
+		logical_path = os.path.join(parent_collection, "get_this_object")
+
+		try:
+			# Create a data object in the remote zone in the remote user0's home collection.
+			content = "we hates it"
+			self.user0.assert_icommand(["istream", "write", logical_path], input=content)
+			self.user0.assert_icommand(["istream", "read", logical_path], "STDOUT", content)
+
+			# Try to get the data as user1 even though the remote user1 has no permissions. This should fail.
+			self.user1.assert_icommand(["iget", logical_path], "STDERR", "-317000 USER_INPUT_PATH_ERR")
+
+			# Give the other user read permission on the parent collection.
+			self.user0.assert_icommand(["ichmod", "read_object", self.local_user1_remote_name, parent_collection])
+
+			# Try to get the data as user1 even though the remote user1 only has permissions on the parent collection.
+			# This should fail, too.
+			self.user1.assert_icommand(["iget", logical_path], "STDERR", "-317000 USER_INPUT_PATH_ERR")
+
+		finally:
+			self.user0.run_icommand(["irm", "-f", logical_path])
+
+
 class Test_GenQuery2_IQuery(SessionsMixin, unittest.TestCase):
 
 	# This test suite expects tempZone to contain the following users:

--- a/scripts/irods/test/test_iquery.py
+++ b/scripts/irods/test/test_iquery.py
@@ -152,3 +152,25 @@ class Test_IQuery(session.make_sessions_mixin(rodsadmins, rodsusers), unittest.T
         query_string = f"select DATA_ACCESS_USER_NAME, DATA_ACCESS_USER_ZONE, count(DATA_ID) where DATA_NAME = '{data_name}' group by DATA_ACCESS_USER_NAME, DATA_ACCESS_USER_ZONE"
         json_string = json.dumps([[self.user.username, self.user.zone_name, '1']], separators=(',', ':'))
         self.user.assert_icommand(['iquery', query_string], 'STDOUT', [json_string])
+
+    def test_iquery_correctly_parses_queries_with_tabs_in_the_where_clause__issue_7795(self):
+        # Run a basic query to get the expected output.
+        query_string = f"select USER_ID where USER_NAME = '{self.user.username}'"
+        expected_output = self.user.assert_icommand(["iquery", query_string], "STDOUT")[1].strip()
+        expected_user_id = json.loads(expected_output)[0][0]
+
+        # Now construct a query that should return the same results, but with a tab in the where clause.
+        query_string_with_tab_in_where_clause = query_string + "\tand USER_TYPE = 'rodsuser'"
+
+        # iquest will fail because there is a tab in the where clause.
+        self.user.assert_icommand(
+            ["iquest", "%s", query_string_with_tab_in_where_clause],
+            "STDOUT",
+            "CAT_NO_ROWS_FOUND: Nothing was found matching your query")
+
+        # iquery will succeed because it uses a real parser.
+        output = self.user.assert_icommand(["iquery", query_string_with_tab_in_where_clause], "STDOUT")[1].strip()
+        user_id = json.loads(output)[0][0]
+
+        # ...should match.
+        self.assertEqual(user_id, expected_user_id)

--- a/server/api/include/irods/rsDataGet.hpp
+++ b/server/api/include/irods/rsDataGet.hpp
@@ -1,11 +1,12 @@
 #ifndef RS_DATA_GET_HPP
 #define RS_DATA_GET_HPP
 
-#include "irods/rodsConnect.h"
-#include "irods/dataObjInpOut.h"
+struct DataOprInp;
+struct RsComm;
+struct portalOprOut;
+struct rodsServerHost;
 
-int rsDataGet( rsComm_t *rsComm, dataOprInp_t *dataGetInp, portalOprOut_t **portalOprOut );
-int remoteDataGet( rsComm_t *rsComm, dataOprInp_t *dataGetInp, portalOprOut_t **portalOprOut, rodsServerHost_t *rodsServerHost );
-int _rsDataGet( rsComm_t *rsComm, dataOprInp_t *dataGetInp, portalOprOut_t **portalOprOut );
+int rsDataGet(RsComm* rsComm, DataOprInp* dataGetInp, portalOprOut** portalOprOut);
+int remoteDataGet(RsComm* rsComm, DataOprInp* dataGetInp, portalOprOut** portalOprOut, rodsServerHost* rodsServerHost);
 
-#endif
+#endif // RS_DATA_GET_HPP

--- a/server/api/include/irods/rsDataPut.hpp
+++ b/server/api/include/irods/rsDataPut.hpp
@@ -1,11 +1,12 @@
 #ifndef RS_DATA_PUT_HPP
 #define RS_DATA_PUT_HPP
 
-#include "irods/rcConnect.h"
-#include "irods/dataObjInpOut.h"
+struct DataOprInp;
+struct RsComm;
+struct portalOprOut;
+struct rodsServerHost;
 
-int rsDataPut( rsComm_t *rsComm, dataOprInp_t *dataPutInp, portalOprOut_t **portalOprOut );
-int remoteDataPut( rsComm_t *rsComm, dataOprInp_t *dataPutInp, portalOprOut_t **portalOprOut, rodsServerHost_t *rodsServerHost );
-int _rsDataPut( rsComm_t *rsComm, dataOprInp_t *dataPutInp, portalOprOut_t **portalOprOut );
+int rsDataPut(RsComm* rsComm, DataOprInp* dataPutInp, portalOprOut** portalOprOut);
+int remoteDataPut(RsComm* rsComm, DataOprInp* dataPutInp, portalOprOut** portalOprOut, rodsServerHost* rodsServerHost);
 
-#endif
+#endif // RS_DATA_PUT_HPP

--- a/server/api/src/rsDataGet.cpp
+++ b/server/api/src/rsDataGet.cpp
@@ -2,6 +2,7 @@
 
 #include "irods/dataGet.h"
 #include "irods/dataObjInpOut.h"
+#include "irods/irods_client_server_negotiation.hpp"
 #include "irods/miscServerFunct.hpp"
 #include "irods/rcGlobalExtern.h"
 #include "irods/rcMisc.h"
@@ -58,6 +59,12 @@ remoteDataGet( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
     if ( ( status = svrToSvrConnect( rsComm, rodsServerHost ) ) < 0 ) {
         return status;
     }
+
+    // Store the negotiation results from the original client-to-server connection because it may differ from
+    // server-to-server communications. If the client is not using SSL/TLS in communications with this server and a
+    // legacy parallel transfer portal is opened to a different server, that other server may be expecting SSL/TLS
+    // communications if encryption is enabled in the server-to-server connection.
+    addKeyVal(&dataOprInp->condInput, irods::CS_NEG_RESULT_KW.c_str(), rsComm->negotiation_results);
 
     dataOprInp->srcL3descInx = convL3descInx( dataOprInp->srcL3descInx );
     status = rcDataGet( rodsServerHost->conn, dataOprInp, portalOprOut );

--- a/server/api/src/rsDataGet.cpp
+++ b/server/api/src/rsDataGet.cpp
@@ -1,18 +1,12 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-/* This is script-generated code (for the most part).  */
-/* See dataGet.h for a description of this API call.*/
-
-#include "irods/rcMisc.h"
-#include "irods/dataGet.h"
-#include "irods/miscServerFunct.hpp"
-#include "irods/rsGlobalExtern.hpp"
-#include "irods/rcGlobalExtern.h"
 #include "irods/rsDataGet.hpp"
 
-/* rsDataGet - this routine setup portalOprOut with the resource server
- * for parallel get operation.
- */
+#include "irods/dataGet.h"
+#include "irods/dataObjInpOut.h"
+#include "irods/miscServerFunct.hpp"
+#include "irods/rcGlobalExtern.h"
+#include "irods/rcMisc.h"
+#include "irods/rodsConnect.h"
+#include "irods/rsGlobalExtern.hpp"
 
 int
 rsDataGet( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
@@ -37,7 +31,7 @@ rsDataGet( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
     }
 
     if ( remoteFlag == LOCAL_HOST ) {
-        status = _rsDataGet( rsComm, dataOprInp, portalOprOut );
+        status = setupSrvPortalForParaOpr(rsComm, dataOprInp, GET_OPR, portalOprOut);
     }
     else {
         addKeyVal( &dataOprInp->condInput, EXEC_LOCALLY_KW, "" );
@@ -48,17 +42,6 @@ rsDataGet( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
 
 
     return status;
-}
-
-int
-_rsDataGet( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
-            portalOprOut_t **portalOprOut ) {
-    return setupSrvPortalForParaOpr(
-               rsComm,
-               dataOprInp,
-               GET_OPR,
-               portalOprOut );
-
 }
 
 int

--- a/server/api/src/rsDataPut.cpp
+++ b/server/api/src/rsDataPut.cpp
@@ -1,19 +1,13 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-/* This is script-generated code (for the most part).  */
-/* See dataPut.h for a description of this API call.*/
-
-#include "irods/rcMisc.h"
-#include "irods/dataPut.h"
-#include "irods/rodsLog.h"
-#include "irods/miscServerFunct.hpp"
-#include "irods/rsGlobalExtern.hpp"
-#include "irods/rcGlobalExtern.h"
 #include "irods/rsDataPut.hpp"
 
-/* rsDataPut - this routine setup portalOprOut with the resource server
- * for parallel put operation.
- */
+#include "irods/dataObjInpOut.h"
+#include "irods/dataPut.h"
+#include "irods/miscServerFunct.hpp"
+#include "irods/rcConnect.h"
+#include "irods/rcGlobalExtern.h"
+#include "irods/rcMisc.h"
+#include "irods/rodsLog.h"
+#include "irods/rsGlobalExtern.hpp"
 
 int
 rsDataPut( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
@@ -38,7 +32,7 @@ rsDataPut( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
     }
 
     if ( remoteFlag == LOCAL_HOST ) {
-        status = _rsDataPut( rsComm, dataOprInp, portalOprOut );
+        status = setupSrvPortalForParaOpr(rsComm, dataOprInp, PUT_OPR, portalOprOut);
     }
     else {
         addKeyVal( &dataOprInp->condInput, EXEC_LOCALLY_KW, "" );
@@ -50,18 +44,6 @@ rsDataPut( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
 
     return status;
 }
-
-int
-_rsDataPut( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
-            portalOprOut_t **portalOprOut ) {
-    int status;
-
-    status = setupSrvPortalForParaOpr( rsComm, dataOprInp, PUT_OPR,
-                                       portalOprOut );
-
-    return status;
-}
-
 
 int
 remoteDataPut( rsComm_t *rsComm, dataOprInp_t *dataOprInp,

--- a/server/api/src/rsDataPut.cpp
+++ b/server/api/src/rsDataPut.cpp
@@ -2,6 +2,7 @@
 
 #include "irods/dataObjInpOut.h"
 #include "irods/dataPut.h"
+#include "irods/irods_client_server_negotiation.hpp"
 #include "irods/miscServerFunct.hpp"
 #include "irods/rcConnect.h"
 #include "irods/rcGlobalExtern.h"
@@ -59,6 +60,12 @@ remoteDataPut( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
     if ( ( status = svrToSvrConnect( rsComm, rodsServerHost ) ) < 0 ) {
         return status;
     }
+
+    // Store the negotiation results from the original client-to-server connection because it may differ from
+    // server-to-server communications. If the client is not using SSL/TLS in communications with this server and a
+    // legacy parallel transfer portal is opened to a different server, that other server may be expecting SSL/TLS
+    // communications if encryption is enabled in the server-to-server connection.
+    addKeyVal(&dataOprInp->condInput, irods::CS_NEG_RESULT_KW.c_str(), rsComm->negotiation_results);
 
     dataOprInp->destL3descInx = convL3descInx( dataOprInp->destL3descInx );
 

--- a/server/core/src/miscServerFunct.cpp
+++ b/server/core/src/miscServerFunct.cpp
@@ -622,9 +622,8 @@ int fillPortalTransferInp(
     return 0;
 }
 
-
-void
-partialDataPut( portalTransferInp_t *myInput ) {
+static void partialDataPut_impl(portalTransferInp_t* myInput)
+{
     int destL3descInx = 0, srcFd = 0;
     unsigned char *buf = 0;
     int bytesWritten = 0;
@@ -641,6 +640,24 @@ partialDataPut( portalTransferInp_t *myInput ) {
     bool use_encryption_flg =
         ( myInput->rsComm->negotiation_results ==
           irods::CS_NEG_USE_SSL );
+
+    // The rsComm negotiation_results represents the server-to-server connection negotiation and this may differ from
+    // that of the original client-to-server connection negotiation. This would result in communications between the
+    // client and the server via the portal to use encryption on the server side and not the client side, which leads
+    // to errors. As such, the client-to-server negotiation is stashed in a key-val pair in the input to the portal
+    // operation for legacy parallel transfers. We check to see whether the the original client-to-server connection
+    // negotiation is using SSL/TLS. If it is not, explicitly set the use_encryption_flg to false so that the client
+    // and this server are communicating with the same protocol via the direct portal.
+    if (use_encryption_flg) {
+        const char* negotiation_result =
+            getValByKey(&myInput->rsComm->portalOpr->dataOprInp.condInput, irods::CS_NEG_RESULT_KW.c_str());
+        if (nullptr == negotiation_result || irods::CS_NEG_USE_SSL != negotiation_result) {
+            log_server::info(
+                "{}: Client is not using SSL/TLS but server-to-server communication is. Not using encryption.",
+                __func__);
+            use_encryption_flg = false;
+        }
+    }
 
     myInput->status = 0;
     destL3descInx = myInput->destFd;
@@ -852,8 +869,23 @@ partialDataPut( portalTransferInp_t *myInput ) {
     return;
 }
 
-void partialDataGet(
-    portalTransferInp_t* myInput ) {
+void partialDataPut(portalTransferInp_t* myInput)
+{
+    // This function acts as a wrapper to ensure that all exceptions are being caught while minimizing changes to this
+    // legacy implementation of parallel transfer.
+    try {
+        partialDataPut_impl(myInput);
+    }
+    catch (const irods::exception& e) {
+        log_server::error("{}: Caught irods::exception: {}", __func__, e.client_display_what());
+    }
+    catch (const std::exception& e) {
+        log_server::error("{}: Caught std::exception: {}", __func__, e.what());
+    }
+} // partialDataPut
+
+static void partialDataGet_impl(portalTransferInp_t* myInput)
+{
     // =-=-=-=-=-=-=-
     //
     int srcL3descInx = 0, destFd = 0;
@@ -891,6 +923,24 @@ void partialDataGet(
     bool use_encryption_flg =
         ( myInput->rsComm->negotiation_results ==
           irods::CS_NEG_USE_SSL );
+
+    // The rsComm negotiation_results represents the server-to-server connection negotiation and this may differ from
+    // that of the original client-to-server connection negotiation. This would result in communications between the
+    // client and the server via the portal to use encryption on the server side and not the client side, which leads
+    // to errors. As such, the client-to-server negotiation is stashed in a key-val pair in the input to the portal
+    // operation for legacy parallel transfers. We check to see whether the the original client-to-server connection
+    // negotiation is using SSL/TLS. If it is not, explicitly set the use_encryption_flg to false so that the client
+    // and this server are communicating with the same protocol via the direct portal.
+    if (use_encryption_flg) {
+        const char* negotiation_result =
+            getValByKey(&myInput->rsComm->portalOpr->dataOprInp.condInput, irods::CS_NEG_RESULT_KW.c_str());
+        if (nullptr == negotiation_result || irods::CS_NEG_USE_SSL != negotiation_result) {
+            log_server::info(
+                "{}: Client is not using SSL/TLS but server-to-server communication is. Not using encryption.",
+                __func__);
+            use_encryption_flg = false;
+        }
+    }
 
     // =-=-=-=-=-=-=-
     // create an encryption context
@@ -1091,6 +1141,21 @@ void partialDataGet(
 
     return;
 }
+
+void partialDataGet(portalTransferInp_t* myInput)
+{
+    // This function acts as a wrapper to ensure that all exceptions are being caught while minimizing changes to this
+    // legacy implementation of parallel transfer.
+    try {
+        partialDataGet_impl(myInput);
+    }
+    catch (const irods::exception& e) {
+        log_server::error("{}: Caught irods::exception: {}", __func__, e.client_display_what());
+    }
+    catch (const std::exception& e) {
+        log_server::error("{}: Caught std::exception: {}", __func__, e.what());
+    }
+} // partialDataGet
 
 void
 remToLocPartialCopy( portalTransferInp_t *myInput ) {


### PR DESCRIPTION
Addresses #4984 
In service of #6421
In service of #7795

Unit tests and federation tests passed. Core tests are running now.

There's no way to automatically test the scenario described in #4984 with our existing test infrastructure. As such, there are no new tests for that scenario, and I confirmed manually that things are working for Puts and Gets.