### PR TITLE
[#7392] fix: Add missing required `irods_environment.json` option (4-3-stable)

### DIFF
--- a/scripts/irods/upgrade_configuration.py
+++ b/scripts/irods/upgrade_configuration.py
@@ -465,7 +465,8 @@ def convert_legacy_configuration_to_json(irods_config):
             'irods_transfer_buffer_size_for_parallel_transfer_in_megabytes': server_config_v2['advanced_settings']['transfer_buffer_size_for_parallel_transfer_in_megabytes'],
             "irods_ssl_verify_server": os.getenv("irodsSSLVerifyServer", 'hostname'),
             "irods_ssl_ca_certificate_file": os.getenv("irodsSSLCACertificateFile", ''),
-            "irods_ssl_ca_certificate_path": os.getenv("irodsSSLCACertificatePath", '')
+            "irods_ssl_ca_certificate_path": os.getenv("irodsSSLCACertificatePath", ''),
+            "irods_connection_pool_refresh_time_in_seconds": int(legacy_irods_environment.get('irodsConnectionPoolRefreshTime', 300))
             }
 
     #optional irods environment keys


### PR DESCRIPTION
Quick link to the issue: #7392.

This PR adds `irods_connection_pool_refresh_time_in_seconds` to the configuration upgrade script, defaulting to 300 if no previous value is found.

---

Needs to be tested.

Needs a companion PR to update documentation.