### PR TITLE
[#3581] Avoid SIGABRT by setting pointers to null after deallocation (4-3-stable)

### DIFF
--- a/plugins/rule_engines/irods_rule_language/src/conversion.cpp
+++ b/plugins/rule_engines/irods_rule_language/src/conversion.cpp
@@ -448,13 +448,16 @@ int updateResToMsParam( msParam_t *var, Res *res, rError_t *errmsg ) {
         /* do not free msParam_t if its inOutStruct and inOutBuf are shared */
         if ( var->inOutStruct != NULL ) {
             free( var->inOutStruct );
+            var->inOutStruct = nullptr;
         }
         if ( var->inpOutBuf != NULL ) {
             free( var->inpOutBuf );
+            var->inpOutBuf = nullptr;
         }
     }
     if ( var->label != NULL ) {
         free( var->label );
+        var->label = nullptr;
     }
     return convertResToMsParam( var, res, errmsg );
 }


### PR DESCRIPTION
Running unit and core tests.

No test for this since it would require reading the log file. I did verify at the bench that the agent no longer exits with signal 6. 