### PR TITLE
Revert #8195, add error handling to legacy parallel transfer (4-3-stable)

### DIFF
--- a/server/api/src/rsDataGet.cpp
+++ b/server/api/src/rsDataGet.cpp
@@ -2,7 +2,6 @@
 
 #include "irods/dataGet.h"
 #include "irods/dataObjInpOut.h"
-#include "irods/irods_client_server_negotiation.hpp"
 #include "irods/miscServerFunct.hpp"
 #include "irods/rcGlobalExtern.h"
 #include "irods/rcMisc.h"
@@ -59,12 +58,6 @@ remoteDataGet( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
     if ( ( status = svrToSvrConnect( rsComm, rodsServerHost ) ) < 0 ) {
         return status;
     }
-
-    // Store the negotiation results from the original client-to-server connection because it may differ from
-    // server-to-server communications. If the client is not using SSL/TLS in communications with this server and a
-    // legacy parallel transfer portal is opened to a different server, that other server may be expecting SSL/TLS
-    // communications if encryption is enabled in the server-to-server connection.
-    addKeyVal(&dataOprInp->condInput, irods::CS_NEG_RESULT_KW.c_str(), rsComm->negotiation_results);
 
     dataOprInp->srcL3descInx = convL3descInx( dataOprInp->srcL3descInx );
     status = rcDataGet( rodsServerHost->conn, dataOprInp, portalOprOut );

--- a/server/api/src/rsDataPut.cpp
+++ b/server/api/src/rsDataPut.cpp
@@ -2,7 +2,6 @@
 
 #include "irods/dataObjInpOut.h"
 #include "irods/dataPut.h"
-#include "irods/irods_client_server_negotiation.hpp"
 #include "irods/miscServerFunct.hpp"
 #include "irods/rcConnect.h"
 #include "irods/rcGlobalExtern.h"
@@ -60,12 +59,6 @@ remoteDataPut( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
     if ( ( status = svrToSvrConnect( rsComm, rodsServerHost ) ) < 0 ) {
         return status;
     }
-
-    // Store the negotiation results from the original client-to-server connection because it may differ from
-    // server-to-server communications. If the client is not using SSL/TLS in communications with this server and a
-    // legacy parallel transfer portal is opened to a different server, that other server may be expecting SSL/TLS
-    // communications if encryption is enabled in the server-to-server connection.
-    addKeyVal(&dataOprInp->condInput, irods::CS_NEG_RESULT_KW.c_str(), rsComm->negotiation_results);
 
     dataOprInp->destL3descInx = convL3descInx( dataOprInp->destL3descInx );
 

--- a/server/core/src/miscServerFunct.cpp
+++ b/server/core/src/miscServerFunct.cpp
@@ -641,24 +641,6 @@ static void partialDataPut_impl(portalTransferInp_t* myInput)
         ( myInput->rsComm->negotiation_results ==
           irods::CS_NEG_USE_SSL );
 
-    // The rsComm negotiation_results represents the server-to-server connection negotiation and this may differ from
-    // that of the original client-to-server connection negotiation. This would result in communications between the
-    // client and the server via the portal to use encryption on the server side and not the client side, which leads
-    // to errors. As such, the client-to-server negotiation is stashed in a key-val pair in the input to the portal
-    // operation for legacy parallel transfers. We check to see whether the the original client-to-server connection
-    // negotiation is using SSL/TLS. If it is not, explicitly set the use_encryption_flg to false so that the client
-    // and this server are communicating with the same protocol via the direct portal.
-    if (use_encryption_flg) {
-        const char* negotiation_result =
-            getValByKey(&myInput->rsComm->portalOpr->dataOprInp.condInput, irods::CS_NEG_RESULT_KW.c_str());
-        if (nullptr == negotiation_result || irods::CS_NEG_USE_SSL != negotiation_result) {
-            log_server::info(
-                "{}: Client is not using SSL/TLS but server-to-server communication is. Not using encryption.",
-                __func__);
-            use_encryption_flg = false;
-        }
-    }
-
     myInput->status = 0;
     destL3descInx = myInput->destFd;
     srcFd = myInput->srcFd;
@@ -923,24 +905,6 @@ static void partialDataGet_impl(portalTransferInp_t* myInput)
     bool use_encryption_flg =
         ( myInput->rsComm->negotiation_results ==
           irods::CS_NEG_USE_SSL );
-
-    // The rsComm negotiation_results represents the server-to-server connection negotiation and this may differ from
-    // that of the original client-to-server connection negotiation. This would result in communications between the
-    // client and the server via the portal to use encryption on the server side and not the client side, which leads
-    // to errors. As such, the client-to-server negotiation is stashed in a key-val pair in the input to the portal
-    // operation for legacy parallel transfers. We check to see whether the the original client-to-server connection
-    // negotiation is using SSL/TLS. If it is not, explicitly set the use_encryption_flg to false so that the client
-    // and this server are communicating with the same protocol via the direct portal.
-    if (use_encryption_flg) {
-        const char* negotiation_result =
-            getValByKey(&myInput->rsComm->portalOpr->dataOprInp.condInput, irods::CS_NEG_RESULT_KW.c_str());
-        if (nullptr == negotiation_result || irods::CS_NEG_USE_SSL != negotiation_result) {
-            log_server::info(
-                "{}: Client is not using SSL/TLS but server-to-server communication is. Not using encryption.",
-                __func__);
-            use_encryption_flg = false;
-        }
-    }
 
     // =-=-=-=-=-=-=-
     // create an encryption context


### PR DESCRIPTION
In service of #4984 

Partially reverts #8195

`SYS_SOCK_READ_ERR` is the closest thing I could find to what I wanted from an existing error code; open to other suggestions. Couldn't find anything related to SSL/TLS that came close. Maybe we need a new error code.

Unit tests passed. Core tests running. Will mark Ready for Review once they're passing.