### PR TITLE
Add error handling to legacy parallel transfer, test iget over federation and iquery with tabs (main)

### DIFF
--- a/scripts/irods/test/test_federation.py
+++ b/scripts/irods/test/test_federation.py
@@ -2412,6 +2412,89 @@ class test_irepl_all_permission_levels__issue_7444_7465(unittest.TestCase):
 					self.user0.assert_icommand(['irm', '-f', logical_path])
 
 
+class test_iget_data_in_remote_zone(unittest.TestCase):
+	@classmethod
+	def setUpClass(self):
+		# Create a session as the administrator for the remote zone so we can do things in the remote zone.
+		self.remote_admin = session.make_session_for_existing_user(
+			test.settings.PREEXISTING_ADMIN_USERNAME,
+			test.settings.PREEXISTING_ADMIN_PASSWORD,
+			test.settings.FEDERATION.REMOTE_HOST,
+			test.settings.FEDERATION.REMOTE_ZONE)
+
+		# Create two users in the local zone and accompanying users in the remote zone.
+		local_user_name0 = 'smeagol'
+		local_user_name1 = 'bilbo'
+		self.user0 = session.mkuser_and_return_session(
+			'rodsuser', local_user_name0, 'spass', lib.get_hostname())
+		self.user1 = session.mkuser_and_return_session(
+			'rodsuser', local_user_name1, 'bpass', lib.get_hostname())
+
+		# Create a user in the remote zone for each local zone's test users. Don't give the user a password.
+		self.local_user0_remote_name = '#'.join([self.user0.username, self.user0.zone_name])
+		self.local_user1_remote_name = '#'.join([self.user1.username, self.user1.zone_name])
+		self.remote_admin.assert_icommand(['iadmin', 'mkuser', self.local_user0_remote_name, 'rodsuser'])
+		self.remote_admin.assert_icommand(['iadmin', 'mkuser', self.local_user1_remote_name, 'rodsuser'])
+
+	@classmethod
+	def tearDownClass(self):
+		# Clean up remote users and sessions.
+		self.remote_admin.run_icommand(['iadmin', 'rmuser', self.local_user0_remote_name])
+		self.remote_admin.run_icommand(['iadmin', 'rmuser', self.local_user1_remote_name])
+		self.remote_admin.__exit__()
+
+		# Clean up local users and sessions.
+		self.user0.__exit__()
+		self.user1.__exit__()
+		with session.make_session_for_existing_admin() as admin_session:
+			admin_session.run_icommand(['iadmin', 'rmuser', self.user0.username])
+			admin_session.run_icommand(['iadmin', 'rmuser', self.user1.username])
+
+	def test_iget_object_in_zoneB_as_user_in_zoneA_that_has_no_remote_user_in_zoneB_fails_correctly__issue_6421(self):
+		remote_zone = test.settings.FEDERATION.REMOTE_ZONE
+		logical_path = os.path.join(self.user0.remote_home_collection(remote_zone), "get_this_object")
+
+		try:
+			# Remove the user1 remote user so that it does not exist.
+			self.remote_admin.assert_icommand(['iadmin', 'rmuser', self.local_user1_remote_name])
+
+			# Create a data object in the remote zone in the remote user0's home collection.
+			content = "we hates it"
+			self.user0.assert_icommand(["istream", "write", logical_path], input=content)
+			self.user0.assert_icommand(["istream", "read", logical_path], "STDOUT", content)
+
+			# Try to get the data as user1 even though there is no remote user for user1. This should fail.
+			self.user1.assert_icommand(["iget", logical_path], "STDERR", "-317000 USER_INPUT_PATH_ERR")
+
+		finally:
+			self.remote_admin.run_icommand(['iadmin', 'mkuser', self.local_user1_remote_name, 'rodsuser'])
+			self.user0.run_icommand(["irm", "-f", logical_path])
+
+	def test_iget_object_in_zoneB_as_user_in_zoneA_that_has_no_permissions_fails_correctly__issue_6421(self):
+		remote_zone = test.settings.FEDERATION.REMOTE_ZONE
+		parent_collection = self.user0.remote_home_collection(remote_zone)
+		logical_path = os.path.join(parent_collection, "get_this_object")
+
+		try:
+			# Create a data object in the remote zone in the remote user0's home collection.
+			content = "we hates it"
+			self.user0.assert_icommand(["istream", "write", logical_path], input=content)
+			self.user0.assert_icommand(["istream", "read", logical_path], "STDOUT", content)
+
+			# Try to get the data as user1 even though the remote user1 has no permissions. This should fail.
+			self.user1.assert_icommand(["iget", logical_path], "STDERR", "-317000 USER_INPUT_PATH_ERR")
+
+			# Give the other user read permission on the parent collection.
+			self.user0.assert_icommand(["ichmod", "read_object", self.local_user1_remote_name, parent_collection])
+
+			# Try to get the data as user1 even though the remote user1 only has permissions on the parent collection.
+			# This should fail, too.
+			self.user1.assert_icommand(["iget", logical_path], "STDERR", "-317000 USER_INPUT_PATH_ERR")
+
+		finally:
+			self.user0.run_icommand(["irm", "-f", logical_path])
+
+
 class Test_GenQuery2_IQuery(SessionsMixin, unittest.TestCase):
 
 	# This test suite expects tempZone to contain the following users:

--- a/server/api/include/irods/rsDataGet.hpp
+++ b/server/api/include/irods/rsDataGet.hpp
@@ -1,11 +1,12 @@
 #ifndef RS_DATA_GET_HPP
 #define RS_DATA_GET_HPP
 
-#include "irods/rodsConnect.h"
-#include "irods/dataObjInpOut.h"
+struct DataOprInp;
+struct RsComm;
+struct portalOprOut;
+struct rodsServerHost;
 
-int rsDataGet( rsComm_t *rsComm, dataOprInp_t *dataGetInp, portalOprOut_t **portalOprOut );
-int remoteDataGet( rsComm_t *rsComm, dataOprInp_t *dataGetInp, portalOprOut_t **portalOprOut, rodsServerHost_t *rodsServerHost );
-int _rsDataGet( rsComm_t *rsComm, dataOprInp_t *dataGetInp, portalOprOut_t **portalOprOut );
+int rsDataGet(RsComm* rsComm, DataOprInp* dataGetInp, portalOprOut** portalOprOut);
+int remoteDataGet(RsComm* rsComm, DataOprInp* dataGetInp, portalOprOut** portalOprOut, rodsServerHost* rodsServerHost);
 
-#endif
+#endif // RS_DATA_GET_HPP

--- a/server/api/include/irods/rsDataPut.hpp
+++ b/server/api/include/irods/rsDataPut.hpp
@@ -1,11 +1,12 @@
 #ifndef RS_DATA_PUT_HPP
 #define RS_DATA_PUT_HPP
 
-#include "irods/rcConnect.h"
-#include "irods/dataObjInpOut.h"
+struct DataOprInp;
+struct RsComm;
+struct portalOprOut;
+struct rodsServerHost;
 
-int rsDataPut( rsComm_t *rsComm, dataOprInp_t *dataPutInp, portalOprOut_t **portalOprOut );
-int remoteDataPut( rsComm_t *rsComm, dataOprInp_t *dataPutInp, portalOprOut_t **portalOprOut, rodsServerHost_t *rodsServerHost );
-int _rsDataPut( rsComm_t *rsComm, dataOprInp_t *dataPutInp, portalOprOut_t **portalOprOut );
+int rsDataPut(RsComm* rsComm, DataOprInp* dataPutInp, portalOprOut** portalOprOut);
+int remoteDataPut(RsComm* rsComm, DataOprInp* dataPutInp, portalOprOut** portalOprOut, rodsServerHost* rodsServerHost);
 
-#endif
+#endif // RS_DATA_PUT_HPP

--- a/server/api/src/rsDataGet.cpp
+++ b/server/api/src/rsDataGet.cpp
@@ -1,18 +1,12 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-/* This is script-generated code (for the most part).  */
-/* See dataGet.h for a description of this API call.*/
-
-#include "irods/rcMisc.h"
-#include "irods/dataGet.h"
-#include "irods/miscServerFunct.hpp"
-#include "irods/rsGlobalExtern.hpp"
-#include "irods/rcGlobalExtern.h"
 #include "irods/rsDataGet.hpp"
 
-/* rsDataGet - this routine setup portalOprOut with the resource server
- * for parallel get operation.
- */
+#include "irods/dataGet.h"
+#include "irods/dataObjInpOut.h"
+#include "irods/miscServerFunct.hpp"
+#include "irods/rcGlobalExtern.h"
+#include "irods/rcMisc.h"
+#include "irods/rodsConnect.h"
+#include "irods/rsGlobalExtern.hpp"
 
 int
 rsDataGet( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
@@ -37,7 +31,7 @@ rsDataGet( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
     }
 
     if ( remoteFlag == LOCAL_HOST ) {
-        status = _rsDataGet( rsComm, dataOprInp, portalOprOut );
+        status = setupSrvPortalForParaOpr(rsComm, dataOprInp, GET_OPR, portalOprOut);
     }
     else {
         addKeyVal( &dataOprInp->condInput, EXEC_LOCALLY_KW, "" );
@@ -48,17 +42,6 @@ rsDataGet( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
 
 
     return status;
-}
-
-int
-_rsDataGet( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
-            portalOprOut_t **portalOprOut ) {
-    return setupSrvPortalForParaOpr(
-               rsComm,
-               dataOprInp,
-               GET_OPR,
-               portalOprOut );
-
 }
 
 int

--- a/server/api/src/rsDataPut.cpp
+++ b/server/api/src/rsDataPut.cpp
@@ -1,19 +1,13 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-/* This is script-generated code (for the most part).  */
-/* See dataPut.h for a description of this API call.*/
-
-#include "irods/rcMisc.h"
-#include "irods/dataPut.h"
-#include "irods/rodsLog.h"
-#include "irods/miscServerFunct.hpp"
-#include "irods/rsGlobalExtern.hpp"
-#include "irods/rcGlobalExtern.h"
 #include "irods/rsDataPut.hpp"
 
-/* rsDataPut - this routine setup portalOprOut with the resource server
- * for parallel put operation.
- */
+#include "irods/dataObjInpOut.h"
+#include "irods/dataPut.h"
+#include "irods/miscServerFunct.hpp"
+#include "irods/rcConnect.h"
+#include "irods/rcGlobalExtern.h"
+#include "irods/rcMisc.h"
+#include "irods/rodsLog.h"
+#include "irods/rsGlobalExtern.hpp"
 
 int
 rsDataPut( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
@@ -38,7 +32,7 @@ rsDataPut( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
     }
 
     if ( remoteFlag == LOCAL_HOST ) {
-        status = _rsDataPut( rsComm, dataOprInp, portalOprOut );
+        status = setupSrvPortalForParaOpr(rsComm, dataOprInp, PUT_OPR, portalOprOut);
     }
     else {
         addKeyVal( &dataOprInp->condInput, EXEC_LOCALLY_KW, "" );
@@ -50,18 +44,6 @@ rsDataPut( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
 
     return status;
 }
-
-int
-_rsDataPut( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
-            portalOprOut_t **portalOprOut ) {
-    int status;
-
-    status = setupSrvPortalForParaOpr( rsComm, dataOprInp, PUT_OPR,
-                                       portalOprOut );
-
-    return status;
-}
-
 
 int
 remoteDataPut( rsComm_t *rsComm, dataOprInp_t *dataOprInp,


### PR DESCRIPTION
In service of https://github.com/irods/irods/issues/4984
In service of https://github.com/irods/irods/issues/6421
In service of https://github.com/irods/irods/issues/7795

Cherry-pick of #8195 
Cherry-pick of #8211 

Supersedes https://github.com/irods/irods/pull/8197

Please note that the cherry-pick has been squashed into a single commit to avoid the revert commit in the main branch. I've noted the cherry-picked SHAs in the commit message for posterity. I've also left changes to the cherry-picked test in this branch as a separate commit to be squashed closer to merge time.

Unit tests passed. Core tests running now.