### PR TITLE
[#8010] Fix: Remove duplicate function declaration (4-3-stable)

### DIFF
--- a/lib/core/include/irods/irods_plugin_base.hpp
+++ b/lib/core/include/irods/irods_plugin_base.hpp
@@ -24,8 +24,6 @@
 
 static double PLUGIN_INTERFACE_VERSION = 2.0;
 
-irods::error add_global_re_params_to_kvp_for_dynpep( keyValPair_t& );
-
 namespace irods
 {
     typedef std::function< irods::error( rcComm_t* ) > pdmo_type;


### PR DESCRIPTION
Issue quick link: #8010

This commit removes a duplicate declaration of the function `add_global_re_params_to_kvp_for_dynpep(...)`.