### PR TITLE
[#7953] Do not log message unless oprType is changed to UNREG_OPR (4-3-stable)

### DIFF
--- a/server/api/src/rsDataObjUnlink.cpp
+++ b/server/api/src/rsDataObjUnlink.cpp
@@ -540,7 +540,7 @@ int dataObjUnlinkS(rsComm_t* rsComm,
                 return err.code();
             }
 
-            if (!has_prefix(dataObjInfo->filePath, vault_path.data())) {
+            if (UNREG_OPR != dataObjUnlinkInp->oprType && !has_prefix(dataObjInfo->filePath, vault_path.data())) {
                 dataObjUnlinkInp->oprType = UNREG_OPR;
 
                 logger::api::info("Replica is not in a vault. Unregistering replica and leaving it on "


### PR DESCRIPTION
I've confirmed at the bench that the code change works as intended. No test necessary since it's just logging.

The message is logged if the oprType is actually changed (i.e. `irm` vs `iunreg`).