### PR TITLE
[#6843] Deprecate modification of ACL policy (4-3-stable)

### DIFF
--- a/packaging/core.re.template
+++ b/packaging/core.re.template
@@ -59,14 +59,20 @@ acRenameLocalZone(*oldZone, *newZone) {
 #acGetUserByDN(*arg,*OUT) {msiExecCmd("t","*arg","null","null","null",*OUT); }
 #
 # --------------------------------------------------------------------------
+# IMPORTANT: Setting the ACL policy to anything other than "STRICT"
+# is deprecated and will be disallowed in later versions of iRODS. It
+# is highly recommended that deployments relying on an ACL policy other
+# than "STRICT" develop a migration plan before upgrading to later
+# versions of iRODS.
+#
 # The following rule is for setting Access Control List (ACL) policy.
 # The possible modifiers are "STRICT", "STANDARD", or any other string,
 # in which case the "STANDARD" behavior will apply.
 #
-# "STANDARD" ACL policy permits permits rodsusers to see other
-# rodsusers' collections by allowing access to metadata which may
-# be sensitive, including data-object and sub-collection names in
-# other users' collections.
+# "STANDARD" ACL policy permits rodsusers to see other rodsusers'
+# collections by allowing access to metadata which may be sensitive,
+# including data-object and sub-collection names in other users'
+# collections.
 #
 # "STRICT" ACL policy will apply the General Query Access Control to
 # collections and dataobject metadata. Thus, ils and other operations

--- a/server/re/src/icatAdminMS.cpp
+++ b/server/re/src/icatAdminMS.cpp
@@ -642,6 +642,10 @@ int msiRenameLocalZoneCollection(msParam_t* _new_zone_name, ruleExecInfo_t* _rei
  *
  * \module core
  *
+ * \deprecated This microservice is deprecated as of 4.3.4 and will be removed
+ * in a later version of iRODS. See the documentation for this microservice in
+ * core.re.template for more information.
+ *
  * \since pre-2.1
  *
  *


### PR DESCRIPTION
The presented implementation logs a warning about setting the ACL policy to something other than STRICT. The problem is that it happens on every fork of an agent due to how 4.3 works. That makes the log file very noisy, especially with the delay server migration check happening every 5 seconds.

As of right now, it seems the solution for the noisy log is to use more IPC. I'd really like to avoid that, but I'm not sure that I can. So, here's some ideas I'm thinking about:
- Use a boost interprocess mutex as a flag
- Or, use a file as a flag

The more I think about this, the more I'm leaning towards removing the edits to the C++ and letting this be purely a job for core.re.template and the release notes.

Thoughts?