### PR TITLE
[#8221] Clear rodsPathInp_t instead of freeing memory (4-3-stable)

### DIFF
--- a/lib/core/src/irods_parse_command_line_options.cpp
+++ b/lib/core/src/irods_parse_command_line_options.cpp
@@ -277,7 +277,7 @@ static int build_irods_path_structure(const path_list_t& _path_list,
         return USER__NULL_INPUT_ERR;
     }
 
-    freeRodsPathInpMembers(_rods_paths);
+    memset(_rods_paths, 0, sizeof(rodsPathInp_t));
 
     if ( _path_list.size() <= 0 ) {
         if ( ( _flag & ALLOW_NO_SRC_FLAG ) == 0 ) {


### PR DESCRIPTION
The test referenced in the issue passed at the bench using a debug build. I only tested the one test case reported in the issue.

Running unit/core tests.

@MartinFlores751 Do you remember if this change was important in the memory leak fix which introduced `freeRodsPathInpMembers`?