### PR TITLE
[#8221] Clear rodsPathInp_t instead of freeing memory (main)

### DIFF
--- a/lib/core/src/irods_parse_command_line_options.cpp
+++ b/lib/core/src/irods_parse_command_line_options.cpp
@@ -277,7 +277,7 @@ static int build_irods_path_structure(const path_list_t& _path_list,
         return USER__NULL_INPUT_ERR;
     }
 
-    freeRodsPathInpMembers(_rods_paths);
+    memset(_rods_paths, 0, sizeof(rodsPathInp_t));
 
     if ( _path_list.size() <= 0 ) {
         if ( ( _flag & ALLOW_NO_SRC_FLAG ) == 0 ) {


### PR DESCRIPTION
Cherry-pick of #8237.