### PR TITLE
[#7934] Ignore SIGPIPE so agents do not terminate immediately (4-3-stable)

### DIFF
--- a/scripts/irods/test/resource_suite.py
+++ b/scripts/irods/test/resource_suite.py
@@ -585,6 +585,8 @@ class ResourceSuite(ResourceBase):
         # function called will return CAT_NO_ROWS_FOUND or something of that sort, which is also fine.
         self.assertNotEqual(str(0), lib.get_replica_size(self.admin, os.path.dirname(logical_path), 0))
 
+        self.admin.assert_icommand(['ils', '-L', logical_path], 'STDOUT') # For debugging.
+
         # Confirm the restart occurs and that the replica is the correct size at the end.
         self.admin.assert_icommand(iputcmd, 'STDOUT', "was restarted successfully")
         self.assertEqual(

--- a/server/core/src/rodsAgent.cpp
+++ b/server/core/src/rodsAgent.cpp
@@ -558,7 +558,9 @@ int runIrodsAgentFactory(sockaddr_un agent_addr)
         std::signal(SIGTERM, SIG_DFL);
         std::signal(SIGCHLD, SIG_DFL);
         std::signal(SIGUSR1, SIG_DFL);
-        std::signal(SIGPIPE, SIG_DFL);
+
+        // Ignore SIGPIPE so agents can handle it at the call site.
+        std::signal(SIGPIPE, SIG_IGN); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
 
         status = receiveDataFromServer(conn_tmp_socket);
         if (status < 0) {


### PR DESCRIPTION
Preparing to run unit/core tests.