### PR TITLE
[#8114] Remove `forkAndExec(...)` (main)

### DIFF
--- a/server/core/include/irods/miscServerFunct.hpp
+++ b/server/core/include/irods/miscServerFunct.hpp
@@ -110,11 +110,7 @@ char *
 getSvrAddr( rodsServerHost_t *rodsServerHost );
 int
 setLocalSrvAddr( char *outLocalAddr );
-int
-forkAndExec( char *av[] );
-int
-setupSrvPortalForParaOpr( rsComm_t *rsComm, dataOprInp_t *dataOprInp,
-                          int oprType, portalOprOut_t **portalOprOut );
+int setupSrvPortalForParaOpr(rsComm_t* rsComm, dataOprInp_t* dataOprInp, int oprType, portalOprOut_t** portalOprOut);
 int
 initServiceUser();
 int

--- a/server/core/src/miscServerFunct.cpp
+++ b/server/core/src/miscServerFunct.cpp
@@ -2515,39 +2515,6 @@ setLocalSrvAddr( char *outLocalAddr ) {
 }
 
 int
-forkAndExec( char *av[] ) {
-    int childPid = 0;
-    int status = -1;
-    int childStatus = 0;
-
-    childPid = RODS_FORK();
-
-    if ( childPid == 0 ) {
-        /* child */
-        execv( av[0], av );
-        /* gets here. must be bad */
-        exit( 1 );
-    }
-    else if ( childPid < 0 ) {
-        rodsLog( LOG_ERROR,
-                 "exectar: RODS_FORK failed. errno = %d", errno );
-        return SYS_FORK_ERROR;
-    }
-
-    /* parent */
-
-    status = waitpid( childPid, &childStatus, 0 );
-    if ( status >= 0 && childStatus != 0 ) {
-        rodsLog( LOG_ERROR,
-                 "forkAndExec: waitpid status = %d, childStatus = %d",
-                 status, childStatus );
-        status = EXEC_CMD_ERROR;
-    }
-
-    return status;
-}
-
-int
 singleRemLocCopy( rsComm_t *rsComm, dataCopyInp_t *dataCopyInp ) {
     dataOprInp_t *dataOprInp;
     int status = 0;


### PR DESCRIPTION
Quick link to issue: #8114

This PR removes the deprecated (in 4.3.4) `forkAndExec(...)` in issue #8109.