### PR TITLE
[#7603] Remove `msiSetResource` (main)

### DIFF
--- a/doxygen/microservices.cpp
+++ b/doxygen/microservices.cpp
@@ -156,7 +156,6 @@
   - #msiSetDataObjAvoidResc - Specifies the copy to avoid
   - #msiSetGraftPathScheme - Sets the scheme for composing the physical path in the vault to GRAFT_PATH
   - #msiSetRandomScheme - Sets the the scheme for composing the physical path in the vault to RANDOM
-  - #msiSetResource  - (Deprecated) sets the resource from default
   - #msiSetNumThreads - specify the parameters for determining the number of threads to use for data transfer
   - #msiNoChkFilePathPerm - Does not check file path permission when registering a file
   - #msiSetChkFilePathPerm - Sets the check type for file path permission check when registering a file

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -192,7 +192,6 @@ class Test_AllRules(resource_suite.ResourceBase, unittest.TestCase, metaclass=me
                 "rulemsiSetPublicUserOpr",
                 "rulemsiSetRandomScheme",
                 "rulemsiSetRescQuotaPolicy",
-                "rulemsiSetResource",
                 "rulemsiNoChkFilePathPerm",
                 "rulemsiNoTrashCan",
             ]

--- a/scripts/irods/test/test_native_rule_engine_plugin.py
+++ b/scripts/irods/test/test_native_rule_engine_plugin.py
@@ -856,30 +856,6 @@ OUTPUT ruleExecOut
             os.unlink(rule_file)
 
     @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'rule language only')
-    def test_msiSetResource__issue_7319(self):
-        rule_map = {
-            'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent('''
-                test_msiSetResource {{
-                    msiSetResource("testResc");
-                }}
-                OUTPUT ruleExecOut
-                ''')
-        }
-
-        rule_file = 'test_msiSetResource.r'
-        with open(rule_file, 'w') as f:
-            f.write(rule_map[self.plugin_name])
-
-        try:
-            rep_name = 'irods_rule_engine_plugin-irods_rule_language-instance'
-
-            self.admin.assert_icommand(['irule', '-r', rep_name, '-F', rule_file], 'STDERR', 'SYS_INTERNAL_NULL_INPUT_ERR', desired_rc=4)
-            self.user0.assert_icommand(['irule', '-r', rep_name, '-F', rule_file], 'STDERR', 'SYS_INTERNAL_NULL_INPUT_ERR', desired_rc=4)
-
-        finally:
-            os.remove(rule_file)
-
-    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'rule language only')
     def test_msiSetDefaultResc__issue_7319(self):
         rule_map = {
             'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent('''

--- a/server/re/include/irods/reAction.hpp
+++ b/server/re/include/irods/reAction.hpp
@@ -37,7 +37,6 @@ int msiBytesBufToStr( msParam_t* buf_msp, msParam_t* str_msp, ruleExecInfo_t *re
 int msiApplyDCMetadataTemplate( msParam_t* inpParam, msParam_t* outParam, ruleExecInfo_t *rei );
 int msiListEnabledMS( msParam_t *outKVPairs, ruleExecInfo_t *rei );
 
-int msiSetResource( msParam_t* xrescName, ruleExecInfo_t *rei );
 int msiPrintKeyValPair( msParam_t* where, msParam_t* inKVPair,  ruleExecInfo_t *rei );
 int msiGetValByKey( msParam_t* inKVPair,  msParam_t* inKey, msParam_t* outVal,  ruleExecInfo_t *rei );
 int msiAddKeyVal( msParam_t *inKeyValPair, msParam_t *key, msParam_t *value, ruleExecInfo_t *rei );
@@ -140,7 +139,6 @@ namespace irods
         table_[ "msiQuota" ] = new irods::ms_table_entry( "msiQuota", 0, std::function<int(ruleExecInfo_t*)>( msiQuota ) );
         table_[ "msiDeleteUnusedAVUs" ] = new irods::ms_table_entry( "msiDeleteUnusedAVUs", 0, std::function<int(ruleExecInfo_t*)>( msiDeleteUnusedAVUs ) );
         table_[ "msiGoodFailure" ] = new irods::ms_table_entry( "msiGoodFailure", 0, std::function<int(ruleExecInfo_t*)>( msiGoodFailure ) );
-        table_[ "msiSetResource" ] = new irods::ms_table_entry( "msiSetResource", 1, std::function<int(msParam_t*,ruleExecInfo_t*)>(  msiSetResource ) );
         table_[ "msiCheckPermission" ] = new irods::ms_table_entry( "msiCheckPermission", 1, std::function<int(msParam_t*,ruleExecInfo_t*)>(  msiCheckPermission ) );
         table_[ "msiCheckAccess" ] = new irods::ms_table_entry( "msiCheckAccess", 3, std::function<int(msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>(  msiCheckAccess ) );
         table_[ "msiCheckOwner" ] = new irods::ms_table_entry( "msiCheckOwner", 0, std::function<int(ruleExecInfo_t*)>( msiCheckOwner ) );

--- a/server/re/src/icatGeneralMS.cpp
+++ b/server/re/src/icatGeneralMS.cpp
@@ -113,52 +113,6 @@ msiQuota( ruleExecInfo_t *rei ) {
 }
 
 /**
- *\fn msiSetResource (msParam_t *xrescName, ruleExecInfo_t *rei)
- *
- * \brief   This microservice sets the resource as part of a workflow execution.
- *
- * \module core
- *
- * \since pre-2.1
- *
- * \deprecated Deprecated in 4.3.2. Its use should be avoided.
- *
- *
- * \note  This microservice sets the resource as part of a workflow execution.
- *
- * \usage See clients/icommands/test/rules/
- *
- * \param[in] xrescName - is a msParam of type STR_MS_T
- * \param[in,out] rei - The RuleExecInfo structure that is automatically
- *    handled by the rule engine. The user does not include rei as a
- *    parameter in the rule invocation.
- *
- * \DolVarDependence none
- * \DolVarModified none
- * \iCatAttrDependence none
- * \iCatAttrModified none
- * \sideeffect none
- *
- * \return integer
- * \retval 0 on success
- * \pre none
- * \post none
- * \sa none
-**/
-int  msiSetResource( msParam_t* xrescName, ruleExecInfo_t *rei ) {
-    char* rescName{static_cast<char*>(xrescName->inOutStruct)};
-
-    if (nullptr == rei->doi) {
-        log_msi::error("{}: Cannot set resource, no DOI (DataObjInfo) attached to REI (RuleExecInfo).", __func__);
-        return SYS_INTERNAL_NULL_INPUT_ERR;
-    }
-
-    std::snprintf(rei->doi->rescName, sizeof(rei->doi->rescName), "%s", rescName);
-    return 0;
-}
-
-
-/**
  * \fn msiCheckOwner (ruleExecInfo_t *rei)
  *
  * \brief   This microservice checks whether the user is the owner


### PR DESCRIPTION
Issue quick link #7603.

This PR removes `msiSetResource(...)`, which was deprecated in iRODS 4.3.2.