### PR TITLE
[#8069] Remove unused config option: agent_factory_watcher_sleep_time_in_seconds (main)

### DIFF
--- a/lib/core/include/irods/irods_configuration_keywords.hpp
+++ b/lib/core/include/irods/irods_configuration_keywords.hpp
@@ -89,7 +89,6 @@ namespace irods
     extern const char* const KW_CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS;
     extern const char* const KW_CFG_MAX_SIZE_OF_DELAY_QUEUE_IN_BYTES;
     extern const char* const KW_CFG_STACKTRACE_FILE_PROCESSOR_SLEEP_TIME_IN_SECONDS;
-    extern const char* const KW_CFG_AGENT_FACTORY_WATCHER_SLEEP_TIME_IN_SECONDS;
     extern const char* const KW_CFG_MIGRATE_DELAY_SERVER_SLEEP_TIME_IN_SECONDS;
 
     extern const char* const KW_CFG_RE_CACHE_SALT;

--- a/lib/core/src/irods_configuration_keywords.cpp
+++ b/lib/core/src/irods_configuration_keywords.cpp
@@ -84,7 +84,6 @@ namespace irods
     const char* const KW_CFG_NUMBER_OF_CONCURRENT_DELAY_RULE_EXECUTORS{"number_of_concurrent_delay_rule_executors"};
     const char* const KW_CFG_MAX_SIZE_OF_DELAY_QUEUE_IN_BYTES{"maximum_size_of_delay_queue_in_bytes"};
     const char* const KW_CFG_STACKTRACE_FILE_PROCESSOR_SLEEP_TIME_IN_SECONDS{"stacktrace_file_processor_sleep_time_in_seconds"};
-    const char* const KW_CFG_AGENT_FACTORY_WATCHER_SLEEP_TIME_IN_SECONDS{"agent_factory_watcher_sleep_time_in_seconds"};
     const char* const KW_CFG_MIGRATE_DELAY_SERVER_SLEEP_TIME_IN_SECONDS{"migrate_delay_server_sleep_time_in_seconds"};
 
     const char* const KW_CFG_RE_CACHE_SALT{"reCacheSalt"};

--- a/packaging/server_config.json.template.in
+++ b/packaging/server_config.json.template.in
@@ -2,7 +2,6 @@
     "schema_name": "server_config",
     "schema_version": "v@IRODS_CONFIGURATION_SCHEMA_VERSION@",
     "advanced_settings": {
-        "agent_factory_watcher_sleep_time_in_seconds": 5,
         "checksum_read_buffer_size_in_bytes": 1048576,
         "default_number_of_transfer_threads": 4,
         "default_temporary_password_lifetime_in_seconds": 120,

--- a/schemas/configuration/v5/server_config.json.in
+++ b/schemas/configuration/v5/server_config.json.in
@@ -6,7 +6,6 @@
         "advanced_settings": {
             "type": "object",
             "properties": {
-                "agent_factory_watcher_sleep_time_in_seconds": {"type": "integer"},
                 "default_number_of_transfer_threads": {"type": "integer"},
                 "default_temporary_password_lifetime_in_seconds": {"type": "integer"},
                 "delay_rule_executors": {

--- a/scripts/irods/upgrade_configuration.py
+++ b/scripts/irods/upgrade_configuration.py
@@ -299,6 +299,7 @@ def convert_to_v5_schema_and_add_missing_properties(server_config):
 
     # Remove keys that are no longer needed by the server.
     # Keys listed here are ones that used to be recognized by the server.
+    new_server_config['advanced_settings'].pop('agent_factory_watcher_sleep_time_in_seconds', None)
     new_server_config.pop('schema_validation_base_uri', None)
     new_server_config.pop('server_control_plane_encryption_algorithm', None)
     new_server_config.pop('server_control_plane_encryption_num_hash_rounds', None)


### PR DESCRIPTION
Need to confirm the upgrade path removes the config option.