### PR TITLE
[#8252] GenQuery1: Return same error as iRODS 4.3.4 on invalid aggregrate function (main)

### DIFF
--- a/lib/genquery1/dsl/parser.y
+++ b/lib/genquery1/dsl/parser.y
@@ -224,7 +224,9 @@ auto add_column_to_projection_list(irods::experimental::genquery1::driver& _drv,
             //     iquest "select COLL_NAME"
             //
             // This flex / bison parser correctly treats this as an error and throws an exception.
-            THROW(INVALID_OPERATION, fmt::format("aggregate function [{}] not supported", *_fn));
+            //
+            // NOTE: As of iRODS 4.3.4, GenQuery1 returns the same error as iRODS 5.
+            THROW(INVALID_GENQUERY_AGGREGATE_FUNCTION, fmt::format("aggregate function [{}] not supported", *_fn));
         }
 
         addInxIval(&_drv.gq_input->selectInp, column_id, aggregate_fn);

--- a/scripts/irods/test/test_iquest.py
+++ b/scripts/irods/test/test_iquest.py
@@ -159,6 +159,10 @@ class Test_Iquest(ResourceBase, unittest.TestCase):
                 self.admin.assert_icommand(['iquest', f"SELECT DATA_NAME, DATA_CREATE_TIME WHERE DATA_NAME = '{data_object}'"], 'STDOUT', expected_output)
                 self.admin.assert_icommand(['iquest', f"SELECT DATA_NAME, DATA_CREATE_TIME WHERE DATA_NAME like '%{data_object}%'"], 'STDOUT', expected_output)
 
+    def test_iquest_returns_error_on_invalid_aggregate_function__issue_8080(self):
+        self.admin.assert_icommand(['iquest', 'select nope(DATA_ID)'], 'STDERR', ['-183000 INVALID_GENQUERY_AGGREGATE_FUNCTION'])
+
+
 class test_iquest_with_data_resc_hier(unittest.TestCase):
     @classmethod
     def setUpClass(self):

--- a/unit_tests/src/test_genquery1_flex_bison_parser.cpp
+++ b/unit_tests/src/test_genquery1_flex_bison_parser.cpp
@@ -109,7 +109,7 @@ TEST_CASE("GenQuery1 flex bison parser returns error on invalid input")
     const std::vector<std::pair<const char*, int>> invalid_queries{
         {"bad formatting", INPUT_ARG_NOT_WELL_FORMED_ERR},
         {"select DATA_RESC_GROUP_NAME where COLL_NAME = '/tempZone/home/otherrods/2024-12-11Z00:41:48--irods-testing-zzdtv1n3' and DATA_NAME = 'test_modifying_restricted_columns'", NO_COLUMN_NAME_FOUND},
-        {"select bad_aggregate_func(COLL_NAME)", INVALID_OPERATION},
+        {"select bad_aggregate_func(COLL_NAME)", INVALID_GENQUERY_AGGREGATE_FUNCTION},
         {"select DATA_RESC_HIER where DATA_NAME = 'foo' and DATA_RESC_HIER  'root;mid;leaf'", INPUT_ARG_NOT_WELL_FORMED_ERR},
         {"select DATA_RESC_HIER where DATA_NAME = 'foo' and DATA_RESC_HIER  'root;mid;leaf1' || like 'root;mid;leaf1'", INPUT_ARG_NOT_WELL_FORMED_ERR},
         {"select DATA_RESC_HIER where DATA_NAME = 'foo' and DATA_RESC_HIER == 'root;mid;leaf'", INPUT_ARG_NOT_WELL_FORMED_ERR},


### PR DESCRIPTION
Still need to run unit/core tests.

```bash
$ iquest "select nope(DATA_ID)"
remote addresses: X.X.X.X ERROR: iquest Error: queryAndShowStrCond failed status = -183000 INVALID_GENQUERY_AGGREGATE_FUNCTION
```