### PR TITLE
[#7578] Remove the `--link` option (main)

### DIFF
--- a/lib/core/include/irods/irods_path_recursion.hpp
+++ b/lib/core/include/irods/irods_path_recursion.hpp
@@ -23,14 +23,15 @@ namespace irods
     // Returns true if the user path is a directory which has not
     // yet been examined, or, throws an irods::exception if the path has
     // already been examined (it's in the set<> already).
-    // The bool parameter is true if the "--link" flag was specified
+    // When the bool parameter is true, symbolic links will not be followed.
+    // See the implementation for more details.
     bool is_path_valid_for_recursion(boost::filesystem::path const &, recursion_map_t &, bool);
 
     // Called in from places where file system loop detection is not desired/needed,
     // regardless of whether or not the recursion_map_t has been initialized by
     // check_directories_for_loops().
     //
-    // The rodsArguments_t object is for checking for the "--link" flag, and the
+    // The rodsArguments_t object is for checking for the "--ignore-symlinks" flag, and the
     // character buffer is for the user filename.
     // Checks for existence of path as a symlink or a directory.
     // Will throw irods::exception if boost fs errors occur in the process.
@@ -44,12 +45,13 @@ namespace irods
     // This is what the icommand xxxxUtil() function uses to scan recursively
     // for directories/symlinks. The path is the user's non-canonical path, and
     // the recursion_map_t is statically defined by the caller as needed.
-    // The bool parameter is true if the "--link" flag was specified
+    // When the bool parameter is true, symbolic links will not be followed.
+    // See the implementation for more details.
     int check_directories_for_loops( boost::filesystem::path const &, irods::recursion_map_t &, bool);
 
     // Issue 3988: For irsync and iput mostly, scan all source physical directories
     // for loops before doing any actual file transfers. Returns a 0 for success or
-    // rodsError error (< 0).  The bool specifies whether the "--link" flag was specified.
+    // rodsError error (< 0).  The bool specifies whether the "--ignore-symlinks" flag was specified.
     int scan_all_source_directories_for_loops(irods::recursion_map_t &, const std::vector<std::string>&, bool);
 
     // This function does the filesystem loop and sanity check

--- a/lib/core/src/irods_parse_command_line_options.cpp
+++ b/lib/core/src/irods_parse_command_line_options.cpp
@@ -49,7 +49,6 @@ static int parse_program_options(
         ("very_verbose,V", "very verbose")
         ("data_type,D", po::value<std::string>(), "dataType - the data type string")
         ("restart_file,X", po::value<std::string>(), "restartFile - specifies that the restart option is on and the restartFile input specifies a local file that contains the restart information.")
-        ("link", "[Deprecated] ignore symlinks. Use --ignore-symlinks.")
         ("ignore-symlinks", "ignore symlinks.")
         ("lfrestart", po::value<std::string>(), "lfRestartFile - specifies that the large file restart option is on and the lfRestartFile input specifies a local file that contains the restart information.")
         ("retries", po::value<int>(), "count - Retry the iput in case of error. The 'count' input specifies the number of times to retry. It must be used with the -X option")
@@ -203,7 +202,7 @@ static int parse_program_options(
             return INVALID_ANY_CAST;
         }
     }
-    if (global_prog_ops_var_map.count("ignore-symlinks") || global_prog_ops_var_map.count("link")) {
+    if (global_prog_ops_var_map.count("ignore-symlinks")) {
         _rods_args.link = 1;
     }
     if ( global_prog_ops_var_map.count( "lfrestart" ) ) {

--- a/lib/core/src/irods_path_recursion.cpp
+++ b/lib/core/src/irods_path_recursion.cpp
@@ -73,7 +73,7 @@ irods::check_for_filesystem_loop(boost::filesystem::path const & cpath,
 }
 
 // Called in places where file system loop detection is not desired/needed.
-// The rodsArguments_t object is for checking for the "--link" flag, and the
+// The rodsArguments_t object is for checking for the "--ignore-symlinks" flag, and the
 // character buffer is for the user filename.
 // Checks for existence of path as a symlink or a directory.
 // Will throw irods::exception if boost file system errors occur in the process.
@@ -93,8 +93,8 @@ irods::is_path_valid_for_recursion( boost::filesystem::path const & userpath,
         }
     }(userpath);
 
-    // Return early if the provided path is a symlink and --link is being used. --link means that symlinks should be
-    // ignored, so the path is going to be ignored - that is, it should not be examined.
+    // Return early if the provided path is a symlink and --ignore-symlinks is being used. --ignore-symlinks means that
+    // symlinks should be ignored, so the path is going to be ignored - that is, it should not be examined.
     if (dashdashlink && fs::is_symlink(normal_path)) {
         return false;
     }
@@ -157,7 +157,7 @@ irods::is_path_valid_for_recursion( boost::filesystem::path const & userpath,
 // regardless of whether or not the recursion_map_t has been initialized by
 // check_directories_for_loops().
 //
-// The rodsArguments_t object is for checking for the "--link" flag, and the
+// The rodsArguments_t object is for checking for the "--ignore-symlinks" flag, and the
 // character buffer is for the user filename.
 //
 // Checks for existence of path as a symlink or a directory.

--- a/lib/core/src/parseCommandLine.cpp
+++ b/lib/core/src/parseCommandLine.cpp
@@ -49,7 +49,7 @@ parseCmdLineOpt( int argc, char **argv, const char *optString, int includeLong,
     /* handle the long options first */
     if ( includeLong ) {
         for ( int i = 0; i < argc; i++ ) {
-            if (std::strcmp("--ignore-symlinks", argv[i]) == 0 || std::strcmp("--link", argv[i]) == 0) {
+            if (std::strcmp("--ignore-symlinks", argv[i]) == 0) {
                 rodsArgs->link = True;
                 argv[i] = "-Z"; /* ignore symlink */
             }

--- a/lib/core/src/putUtil.cpp
+++ b/lib/core/src/putUtil.cpp
@@ -818,7 +818,7 @@ putDirUtil( rcComm_t **myConn, char *srcDir, char *targColl,
 
             if ( is_symlink( p ) ) {
                 if (rodsArgs->link) {
-                    // --link option means ignore symlinks.
+                    // --ignore-symlinks option means ignore symlinks.
                     continue;
                 }
                 fs::path cp = read_symlink( p );

--- a/lib/core/src/rodsPath.cpp
+++ b/lib/core/src/rodsPath.cpp
@@ -36,10 +36,10 @@ auto parse_local_path(const RodsArguments* _args, RodsPath* _path) -> int
         std::strncpy(_path->outPath, _path->inPath, MAX_NAME_LEN);
     }
 
-    // getFileType calls boost::filesystem::exists, which follows symlinks. --link is supposed to ignore symlinks.
-    // We do not know whether this symlink exists, and we do not care whether it exists. The path could be removed
-    // from the list at this point, but this could create a hole which has not happened in the past. Therefore, we
-    // must now lie in order to keep up the historical interfaces and trust that the symlink will continue to be
+    // getFileType calls boost::filesystem::exists, which follows symlinks. --ignore-symlinks is supposed to ignore
+    // symlinks. We do not know whether this symlink exists, and we do not care whether it exists. The path could be
+    // removed from the list at this point, but this could create a hole which has not happened in the past. Therefore,
+    // we must now lie in order to keep up the historical interfaces and trust that the symlink will continue to be
     // ignored down the line. The lie is that the symlink is a local file and that it exists.
     if (_args->link == True && fs::is_symlink(fs::path{_path->inPath})) {
         _path->objType = LOCAL_FILE_T;

--- a/lib/core/src/rsyncUtil.cpp
+++ b/lib/core/src/rsyncUtil.cpp
@@ -855,7 +855,7 @@ rsyncDirToCollUtil( rcComm_t *conn, rodsPath_t *srcPath,
                   targColl, childPath.c_str() );
         if ( is_symlink( p ) ) {
             if (rodsArgs->link) {
-                // --link option means ignore symlinks.
+                // --ignore-symlinks option means ignore symlinks.
                 continue;
             }
             fs::path cp = read_symlink( p );

--- a/scripts/irods/test/test_iput.py
+++ b/scripts/irods/test/test_iput.py
@@ -616,7 +616,7 @@ class Test_Iput(session.make_sessions_mixin(rodsadmins, rodsusers), unittest.Tes
             self.admin.run_icommand(['iadmin', 'rmresc', ufs_resource_2])
 
     def test_iput_link_option_ignores_symlinks__issue_5359(self):
-        """Creates a directory to target for iput -r --link with good and bad symlinks which should all be ignored."""
+        """Creates a directory to target for iput -r --ignore-symlinks with good and bad symlinks which should all be ignored."""
 
         import shutil
 
@@ -703,9 +703,9 @@ class Test_Iput(session.make_sessions_mixin(rodsadmins, rodsusers), unittest.Tes
             self.assertFalse(os.path.exists(deleted_file_path))
             self.assertTrue(os.path.lexists(broken_symlink_file_path))
 
-            # Run iput to upload the directory. Use the --link option to instruct that symlinks are to be ignored,
+            # Run iput to upload the directory. Use the --ignore-symlinks option to instruct that symlinks are to be ignored,
             # broken or not.
-            self.user.assert_icommand(['iput', '--link', '-r', put_dir, collection_path])
+            self.user.assert_icommand(['iput', '--ignore-symlinks', '-r', put_dir, collection_path])
 
             # Confirm that the main collection was created - no funny business there.
             self.assertTrue(lib.collection_exists(self.user, collection_path))

--- a/scripts/irods/test/test_irsync.py
+++ b/scripts/irods/test/test_irsync.py
@@ -442,7 +442,7 @@ class Test_iRsync(ResourceBase, unittest.TestCase):
         self.user0.assert_icommand("irsync -r {local_dir} i:{base_name}".format(**locals()))
 
     def test_irsync_link_option_ignores_symlinks__issue_5359(self):
-        """Creates a directory to target for irsync -r --link with good and bad symlinks which should all be ignored."""
+        """Creates a directory to target for irsync -r --ignore-symlinks with good and bad symlinks which should all be ignored."""
 
         dirname = 'test_irsync_link_option_ignores_broken_symlinks__issue_5359'
         collection_path = os.path.join(self.user0.session_collection, dirname)
@@ -527,9 +527,9 @@ class Test_iRsync(ResourceBase, unittest.TestCase):
             self.assertFalse(os.path.exists(deleted_file_path))
             self.assertTrue(os.path.lexists(broken_symlink_file_path))
 
-            # Run irsync between the local directory and the collection (which is basically an iput). Use the --link
+            # Run irsync between the local directory and the collection (which is basically an iput). Use the --ignore-symlinks
             # option to instruct that symlinks are to be ignored, broken or not.
-            self.user0.assert_icommand(['irsync', '--link', '-r', sync_dir, f'i:{collection_path}'])
+            self.user0.assert_icommand(['irsync', '--ignore-symlinks', '-r', sync_dir, f'i:{collection_path}'])
 
             # Confirm that the main collection was created - no funny business there.
             self.assertTrue(lib.collection_exists(self.user0, collection_path))

--- a/scripts/irods/test/test_symlink_operations.py
+++ b/scripts/irods/test/test_symlink_operations.py
@@ -37,7 +37,7 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
     def test_iput_r_symlink_issue_4009_4013_with_no_symlinks(self):
 
         # Construct the file system version of a directory with a file and symbolic links,
-        # and then move them to a collection in irods - with the --link flag.
+        # and then move them to a collection in irods - with the --ignore-symlinks flag.
 
         base_name = 'test_iput_r_no_symlinks_4009_4013'
         target_collection = 'target_' + base_name
@@ -74,7 +74,7 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
         anotherdirsym1 = os.path.join(local_dir, 'anotherdirsym1')
         lib.execute_command(['ln', '-s', local_anotherdir, anotherdirsym1])
 
-        self.user0.assert_icommand('iput -r --link {local_dir} {target_collection_path}'.format(**locals()))
+        self.user0.assert_icommand('iput -r --ignore-symlinks {local_dir} {target_collection_path}'.format(**locals()))
 
         cmd = 'ils -lr {target_collection_path}'.format(**locals())
         stdout,_,_ = self.user0.run_icommand(cmd)
@@ -85,7 +85,7 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
         # /tempZone/home/alice/2018-07-10Z05:35:12--irods-testing-ZIqHQ6/target_test_iput_r_symlink_4009_4013/test_iput_r_symlink_4009_4013:
         #   alice             0 demoResc           10 2018-07-10.01:35 & the_file
         #
-        # and that's it.  What we should not see, is this (because of the --link flag):
+        # and that's it.  What we should not see, is this (because of the --ignore-symlinks flag):
         #
         #   alice             0 demoResc           10 2018-07-10.01:35 & link1
         #   alice             0 demoResc           10 2018-07-10.01:35 & link2
@@ -122,7 +122,7 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
     def test_iput_r_symlink_issue_4009_4013_with_symlinks(self):
 
         # Construct the file system version of a directory with a file and symbolic links,
-        # and then move them to a collection in irods - with no --link flag.
+        # and then move them to a collection in irods - with no --ignore-symlinks flag.
 
         base_name = 'test_iput_r_symlink_4009_4013'
         target_collection = 'target_' + base_name
@@ -160,7 +160,7 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
         lib.execute_command(['ln', '-s', local_anotherdir, anotherdirsym1])
 
         ##################################
-        # --link flag OFF:  Move the data into irods, with all valid symbolic links
+        # --ignore-symlinks flag OFF:  Move the data into irods, with all valid symbolic links
         ########
         self.user0.assert_icommand('iput -r {local_dir} {target_collection_path}'.format(**locals()))
 
@@ -213,11 +213,11 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
         ########
         test_list = [
                         'irsync -r {dirname1} i:{target_collection_path}',
-                        'irsync --link -r {dirname1} i:{target_collection_path}',
+                        'irsync --ignore-symlinks -r {dirname1} i:{target_collection_path}',
                         'iput -r {dirname1} {target_collection_path}',
-                        'iput --link -r {dirname1} {target_collection_path}',
+                        'iput --ignore-symlinks -r {dirname1} {target_collection_path}',
                         'iput -r {dirname1}',
-                        'iput --link -r {dirname1}'
+                        'iput --ignore-symlinks -r {dirname1}'
                     ]
 
         base_name = 'iputrsync_recursive_dangling_symlink'
@@ -249,7 +249,7 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
                     # Create the test collection every time because it has to be cleaned up every time.
                     self.user0.run_icommand(['imkdir', target_collection_path])
 
-                    ignore_symlinks = '--link' in teststring
+                    ignore_symlinks = '--ignore-symlinks' in teststring
 
                     cmd = teststring.format(**locals())
                     stdout,stderr,_ = self.user0.run_icommand(cmd)
@@ -303,9 +303,9 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
         ########
         test_list = [
                         'iput {dangling_symlink}',
-                        'iput --link {dangling_symlink}',
+                        'iput --ignore-symlinks {dangling_symlink}',
                         'irsync {dangling_symlink} i:{target_collection_path}',
-                        'irsync --link {dangling_symlink} i:{target_collection_path}',
+                        'irsync --ignore-symlinks {dangling_symlink} i:{target_collection_path}',
                     ]
 
         base_name = 'iputrsync_file_dangling_symlink'
@@ -335,7 +335,7 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
             ########
             for teststring in test_list:
                 with self.subTest(teststring):
-                    ignore_symlinks = '--link' in teststring
+                    ignore_symlinks = '--ignore-symlinks' in teststring
 
                     cmd = teststring.format(**locals())
                     stdout,stderr,_ = self.user0.run_icommand(cmd)
@@ -384,7 +384,7 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
                     ]
 
         # Construct the file system version of a directory with a file and symbolic links,
-        # and then move them to a collection in irods - with no --link flag.
+        # and then move them to a collection in irods - with no --ignore-symlinks flag.
 
         base_name = 'iput_irsync_sanity_with_symlinks'
         local_dir = os.path.join(self.testing_tmp_dir, base_name)
@@ -574,7 +574,7 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
     ##################################
     # Tests the normal operation of both iput and irsync with directories
     # and files, which inlucde valid symbolic links to files and directories
-    # as well, with the --link flag specified.
+    # as well, with the --ignore-symlinks flag specified.
     #
     # The scenarios being tested here are enumerated in the list of strings
     # "test_list" below.
@@ -585,13 +585,13 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
         # Both of these tests (should) produce the same behavior and results:
         ########
         test_list = [
-                        'iput --link -r {dirname1} {dirname2} {target_collection_path}',
-                        'irsync --link -r {dirname1} {dirname2} i:{target_collection_path}'
+                        'iput --ignore-symlinks -r {dirname1} {dirname2} {target_collection_path}',
+                        'irsync --ignore-symlinks -r {dirname1} {dirname2} i:{target_collection_path}'
                     ]
 
         ##################################
         # Construct the file system version of a directory with a file and symbolic links,
-        # and then move them to a collection in irods - with no --link flag.
+        # and then move them to a collection in irods - with no --ignore-symlinks flag.
         ########
         base_name = 'iput_irsync_sanity_no_symlinks'
         local_dir = os.path.join(self.testing_tmp_dir, base_name)
@@ -750,24 +750,24 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
         ########
         test_list = [
                         'iput -r {dirname1} {target_collection_path}',
-                        'iput --link -r {dirname1} {target_collection_path}',
+                        'iput --ignore-symlinks -r {dirname1} {target_collection_path}',
                         'iput -r {dirname1}',
-                        'iput --link -r {dirname1}',
+                        'iput --ignore-symlinks -r {dirname1}',
                         'irsync -r {dirname1} i:{target_collection_path}',
-                        'irsync --link -r {dirname1} i:{target_collection_path}'
+                        'irsync --ignore-symlinks -r {dirname1} i:{target_collection_path}'
                     ]
 
         second_test_list = [
                         'iput {dirname1}/symself {target_collection_path}',
-                        'iput --link -r {dirname1}/symself {target_collection_path}',
+                        'iput --ignore-symlinks -r {dirname1}/symself {target_collection_path}',
                         'iput -r {dirname1}/symself',
-                        'iput --link -r {dirname1}/symself',
+                        'iput --ignore-symlinks -r {dirname1}/symself',
                         'irsync -r {dirname1}/symself i:{target_collection_path}',
-                        'irsync --link -r {dirname1}/symself i:{target_collection_path}'
+                        'irsync --ignore-symlinks -r {dirname1}/symself i:{target_collection_path}'
                     ]
 
         # Construct the file system version of a directory with a file and symbolic links,
-        # and then move them to a collection in irods - with no --link flag.
+        # and then move them to a collection in irods - with no --ignore-symlinks flag.
 
         base_name = 'iput_irsync_recursive_symlink_loop_to_self'
         local_dir = os.path.join(self.testing_tmp_dir, base_name)
@@ -796,7 +796,7 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
             ########
             for teststring in test_list:
                 with self.subTest(teststring):
-                    ignore_symlinks = '--link' in teststring
+                    ignore_symlinks = '--ignore-symlinks' in teststring
 
                     # Run the command:
                     cmd = teststring.format(**locals())
@@ -843,7 +843,7 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
             ########
             for teststring in second_test_list:
                 with self.subTest(teststring):
-                    ignore_symlinks = '--link' in teststring
+                    ignore_symlinks = '--ignore-symlinks' in teststring
 
                     # Run the command:
                     cmd = teststring.format(**locals())
@@ -882,7 +882,7 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
 
         ##################################
         # Construct the file system version of a directory with a file and symbolic links,
-        # and then move them to a collection in irods - with no --link flag.
+        # and then move them to a collection in irods - with no --ignore-symlinks flag.
         ########
         base_name = 'iput_irsync_symlink_loop_general'
         local_dir = os.path.join(self.testing_tmp_dir, base_name)
@@ -981,14 +981,14 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
         # All of these tests (should) produce the same behavior and results: SUCCEED
         ########
         ok_test_list = [
-                        'iput --link -r {dirname1}',
-                        'iput --link -r {dirname1} {target_collection_path}',
-                        'irsync --link -r {dirname1} i:{target_collection_path}',
+                        'iput --ignore-symlinks -r {dirname1}',
+                        'iput --ignore-symlinks -r {dirname1} {target_collection_path}',
+                        'irsync --ignore-symlinks -r {dirname1} i:{target_collection_path}',
                     ]
 
 
         # Construct the file system version of a directory with a file and symbolic links,
-        # and then move them to a collection in irods - with no --link flag.
+        # and then move them to a collection in irods - with no --ignore-symlinks flag.
         base_name = 'test_iput_irsync_no_permissions'
         local_dir = os.path.join(self.testing_tmp_dir, base_name)
         target_collection = 'target_' + base_name
@@ -1067,7 +1067,7 @@ class Test_Symlink_Operations(resource_suite.ResourceBase, unittest.TestCase):
                 self.assertIn('Permission denied', stderr,
                                 '{0}: Expected stderr: "...{1}...", got: "{2}"'.format(cmd, errstr, stderr))
 
-                # Given --link, make sure the loop link is nowhere in this collection tree:
+                # Given --ignore-symlinks, make sure the loop link is nowhere in this collection tree:
                 cmd = 'ils -lr {target_collection_path}'.format(**locals())
                 self.user0.assert_icommand_fail( cmd, 'STDOUT_SINGLELINE', 'validsymlinktodir2' );
 


### PR DESCRIPTION
Issue quick link: #7578.

This PR removes all documentation and code on `--link` option, and substitutes with `--ignore-symlinks` when able.
Since there were a lot of `--links` in the tests, a bulk substitution was done there.

Core and unit tests passed (save for `Test_ImetaQu`, which is handled here: https://github.com/irods/irods/pull/8320#issue-2943716157).