### PR TITLE
[#8261] Give control of SQL DISTINCT to caller (4-3-stable)

### DIFF
--- a/server/genquery2/dsl/lexer.l
+++ b/server/genquery2/dsl/lexer.l
@@ -63,7 +63,6 @@
 (?i:like)              return yy::parser::make_LIKE(loc);
 (?i:in)                return yy::parser::make_IN(loc);
 (?i:between)           return yy::parser::make_BETWEEN(loc);
-(?i:no)                return yy::parser::make_NO(loc);
 (?i:distinct)          return yy::parser::make_DISTINCT(loc);
 (?i:order)             return yy::parser::make_ORDER(loc);
 (?i:by)                return yy::parser::make_BY(loc);

--- a/server/genquery2/dsl/parser.y
+++ b/server/genquery2/dsl/parser.y
@@ -91,7 +91,7 @@ This option causes make_* functions to be generated for each token kind.
     LESS_THAN_OR_EQUAL_TO
     LIKE
     LIMIT
-    NO DISTINCT
+    DISTINCT
     NOT
     NOT_EQUAL
     NULL
@@ -162,8 +162,8 @@ genquery2:
 select:
   SELECT projection_list { std::swap(drv.select.projections, $2); }
 | SELECT projection_list WHERE condition_list { std::swap(drv.select.projections, $2); std::swap(drv.select.conditions, $4); }
-| SELECT NO DISTINCT projection_list { drv.select.distinct = false; std::swap(drv.select.projections, $4); }
-| SELECT NO DISTINCT projection_list WHERE condition_list { drv.select.distinct = false; std::swap(drv.select.projections, $4); std::swap(drv.select.conditions, $6); }
+| SELECT DISTINCT projection_list { drv.select.distinct = true; std::swap(drv.select.projections, $3); }
+| SELECT DISTINCT projection_list WHERE condition_list { drv.select.distinct = true; std::swap(drv.select.projections, $3); std::swap(drv.select.conditions, $5); }
 ;
 
 group_by:

--- a/server/genquery2/dsl/parser.y
+++ b/server/genquery2/dsl/parser.y
@@ -248,6 +248,7 @@ argument_list:
 
 function:
   IDENTIFIER PAREN_OPEN argument_list PAREN_CLOSE { $$ = gq2_detail::function{std::move($1), std::move($3)}; }
+| IDENTIFIER PAREN_OPEN DISTINCT argument_list PAREN_CLOSE { $$ = gq2_detail::function{std::move($1), std::move($4), true}; }
 ;
 
 condition_list:

--- a/server/genquery2/include/irods/private/genquery2_ast_types.hpp
+++ b/server/genquery2/include/irods/private/genquery2_ast_types.hpp
@@ -33,14 +33,18 @@ namespace irods::experimental::genquery2
     {
         function() = default;
 
-        function(std::string name, std::vector<std::variant<std::string, column, function>> _arguments)
+        function(std::string name,
+                 std::vector<std::variant<std::string, column, function>> _arguments,
+                 bool _distinct = false)
             : name{std::move(name)}
             , arguments{std::move(_arguments)}
+            , distinct{_distinct}
         {
         }
 
         std::string name;
         std::vector<std::variant<std::string, column, function>> arguments;
+        bool distinct;
     }; // struct function
 
     struct condition_like

--- a/server/genquery2/include/irods/private/genquery2_ast_types.hpp
+++ b/server/genquery2/include/irods/private/genquery2_ast_types.hpp
@@ -277,7 +277,7 @@ namespace irods::experimental::genquery2
         group_by group_by;
         order_by order_by;
         range range;
-        bool distinct = true;
+        bool distinct = false;
     }; // struct select
 } // namespace irods::experimental::genquery2
 

--- a/server/genquery2/src/genquery2_sql.cpp
+++ b/server/genquery2/src/genquery2_sql.cpp
@@ -703,11 +703,15 @@ namespace
             }
         });
 
+        if (_function.distinct) {
+            return fmt::format("{}(distinct {})", _function.name, fmt::join(args, ", "));
+        }
+
         return fmt::format("{}({})", _function.name, fmt::join(args, ", "));
     } // to_sql_for_order_by_clause
 
     auto generate_order_by_clause(
-        const gq_state& _state,
+        gq_state& _state,
         const gq::order_by& _order_by,
         [[maybe_unused]] const std::map<std::string_view, gq::column_info>& _column_name_mappings) -> std::string
     {
@@ -1027,6 +1031,16 @@ namespace irods::experimental::genquery2
                 args.emplace_back(fmt::format("cast({}.{} as {})", alias, iter->second.name, p->type_name));
             }
         });
+
+        // Limits use of COUNT(DISTINCT) to the SELECT clause. We allow a comma-separated list of arguments
+        // because some databases (e.g. MySQL) support COUNT(DISTINCT ARG0, ..., ARGN).
+        if (_function.distinct) {
+            if (!_state.in_select_clause) {
+                throw std::runtime_error{"use of DISTINCT keyword in function outside of SELECT clause is not allowed"};
+            }
+
+            return fmt::format("{}(distinct {})", _function.name, fmt::join(args, ", "));
+        }
 
         return fmt::format("{}({})", _function.name, fmt::join(args, ", "));
     } // to_sql

--- a/server/genquery2/src/genquery2_sql.cpp
+++ b/server/genquery2/src/genquery2_sql.cpp
@@ -706,10 +706,10 @@ namespace
         return fmt::format("{}({})", _function.name, fmt::join(args, ", "));
     } // to_sql_for_order_by_clause
 
-    auto generate_order_by_clause(const gq_state& _state,
-                                  const gq::order_by& _order_by,
-                                  const std::map<std::string_view, gq::column_info>& _column_name_mappings)
-        -> std::string
+    auto generate_order_by_clause(
+        const gq_state& _state,
+        const gq::order_by& _order_by,
+        [[maybe_unused]] const std::map<std::string_view, gq::column_info>& _column_name_mappings) -> std::string
     {
         if (_order_by.sort_expressions.empty()) {
             return {};


### PR DESCRIPTION
Cherry-pick of #8339.

84e6882f2a4cb02d8418399ca941b090cf259bc3 is not included because it is specific to iRODS 5.