### PR TITLE
[#8016] Erase AUTH_PASSWORD_KEY from response in pam_password (main)

### DIFF
--- a/plugins/authentication/src/pam_password.cpp
+++ b/plugins/authentication/src/pam_password.cpp
@@ -287,8 +287,18 @@ namespace irods
 
             json resp{req};
 
+            // This operation asserts that the key exists in the request above, so we know that it is there.
+            const auto password_iter = resp.find(irods::AUTH_PASSWORD_KEY);
+            const auto password = password_iter->get<std::string>();
+
+            // Erase the password key as soon as it is no longer needed to avoid sending it back in the response.
+            resp.erase(password_iter);
+
             log_auth::trace("getting TTL param");
 
+            // Check TTL parameters before checking the password so that we avoid unnecessary communication with the PAM
+            // service. If we cannot authenticate with the iRODS server because of a bad TTL input, there is no reason
+            // to check the PAM credentials.
             int ttl = 0;
             if (const auto ttl_iter = req.find(irods::AUTH_TTL_KEY); ttl_iter != req.end()) {
                 if (const auto& ttl_str = ttl_iter->get_ref<const std::string&>(); !ttl_str.empty()) {
@@ -302,7 +312,6 @@ namespace irods
             }
 
             const auto& username = req.at("user_name").get_ref<const std::string&>();
-            const auto& password = req.at(irods::AUTH_PASSWORD_KEY).get_ref<const std::string&>();
 
             log_auth::trace("performing PAM auth check for [{}]", username);
 


### PR DESCRIPTION
In service of #8016

Only ran `test_pam_password_authentication` and it passes. Can run the whole test suite if desired.