### PR TITLE
Enable auth plugins to accept passwords in requests, add 5.0 error code (4-3-stable)

### DIFF
--- a/lib/core/include/irods/rodsErrorTable.h
+++ b/lib/core/include/irods/rodsErrorTable.h
@@ -896,6 +896,7 @@ NEW_ERROR(OOI_REVID_NOT_FOUND,                         -2211000)
  */
 NEW_ERROR(DEPRECATED_PARAMETER,                        -3000000)
 NEW_ERROR(DEPRECATED_API,                              -3001000)
+NEW_ERROR(DEPRECATED_AUTHENTICATION_PLUGIN,            -3002000) // iRODS 5 error code
 /** @} */
 
 /* XML parsing and TDS error */

--- a/plugins/auth/src/native.cpp
+++ b/plugins/auth/src/native.cpp
@@ -7,6 +7,8 @@
 #include "irods/authResponse.h"
 #include "irods/authenticate.h"
 #include "irods/base64.hpp"
+#include "irods/checksum.h" // for hashToStr
+#include "irods/irods_at_scope_exit.hpp"
 #include "irods/irods_auth_constants.hpp"
 #include "irods/irods_auth_plugin.hpp"
 #include "irods/irods_logger.hpp"
@@ -35,9 +37,42 @@ int get64RandomBytes( char *buf );
 void setSessionSignatureClientside( char* _sig );
 void _rsSetAuthRequestGetChallenge( const char* _c );
 
-using json = nlohmann::json;
-using log_auth = irods::experimental::log::authentication;
-namespace irods_auth = irods::experimental::auth;
+namespace
+{
+    using json = nlohmann::json;
+    using log_auth = irods::experimental::log::authentication;
+    namespace irods_auth = irods::experimental::auth;
+
+    auto get_password_from_client_stdin() -> std::string
+    {
+        termios tty{};
+        tcgetattr(STDIN_FILENO, &tty);
+        const tcflag_t oldflag = tty.c_lflag;
+        // NOLINTNEXTLINE(hicpp-signed-bitwise)
+        tty.c_lflag &= ~ECHO;
+        if (const int error = tcsetattr(STDIN_FILENO, TCSANOW, &tty); 0 != error) {
+            fmt::print("WARNING: Error {} disabling echo mode. "
+                       "Password will be displayed in plaintext.\n",
+                       errno);
+        }
+        fmt::print("Enter your current iRODS password:");
+        std::string password{};
+        getline(std::cin, password);
+        fmt::print("\n");
+        tty.c_lflag = oldflag;
+        if (0 != tcsetattr(STDIN_FILENO, TCSANOW, &tty)) {
+            fmt::print("Error reinstating echo mode.");
+        }
+
+        return password;
+    } // get_password_from_client_stdin
+
+    auto force_password_prompt(const nlohmann::json& _req) -> bool
+    {
+        const auto force_prompt = _req.find(irods_auth::force_password_prompt);
+        return _req.end() != force_prompt && force_prompt->get<bool>();
+    } // force_password_prompt
+} // anonymous namespace
 
 namespace irods
 {
@@ -98,38 +133,62 @@ namespace irods
             // backwards compatibility.
             set_session_signature_client_side(&_comm, md5_buf, sizeof(md5_buf));
 
-            // determine if a password challenge is needed, are we anonymous or not?
-            bool need_password = false;
+            // Store the user's password in here so that it can be restored later. It needs to be removed from the
+            // request payload sent to the server in case secure communications (TLS) have not been enabled.
+            [[maybe_unused]] std::string client_provided_password;
+
+            // Determine if a password is needed.
+            const auto password_key_iter = resp.find(irods::AUTH_PASSWORD_KEY);
+
+            // This if-ladder could no doubt be made better. However, it correctly implements the means of obtaining a
+            // password to use for authentication in priority order. The case for forcing a password prompt and the
+            // fallback behavior of prompting the user for a password when no password was otherwise provided are
+            // identical, and this makes clang-tidy upset. The forced password prompt takes priority over the other
+            // cases, and the other cases take priority over the default case. We will ignore "bugprone-branch-clone"
+            // here because while the branches are clones, they should not be collapsed.
+
+            // NOLINTBEGIN(bugprone-branch-clone)
+
+            // Anonymous user does not need (or have) a password.
             if (req.at("user_name").get_ref<const std::string&>() == ANONYMOUS_USER) {
                 md5_buf[CHALLENGE_LEN + 1] = '\0';
             }
+            // If the client wants to forcibly prompt for a password, get the password from stdin.
+            else if (force_password_prompt(req)) {
+                client_provided_password = get_password_from_client_stdin();
+            }
+            // If the client has provided a password in the request, use that. Historically, we have given preference to
+            // the .irodsA file, but we want to honor explicit provision of the password in the request now.
+            else if (password_key_iter != resp.end()) {
+                const auto& password = password_key_iter->get_ref<const std::string&>();
+                if (password.length() > MAX_PASSWORD_LEN) {
+                    THROW(PASSWORD_EXCEEDS_MAX_SIZE,
+                          fmt::format("Provided password exceeds maximum length [{}].", MAX_PASSWORD_LEN));
+                }
+                // We do not need to remove the password from the request payload because no server communication
+                // occurs in this operation.
+                client_provided_password = password;
+            }
+            // If an .irodsA file exists, use the password from there. The array size matches the buffer in obfGetPw.
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+            else if (std::array<char, MAX_PASSWORD_LEN + 10> password{}; 0 == obfGetPw(password.data())) {
+                client_provided_password = password.data();
+                // Clear out the buffer since it exists on the stack and contains a password.
+                password.fill('\0');
+            }
+            // If the password cannot be derived any other way, prompt from stdin.
             else {
-                need_password = obfGetPw(md5_buf + CHALLENGE_LEN);
+                client_provided_password = get_password_from_client_stdin();
             }
 
-            // prompt for a password if necessary
-            if (need_password) {
-                struct termios tty;
-                memset( &tty, 0, sizeof( tty ) );
-                tcgetattr( STDIN_FILENO, &tty );
-                tcflag_t oldflag = tty.c_lflag;
-                tty.c_lflag &= ~ECHO;
-                int error = tcsetattr( STDIN_FILENO, TCSANOW, &tty );
-                int errsv = errno;
+            // NOLINTEND(bugprone-branch-clone)
 
-                if (error) {
-                    fmt::print("WARNING: Error {} disabling echo mode. "
-                               "Password will be displayed in plaintext.\n", errsv);
-                }
-                fmt::print("Enter your current iRODS password:");
-                std::string password{};
-                getline(std::cin, password);
-                strncpy(md5_buf + CHALLENGE_LEN, password.c_str(), MAX_PASSWORD_LEN);
-                fmt::print("\n");
-                tty.c_lflag = oldflag;
-                if (tcsetattr(STDIN_FILENO, TCSANOW, &tty)) {
-                    fmt::print("Error reinstating echo mode.");
-                }
+            if (!client_provided_password.empty()) {
+                std::strncpy(
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                    static_cast<char*>(md5_buf) + CHALLENGE_LEN,
+                    client_provided_password.c_str(),
+                    MAX_PASSWORD_LEN);
             }
 
             // create a md5 hash of the challenge
@@ -155,6 +214,11 @@ namespace irods
                 THROW(err, "base64 encoding of digest failed.");
             }
 
+            // If a password was saved and not provided in the request, put it in the payload here.
+            if (resp.end() == password_key_iter && !client_provided_password.empty()) {
+                resp[irods::AUTH_PASSWORD_KEY] = client_provided_password;
+            }
+
             resp["digest"] = std::string{reinterpret_cast<char*>(out), out_len};
             resp[irods_auth::next_operation] = AUTH_CLIENT_AUTH_RESPONSE;
 
@@ -164,10 +228,25 @@ namespace irods
         json native_auth_client_request(rcComm_t& comm, const json& req)
         {
             json svr_req{req};
+
+            // Do not transmit the password in the request to the server if it was supplied by the client application.
+            // This plugin does not require secure communications, so we cannot transmit the password in the clear.
+            // Copy the password contents and remove the key from the request payload. It will be restored.
+            std::string client_provided_password_copy;
+            if (const auto password_iter = svr_req.find(irods::AUTH_PASSWORD_KEY); password_iter != svr_req.end()) {
+                client_provided_password_copy = password_iter->get<std::string>();
+                svr_req.erase(password_iter);
+            }
+
             svr_req[irods_auth::next_operation] = AUTH_AGENT_AUTH_REQUEST;
             auto resp = irods_auth::request(comm, svr_req);
 
             resp[irods_auth::next_operation] = AUTH_ESTABLISH_CONTEXT;
+
+            // If a password was provided in the request payload, restore it here.
+            if (!client_provided_password_copy.empty()) {
+                resp[irods::AUTH_PASSWORD_KEY] = client_provided_password_copy;
+            }
 
             return resp;
         } // native_auth_client_request
@@ -179,6 +258,16 @@ namespace irods
             );
 
             json svr_req{req};
+
+            // Do not transmit the password in the request to the server if it was supplied by the client application.
+            // This plugin does not require secure communications, so we cannot transmit the password in the clear.
+            // Copy the password contents and remove the key from the request payload. It will be restored if needed.
+            std::string client_provided_password_copy;
+            if (const auto password_iter = svr_req.find(irods::AUTH_PASSWORD_KEY); password_iter != svr_req.end()) {
+                client_provided_password_copy = password_iter->get<std::string>();
+                svr_req.erase(password_iter);
+            }
+
             svr_req[irods_auth::next_operation] = AUTH_AGENT_AUTH_RESPONSE;
             auto resp = irods_auth::request(comm, svr_req);
 

--- a/plugins/auth/src/pam_password.cpp
+++ b/plugins/auth/src/pam_password.cpp
@@ -155,13 +155,14 @@ namespace irods
             if (req.end() != force_prompt && force_prompt->get<bool>()) {
                 resp[irods::AUTH_PASSWORD_KEY] = get_password_from_client_stdin();
             }
-            else {
+            // If the client has provided a password in the request, use that.
+            else if (!resp.contains(irods::AUTH_PASSWORD_KEY)) {
                 // obfGetPw returns 0 if the password is retrieved successfully. Therefore,
                 // we do NOT need a password in this case. This being the case, we conclude
                 // that the user has already been authenticated via PAM with the server. We
                 // proceed with steps for native authentication which will use the stored
                 // password. This is the legacy behavior for the PAM authentication plugin.
-                if (const bool need_password = obfGetPw(nullptr); !need_password) {
+                if (0 == obfGetPw(nullptr)) {
                     resp[irods_auth::next_operation] = perform_native_auth;
                     return resp;
                 }

--- a/scripts/irods/test/test_auth.py
+++ b/scripts/irods/test/test_auth.py
@@ -473,7 +473,7 @@ class test_iinit(session.make_sessions_mixin([('otherrods', 'rods')], []), unitt
             self.user,
             self.zone,
             auth_scheme,
-            self.password]) + os.linesep
+            ]) + os.linesep
         stdout, stderr, rc = lib.execute_command_permissive(cmd, input=user_input, env=self.env)
         lib.log_command_result(cmd, stdout, stderr, rc)
 
@@ -485,7 +485,6 @@ class test_iinit(session.make_sessions_mixin([('otherrods', 'rods')], []), unitt
         self.assertIn(error_string, stderr)
 
         self.assert_basic_iinit_prompts_are_in_stdout(stdout)
-        self.assertIn('Enter your current iRODS password', stdout)
         self.assert_auth_scheme_iinit_prompts_are_in_stdout(stdout)
 
         # Make sure that the environment file saved despite authentication failure.

--- a/unit_tests/src/test_atomic_apply_acl_operations.cpp
+++ b/unit_tests/src/test_atomic_apply_acl_operations.cpp
@@ -9,6 +9,7 @@
 #include "irods/rodsErrorTable.h"
 #include "irods/user_administration.hpp"
 #include "irods/irods_at_scope_exit.hpp"
+#include "irods/irods_auth_constants.hpp"
 #include "irods/transport/default_transport.hpp"
 #include "irods/dstream.hpp"
 #include "irods/zone_administration.hpp"
@@ -357,8 +358,8 @@ TEST_CASE("Non-admin users can modify ACLs of collections and data objects")
     auto* conn_ptr = rcConnect(env.rodsHost, env.rodsPort, test_user.name.c_str(), env.rodsZone, 0, &error);
     REQUIRE(conn_ptr);
     irods::at_scope_exit disconnect_test_user{[conn_ptr] { rcDisconnect(conn_ptr); }};
-    char password[] = "rods";
-    REQUIRE(clientLoginWithPassword(conn_ptr, password) == 0);
+    const auto ctx = nlohmann::json{{irods::AUTH_PASSWORD_KEY, "rods"}};
+    REQUIRE(clientLogin(conn_ptr, ctx.dump().c_str()) == 0);
 
     // Capture the home collection of the test user.
     const auto test_user_home = fs::path{"/"} / env.rodsZone / "home" / test_user.name;

--- a/unit_tests/src/test_rcTicketAdmin.cpp
+++ b/unit_tests/src/test_rcTicketAdmin.cpp
@@ -3,10 +3,13 @@
 #include "irods/client_connection.hpp"
 #include "irods/filesystem.hpp"
 #include "irods/irods_at_scope_exit.hpp"
+#include "irods/irods_auth_constants.hpp"
 #include "irods/rcConnect.h"
 #include "irods/rodsClient.h"
 #include "irods/ticket_administration.hpp"
 #include "irods/user_administration.hpp"
+
+#include <nlohmann/json.hpp>
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE("rcTicketAdmin")
@@ -47,7 +50,8 @@ TEST_CASE("rcTicketAdmin")
         // Enable the ticket and show the test_user can read the rodsadmin's home collection.
         irods::experimental::client_connection test_user_conn{
             irods::experimental::defer_authentication, env.rodsHost, env.rodsPort, {test_user.name, env.rodsZone}};
-        REQUIRE(clientLoginWithPassword(static_cast<RcComm*>(test_user_conn), password_prop.value.data()) == 0);
+        const auto ctx = nlohmann::json{{irods::AUTH_PASSWORD_KEY, password_prop.value.data()}};
+        REQUIRE(clientLogin(static_cast<RcComm*>(test_user_conn), ctx.dump().c_str()) == 0);
 
         TicketAdminInput input{};
         input.arg1 = "session";


### PR DESCRIPTION
In service of #7948 
Addresses #8016
Addresses #8391 

Cherry-picked from: #8383
Cherry-picked from: #8393

Companion PR: https://github.com/irods/irods_client_icommands/pull/562

Unit tests passed, auth-based tests are passing. Running the full core test suite now.