### PR TITLE
[#7975] Update database plugin stanza

### DIFF
--- a/lib/core/include/irods/irods_configuration_keywords.hpp
+++ b/lib/core/include/irods/irods_configuration_keywords.hpp
@@ -10,16 +10,17 @@ namespace irods
     extern const char* const KW_CFG_PAM_PASSWORD_MAX_TIME;
     extern const char* const KW_CFG_PAM_PASSWORD_EXTEND_LIFETIME;
 
+    extern const char* const KW_CFG_DB_TECHNOLOGY;
     extern const char* const KW_CFG_DB_HOST;
     extern const char* const KW_CFG_DB_PORT;
     extern const char* const KW_CFG_DB_NAME;
     extern const char* const KW_CFG_DB_ODBC_DRIVER;
     extern const char* const KW_CFG_DB_USERNAME;
     extern const char* const KW_CFG_DB_PASSWORD;
-    extern const char* const KW_CFG_DB_SSLMODE;
-    extern const char* const KW_CFG_DB_SSLROOTCERT;
-    extern const char* const KW_CFG_DB_SSLCERT;
-    extern const char* const KW_CFG_DB_SSLKEY;
+    extern const char* const KW_CFG_DB_TLSMODE;
+    extern const char* const KW_CFG_DB_TLSROOTCERT;
+    extern const char* const KW_CFG_DB_TLSCERT;
+    extern const char* const KW_CFG_DB_TLSKEY;
     extern const char* const KW_CFG_ZONE_NAME;
     extern const char* const KW_CFG_ZONE_KEY;
     extern const char* const KW_CFG_NEGOTIATION_KEY;

--- a/lib/core/src/irods_configuration_keywords.cpp
+++ b/lib/core/src/irods_configuration_keywords.cpp
@@ -9,16 +9,17 @@ namespace irods
     const char* const KW_CFG_PAM_PASSWORD_MAX_TIME{"password_max_time"};
     const char* const KW_CFG_PAM_PASSWORD_EXTEND_LIFETIME{"password_extend_lifetime"};
 
-    const char* const KW_CFG_DB_HOST{"db_host"};
-    const char* const KW_CFG_DB_PORT{"db_port"};
-    const char* const KW_CFG_DB_NAME{"db_name"};
-    const char* const KW_CFG_DB_ODBC_DRIVER{"db_odbc_driver"};
-    const char* const KW_CFG_DB_USERNAME{"db_username"};
-    const char* const KW_CFG_DB_PASSWORD{"db_password"};
-    const char* const KW_CFG_DB_SSLMODE{"db_sslmode"};
-    const char* const KW_CFG_DB_SSLROOTCERT{"db_sslrootcert"};
-    const char* const KW_CFG_DB_SSLCERT{"db_sslcert"};
-    const char* const KW_CFG_DB_SSLKEY{"db_sslkey"};
+    const char* const KW_CFG_DB_TECHNOLOGY{"technology"};
+    const char* const KW_CFG_DB_HOST{"host"};
+    const char* const KW_CFG_DB_PORT{"port"};
+    const char* const KW_CFG_DB_NAME{"name"};
+    const char* const KW_CFG_DB_ODBC_DRIVER{"odbc_driver"};
+    const char* const KW_CFG_DB_USERNAME{"username"};
+    const char* const KW_CFG_DB_PASSWORD{"password"};
+    const char* const KW_CFG_DB_TLSMODE{"tlsmode"};
+    const char* const KW_CFG_DB_TLSROOTCERT{"tlsrootcert"};
+    const char* const KW_CFG_DB_TLSCERT{"tlscert"};
+    const char* const KW_CFG_DB_TLSKEY{"tlskey"};
     const char* const KW_CFG_ZONE_NAME{"zone_name"};
     const char* const KW_CFG_ZONE_KEY{"zone_key"};
     const char* const KW_CFG_NEGOTIATION_KEY{"negotiation_key"};

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -1828,11 +1828,18 @@ irods::error db_open_op(
     // cache db creds
     try {
         const auto db_plugin_map = irods::get_server_property<nlohmann::json>(std::vector<std::string>{irods::KW_CFG_PLUGIN_CONFIGURATION, irods::KW_CFG_PLUGIN_TYPE_DATABASE});
-        const auto db_type   = db_plugin_map.items().begin().key();
-        const auto db_plugin = db_plugin_map.items().begin().value();
-        snprintf(icss.databaseUsername, DB_USERNAME_LEN, "%s", db_plugin.at(irods::KW_CFG_DB_USERNAME).get<std::string>().c_str());
-        snprintf(icss.databasePassword, DB_PASSWORD_LEN, "%s", db_plugin.at(irods::KW_CFG_DB_PASSWORD).get<std::string>().c_str());
-        snprintf(icss.database_plugin_type, DB_TYPENAME_LEN, "%s", db_type.c_str());
+        snprintf(icss.databaseUsername,
+                 DB_USERNAME_LEN,
+                 "%s",
+                 db_plugin_map.at(irods::KW_CFG_DB_USERNAME).get_ref<const std::string&>().c_str());
+        snprintf(icss.databasePassword,
+                 DB_PASSWORD_LEN,
+                 "%s",
+                 db_plugin_map.at(irods::KW_CFG_DB_PASSWORD).get_ref<const std::string&>().c_str());
+        snprintf(icss.database_plugin_type,
+                 DB_TYPENAME_LEN,
+                 "%s",
+                 db_plugin_map.at(irods::KW_CFG_DB_TECHNOLOGY).get_ref<const std::string&>().c_str());
     } catch ( const irods::exception& e ) {
         return irods::error(e);
     } catch ( const boost::exception& e ) {

--- a/schemas/configuration/v5/database_config.json.in
+++ b/schemas/configuration/v5/database_config.json.in
@@ -3,23 +3,25 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
-        "db_host": {"type": "string"},
-        "db_name": {"type": "string"},
-        "db_odbc_driver": {"type": "string"},
-        "db_password": {"type": "string"},
-        "db_port": {"type": "integer"},
-        "db_username": {"type": "string"},
-        "db_sslmode": {"type": "string"},
-        "db_sslrootcert": {"type": "string"},
-        "db_sslcert": {"type": "string"},
-        "db_sslkey": {"type": "string"}
+        "technology": {"type": "string"},
+        "host": {"type": "string"},
+        "name": {"type": "string"},
+        "odbc_driver": {"type": "string"},
+        "password": {"type": "string"},
+        "port": {"type": "integer"},
+        "username": {"type": "string"},
+        "tlsmode": {"type": "string"},
+        "tlsrootcert": {"type": "string"},
+        "tlscert": {"type": "string"},
+        "tlskey": {"type": "string"}
     },
     "required": [
-        "db_host",
-        "db_name",
-        "db_odbc_driver",
-        "db_password",
-        "db_port",
-        "db_username"
+        "technology",
+        "host",
+        "name",
+        "odbc_driver",
+        "password",
+        "port",
+        "username"
     ]
 }

--- a/schemas/configuration/v5/server_config.json.in
+++ b/schemas/configuration/v5/server_config.json.in
@@ -302,17 +302,7 @@
                     "properties": {}
                 },
                 "database": {
-                    "type": "object",
-                    "propertyNames": {
-                        "pattern": "^[^\\s]+$"
-                    },
-                    "patternProperties": {
-                        "^[^\\s]+$": {
-                            "$ref": "database_config.json"
-                        }
-                    },
-                    "maxProperties" : 1,
-                    "minProperties" : 1
+                    "$ref": "database_config.json"
                 },
                 "network": {
                     "type": "object",

--- a/scripts/irods/configuration.py
+++ b/scripts/irods/configuration.py
@@ -83,10 +83,10 @@ class IrodsConfig(object):
     @property
     def database_config(self):
         try:
-            database_config = [e for e in self.server_config['plugin_configuration']['database'].values()][0]
-        except (KeyError, IndexError):
+            database_config = self.server_config['plugin_configuration']['database']
+        except KeyError:
             return None
-        if not 'db_odbc_driver' in database_config.keys():
+        if not 'odbc_driver' in database_config.keys():
             l = logging.getLogger(__name__)
             l.debug('No driver found in the database config, attempting to retrieve the one in the odbc ini file at "%s"...', self.odbc_ini_path)
             if os.path.exists(self.odbc_ini_path):
@@ -97,8 +97,8 @@ class IrodsConfig(object):
                 l.debug('No odbc.ini file present')
                 odbc_ini_contents = {}
             if self.catalog_database_type in odbc_ini_contents.keys() and 'Driver' in odbc_ini_contents[self.catalog_database_type].keys():
-                database_config['db_odbc_driver'] = odbc_ini_contents[self.catalog_database_type]['Driver']
-                l.debug('Adding driver "%s" to database_config', database_config['db_odbc_driver'])
+                database_config['odbc_driver'] = odbc_ini_contents[self.catalog_database_type]['Driver']
+                l.debug('Adding driver "%s" to database_config', database_config['odbc_driver'])
                 self.commit(self._server_config, paths.server_config_path(), clear_cache=False)
             else:
                 l.debug('Unable to retrieve "Driver" field from odbc ini file')
@@ -108,8 +108,8 @@ class IrodsConfig(object):
     @property
     def catalog_database_type(self):
         try:
-            return [e for e in self.server_config['plugin_configuration']['database'].keys()][0]
-        except (KeyError, IndexError):
+            return self.server_config['plugin_configuration']['database']['technology']
+        except KeyError:
             return None
 
     @property

--- a/server/core/src/catalog.cpp
+++ b/server/core/src/catalog.cpp
@@ -24,10 +24,10 @@ namespace
                                std::string& _db_username,
                                std::string& _db_password) -> void
     {
-        const auto& db_plugin_config = _server_config.at(irods::KW_CFG_PLUGIN_CONFIGURATION).at(irods::KW_CFG_PLUGIN_TYPE_DATABASE);
-        const auto& db_instance = db_plugin_config.front();
+        const auto& db_instance =
+            _server_config.at(irods::KW_CFG_PLUGIN_CONFIGURATION).at(irods::KW_CFG_PLUGIN_TYPE_DATABASE);
 
-        _db_instance_name = std::begin(db_plugin_config).key();
+        _db_instance_name = db_instance.at(irods::KW_CFG_DB_TECHNOLOGY).get<std::string>();
         _db_username = db_instance.at(irods::KW_CFG_DB_USERNAME).get<std::string>();
         _db_password = db_instance.at(irods::KW_CFG_DB_PASSWORD).get<std::string>();
     }


### PR DESCRIPTION
Issue quick link: #7975

This PR attempts to update the database plugin stanza in `server_config.json` to 'flatten' the structure. Several other files were modified to add new lines and update existing lines that referenced the old schema.

Testing:
- New install (this covers the provider case)
  - [x] Run all unit tests - i.e. run_unit_tests.py
  - [x] Run all core tests - i.e. run_core_tests.py
- [x] New install, configure as catalog consumer
  - Run the topology tests for consumer
  - Unit tests do not apply to this case
  - Requires you to pass the iRODS 5 packages to the run script
- [x] Upgrade iRODS 4.3 provider to iRODS 5 provider
  - Launch the run_core_tests.py script with `--leak-containers` and a short-running test
  - Manually upgrade packages to iRODS 5
  - Rerun run_core_tests.py, adding `--skip-setup`, remove `--tests` so that all core tests are run
- [x] Upgrade iRODS 4.3 consumer to iRODS 5 consumer
  - Same steps as the provider case, but with run_topology_tests.py instead of run_core_tests.py
  - _This case could be combined with the provider case since they run in identical setups_

---

Currently, the PR does not pass any tests and gets stuck on the following snippet seen in `setup_log.txt`:
```
...
+---------------------------+
| Running Post-Install Test |
+---------------------------+

2025-04-25T21:16:49.548Z -   DEBUG -                     execute.py:  50 - Calling ['/usr/sbin/irodsTestPutGet'] with options:
{'shell': False, 'stderr': -1, 'stdout': -1}
2025-04-25T21:16:49.884Z -   DEBUG -                     execute.py:  35 - Command /usr/sbin/irodsTestPutGet returned with code -6.
stderr:
  remote addresses: 172.18.0.5 ERROR: read_client_server_negotiation_message :: received error message -130000
  remote addresses: 172.18.0.5 ERROR: _rcConnect: connectToRhost error, server on 54a0e1d06149:1247 is probably down status = -130000 SYS_INVALID_INPUT_PARAM
...
```