### PR TITLE
[#8439] GenQuery2: Do not pass nullptr to logger (4-3-stable)

### DIFF
--- a/server/api/src/rs_genquery2.cpp
+++ b/server/api/src/rs_genquery2.cpp
@@ -74,7 +74,7 @@ auto rs_genquery2(RsComm* _comm, Genquery2Input* _input, char** _output) -> int
     }
 
     if (host_info->localFlag != LOCAL_HOST) {
-        log_api::trace("{}: Redirecting request to remote zone [{}].", __func__, _input->zone);
+        log_api::trace("{}: Redirecting request to server [{}].", __func__, host_info->hostName->name);
         return rc_genquery2(host_info->conn, _input, _output);
     }
 


### PR DESCRIPTION
Cherry-picked from #8442.