### PR TITLE
[#8147] Make agent factory notify main server process of readiness (main)

### DIFF
--- a/server/main_server/src/agent_main.cpp
+++ b/server/main_server/src/agent_main.cpp
@@ -310,6 +310,10 @@ auto main(int _argc, char* _argv[]) -> int
         // This allows rule engine plugins to setup state which doesn't change frequently.
         irods::re_plugin_globals->global_re_mgr.call_setup_operations();
 
+        // Notify the main server process that the agent factory has completed initialization and
+        // is ready for client requests.
+        kill(getppid(), SIGUSR2);
+
         // Enter parent process main loop.
         //
         // This process should never introduce threads. Everything it cares about must be handled


### PR DESCRIPTION
This has not been tested yet, but feel free to start reviewing it.

One thing that stands out to me is the fact that this implementation allows the service account user to send SIGUSR2 to the main server process, potentially affecting its ability to accurately detect when the agent factory is ready.

Now, this isn't a huge concern because it requires a user to have access to the service account or root access.

I've left a TODO comment in the code to highlight this situation. We could limit communication of SIGUSR2 to just the agent factory, but I'm not sure that's a good idea. One could argue that allowing the admin to send this signal is actually a good thing.

There's also the question of - when is the agent factory (or config reload) considered to be complete? Is it when the agent factory is able to take a client request? Or maybe it's when the agent factory process has a PID in the process tree?