### PR TITLE
Fix some memleaks reported by ASAN (main)

### DIFF
--- a/lib/api/include/irods/dataObjCopy.h
+++ b/lib/api/include/irods/dataObjCopy.h
@@ -42,8 +42,6 @@ typedef struct DataObjCopyInp {
  *                      REG_CHKSUM_KW - compute the checksum value
  *                      VERIFY_CHKSUM_KW - compute and verify the checksum on
  *                        the data.
- *                      FILE_PATH_KW - "value" = the physical path of the
- *                        destination file.
  *                      DEST_RESC_NAME_KW - "value" = The destination Resource.
  *          numThreads - number of threads to use. NO_THREADING = no threading.
  *          openFlags - Open flag for the copy operation. Should be O_WRONLY.

--- a/lib/api/include/irods/dataObjCreate.h
+++ b/lib/api/include/irods/dataObjCreate.h
@@ -22,8 +22,6 @@
  *          FORCE_FLAG_KW - overwrite an existing data object
  *          REG_CHKSUM_KW - compute the checksum value
  *          VERIFY_CHKSUM_KW - compute and verify the checksum on the data.
- *          FILE_PATH_KW - "value" = the physical path of the
- *              destination file.
  *          REPL_NUM_KW  - "value" = The replica number of the copy to
  *              overwrite.
  *          DEST_RESC_NAME_KW - "value" = The destination Resource.

--- a/lib/api/include/irods/dataObjCreateAndStat.h
+++ b/lib/api/include/irods/dataObjCreateAndStat.h
@@ -23,8 +23,6 @@
  *          FORCE_FLAG_KW - overwrite an existing data object
  *          REG_CHKSUM_KW - compute the checksum value
  *          VERIFY_CHKSUM_KW - compute and verify the checksum on the data.
- *          FILE_PATH_KW - "value" = the physical path of the
- *              destination file.
  *          REPL_NUM_KW  - "value" = The replica number of the copy to
  *              overwrite.
  *          DEST_RESC_NAME_KW - "value" = The destination Resource.

--- a/lib/api/include/irods/dataObjOpen.h
+++ b/lib/api/include/irods/dataObjOpen.h
@@ -29,8 +29,6 @@
  *          FORCE_FLAG_KW - overwrite an existing data object
  *          REG_CHKSUM_KW - compute the checksum value
  *          VERIFY_CHKSUM_KW - compute and verify the checksum on the data.
- *          FILE_PATH_KW - "value" = the physical path of the
- *              destination file. Valid only if O_CREAT is on.
  *          REPL_NUM_KW  - "value" = The replica number of the copy to
  *              open.
  *          DEST_RESC_NAME_KW - "value" = The destination Resource. Valid
@@ -39,7 +37,6 @@
  * OutPut -
  *   int l1descInx - an integer descriptor.
  */
-
 
 #ifdef __cplusplus
 extern "C"

--- a/lib/api/include/irods/dataObjOpenAndStat.h
+++ b/lib/api/include/irods/dataObjOpenAndStat.h
@@ -31,8 +31,6 @@ typedef struct OpenStat {
  *          FORCE_FLAG_KW - overwrite an existing data object
  *          REG_CHKSUM_KW - compute the checksum value
  *          VERIFY_CHKSUM_KW - compute and verify the checksum on the data.
- *          FILE_PATH_KW - "value" = the physical path of the
- *              destination file. Valid only if O_CREAT is on.
  *          REPL_NUM_KW  - "value" = The replica number of the copy to
  *              open.
  *          DEST_RESC_NAME_KW - "value" = The destination Resource. Valid

--- a/lib/api/include/irods/dataObjPut.h
+++ b/lib/api/include/irods/dataObjPut.h
@@ -21,8 +21,6 @@
  *          DATA_TYPE_KW - "value" = the data type of the file.
  *          REPL_NUM_KW  - "value" = The replica number of the copy to
  *              upload.
- *          FILE_PATH_KW - "value" = the physical path of the
- *              destination file. Valid only if O_CREAT is on.
  *          DEST_RESC_NAME_KW - "value" = The destination Resource. Valid
  *              only if O_CREAT is on.
  *   return value - The status of the operation.

--- a/lib/api/src/rcDataObjCopy.cpp
+++ b/lib/api/src/rcDataObjCopy.cpp
@@ -57,8 +57,6 @@
  *    \n VERIFY_CHKSUM_KW - verify and register the target checksum value
  *            after the copy. This keyWd has no value.
  *    \n DEST_RESC_NAME_KW - The resource to store this data object
- *    \n FILE_PATH_KW - The physical file path for this data object if the
- *             normal resource vault is not used.
  *
  * \return integer
  * \retval 0 on success

--- a/lib/api/src/rcDataObjCreate.cpp
+++ b/lib/api/src/rcDataObjCreate.cpp
@@ -42,8 +42,6 @@
  *    \li keyValPair_t \b condInput - keyword/value pair input. Valid keywords:
  *    \n DATA_TYPE_KW - the data type of the data object.
  *    \n DEST_RESC_NAME_KW - The resource to store this data object
- *    \n FILE_PATH_KW - The physical file path for this data object if the
- *             normal resource vault is not used.
  *    \n FORCE_FLAG_KW - overwrite existing copy. This keyWd has no value
  *
  * \return integer

--- a/lib/api/src/rcDataObjCreateAndStat.cpp
+++ b/lib/api/src/rcDataObjCreateAndStat.cpp
@@ -46,8 +46,6 @@
  *    \li keyValPair_t \b condInput - keyword/value pair input. Valid keywords:
  *    \n DATA_TYPE_KW - the data type of the data object.
  *    \n DEST_RESC_NAME_KW - The resource to store this data object
- *    \n FILE_PATH_KW - The physical file path for this data object if the
- *             normal resource vault is not used.
  *    \n FORCE_FLAG_KW - overwrite existing copy. This keyWd has no value
  *
  * \param[out] openStat - Pointer to a openStat_t containing the stat of the

--- a/lib/api/src/rcDataObjPut.cpp
+++ b/lib/api/src/rcDataObjPut.cpp
@@ -55,8 +55,6 @@
  *    \li keyValPair_t \b condInput - keyword/value pair input. Valid keywords:
  *    \n DATA_TYPE_KW - the data type of the data object.
  *    \n DEST_RESC_NAME_KW - The resource to store this data object
- *    \n FILE_PATH_KW - The physical file path for this data object if the
- *             normal resource vault is not used.
  *    \n FORCE_FLAG_KW - overwrite existing copy. This keyWd has no value
  *    \n REPL_NUM_KW - If the data object already exist, the replica number
  *            of the copy to overwrite.

--- a/lib/api/src/rcDataObjRepl.cpp
+++ b/lib/api/src/rcDataObjRepl.cpp
@@ -48,8 +48,6 @@
  *    \n DEST_RESC_NAME_KW - The resource to store the new replica.
  *    \n ADMIN_KW - admin user backup/replicate other user's files.
  *            This keyWd has no value.
- *    \n FILE_PATH_KW - The physical file path for this data object if the
- *             normal resource vault is not used.
  *
  * \return integer
  * \retval 0 on success

--- a/lib/core/src/cpUtil.cpp
+++ b/lib/core/src/cpUtil.cpp
@@ -202,18 +202,6 @@ initCondForCp( rodsEnv *myRodsEnv, rodsArguments_t *rodsArgs,
         }
     }
 
-    if ( rodsArgs->physicalPath == True ) {
-        if ( rodsArgs->physicalPathString == NULL ) {
-            rodsLog( LOG_ERROR,
-                     "initCondForCp: NULL physicalPathString error" );
-            return USER__NULL_INPUT_ERR;
-        }
-        else {
-            addKeyVal( &dataObjCopyInp->destDataObjInp.condInput, FILE_PATH_KW,
-                       rodsArgs->physicalPathString );
-        }
-    }
-
     if ( rodsArgs->resource == True ) {
         if ( rodsArgs->resourceString == NULL ) {
             rodsLog( LOG_ERROR,

--- a/lib/core/src/irods_parse_command_line_options.cpp
+++ b/lib/core/src/irods_parse_command_line_options.cpp
@@ -38,7 +38,6 @@ static int parse_program_options(
         ("verify_checksum,K", "verify checksum - calculate and verify the checksum on the data, both client-side and server-side, without storing in the catalog.")
         ("repl_num,n", po::value<std::string>(), "replNum  - the replica to be replaced, typically not needed")
         ("num_threads,N", po::value<int>(), "numThreads - the number of threads to use for the transfer. A value of 0 means no threading. By default (-N option not used) the server decides the number of threads to use.")
-        ("physical_path,p", po::value<std::string>(), "physicalPath - the absolute physical path of the uploaded file on the server")
         ("progress,P", "output the progress of the upload.")
         ("recursive,r", "recursive - store the whole subdirectory")
         ("dest_resc,R", po::value<std::string>(), "resource - specifies the resource to store to. This can also be specified in your environment or via a rule set up by the administrator")
@@ -129,15 +128,6 @@ static int parse_program_options(
         _rods_args.number = 1;
         try {
             _rods_args.numberValue = global_prog_ops_var_map[ "num_threads" ].as<int>();
-        }
-        catch ( const boost::bad_any_cast& ) {
-            return INVALID_ANY_CAST;
-        }
-    }
-    if ( global_prog_ops_var_map.count( "physical_path" ) ) {
-        _rods_args.physicalPath = 1;
-        try {
-            _rods_args.physicalPathString = ( char* )global_prog_ops_var_map[ "physical_path" ].as< std::string >().c_str();
         }
         catch ( const boost::bad_any_cast& ) {
             return INVALID_ANY_CAST;

--- a/lib/core/src/irods_parse_command_line_options.cpp
+++ b/lib/core/src/irods_parse_command_line_options.cpp
@@ -240,6 +240,7 @@ static int parse_program_options(
 
 } // parse_program_options
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static int build_irods_path_structure(const path_list_t& _path_list,
                                       const RodsArguments& _rods_args,
                                       rodsEnv* _rods_env,
@@ -301,6 +302,11 @@ static int build_irods_path_structure(const path_list_t& _path_list,
     }
 
     if ( _dst_type != NO_INPUT_T ) {
+        if (nullptr != _rods_paths->destPath) {
+            clearRodsPath(_rods_paths->destPath);
+            // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+            std::free(_rods_paths->destPath);
+        }
         _rods_paths->destPath = ( rodsPath_t* )malloc( sizeof( rodsPath_t ) );
         memset( _rods_paths->destPath, 0, sizeof( rodsPath_t ) );
         if ( _path_list.size() > 1 ) {

--- a/lib/core/src/miscUtil.cpp
+++ b/lib/core/src/miscUtil.cpp
@@ -249,8 +249,9 @@ getRodsObjType( rcComm_t *conn, rodsPath_t *rodsPath ) {
             rstrcpy( rodsPath->chksum, rodsObjStatOut->chksum, NAME_LEN );
         }
     }
-    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
-    std::free(rodsPath->rodsObjStat);
+    if (nullptr != rodsPath->rodsObjStat) {
+        freeRodsObjStat(rodsPath->rodsObjStat);
+    }
     rodsPath->rodsObjStat = rodsObjStatOut;
 
     return rodsPath->objState;

--- a/lib/core/src/putUtil.cpp
+++ b/lib/core/src/putUtil.cpp
@@ -547,28 +547,6 @@ initCondForPut( rcComm_t *conn, rodsEnv *myRodsEnv, rodsArguments_t *rodsArgs,
     }
 #endif
 
-    if ( rodsArgs->physicalPath == True ) {
-        if ( rodsArgs->physicalPathString == NULL ) {
-            rodsLog( LOG_ERROR,
-                     "initCondForPut: NULL physicalPathString error" );
-            return USER__NULL_INPUT_ERR;
-        }
-        else {
-            fs::path slash( "/" );
-            std::string preferred_slash = slash.make_preferred().native();
-            if ( preferred_slash[0] != rodsArgs->physicalPathString[0] ) {
-                rodsLog(
-                    LOG_ERROR,
-                    "initCondForPut: physical path [%s] must be absolute, not relative",
-                    rodsArgs->physicalPathString );
-                return USER_INPUT_PATH_ERR;
-            }
-
-            addKeyVal( &dataObjOprInp->condInput, FILE_PATH_KW,
-                       rodsArgs->physicalPathString );
-        }
-    }
-
     if ( rodsArgs->resource == True ) {
         if ( rodsArgs->resourceString == NULL ) {
             rodsLog( LOG_ERROR,

--- a/plugins/api/src/data_object_finalize.cpp
+++ b/plugins/api/src/data_object_finalize.cpp
@@ -460,10 +460,6 @@ extern "C"
 auto plugin_factory(const std::string& _instance_name,
                     const std::string& _context) -> irods::api_entry*
 {
-#ifdef RODS_SERVER
-    irods::client_api_allowlist::add(DATA_OBJECT_FINALIZE_APN);
-#endif // RODS_SERVER
-
     // clang-format off
     irods::apidef_t def{
         DATA_OBJECT_FINALIZE_APN,   // API number

--- a/plugins/authentication/src/native.cpp
+++ b/plugins/authentication/src/native.cpp
@@ -478,6 +478,7 @@ namespace irods::authentication
             return resp;
         } // native_auth_agent_request
 
+        // NOLINTNEXTLINE(readability-function-cognitive-complexity)
         json native_auth_agent_response(rsComm_t& comm, const json& req)
         {
             irods_auth::throw_if_request_message_is_missing_key(
@@ -518,6 +519,16 @@ namespace irods::authentication
             authCheckInp.username = const_cast<char*>(username.data());
 
             authCheckOut_t* authCheckOut = nullptr;
+            const auto free_authCheckOut = irods::at_scope_exit{[&authCheckOut] {
+                if (nullptr != authCheckOut) {
+                    if (nullptr != authCheckOut->serverResponse) {
+                        // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+                        std::free(authCheckOut->serverResponse);
+                    }
+                    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+                    std::free(authCheckOut);
+                }
+            }};
             if (LOCAL_HOST == rodsServerHost->localFlag) {
                 status = rsAuthCheck(&comm, &authCheckInp, &authCheckOut);
             }
@@ -662,13 +673,6 @@ namespace irods::authentication
             else {          /* proxyUser and clientUser are the same */
                 comm.proxyUser.authInfo.authFlag =
                     comm.clientUser.authInfo.authFlag = authCheckOut->privLevel;
-            }
-
-            if ( authCheckOut != NULL ) {
-                if ( authCheckOut->serverResponse != NULL ) {
-                    free( authCheckOut->serverResponse );
-                }
-                free( authCheckOut );
             }
 
             return resp;

--- a/scripts/irods/test/resource_suite.py
+++ b/scripts/irods/test/resource_suite.py
@@ -587,60 +587,6 @@ class ResourceSuite(ResourceBase):
         self.assertEqual(
             str(os.stat(local_filepath).st_size), lib.get_replica_size(self.admin, os.path.basename(logical_path), 0))
 
-    def test_local_iput_physicalpath_no_permission(self):
-        # local setup
-        datafilename = "newfile.txt"
-        with open(datafilename, 'wt') as f:
-            print("TESTFILE -- [" + datafilename + "]", file=f, end='')
-        # assertions
-        self.admin.assert_icommand("iput -p /newfileinroot.txt " + datafilename, 'STDERR_SINGLELINE',
-                                   ["UNIX_FILE_CREATE_ERR", "Permission denied"])  # should fail to write
-        # local cleanup
-        if os.path.exists(datafilename):
-            os.unlink(datafilename)
-
-    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Needs investigation refer issue 4932")
-    def test_local_iput_physicalpath(self):
-        # local setup
-        datafilename = "newfile.txt"
-        with open(datafilename, 'wt') as f:
-            print("TESTFILE -- [" + datafilename + "]", file=f, end='')
-        # assertions
-        fullpath = IrodsConfig().irods_directory + "/newphysicalpath.txt"
-        self.admin.assert_icommand("iput -p " + fullpath + " " + datafilename)  # should complete
-        self.admin.assert_icommand("ils -L " + datafilename, 'STDOUT_SINGLELINE', datafilename)  # should be listed
-        self.admin.assert_icommand("ils -L " + datafilename, 'STDOUT_SINGLELINE', fullpath)  # should be listed
-        # local cleanup
-        if os.path.exists(datafilename):
-            os.unlink(datafilename)
-        if os.path.exists(fullpath):
-            os.unlink(fullpath)
-
-    def test_admin_local_iput_relative_physicalpath_into_server_bin(self):
-        # local setup
-        datafilename = "newfile.txt"
-        with open(datafilename, 'wt') as f:
-            print("TESTFILE -- [" + datafilename + "]", file=f, end='')
-        # assertions
-        relpath = "relativephysicalpath.txt"
-        # should disallow relative path
-        self.admin.assert_icommand("iput -p " + relpath + " " + datafilename, 'STDERR_SINGLELINE', "absolute")
-        # local cleanup
-        if os.path.exists(datafilename):
-            os.unlink(datafilename)
-
-    def test_local_iput_relative_physicalpath_into_server_bin(self):
-        # local setup
-        datafilename = "newfile.txt"
-        with open(datafilename, 'wt') as f:
-            print("TESTFILE -- [" + datafilename + "]", file=f, end='')
-        # assertions
-        relpath = "relativephysicalpath.txt"
-        self.user0.assert_icommand("iput -p " + relpath + " " + datafilename, 'STDERR_SINGLELINE', "absolute")  # should error
-        # local cleanup
-        if os.path.exists(datafilename):
-            os.unlink(datafilename)
-
     def test_local_iput_with_changed_target_filename(self):
         # local setup
         datafilename = "newfile.txt"

--- a/server/api/src/rsDataObjOpen.cpp
+++ b/server/api/src/rsDataObjOpen.cpp
@@ -260,10 +260,6 @@ namespace
                 new_replica.data_id(std::atoll(cond_input.at(DATA_ID_KW).value().data()));
             }
 
-            if (cond_input.contains(FILE_PATH_KW)) {
-                new_replica.physical_path(cond_input.at(FILE_PATH_KW).value());
-            }
-
             cond_input[OPEN_TYPE_KW] = std::to_string(CREATE_TYPE);
             const int l1_index = irods::populate_L1desc_with_inp(_inp, *new_replica.get(), _inp.dataSize);
 
@@ -1323,6 +1319,12 @@ int rsDataObjOpen(rsComm_t *rsComm, dataObjInp_t *dataObjInp)
     }
 
     const auto data_object_exists = fs::server::exists(*rsComm, dataObjInp->objPath);
+
+    // Remove the FILE_PATH_KW from the condInput to ensure it is not used at any stage in this API.
+    if (const auto* file_path_cstr = getValByKey(&dataObjInp->condInput, FILE_PATH_KW); nullptr != file_path_cstr) {
+        rmKeyVal(&dataObjInp->condInput, FILE_PATH_KW);
+    }
+
     const auto fd = rsDataObjOpen_impl(rsComm, dataObjInp);
 
     // Do not update the collection mtime if the logical path refers to a remote

--- a/server/core/include/irods/objDesc.hpp
+++ b/server/core/include/irods/objDesc.hpp
@@ -112,8 +112,6 @@ int initDataOprInp(dataOprInp_t* dataOprInp, int l1descInx, int oprType);
 
 int convL3descInx(int l3descInx);
 
-int initDataObjInfoWithInp(dataObjInfo_t* dataObjInfo, dataObjInp_t* dataObjInp);
-
 int allocL1desc();
 
 int closeAllL1desc(rsComm_t* rsComm);

--- a/server/core/src/objDesc.cpp
+++ b/server/core/src/objDesc.cpp
@@ -341,59 +341,6 @@ fillL1desc( int l1descInx, dataObjInp_t *dataObjInp,
 }
 
 int
-initDataObjInfoWithInp( dataObjInfo_t *dataObjInfo, dataObjInp_t *dataObjInp ) {
-    namespace ix = irods::experimental;
-
-    if (!dataObjInp || !dataObjInfo) {
-        rodsLog(LOG_ERROR, "[%s] - null input", __FUNCTION__);
-        return SYS_INTERNAL_NULL_INPUT_ERR;
-    }
-    auto kvp = ix::make_key_value_proxy(dataObjInp->condInput);
-    memset( dataObjInfo, 0, sizeof( dataObjInfo_t ) );
-
-    rstrcpy( dataObjInfo->objPath, dataObjInp->objPath, MAX_NAME_LEN );
-
-    if (kvp.contains(DATA_ID_KW)) {
-        dataObjInfo->dataId = std::atoll(kvp.at(DATA_ID_KW).value().data());
-    }
-
-    if (kvp.contains(RESC_NAME_KW)) {
-        const auto resc_name = kvp.at(RESC_NAME_KW).value();
-        rstrcpy(dataObjInfo->rescName, resc_name.data(), NAME_LEN);
-        if (!kvp.contains(RESC_HIER_STR_KW)) {
-            rstrcpy( dataObjInfo->rescHier, resc_name.data(), MAX_NAME_LEN );
-        }
-    }
-
-    if (kvp.contains(RESC_HIER_STR_KW)) {
-        auto hier = kvp.at(RESC_HIER_STR_KW).value();
-        rstrcpy(dataObjInfo->rescHier, hier.data(), MAX_NAME_LEN);
-    }
-
-    irods::error ret = resc_mgr.hier_to_leaf_id(dataObjInfo->rescHier,dataObjInfo->rescId);
-    if( !ret.ok() ) {
-        irods::log(PASS(ret));
-    }
-
-    snprintf( dataObjInfo->dataMode, SHORT_STR_LEN, "%d", dataObjInp->createMode );
-
-    if (kvp.contains(DATA_TYPE_KW)) {
-        auto data_type = kvp.at(DATA_TYPE_KW).value();
-        rstrcpy(dataObjInfo->dataType, data_type.data(), NAME_LEN);
-    }
-    else {
-        rstrcpy(dataObjInfo->dataType, "generic", NAME_LEN);
-    }
-
-    if (kvp.contains(FILE_PATH_KW)) {
-        auto file_path = kvp.at(FILE_PATH_KW).value();
-        rstrcpy( dataObjInfo->filePath, file_path.data(), MAX_NAME_LEN );
-    }
-
-    return 0;
-}
-
-int
 getL1descIndexByDataObjInfo( const dataObjInfo_t * dataObjInfo ) {
     int index;
     for ( index = 3; index < NUM_L1_DESC; index++ ) {

--- a/server/delay_server/src/irodsDelayServer.cpp
+++ b/server/delay_server/src/irodsDelayServer.cpp
@@ -600,9 +600,8 @@ namespace
 
         ruleExecSubmitInp_t rule_exec_submit_inp{};
 
-        irods::at_scope_exit at_scope_exit{[&rule_exec_submit_inp] {
-            freeBBuf(rule_exec_submit_inp.packedReiAndArgBBuf);
-        }};
+        const auto free_rule_exec_submit_inp_members =
+            irods::at_scope_exit{[&rule_exec_submit_inp] { clearRuleExecSubmitInput(&rule_exec_submit_inp); }};
 
         ix::client_connection conn = get_new_connection(std::nullopt);
 

--- a/server/re/src/reDataObjOpr.cpp
+++ b/server/re/src/reDataObjOpr.cpp
@@ -1161,9 +1161,8 @@ msiDataObjCopy( msParam_t *inpParam1, msParam_t *inpParam2,
         return rei->status;
     }
 
-    validKwFlags = OBJ_PATH_FLAG   | DEST_RESC_NAME_FLAG | FILE_PATH_FLAG |
-                   DATA_TYPE_FLAG  | VERIFY_CHKSUM_FLAG  |
-                   FORCE_FLAG_FLAG | NUM_THREADS_FLAG;
+    validKwFlags =
+        OBJ_PATH_FLAG | DEST_RESC_NAME_FLAG | DATA_TYPE_FLAG | VERIFY_CHKSUM_FLAG | FORCE_FLAG_FLAG | NUM_THREADS_FLAG;
     rei->status = parseMsKeyValStrForDataObjInp( msKeyValStr, &myDataObjCopyInp->destDataObjInp,
                   DEST_RESC_NAME_KW, validKwFlags, &outBadKeyWd );
 
@@ -1308,8 +1307,7 @@ msiDataObjPut( msParam_t *inpParam1, msParam_t *inpParam2,
         return rei->status;
     }
 
-    validKwFlags = LOCAL_PATH_FLAG | DEST_RESC_NAME_FLAG | FILE_PATH_FLAG |
-                   REPL_NUM_FLAG | DATA_TYPE_FLAG | VERIFY_CHKSUM_FLAG |
+    validKwFlags = LOCAL_PATH_FLAG | DEST_RESC_NAME_FLAG | REPL_NUM_FLAG | DATA_TYPE_FLAG | VERIFY_CHKSUM_FLAG |
                    ALL_FLAG | FORCE_FLAG_FLAG | NUM_THREADS_FLAG | OBJ_PATH_FLAG;
     rei->status = parseMsKeyValStrForDataObjInp( msKeyValStr, dataObjInp,
                   LOCAL_PATH_KW, validKwFlags, &outBadKeyWd );


### PR DESCRIPTION
In service of #4932
In service of #8334 

After these changes and those in the companion PR for `iput`, the remaining issues reported by ASAN are coming from `irods_user_administration` and `irods_json_apis_from_client`. The rest of the ones reported in #8334 have been addressed.

Unit tests pass. Still need to run core tests, so leaving in draft for now.