### PR TITLE
[#8315] Show access time note on server upgrade only (main)

### DIFF
--- a/scripts/irods/controller.py
+++ b/scripts/irods/controller.py
@@ -82,7 +82,7 @@ class IrodsController(object):
 
         if self.config.is_provider:
             from . import database_interface
-            database_interface.run_catalog_update(self.config)
+            database_interface.run_catalog_update(self.config, is_upgrade=True)
 
     def start(self, write_to_stdout=False, test_mode=False):
         l = logging.getLogger(__name__)

--- a/scripts/irods/database_interface.py
+++ b/scripts/irods/database_interface.py
@@ -32,7 +32,7 @@ def setup_catalog(irods_config, default_resource_directory=None, default_resourc
                 cursor.rollback()
                 raise
 
-def run_catalog_update(irods_config):
+def run_catalog_update(irods_config, is_upgrade):
     l = logging.getLogger(__name__)
     l.debug('Syncing .odbc.ini file...')
     def update_catalog_schema(irods_config, cursor):
@@ -45,7 +45,7 @@ def run_catalog_update(irods_config):
                 return
             elif schema_version_in_database < irods_config.version['catalog_schema_version']:
                 try:
-                    database_upgrade.run_update(irods_config, cursor)
+                    database_upgrade.run_update(irods_config, cursor, is_upgrade)
                     l.debug('Committing database changes...')
                     cursor.commit()
                 except:

--- a/scripts/setup_irods.py
+++ b/scripts/setup_irods.py
@@ -135,7 +135,7 @@ def setup_server(irods_config, json_configuration_file=None, test_mode=False):
         l.info(irods.lib.get_header('Setting up the database'))
         database_interface.setup_catalog(irods_config, default_resource_directory=default_resource_directory, default_resource_name=default_resource_name)
         l.info(irods.lib.get_header('Applying updates to database'))
-        database_interface.run_catalog_update(irods_config)
+        database_interface.run_catalog_update(irods_config, is_upgrade=False)
 
     # Copy iRODS Rule Language (NREP) files into correct directory if this is a new install.
     for f in ['core.re', 'core.dvm', 'core.fnm']:


### PR DESCRIPTION
The `is_upgrade` parameter is false when `setup_irods.py` is executed. `is_upgrade` is true when `upgrade_irods.py` is executed.

Will test this as soon as I work through setting up the testing environment.