### PR TITLE
Fix issues around mysql (main)

### DIFF
--- a/scripts/irods/database_upgrade.py
+++ b/scripts/irods/database_upgrade.py
@@ -146,17 +146,17 @@ def run_update(irods_config, cursor, is_upgrade):
             with tempfile.NamedTemporaryFile() as f:
                 f.write('\n'.join([
                     '[client]',
-                    '='.join(['user', irods_config.database_config['db_username']]),
-                    '='.join(['password', irods_config.database_config['db_password']]),
-                    '='.join(['port', str(irods_config.database_config['db_port'])]),
-                    '='.join(['host', irods_config.database_config['db_host']])
+                    '='.join(['user', irods_config.database_config['username']]),
+                    '='.join(['password', irods_config.database_config['password']]),
+                    '='.join(['port', str(irods_config.database_config['port'])]),
+                    '='.join(['host', irods_config.database_config['host']])
                 ]).encode())
 
                 f.flush()
 
                 with open(os.path.join(irods_config.irods_directory, 'packaging', 'sql', 'mysql_functions.sql'), 'r') as sql_file:
                     lib.execute_command(
-                        [mysql_exec, '='.join(['--defaults-file', f.name]), irods_config.database_config['db_name']],
+                        [mysql_exec, '='.join(['--defaults-file', f.name]), irods_config.database_config['name']],
                         stdin=sql_file)
 
         # Add a new column that will be responsible for holding the fractional part of the modify_ts

--- a/server/api/src/rs_genquery2.cpp
+++ b/server/api/src/rs_genquery2.cpp
@@ -115,8 +115,8 @@ auto rs_genquery2(RsComm* _comm, Genquery2Input* _input, char** _output) -> int
             // Get the database type string from server_config.json.
             const auto handle = irods::server_properties::instance().map();
             const auto& config = handle.get_json();
-            const auto& db = config.at(nlohmann::json::json_pointer{"/plugin_configuration/database"});
-            opts.database = std::begin(db).key();
+            const auto& db = config.at(nlohmann::json::json_pointer{"/plugin_configuration/database/technology"});
+            opts.database = db.get_ref<const std::string&>();
         }
 
         opts.user_name = _comm->clientUser.userName;


### PR DESCRIPTION
In service of #7975
Addresses #8482
Addresses #8485

Need to run same tests as in https://github.com/irods/irods/pull/8437, I suppose:
- New install (this covers the provider case)
  - [x] Run all unit tests - i.e. run_unit_tests.py
  - [x] Run all core tests - i.e. run_core_tests.py
- [x] New install, configure as catalog consumer
  - Run the topology tests for consumer
  - Unit tests do not apply to this case
  - Requires you to pass the iRODS 5 packages to the run script
- [x] Upgrade iRODS 4.3 provider to iRODS 5 provider
  - Launch the run_core_tests.py script with `--leak-containers` and a short-running test
  - Manually upgrade packages to iRODS 5
  - Rerun run_core_tests.py, adding `--skip-setup`, remove `--tests` so that all core tests are run
- [x] Upgrade iRODS 4.3 consumer to iRODS 5 consumer
  - Same steps as the provider case, but with run_topology_tests.py instead of run_core_tests.py
  - _This case could be combined with the provider case since they run in identical setups_
