### PR TITLE
[#8498] Replace invalid UTF-8 sequences in log messages (4-3-stable)

### DIFF
--- a/lib/core/include/irods/irods_logger.hpp
+++ b/lib/core/include/irods/irods_logger.hpp
@@ -756,7 +756,7 @@ namespace irods::experimental::log
                 object[tag::server::timestamp] = utc_timestamp();
                 object[tag::server::zone] = get_server_zone();
 
-                return object.dump();
+                return object.dump(-1, ' ', false, json::error_handler_t::replace);
             } // to_json_string
 
             template <


### PR DESCRIPTION
Cherry-picked from #8488.