### PR TITLE
[8497] replace use of 'iadmin ls' in tests

### DIFF
--- a/scripts/irods/lib.py
+++ b/scripts/irods/lib.py
@@ -713,11 +713,56 @@ def get_replica_atime(session, logical_path, replica_number):
     out, _, _ = session.run_icommand(['iquery', query])
     return json.loads(out.strip())[0][0]
 
+
 def collection_exists(session, logical_path):
     logical_path = logical_path.replace("'", "\\x27")
     out = session.run_icommand(['iquest', f"select COLL_ID where COLL_NAME = '{logical_path}'"])[0]
 
     return 'CAT_NO_ROWS_FOUND' not in out
+
+
+def get_replica_full_row(session, logical_path, replica_number):
+    logical_path = logical_path.replace("'", "\\x27")
+    coll_name = os.path.dirname(logical_path)
+    data_name = os.path.basename(logical_path)
+    query = "select " \
+            "COLL_ID, " \
+            "DATA_CREATE_TIME, " \
+            "DATA_CHECKSUM, " \
+            "DATA_EXPIRY, " \
+            "DATA_ID, " \
+            "DATA_REPL_STATUS, " \
+            "DATA_MAP_ID, " \
+            "DATA_MODE, " \
+            "DATA_NAME, " \
+            "DATA_OWNER_NAME, " \
+            "DATA_OWNER_ZONE, " \
+            "DATA_PATH, " \
+            "DATA_REPL_NUM, " \
+            "DATA_SIZE, " \
+            "DATA_STATUS, " \
+            "DATA_TYPE_NAME, " \
+            "DATA_VERSION, " \
+            "DATA_ACCESS_TIME, " \
+            "DATA_MODIFY_TIME, " \
+            "DATA_COMMENTS, " \
+            "DATA_RESC_HIER, " \
+            "DATA_RESC_ID, " \
+            "DATA_RESC_NAME " \
+            "where " \
+            f"COLL_NAME = '{coll_name}' and " \
+            f"DATA_NAME = '{data_name}' and " \
+            f"DATA_REPL_NUM = '{replica_number}'"
+    out, _, _ = session.run_icommand(["iquest", query])
+    # Take each column / value pair and turn it into a dict. There's probably a more Pythonic way to do this.
+    out_dict = {}
+    for line in out.splitlines():
+        if (" = " not in line):
+            continue
+        key, val = line.split(" = ")
+        out_dict[key] = val
+    return out_dict
+
 
 def iterfy(iterable):
     """Will return an iterable, even if input is a single item

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -869,13 +869,12 @@ OUTPUT ruleExecOut
             with open(rule_file, 'wt') as f:
                 print(rule_string.format(logical_path, leaf_resource, source_resource), file=f, end='')
             self.admin.assert_icommand(['iput', rule_file, logical_path])
-            self.admin.assert_icommand(['iadmin', 'ls', 'logical_path', logical_path, 'replica_number', '0'],
-                'STDOUT', 'DATA_RESC_HIER: {}'.format(source_resource))
+            self.assertEqual(source_resource, lib.get_replica_full_row(self.admin, logical_path, "0")["DATA_RESC_HIER"])
 
             rep_name = 'irods_rule_engine_plugin-irods_rule_language-instance'
             self.admin.assert_icommand(['irule', '-r', rep_name, '-F', rule_file], 'STDOUT', 'msiDataObjPhymv status')
-            self.admin.assert_icommand(['iadmin', 'ls', 'logical_path', logical_path, 'replica_number', '0'],
-                'STDOUT', 'DATA_RESC_HIER: {}'.format(resource_hierarchy))
+            self.assertEqual(
+                resource_hierarchy, lib.get_replica_full_row(self.admin, logical_path, "0")["DATA_RESC_HIER"])
 
         finally:
             if os.path.exists(rule_file):

--- a/scripts/irods/test/test_irepl.py
+++ b/scripts/irods/test/test_irepl.py
@@ -674,25 +674,20 @@ class test_irepl_with_two_basic_ufs_resources(session.make_sessions_mixin([('oth
             # Put data object to play with...
             user0.assert_icommand(
                 ['iput', '-R', self.resource_1, physical_path, logical_path])
-            self.admin.assert_icommand(
-                ['iadmin', 'ls', 'logical_path', logical_path, 'resource_hierarchy', self.resource_1],
-                'STDOUT', 'DATA_REPL_STATUS: 1')
+            self.assertEqual(int(lib.get_replica_status(self.admin, os.path.basename(logical_path), 0)), 1)
             self.admin.assert_icommand(['iscan', '-d', logical_path])
 
             # Attempt to replicate data object for which admin has no permissions...
             self.admin.assert_icommand(
                 ['irepl', '-R', self.resource_2, logical_path],
                 'STDERR', 'CAT_NO_ACCESS_PERMISSION')
-            self.admin.assert_icommand(
-                ['iadmin', 'ls', 'logical_path', logical_path, 'resource_hierarchy', self.resource_2],
-                'STDOUT', 'No results found.')
+            self.assertFalse(lib.replica_exists_on_resource(self.admin, logical_path, self.resource_2))
+            self.assertFalse(lib.replica_exists(self.admin, logical_path, 1))
             # TODO: #4770 Use test tool to assert that file was not created on resource_2 (i.e. iscan on remote physical file)
 
             # Try again with admin flag (with success)
             self.admin.assert_icommand(['irepl', '-M', '-R', self.resource_2, logical_path])
-            self.admin.assert_icommand(
-                ['iadmin', 'ls', 'logical_path', logical_path, 'resource_hierarchy', self.resource_2],
-                'STDOUT', 'DATA_REPL_STATUS: 1')
+            self.assertEqual(int(lib.get_replica_status(self.admin, os.path.basename(logical_path), 1)), 1)
             self.admin.assert_icommand(['iscan', '-d', logical_path])
 
         finally:

--- a/scripts/irods/test/test_rulebase.py
+++ b/scripts/irods/test/test_rulebase.py
@@ -646,8 +646,7 @@ class Test_Rulebase(ResourceBase, unittest.TestCase):
         self.admin.assert_icommand(['irule', '-F', rule_file], 'STDOUT', 'created [{}]'.format(logical_path))
         os.unlink(rule_file)
 
-        self.admin.assert_icommand(['iadmin', 'ls', 'logical_path', logical_path, 'replica_number', '0'], 'STDOUT', 'DATA_REPL_STATUS: 1')
-
+        self.assertEqual(int(lib.get_replica_status(self.admin, os.path.basename(logical_path), 0)), 1)
 
     @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for irods_rule_language REP')
     def test_msiExecCmd_closeAllL1Desc__issue_6623(self):


### PR DESCRIPTION
blind first attempt, tests have not been run

only touches a few suites

companion to https://github.com/irods/irods_client_icommands/pull/571