### PR TITLE
[#8515] rx_delay_rule_unlock: Return error on non-numeric rule IDs (main)

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -15243,7 +15243,22 @@ auto db_delay_rule_unlock(irods::plugin_context& _ctx, const char* _rule_ids) ->
         // triggering OOM errors.
         for (auto&& rule_id : rule_ids) {
             stmt.bind(0, secs.c_str());
-            stmt.bind(1, rule_id.get_ref<const std::string&>().c_str());
+
+            const auto& rule_id_string = rule_id.get_ref<const std::string&>();
+            try {
+                log_db::debug("{}: Successfully converted rule_id string [{}] to integer [{}].",
+                              __func__,
+                              rule_id_string,
+                              std::stoll(rule_id_string));
+            }
+            catch (const std::exception& e) {
+                log_db::error(
+                    "{}: Could not convert rule_id string [{}] to integer: {}", __func__, rule_id_string, e.what());
+                return ERROR(SYS_INVALID_INPUT_PARAM,
+                             fmt::format("Could not convert rule_id string [{}] to integer", rule_id_string));
+            }
+            stmt.bind(1, rule_id_string.c_str());
+
             nanodbc::execute(stmt);
         }
 

--- a/plugins/microservices/src/test_delay_rule_locking_api.cpp
+++ b/plugins/microservices/src/test_delay_rule_locking_api.cpp
@@ -7,6 +7,7 @@
 #include "irods/msParam.h"
 #include "irods/rcConnect.h"
 #include "irods/rcMisc.h"
+#include "irods/rodsErrorTable.h"
 #include "irods/rs_delay_rule_lock.hpp"
 #include "irods/rs_delay_rule_unlock.hpp"
 #include "irods/rs_genquery2.hpp"
@@ -256,7 +257,7 @@ namespace
 
         // Not an integer.
         unlock_input.rule_ids = strdup(R"(["xyz"])");
-        IRODS_MSI_ASSERT(rs_delay_rule_unlock(_rei->rsComm, &unlock_input) == SYS_LIBRARY_ERROR);
+        IRODS_MSI_ASSERT(rs_delay_rule_unlock(_rei->rsComm, &unlock_input) == SYS_INVALID_INPUT_PARAM);
 
         IRODS_MSI_TEST_END
     } // test_unlock_multiple_delay_rules

--- a/unit_tests/src/test_delay_rule_locking_api.cpp
+++ b/unit_tests/src/test_delay_rule_locking_api.cpp
@@ -242,7 +242,7 @@ TEST_CASE("invalid delay rule ids")
     SECTION("not an integer")
     {
         unlock_input.rule_ids = strdup(R"(["xyz"])");
-        REQUIRE(rc_delay_rule_unlock(static_cast<RcComm*>(conn), &unlock_input) == SYS_LIBRARY_ERROR);
+        REQUIRE(rc_delay_rule_unlock(static_cast<RcComm*>(conn), &unlock_input) == SYS_INVALID_INPUT_PARAM);
     }
 }
 


### PR DESCRIPTION
I've confirmed the change to the API reports the expected error code, `SYS_INVALID_INPUT_PARAM`.

I've confirmed `irods_delay_rule_locking_api` and `test_misc.py` pass with these changes. Tests were run against PostgreSQL, MySQL, and MariaDB.

Test results for `irods_delay_rule_locking_api`:
```
2025-05-14 13:04:25,444 - [debian-12-mariadb-1011_irods-catalog-provider_1]: running test [irods_delay_rule_locking_api]
2025-05-14 13:04:27,587 - [debian-12-mariadb-1011_irods-catalog-provider_1]: test passed [[   2.1426]s] [irods_delay_rule_locking_api]
2025-05-14 13:04:27,588 - [debian-12-mariadb-1011_irods-catalog-provider_1]: tests completed successfully
2025-05-14 13:04:27,588 - ==== begin test run results ====
-----
results for [debian-12-mariadb-1011_irods-catalog-provider_1]
        passed tests:
                [[   2.1426]s]  [irods_delay_rule_locking_api]
        skipped tests:
        failed tests:
        return code:[0]
        time elapsed: [    2.143]seconds ([   0]hours [  0.03572]minutes)
-----
All tests passed! :)
time elapsed: [   2.1442]seconds ([   0]hours [ 0.0357]minutes)
==== end of test run results ====

2025-05-14 13:04:27,684 - version:[5.0.0]
2025-05-14 13:04:27,685 - sha:[20e8be3141947d7895bb24c2080244799fa516b4]
```
```
2025-05-14 13:05:02,129 - [ubuntu-2204-mariadb-1011_irods-catalog-provider_1]: running test [irods_delay_rule_locking_api]
2025-05-14 13:05:03,723 - [ubuntu-2204-mariadb-1011_irods-catalog-provider_1]: test passed [[   1.5939]s] [irods_delay_rule_locking_api]
2025-05-14 13:05:03,723 - [ubuntu-2204-mariadb-1011_irods-catalog-provider_1]: tests completed successfully
2025-05-14 13:05:03,724 - ==== begin test run results ====
-----
results for [ubuntu-2204-mariadb-1011_irods-catalog-provider_1]
        passed tests:
                [[   1.5939]s]  [irods_delay_rule_locking_api]
        skipped tests:
        failed tests:
        return code:[0]
        time elapsed: [    1.595]seconds ([   0]hours [  0.02658]minutes)
-----
All tests passed! :)
time elapsed: [   1.5956]seconds ([   0]hours [ 0.0266]minutes)
==== end of test run results ====

2025-05-14 13:05:03,827 - version:[5.0.0]
2025-05-14 13:05:03,827 - sha:[20e8be3141947d7895bb24c2080244799fa516b4]
```

Test results for `test_misc.py`:
```
2025-05-14 13:08:30,567 - [debian-12-mariadb-1011_irods-catalog-provider_1]: running test [test_misc]
2025-05-14 13:10:13,162 - [debian-12-mariadb-1011_irods-catalog-provider_1]: test passed [[ 102.5941]s] [test_misc]
2025-05-14 13:10:13,162 - [debian-12-mariadb-1011_irods-catalog-provider_1]: tests completed successfully
2025-05-14 13:10:13,163 - ==== begin test run results ====
-----
results for [debian-12-mariadb-1011_irods-catalog-provider_1]
        passed tests:
                [[ 102.5941]s]  [test_misc]
        skipped tests:
        failed tests:
        return code:[0]
        time elapsed: [    102.6]seconds ([   0]hours [     1.71]minutes)
-----
All tests passed! :)
time elapsed: [ 102.5961]seconds ([   0]hours [ 1.7099]minutes)
==== end of test run results ====

2025-05-14 13:10:13,257 - version:[5.0.0]
2025-05-14 13:10:13,257 - sha:[20e8be3141947d7895bb24c2080244799fa516b4]
```
```
2025-05-14 13:08:37,651 - [ubuntu-2204-mariadb-1011_irods-catalog-provider_1]: running test [test_misc]
2025-05-14 13:10:19,392 - [ubuntu-2204-mariadb-1011_irods-catalog-provider_1]: test passed [[ 101.7401]s] [test_misc]
2025-05-14 13:10:19,392 - [ubuntu-2204-mariadb-1011_irods-catalog-provider_1]: tests completed successfully
2025-05-14 13:10:19,394 - ==== begin test run results ====
-----
results for [ubuntu-2204-mariadb-1011_irods-catalog-provider_1]
        passed tests:
                [[ 101.7401]s]  [test_misc]
        skipped tests:
        failed tests:
        return code:[0]
        time elapsed: [    101.7]seconds ([   0]hours [    1.696]minutes)
-----
All tests passed! :)
time elapsed: [ 101.7429]seconds ([   0]hours [ 1.6957]minutes)
==== end of test run results ====

2025-05-14 13:10:19,488 - version:[5.0.0]
2025-05-14 13:10:19,488 - sha:[20e8be3141947d7895bb24c2080244799fa516b4]
```