### PR TITLE
[#8373] DataObjGet: Enforce max size for single buffer (main)

### DIFF
--- a/schemas/configuration/v5/server_config.json.in
+++ b/schemas/configuration/v5/server_config.json.in
@@ -74,7 +74,8 @@
                 },
                 "maximum_size_for_single_buffer_in_megabytes": {
                     "type": "integer",
-                    "minimum": 1
+                    "minimum": 1,
+                    "maximum": 2047
                 },
                 "maximum_size_of_delay_queue_in_bytes": {
                     "type": "integer",


### PR DESCRIPTION
Addresses #8373

`test_iget` passes. Running other core tests now.