### PR TITLE
[#8373] DataObjGet: Enforce max size for single buffer (4-3-stable)

### DIFF
--- a/schemas/configuration/v4/server_config.json.in
+++ b/schemas/configuration/v4/server_config.json.in
@@ -31,7 +31,11 @@
                         "cache_clearer_sleep_time_in_seconds": {"type": "integer"}
                     }
                 },
-                "maximum_size_for_single_buffer_in_megabytes": {"type": "integer"},
+                "maximum_size_for_single_buffer_in_megabytes": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 2047
+                },
                 "maximum_size_of_delay_queue_in_bytes": {"type": "integer"},
                 "maximum_temporary_password_lifetime_in_seconds": {"type": "integer"},
                 "migrate_delay_server_sleep_time_in_seconds":  {"type": "integer"},


### PR DESCRIPTION
Addresses #8373 

Cherry-picked from https://github.com/irods/irods/pull/8570

The test was not cherry-picked because `test_configuration` does not exist in 4-3-stable and there is no configuration check feature in the server for 4.3. I can add an equivalent test, but I figured this is probably good enough for 4.3.

That said, running core tests now.