### PR TITLE
[8295] Avoid error in rsDataObjPut when ALL_KW is set (4-3-stable)

### DIFF
--- a/server/api/src/rsDataObjPut.cpp
+++ b/server/api/src/rsDataObjPut.cpp
@@ -417,9 +417,22 @@ namespace
         if (getValByKey(&_inp.condInput, ALL_KW)) {
             /* update the rest of copies */
             transferStat_t *transStat{};
+
+            const auto* dest_resc_name = getValByKey(&_inp.condInput, DEST_RESC_NAME_KW);
+            const auto stored_resc_name = dest_resc_name ? std::optional<std::string>{dest_resc_name} : std::nullopt;
+
+            // rsDataObjRepl will error if ALL_KW and DEST_RESC_NAME_KW are set simultaneously
+            // It's also set by rsDataObjOpen in some cases, so it needs to be removed here,
+            // not in the client.
+            rmKeyVal(&_inp.condInput, DEST_RESC_NAME_KW);
+
             status = rsDataObjRepl(&_comm, &_inp, &transStat);
             if (transStat) {
                 free(transStat);
+            }
+
+            if (stored_resc_name) {
+                addKeyVal(&_inp.condInput, DEST_RESC_NAME_KW, stored_resc_name.value().c_str());
             }
         }
 


### PR DESCRIPTION
A bunch of research for a one-line change...

Works when I test it by  hand on the test case in the original issue. Taking suggestions if this change triggers any red flags for anyone.

Still needs a unit test.