### PR TITLE
[#8083] Simplify iRODS error message (4-3-stable)

### DIFF
--- a/lib/core/src/irods_log.cpp
+++ b/lib/core/src/irods_log.cpp
@@ -1,4 +1,5 @@
 #include "irods/irods_log.hpp"
+#include "irods/rcGlobalExtern.h"
 #include "irods/rodsLog.h"
 
 namespace irods {
@@ -19,6 +20,11 @@ namespace irods {
     }
 
     void log(const irods::exception& e) {
-        log(LOG_ERROR, e.what());
+        if (CLIENT_PT == ::ProcessType) {
+            log(LOG_ERROR, e.client_display_what());
+        }
+        else {
+            log(LOG_ERROR, e.what());
+        }
     }
 }


### PR DESCRIPTION
Issue quick link: #8083

This PR simplifies the error produced when using an iRODS environment file that does not exist. Following is an example of the new output:

```console
$ IRODS_ENVIRONMENT_FILE=test1 ils
 ERROR: environment_properties::capture: missing environment file. should be at [test1]
 ERROR: _rcConnect: setRhostInfo error, IRODS_HOST is probably not set correctly status = -302000 USER_RODS_HOST_EMPTY
```

---

I modified `irods::log(const irods::exception& e)` as it was the lowest level this change can happen at, potentially dealing with other related issues as well of client logging. I used `::ProcessType` to use the appropriate logging since `irods::log` is in the common lib.

Core and unit tests both passed.