### PR TITLE
[#7494] Use `option` to set MySQL and MariaDB options (4-3-stable)

### DIFF
--- a/scripts/irods/database_connect.py
+++ b/scripts/irods/database_connect.py
@@ -86,8 +86,7 @@ def get_odbc_entry(db_config, catalog_database_type):
             'Server': db_config['db_host'],
             'Port': str(db_config['db_port']),
             'Database': db_config['db_name'],
-            'FOUND_ROWS': '1',
-            'BIG_PACKETS': '1',
+            'option': '10', # Set both FOUND_ROWS (2) and BIG_PACKETS (8)
             'Charset': 'UTF8'
         }
     elif catalog_database_type == 'oracle':


### PR DESCRIPTION
Issue quick link: #7494

This PR attempts to fix the issue relating to MariaDB having unexpected behavior by setting `option` to return the number of found rows instead of the number of changed rows. The settings in `option` are set by toggling the relevant bits, e.g., `2` sets bit `1` which is equivalent to enabling `FOUND_ROWS` in MySQL.

`option` is used here since MariaDB does not support some MySQL aliases such as `FOUND_ROWS`. They must be set in `option`.

The relevant MySQL documentation for `option` can be found here: https://dev.mysql.com/doc/connector-odbc/en/connector-odbc-configuration-connection-parameters.html#codbc-dsn-option-flags

The documentation for MariaDB `option` can be found here: https://mariadb.com/docs/connectors/mariadb-connector-odbc/mariadb-connector-odbc-guide#general-connection-parameters

---

Before getting out of draft the following will be completed:
- Test against MySQL with the following `option`:
  - [ ] "10" or both `BIG_PACKETS` and `FOUND_ROWS`
  - [ ] "8" or just `BIG_PACKETS`
  - [ ] "2" or just `FOUND_ROWS`