### PR TITLE
Revert GenQuery2 enhancements (5-0-stable)

### DIFF
--- a/scripts/irods/test/test_iquery.py
+++ b/scripts/irods/test/test_iquery.py
@@ -1,10 +1,11 @@
 import json
 import unittest
 
-from .. import lib, test
+from . import session
+from .. import lib
+from .. import test
 from ..configuration import IrodsConfig
 from ..controller import IrodsController
-from . import session
 
 rodsadmins = [('otherrods', 'rods')]
 rodsusers  = [('alice', 'apass')]
@@ -321,38 +322,3 @@ class Test_IQuery(session.make_sessions_mixin(rodsadmins, rodsusers), unittest.T
 
         finally:
             controller.reload_configuration()
-
-    def test_genquery2_group_by_with_functions__issue_8093(self):
-        data_objects = [f"issue_8093_data_object_{'{0:b}'.format(x)}.txt" for x in range(5)]
-        try:
-            for x in range(5):
-                self.user.assert_icommand(['itouch', data_objects[x]])
-
-            with self.subTest('Grouping by a column'):
-                query_string = "select count(DATA_NAME) group by DATA_SIZE"
-                json_string = json.dumps([['5']], separators=(',', ':'))
-                self.user.assert_icommand(['iquery', query_string], 'STDOUT', [json_string])
-
-            with self.subTest('Grouping by multiple columns'):
-                query_string = "select count(DATA_NAME) group by DATA_SIZE, DATA_NAME"
-                json_string = json.dumps([['1'],['1'],['1'],['1'],['1']], separators=(',', ':'))
-                self.user.assert_icommand(['iquery', query_string], 'STDOUT', [json_string])
-
-            with self.subTest('Grouping by a function'):
-                query_string = "select count(DATA_NAME) group by length(DATA_NAME)"
-                json_string = json.dumps([['2'],['2'],['1']], separators=(',', ':'))
-                self.user.assert_icommand(['iquery', query_string], 'STDOUT', [json_string])
-
-            with self.subTest('Grouping by multiple functions'):
-                query_string = "select count(DATA_NAME) group by length(DATA_NAME), substring(DATA_PATH, 0, 1)"
-                json_string = json.dumps([['2'],['2'],['1']], separators=(',', ':'))
-                self.user.assert_icommand(['iquery', query_string], 'STDOUT', [json_string])
-
-            with self.subTest('Grouping by a column and a function'):
-                query_string = "select count(DATA_NAME) group by DATA_NAME, substring(DATA_PATH, 0, 1)"
-                json_string = json.dumps([['1'],['1'],['1'],['1'],['1']], separators=(',', ':'))
-                self.user.assert_icommand(['iquery', query_string], 'STDOUT', [json_string])
-
-        finally:
-            for x in range(5):
-                self.user.run_icommand(['irm', '-f', data_objects[x]])

--- a/server/genquery2/dsl/parser.y
+++ b/server/genquery2/dsl/parser.y
@@ -11,7 +11,7 @@ Request that symbols be handled as a whole (type, value, and possibly location)
 in the scanner. In C++, only works when variant-based semantic values are enabled.
 This option causes make_* functions to be generated for each token kind.
 */
-%define api.token.constructor
+%define api.token.constructor 
 
 /* The type used for semantic values. */
 %define api.value.type variant
@@ -119,7 +119,7 @@ This option causes make_* functions to be generated for each token kind.
 %token does not define associativity or precedence.
 %precedence does not define associativity.
 
-Operator precedence is determined by the line ordering of the declarations.
+Operator precedence is determined by the line ordering of the declarations. 
 The further down the page the line is, the higher the precedence. For example,
 NOT has higher precedence than AND.
 
@@ -134,7 +134,6 @@ rules only.
 %nterm <gq2_detail::projections>                  projection_list;
 %nterm <gq2_detail::conditions>                   condition_list;
 %nterm <gq2_detail::group_by>                     group_by;
-%nterm <std::vector<std::variant<gq2_detail::function, gq2_detail::column>>> group_expression;
 %nterm <gq2_detail::order_by>                     order_by;
 %nterm <std::vector<gq2_detail::sort_expression>> sort_expression;
 %nterm <gq2_detail::range>                        range;
@@ -145,6 +144,7 @@ rules only.
 %nterm <gq2_detail::condition>                    condition;
 %nterm <gq2_detail::condition_expression>         condition_expression;
 %nterm <std::vector<std::string>>                 string_literal_list;
+%nterm <std::vector<std::string>>                 identifier_list;
 %nterm <std::string>                              integer;
 
 %start genquery2 /* Defines where grammar starts */
@@ -168,18 +168,11 @@ select:
 
 group_by:
   %empty { /* Generates a default initialized group_by structure. */ }
-| GROUP BY group_expression { std::swap($$.expressions, $3); }
+| GROUP BY identifier_list { std::swap($$.columns, $3); }
 ;
 
 order_by:
   ORDER BY sort_expression { std::swap($$.sort_expressions, $3); }
-;
-
-group_expression:
-  column { $$.push_back($1); }
-| group_expression COMMA column { $1.push_back($3); std::swap($$, $1); }
-| function { $$.push_back($1); }
-| group_expression COMMA function { $1.push_back($3); std::swap($$, $1); }
 ;
 
 /*
@@ -199,8 +192,6 @@ The following would be possible if everything used std::variant.
     | sort_expression COMMA projection ASC { $1.push_back(gq2_detail::sort_expression{$3, true}); std::swap($$, $1); }
     | sort_expression COMMA projection DESC { $1.push_back(gq2_detail::sort_expression{$3, false}); std::swap($$, $1); }
     ;
-
-This also applies to the above group by clause.
 */
 sort_expression:
   column { $$.push_back(gq2_detail::sort_expression{$1, true}); }
@@ -293,6 +284,11 @@ condition_expression:
 string_literal_list:
   STRING_LITERAL { $$ = std::vector<std::string>{std::move($1)}; }
 | string_literal_list COMMA STRING_LITERAL { $1.push_back(std::move($3)); std::swap($$, $1); }
+;
+
+identifier_list:
+  IDENTIFIER { $$ = std::vector<std::string>{std::move($1)}; }
+| identifier_list COMMA IDENTIFIER { $1.push_back(std::move($3)); std::swap($$, $1); }
 ;
 
 integer:

--- a/server/genquery2/include/irods/private/genquery2_ast_types.hpp
+++ b/server/genquery2/include/irods/private/genquery2_ast_types.hpp
@@ -252,7 +252,7 @@ namespace irods::experimental::genquery2
 
     struct group_by
     {
-        std::vector<std::variant<function, column>> expressions;
+        std::vector<std::string> columns;
     }; // struct group_by
 
     struct order_by

--- a/server/genquery2/src/genquery2_sql.cpp
+++ b/server/genquery2/src/genquery2_sql.cpp
@@ -593,8 +593,55 @@ namespace
         return std::nullopt;
     } // get_special_table_alias_for_column
 
-    auto to_sql_for_order_or_group_by_clause(const gq_state& _state,
-                                             const irods::experimental::genquery2::column& _column) -> std::string
+    auto generate_group_by_clause(const gq_state& _state,
+                                  const gq::group_by& _group_by,
+                                  const std::map<std::string_view, gq::column_info>& _column_name_mappings)
+        -> std::string
+    {
+        if (_group_by.columns.empty()) {
+            return {};
+        }
+
+        std::vector<std::string> resolved_columns;
+        resolved_columns.reserve(_group_by.columns.size());
+
+        for (const auto& c : _group_by.columns) {
+            const auto iter = _column_name_mappings.find(c);
+
+            if (iter == std::end(_column_name_mappings)) {
+                throw std::invalid_argument{fmt::format("unknown column in group-by clause: {}", c)};
+            }
+
+            auto alias = get_special_table_alias_for_column(c);
+
+            if (!alias) {
+                alias = _state.table_aliases.at(std::string{iter->second.table});
+            }
+
+            const auto ast_iter =
+                std::find_if(std::begin(_state.ast_column_ptrs),
+                             std::end(_state.ast_column_ptrs),
+                             [&c](const irods::experimental::genquery2::column* _p) { return _p->name == c; });
+
+            if (std::end(_state.ast_column_ptrs) == ast_iter) {
+                throw std::invalid_argument{"cannot generate SQL from General Query."};
+            }
+
+            if ((*ast_iter)->type_name.empty()) {
+                resolved_columns.push_back(fmt::format("{}.{}", *alias, iter->second.name));
+            }
+            else {
+                resolved_columns.push_back(
+                    fmt::format("cast({}.{} as {})", *alias, iter->second.name, (*ast_iter)->type_name));
+            }
+        }
+
+        // All columns in the group-by clause must exist in the list of columns to project.
+        return fmt::format(" group by {}", fmt::join(resolved_columns, ", "));
+    } // generate_group_by_clause
+
+    auto to_sql_for_order_by_clause(const gq_state& _state, const irods::experimental::genquery2::column& _column)
+        -> std::string
     {
         using irods::experimental::genquery2::column_name_mappings;
 
@@ -615,10 +662,10 @@ namespace
         }
 
         return fmt::format("cast({}.{} as {})", alias, iter->second.name, _column.type_name);
-    } // to_sql_for_order_or_group_by_clause
+    } // to_sql_for_order_by_clause
 
-    auto to_sql_for_order_or_group_by_clause(const gq_state& _state,
-                                             const irods::experimental::genquery2::function& _function) -> std::string
+    auto to_sql_for_order_by_clause(const gq_state& _state, const irods::experimental::genquery2::function& _function)
+        -> std::string
     {
         std::vector<std::string> args;
         args.reserve(_function.arguments.size());
@@ -630,7 +677,7 @@ namespace
             }
 
             if (const auto* p = std::get_if<irods::experimental::genquery2::function>(&_arg); p) {
-                args.emplace_back(to_sql_for_order_or_group_by_clause(_state, *p));
+                args.emplace_back(to_sql_for_order_by_clause(_state, *p));
                 return;
             }
 
@@ -662,34 +709,7 @@ namespace
         }
 
         return fmt::format("{}({})", _function.name, fmt::join(args, ", "));
-    } // to_sql_for_order_or_group_by_clause
-
-    auto generate_group_by_clause(
-        gq_state& _state,
-        const gq::group_by& _group_by,
-        [[maybe_unused]] const std::map<std::string_view, gq::column_info>& _column_name_mappings) -> std::string
-    {
-        if (_group_by.expressions.empty()) {
-            return {};
-        }
-
-        const auto& expressions = _group_by.expressions;
-
-        std::vector<std::string> group_expr;
-        group_expr.reserve(expressions.size());
-
-        for (const auto& expr : expressions) {
-            if (const auto* p = std::get_if<irods::experimental::genquery2::column>(&expr); p) {
-                group_expr.emplace_back(to_sql_for_order_or_group_by_clause(_state, *p));
-                continue;
-            }
-
-            const auto& fn = std::get<irods::experimental::genquery2::function>(expr);
-            group_expr.emplace_back(to_sql_for_order_or_group_by_clause(_state, fn));
-        }
-
-        return fmt::format(" group by {}", fmt::join(group_expr, ", "));
-    } // generate_group_by_clause
+    } // to_sql_for_order_by_clause
 
     auto generate_order_by_clause(
         gq_state& _state,
@@ -707,14 +727,14 @@ namespace
 
         for (const auto& se : sort_expressions) {
             if (const auto* p = std::get_if<irods::experimental::genquery2::column>(&se.expr); p) {
-                sort_expr.emplace_back(fmt::format(
-                    "{} {}", to_sql_for_order_or_group_by_clause(_state, *p), se.ascending_order ? "asc" : "desc"));
+                sort_expr.emplace_back(
+                    fmt::format("{} {}", to_sql_for_order_by_clause(_state, *p), se.ascending_order ? "asc" : "desc"));
                 continue;
             }
 
             const auto& fn = std::get<irods::experimental::genquery2::function>(se.expr);
-            sort_expr.emplace_back(fmt::format(
-                "{} {}", to_sql_for_order_or_group_by_clause(_state, fn), se.ascending_order ? "asc" : "desc"));
+            sort_expr.emplace_back(
+                fmt::format("{} {}", to_sql_for_order_by_clause(_state, fn), se.ascending_order ? "asc" : "desc"));
         }
 
         // All columns/expressions in the order by clause must exist in the list of columns to project.


### PR DESCRIPTION
This PR reverts enhancements for GenQuery2's GROUP-BY clause. These changes cannot exist in the 5-0-stable branch because that would require a bump in the minor version number of the server.