### PR TITLE
[#8417] Deprecate functions for dns/hostname cache config properties (4-3-stable)

### DIFF
--- a/lib/core/include/irods/irods_server_properties.hpp
+++ b/lib/core/include/irods/irods_server_properties.hpp
@@ -275,8 +275,10 @@ namespace irods
     /// \retval 5000000          If an error occurred or the size was less than or equal to zero.
     /// \retval Configured-Value Otherwise.
     ///
+    /// \deprecated Deprecated in 4.3.5. Use #get_server_property functions.
+    ///
     /// \since 4.2.9
-    auto get_dns_cache_shared_memory_size() noexcept -> int;
+    [[deprecated("Use get_server_property functions")]] auto get_dns_cache_shared_memory_size() noexcept -> int;
 
     /// Returns the DNS cache eviction age from server_config.json.
     ///
@@ -284,8 +286,10 @@ namespace irods
     /// \retval 3600             If an error occurred or the age was less than zero.
     /// \retval Configured-Value Otherwise.
     ///
+    /// \deprecated Deprecated in 4.3.5. Use #get_server_property functions.
+    ///
     /// \since 4.2.9
-    auto get_dns_cache_eviction_age() noexcept -> int;
+    [[deprecated("Use get_server_property functions")]] auto get_dns_cache_eviction_age() noexcept -> int;
 
     /// Returns the amount of shared memory that should be allocated for the Hostname cache.
     ///
@@ -293,8 +297,10 @@ namespace irods
     /// \retval 2500000          If an error occurred or the size was less than or equal to zero.
     /// \retval Configured-Value Otherwise.
     ///
+    /// \deprecated Deprecated in 4.3.5. Use #get_server_property functions.
+    ///
     /// \since 4.2.9
-    auto get_hostname_cache_shared_memory_size() noexcept -> int;
+    [[deprecated("Use get_server_property functions")]] auto get_hostname_cache_shared_memory_size() noexcept -> int;
 
     /// Returns the hostname cache eviction age from server_config.json.
     ///
@@ -302,8 +308,10 @@ namespace irods
     /// \retval 3600             If an error occurred or the age was less than zero.
     /// \retval Configured-Value Otherwise.
     ///
+    /// \deprecated Deprecated in 4.3.5. Use #get_server_property functions.
+    ///
     /// \since 4.2.9
-    auto get_hostname_cache_eviction_age() noexcept -> int;
+    [[deprecated("Use get_server_property functions")]] auto get_hostname_cache_eviction_age() noexcept -> int;
 } // namespace irods
 
 #endif // IRODS_SERVER_PROPERTIES_HPP

--- a/lib/core/src/rcMisc.cpp
+++ b/lib/core/src/rcMisc.cpp
@@ -4867,7 +4867,10 @@ int get_canonical_name(const char *_hostname, char* _buf, size_t _len)
     snprintf(_buf, _len, "%s", p_addrinfo->ai_canonname);
 
     if (CLIENT_PT != ::ProcessType) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         const std::chrono::seconds age{irods::get_dns_cache_eviction_age()};
+#pragma GCC diagnostic pop
         const auto inserted = dnsc::insert_or_assign(key, *p_addrinfo, age);
 
         rodsLog(LOG_DEBUG, "%s :: Added addrinfo to DNS cache [hostname=%s, inserted=%d, key=%s, age=%d].",
@@ -4908,7 +4911,10 @@ int load_in_addr_from_hostname(const char* _hostname, struct in_addr* _out)
     *_out = reinterpret_cast<struct sockaddr_in*>(p_addrinfo->ai_addr)->sin_addr;
 
     if (CLIENT_PT != ::ProcessType) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         const std::chrono::seconds age{irods::get_dns_cache_eviction_age()};
+#pragma GCC diagnostic pop
         const auto inserted = dnsc::insert_or_assign(key, *p_addrinfo, age);
 
         rodsLog(LOG_DEBUG, "%s :: Added addrinfo to DNS cache [hostname=%s, inserted=%d, key=%s, age=%d].",

--- a/lib/core/src/sockComm.cpp
+++ b/lib/core/src/sockComm.cpp
@@ -492,7 +492,10 @@ sockOpenForInConn( rsComm_t *rsComm, int *portNum, char **addr, int proto ) {
                     std::strncpy(*addr, alias->data(), alias->size());
                 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                 const std::chrono::seconds age{irods::get_hostname_cache_eviction_age()};
+#pragma GCC diagnostic pop
                 const auto inserted = hnc::insert_or_assign("localhost", *addr, age);
 
                 rodsLog(LOG_DEBUG, "%s :: Added alias to hostname cache for localhost [alias=%s, inserted=%d].",

--- a/server/core/src/rodsAgent.cpp
+++ b/server/core/src/rodsAgent.cpp
@@ -301,13 +301,19 @@ void set_eviction_age_for_dns_and_hostname_caches()
     // Update the eviction age for DNS cache entries.
     irods::set_server_property(
         key_path_t{irods::KW_CFG_ADVANCED_SETTINGS, irods::KW_CFG_DNS_CACHE, irods::KW_CFG_EVICTION_AGE_IN_SECONDS},
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         irods::get_dns_cache_eviction_age());
+#pragma GCC diagnostic pop
 
     // Update the eviction age for hostname cache entries.
     irods::set_server_property(
         key_path_t{
             irods::KW_CFG_ADVANCED_SETTINGS, irods::KW_CFG_HOSTNAME_CACHE, irods::KW_CFG_EVICTION_AGE_IN_SECONDS},
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         irods::get_hostname_cache_eviction_age());
+#pragma GCC diagnostic pop
 } // set_eviction_age_for_dns_and_hostname_caches
 
 void set_log_levels_for_all_log_categories()

--- a/server/main_server/src/rodsServer.cpp
+++ b/server/main_server/src/rodsServer.cpp
@@ -1255,11 +1255,17 @@ int main(int argc, char** argv)
     create_stacktrace_directory();
 
     namespace hnc = irods::experimental::net::hostname_cache;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     hnc::init("irods_hostname_cache", irods::get_hostname_cache_shared_memory_size());
+#pragma GCC diagnostic pop
     irods::at_scope_exit deinit_hostname_cache{[] { hnc::deinit(); }};
 
     namespace dnsc = irods::experimental::net::dns_cache;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     dnsc::init("irods_dns_cache", irods::get_dns_cache_shared_memory_size());
+#pragma GCC diagnostic pop
     irods::at_scope_exit deinit_dns_cache{[] { dnsc::deinit(); }};
 
     ix::replica_access_table::init();
@@ -1279,12 +1285,19 @@ int main(int argc, char** argv)
     // Set the default value for evicting DNS cache entries.
     irods::set_server_property(
         key_path_t{irods::KW_CFG_ADVANCED_SETTINGS, irods::KW_CFG_DNS_CACHE, irods::KW_CFG_EVICTION_AGE_IN_SECONDS},
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         irods::get_dns_cache_eviction_age());
+#pragma GCC diagnostic pop
 
     // Set the default value for evicting hostname cache entries.
     irods::set_server_property(
-        key_path_t{irods::KW_CFG_ADVANCED_SETTINGS, irods::KW_CFG_HOSTNAME_CACHE, irods::KW_CFG_EVICTION_AGE_IN_SECONDS},
+        key_path_t{
+            irods::KW_CFG_ADVANCED_SETTINGS, irods::KW_CFG_HOSTNAME_CACHE, irods::KW_CFG_EVICTION_AGE_IN_SECONDS},
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         irods::get_hostname_cache_eviction_age());
+#pragma GCC diagnostic pop
 
     setup_signal_handlers();
 


### PR DESCRIPTION
Unit tests pass. I don't think this requires running the core tests since it's just marking functions deprecated.

Here's what the compiler prints when someone attempts to use the functions in iRODS code.
```
/irods_source/lib/core/src/rcMisc.cpp:4870:47: error: 'get_dns_cache_eviction_age' is deprecated: Use get_server_property functions [-Werror,-Wdeprecated-declarations]
        const std::chrono::seconds age{irods::get_dns_cache_eviction_age()};                                                                                           
                                              ^                                                                                                                        
/irods_source/lib/core/include/irods/irods_server_properties.hpp:292:7: note: 'get_dns_cache_eviction_age' has been explicitly marked deprecated here                  
    [[deprecated("Use get_server_property functions")]] auto get_dns_cache_eviction_age() noexcept -> int;                                                             
      ^                                                                                                                                                                
1 error generated.                                                                                                                                                     
ninja: build stopped: subcommand failed.                                                                                                                               
```