### PR TITLE
[#6756] Deprecate and replace use of uint (4-3-stable)

### DIFF
--- a/lib/api/include/irods/getMiscSvrInfo.h
+++ b/lib/api/include/irods/getMiscSvrInfo.h
@@ -12,7 +12,7 @@
 
 typedef struct MiscSvrInfo {
     int serverType;     // RCAT_ENABLED or RCAT_NOT_ENABLED
-    uint serverBootTime;
+    unsigned int serverBootTime;
     char relVersion[NAME_LEN];    // the release version number
     char apiVersion[NAME_LEN];    // the API version number
     char rodsZone[NAME_LEN];      // the zone of this server

--- a/lib/api/include/irods/objStat.h
+++ b/lib/api/include/irods/objStat.h
@@ -8,7 +8,7 @@
 typedef struct rodsObjStat {
     rodsLong_t          objSize;        // file size
     objType_t           objType;        // DATA_OBJ_T or COLL_OBJ_T
-    uint                dataMode;
+    unsigned int        dataMode;
     char                dataId[NAME_LEN];
     char                chksum[NAME_LEN];
     char                ownerName[NAME_LEN];

--- a/lib/api/src/rcBulkDataObjPut.cpp
+++ b/lib/api/src/rcBulkDataObjPut.cpp
@@ -63,7 +63,7 @@
  * \n .... handle the error
  * \n }
 
- * \n status = read (fd, bufPtr, (uint) size1);
+ * \n status = read (fd, bufPtr, (unsigned int) size1);
  * \n if (status != size1) {
  * \n .... handle the error
  * \n }
@@ -80,7 +80,7 @@
  * \n if (fd < 0) {
  * \n .... handle the error
  * \n }
- * \n status = read (fd, bufPtr, (uint) size2);
+ * \n status = read (fd, bufPtr, (unsigned int) size2);
  * \n if (status != size2) {
  * \n .... handle the error
  * \n }

--- a/lib/core/include/irods/alignPointer.hpp
+++ b/lib/core/include/irods/alignPointer.hpp
@@ -21,8 +21,8 @@ T alignAddrToBoundary( T ptr, std::size_t boundary ) {
     return ( char * )ptr + boundary - m;
 
 #else
-    uint b, m;
-    b = ( uint ) ptr;
+    unsigned int b, m;
+    b = (unsigned int) ptr;
 
     m = b % boundary;
 

--- a/lib/core/include/irods/getUtil.h
+++ b/lib/core/include/irods/getUtil.h
@@ -15,10 +15,13 @@ extern "C" {
 int
 getUtil( rcComm_t **myConn, rodsEnv *myEnv, rodsArguments_t *myRodsArgs,
          rodsPathInp_t *rodsPathInp );
-int
-getDataObjUtil( rcComm_t *conn, char *srcPath, char *targPath,
-                rodsLong_t srcSize, uint dataMode,
-                rodsArguments_t *rodsArgs, dataObjInp_t *dataObjOprInp );
+int getDataObjUtil(rcComm_t* conn,
+                   char* srcPath,
+                   char* targPath,
+                   rodsLong_t srcSize,
+                   unsigned int dataMode,
+                   rodsArguments_t* rodsArgs,
+                   dataObjInp_t* dataObjOprInp);
 
 int
 initCondForGet( rcComm_t *conn, rodsArguments_t *rodsArgs,

--- a/lib/core/include/irods/miscUtil.h
+++ b/lib/core/include/irods/miscUtil.h
@@ -115,7 +115,7 @@ typedef struct CollEnt {
     objType_t objType;
     int replNum;
     int replStatus;
-    uint dataMode;
+    unsigned int dataMode;
     rodsLong_t dataSize;
     char *collName;      // valid for dataObj and collection */
     char *dataName;
@@ -234,8 +234,7 @@ int
 freeCollEnt( collEnt_t *collEnt );
 int
 clearCollEnt( collEnt_t *collEnt );
-int
-myChmod( char *inPath, uint dataMode );
+int myChmod(char* inPath, unsigned int dataMode);
 char *
 getZoneHintForGenQuery( genQueryInp_t *genQueryInp );
 int

--- a/lib/core/include/irods/rodsPath.h
+++ b/lib/core/include/irods/rodsPath.h
@@ -17,7 +17,7 @@ typedef struct RodsPath {
     objType_t objType;
     objStat_t objState;
     rodsLong_t size;
-    uint objMode;
+    unsigned int objMode;
     char inPath[MAX_NAME_LEN];	 /* input from command line */
     char outPath[MAX_NAME_LEN];	 /* the path after parsing the inPath */
     char dataId[NAME_LEN];

--- a/lib/core/include/irods/rodsType.h
+++ b/lib/core/include/irods/rodsType.h
@@ -21,6 +21,7 @@ typedef int64_t u_longlong_t;
 typedef long long rodsLong_t;
 typedef unsigned long long rodsULong_t;
 #elif defined(windows_platform)
+__attribute__((deprecated("Use unsigned int directly")))
 typedef unsigned int uint;
 typedef __int64 rodsLong_t;
 typedef unsigned __int64 rodsULong_t;

--- a/lib/core/src/getUtil.cpp
+++ b/lib/core/src/getUtil.cpp
@@ -197,10 +197,14 @@ getUtil( rcComm_t **myConn, rodsEnv *myRodsEnv, rodsArguments_t *myRodsArgs,
     return status;
 }
 
-int
-getDataObjUtil( rcComm_t *conn, char *srcPath, char *targPath,
-                rodsLong_t srcSize, uint dataMode,
-                rodsArguments_t *rodsArgs, dataObjInp_t *dataObjOprInp ) {
+int getDataObjUtil(rcComm_t* conn,
+                   char* srcPath,
+                   char* targPath,
+                   rodsLong_t srcSize,
+                   unsigned int dataMode,
+                   rodsArguments_t* rodsArgs,
+                   dataObjInp_t* dataObjOprInp)
+{
     int status;
     struct timeval startTime, endTime;
 

--- a/lib/core/src/miscUtil.cpp
+++ b/lib/core/src/miscUtil.cpp
@@ -22,7 +22,7 @@
 /* VERIFY_DIV - contributed by g.soudlenkov@auckland.ac.nz */
 #define VERIFY_DIV(_v1_,_v2_) ((_v2_)? (float)(_v1_)/(_v2_):0.0)
 
-static uint Myumask = INIT_UMASK_VAL;
+static unsigned int Myumask = INIT_UMASK_VAL;
 
 // A GenQuery condition string (i.e. not equal to the root collection).
 const char NON_ROOT_COLL_CHECK_STR[] = "<>'/'";
@@ -1811,9 +1811,8 @@ clearCollEnt( collEnt_t *collEnt ) {
     return 0;
 }
 
-
-int
-myChmod( char *inPath, uint dataMode ) {
+int myChmod(char* inPath, unsigned int dataMode)
+{
     if ( dataMode < 0100 ) {
         return 0;
     }

--- a/lib/core/src/rcMisc.cpp
+++ b/lib/core/src/rcMisc.cpp
@@ -1878,7 +1878,7 @@ getNowStr( char *timeStr ) {
     time_t myTime;
 
     myTime = time( NULL );
-    snprintf( timeStr, 15, "%011d", ( uint ) myTime );
+    snprintf(timeStr, 15, "%011d", (unsigned int) myTime);
 }
 
 /*
@@ -2375,7 +2375,7 @@ localToUnixTime( char * localTime, char * unixTime ) {
         snprintf( unixTime, TIME_LEN, "%lld", ( rodsLong_t ) newTime );
     }
     else {
-        snprintf( unixTime, TIME_LEN, "%d", ( uint ) newTime );
+        snprintf(unixTime, TIME_LEN, "%d", (unsigned int) newTime);
     }
     return 0;
 }

--- a/lib/core/src/sockComm.cpp
+++ b/lib/core/src/sockComm.cpp
@@ -1006,7 +1006,7 @@ connectToRhostWithTout(struct sockaddr *sin ) {
 #if defined(aix_platform)
                 socklen_t mylen = sizeof( int );
 #else
-                uint mylen = sizeof( int );
+                unsigned int mylen = sizeof(int);
 #endif
                 if ( getsockopt( sock, SOL_SOCKET, SO_ERROR, ( void* )( &myval ),
                                  &mylen ) < 0 ) {
@@ -1097,9 +1097,9 @@ setConnAddr( rcComm_t *conn ) {
 int
 setRemoteAddr( int sock, struct sockaddr_in *remoteAddr ) {
 #if defined(aix_platform)
-    socklen_t       laddrlen = sizeof( struct sockaddr );
+    socklen_t laddrlen = sizeof(struct sockaddr);
 #else
-    uint         laddrlen = sizeof( struct sockaddr );
+    unsigned int laddrlen = sizeof(struct sockaddr);
 #endif
 
     /* fill in the server address. This is for case where the conn->host
@@ -1118,9 +1118,9 @@ setRemoteAddr( int sock, struct sockaddr_in *remoteAddr ) {
 int
 setLocalAddr( int sock, struct sockaddr_in *localAddr ) {
 #if defined(aix_platform)
-    socklen_t       laddrlen = sizeof( struct sockaddr );
+    socklen_t laddrlen = sizeof(struct sockaddr);
 #else
-    uint         laddrlen = sizeof( struct sockaddr );
+    unsigned int laddrlen = sizeof(struct sockaddr);
 #endif
 
 

--- a/lib/rbudp/src/QUANTAnet_rbudpReceiver_c.cpp
+++ b/lib/rbudp/src/QUANTAnet_rbudpReceiver_c.cpp
@@ -333,11 +333,11 @@ getfileByFd( rbudpReceiver_t *rbudpReceiver, int fd, int packetSize ) {
     }
     long long remaining = filesize;
     while ( remaining > 0 ) {
-        uint toRead;
+        unsigned int toRead;
         char *buf;
 
-        if ( remaining > ( uint ) ONE_GIGA ) {
-            toRead = ( uint ) ONE_GIGA;
+        if (remaining > (unsigned int) ONE_GIGA) {
+            toRead = (unsigned int) ONE_GIGA;
         }
         else {
             toRead = remaining;

--- a/lib/rbudp/src/QUANTAnet_rbudpSender_c.cpp
+++ b/lib/rbudp/src/QUANTAnet_rbudpSender_c.cpp
@@ -369,10 +369,10 @@ int  sendfileByFd( rbudpSender_t *rbudpSender, int sendRate, int packetSize,
 
     remaining = filesize;
     while ( remaining > 0 ) {
-        uint toSend;
+        unsigned int toSend;
 
-        if ( remaining > ( uint ) ONE_GIGA ) {
-            toSend = ( uint ) ONE_GIGA;
+        if (remaining > (unsigned int) ONE_GIGA) {
+            toSend = (unsigned int) ONE_GIGA;
         }
         else {
             toSend = remaining;

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -11789,7 +11789,7 @@ irods::error db_purge_server_load_op(
     nowTime = atoll( nowStr );
     secondsAgoTime = atoll( _seconds_ago );
     thenTime = nowTime - secondsAgoTime;
-    snprintf( thenStr, sizeof thenStr, "%011d", ( uint ) thenTime );
+    snprintf(thenStr, sizeof thenStr, "%011d", (unsigned int) thenTime);
 
     if ( logSQL != 0 ) {
         log_sql::debug("chlPurgeServerLoad SQL 1");
@@ -11928,7 +11928,7 @@ irods::error db_purge_server_load_digest_op(
     nowTime = atoll( nowStr );
     secondsAgoTime = atoll( _seconds_ago );
     thenTime = nowTime - secondsAgoTime;
-    snprintf( thenStr, sizeof thenStr, "%011d", ( uint ) thenTime );
+    snprintf(thenStr, sizeof thenStr, "%011d", (unsigned int) thenTime);
 
     if ( logSQL != 0 ) {
         log_sql::debug("chlPurgeServerLoadDigest SQL 1");

--- a/server/core/src/miscServerFunct.cpp
+++ b/server/core/src/miscServerFunct.cpp
@@ -2090,9 +2090,9 @@ svrPortalPutGetRbudp( rsComm_t *rsComm ) {
     int udpPortBuf;
     int status;
 #if defined(aix_platform)
-    socklen_t      laddrlen = sizeof( struct sockaddr );
+    socklen_t laddrlen = sizeof(struct sockaddr);
 #else
-    uint         laddrlen = sizeof( struct sockaddr );
+    unsigned int laddrlen = sizeof(struct sockaddr);
 #endif
     int packetSize;
     char *tmpStr;

--- a/server/core/src/physPath.cpp
+++ b/server/core/src/physPath.cpp
@@ -325,9 +325,15 @@ setPathForRandomScheme( char *objPath, const char *vaultPath, char *userName,
         return status;
     }
 
-    snprintf( outPath, MAX_NAME_LEN,
-              "%s/%s/%d/%d/%s.%d", vaultPath, userName, dir1, dir2,
-              logicalFileName, ( uint ) time( NULL ) );
+    snprintf(outPath,
+             MAX_NAME_LEN,
+             "%s/%s/%d/%d/%s.%d",
+             vaultPath,
+             userName,
+             dir1,
+             dir2,
+             logicalFileName,
+             (unsigned int) time(NULL));
     return 0;
 }
 

--- a/server/re/src/printMS.cpp
+++ b/server/re/src/printMS.cpp
@@ -8,7 +8,7 @@
 #if defined(_LP64) || defined(__LP64__)
 #define CAST_PTR_INT (long int)
 #else
-#define CAST_PTR_INT (uint)
+#  define CAST_PTR_INT (unsigned int)
 #endif
 
 /**


### PR DESCRIPTION
Code compiles, but has not been tested.

This needs to be tested on all platforms we support before merging.