### PR TITLE
[#8577] Do not prompt for server host on unattended install (main)

### DIFF
--- a/scripts/setup_irods.py
+++ b/scripts/setup_irods.py
@@ -72,14 +72,13 @@ except:
 def setup_server(irods_config, json_configuration_file=None, test_mode=False):
     l = logging.getLogger(__name__)
 
-    # Setup the hostname, FQDN, or IP to listen on for client requests.
-    setup_server_host(irods_config)
-
     if json_configuration_file is not None:
         with open(json_configuration_file) as f:
             json_configuration_dict = json.load(f)
     else:
         json_configuration_dict = None
+        # Setup the hostname, FQDN, or IP to listen on for client requests.
+        setup_server_host(irods_config)
 
     if IrodsController(irods_config).get_server_proc():
         l.info(irods.lib.get_header('Stopping iRODS...'))


### PR DESCRIPTION
This code change comes directly from the issue. It skips the prompt when unattended installs are performed. I don't think we need to test this since the change is very obvious.

I'm much more interested in adding support for unattended installation to the testing environment and catching issues during release testing.