### PR TITLE
[#8676] Do not stacktrace on detection of server downgrade (5-0-stable)

### DIFF
--- a/scripts/irods/upgrade_configuration.py
+++ b/scripts/irods/upgrade_configuration.py
@@ -93,7 +93,7 @@ def raise_exception_if_downgrade_is_detected(irods_config):
 
     l.debug('Comparing version information to determine if a downgrade would occur.')
     if new_version_tuple < old_version_tuple:
-        raise IrodsError(f'Downgrade detected. Downgrading is unsupported, please reinstall iRODS version [{irods_config.version["irods_version"]}] or newer.')
+        raise IrodsError(f'Downgrade detected. Downgrading is unsupported, please reinstall iRODS version [{old_version["irods_version"]}] or newer.')
 
     l.info('No downgrade issue present.')
 

--- a/scripts/upgrade_irods.py
+++ b/scripts/upgrade_irods.py
@@ -65,7 +65,7 @@ def main():
     try:
         IrodsController(irods_config).upgrade()
     except IrodsError as e:
-        l.error('Error encountered running upgrade. Exiting...')
+        l.error('%s', e)
         return 1
 
     return 0


### PR DESCRIPTION
When attempting to downgrade from 5.0.90 to 5.0.2, the following is printed.
```
irods:~$ python3 scripts/upgrade_irods.py -v
Downgrade detected. Downgrading is unsupported, please reinstall iRODS version [5.0.90] or newer.
```