### PR TITLE
[8699] Make total quota update only apply to correct resc_id (main)

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -1371,8 +1371,8 @@ int _modInheritance( int inheritFlag, int recursiveFlag, const char *collIdStr, 
 
 /*
   Set the over_quota values (if any) using the limits and
-  and the current usage; handling the various types: per-user per-resource,
-  per-user total-usage, group per-resource, and group-total.
+  and the current usage; handling the various types: 
+  group per-resource, and group-total.
 
   The over_quota column is positive if over_quota and the negative value
   indicates how much space is left before reaching the quota.
@@ -1392,7 +1392,7 @@ int setOverQuota( rsComm_t *rsComm ) {
     char mySQL2a[] = "select sum(quota_usage), R_QUOTA_MAIN.quota_limit, UM1.user_id from R_QUOTA_USAGE, R_QUOTA_MAIN, R_USER_MAIN UM1, R_USER_GROUP, R_USER_MAIN UM2 where R_QUOTA_MAIN.user_id = UM1.user_id and UM1.user_type_name = 'rodsgroup' and R_USER_GROUP.group_user_id = UM1.user_id and UM2.user_id = R_USER_GROUP.user_id and R_QUOTA_USAGE.user_id = UM2.user_id and R_QUOTA_USAGE.resc_id != %s and R_QUOTA_MAIN.resc_id = %s group by UM1.user_id,  R_QUOTA_MAIN.quota_limit";
     char mySQL2b[MAX_SQL_SIZE];
 
-    char mySQL3a[] = "update R_QUOTA_MAIN set quota_over= %s - ?, modify_ts=? where user_id=? and %s - ? > quota_over";
+    char mySQL3a[] = "update R_QUOTA_MAIN set quota_over= %s - ?, modify_ts=? where user_id=? and %s - ? > quota_over and resc_id = %s";
     char mySQL3b[MAX_SQL_SIZE];
 
 
@@ -1520,15 +1520,15 @@ int setOverQuota( rsComm_t *rsComm ) {
     snprintf( mySQL2b, sizeof mySQL2b, mySQL2a,
               "cast('0' as integer)", "cast('0' as integer)" );
     snprintf( mySQL3b, sizeof mySQL3b, mySQL3a,
-              "cast(? as integer)", "cast(? as integer)" );
+              "cast(? as integer)", "cast(? as integer)", "cast('0' as integer)" );
 #elif MY_ICAT
     snprintf( mySQL2b, sizeof mySQL2b, mySQL2a, "'0'", "'0'" );
-    snprintf( mySQL3b, sizeof mySQL3b, mySQL3a, "?", "?" );
+    snprintf( mySQL3b, sizeof mySQL3b, mySQL3a, "?", "?", "'0'" );
 #else
     snprintf( mySQL2b, sizeof mySQL2b, mySQL2a,
               "cast('0' as bigint)", "cast('0' as bigint)" );
     snprintf( mySQL3b, sizeof mySQL3b, mySQL3a,
-              "cast(? as bigint)", "cast(? as bigint)" );
+              "cast(? as bigint)", "cast(? as bigint)", "cast('0' as bigint)" );
 #endif
     if ( logSQL != 0 ) {
         log_sql::debug("setOverQuota SQL 7");


### PR DESCRIPTION
Seems to work,, though hopefully it doesn't mess up anything else quota-related.
From what I can tell, `mySQL3a` is only intended to update total quotas, so I ensured that it did so. I'm not sure why it didn't previously-- maybe there was some intent?

Either way, since the update only applied when it was a larger overrun, it probably went unnoticed since it didn't actually break anything.

Taking suggestions, as always. I also ran these against the existing quota tests and they seem to pass.