### PR TITLE
[irods/irods_rule_engine_plugins_policy#5] Properly free `bytesBuf_t` (main)

### DIFF
--- a/plugins/api/src/register_physical_path.cpp
+++ b/plugins/api/src/register_physical_path.cpp
@@ -629,7 +629,7 @@ namespace
                     status = filePathReg(_comm, &subPhyPathRegInp, _resc_name, &out);
                 }
 
-                std::free(out);
+                freeBBuf(out);
                 out = nullptr;
 
                 if ( status != 0 ) {


### PR DESCRIPTION
Issue quick link: irods/irods_rule_engine_plugins_policy#5

This PR fixes a memory leak found while testing policy composition code.