### PR TITLE
[???] Allow tests to be passed in as regular args to script (main)

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -131,7 +131,7 @@ if __name__ == '__main__':
     irods.log.register_file_handler(IrodsConfig().test_log_path)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--run_specific_test', metavar='dotted name')
+    parser.add_argument('--run_specific_test', metavar='dotted name', help='deprecated')
     parser.add_argument('--skip_until', action="store")
     parser.add_argument('--run_python_suite', action='store_true')
     parser.add_argument('--run_plugin_tests', action='store_true')


### PR DESCRIPTION
This PR attempts to allow for the passing of multiple tests as plain arguments. An example follows:
```console
$ python3 scripts/run_tests.py test_plugin_policy_engine-data_retention test_plugin_policy_engine-verify_checksum test_plugin_event_handler-collection_modified
```

For a clearer example the following would run tests `A`, `B`, and `C`:
```console
$ python3 scripts/run_tests.py A B C
```

---

This update to the script is useful in the case where you wish to run multiple tests directly using `run_tests.py`, but don't wish to set up a bash script to run `for i in "${test_list[@]}"; do python3 scripts/run_tests.py --run_specific-test "${i}"; done`.

I'l briefly mention, the previous bash script is great for setting `ASAN_OPTIONS` to produce better reports (e.g., set `log_path=/tmp/asan-${i}-part-four` to denote the test the log is from and what run you are in).