### PR TITLE
[8758] Fix quota processing logic (main)

### DIFF
--- a/plugins/database/src/general_query.cpp
+++ b/plugins/database/src/general_query.cpp
@@ -1734,10 +1734,15 @@ int specialQueryIx( int ix ) {
 
  The caller specifies a user (COL_USER_NAME) and optionally a resource
  (COL_R_RESC_NAME).  Rows are returned with the quotas that apply,
- most severe (most over or closest to going over) first, if any.  For
+ least severe (least over or farthest to going over) first, if any.  For
  global-usage quotas, the returned RESC_ID is 0.  If the user is a
  member of a group with a quota (per-resource or total-usage) a row is
  returned for that quota too.  All in the appropriate order.
+
+ Note: We return rows least-severe first because the linked list of
+ quota structures is generated tail-to-head, so the head of the linked list
+ becomes the most-severe quota. See queRescQuota in rsGetRescQuota.cpp for
+ more details.
  */
 int
 generateSpecialQuery( genQueryInp_t genQueryInp, char *resultingSQL ) {
@@ -1745,10 +1750,120 @@ generateSpecialQuery( genQueryInp_t genQueryInp, char *resultingSQL ) {
     static char userName[NAME_LEN] = "";
     static char userZone[NAME_LEN] = "";
 
-    char quotaQuery1[] = "( select distinct QM.user_id, RM.resc_name, QM.quota_limit, QM.quota_over, QM.resc_id from R_QUOTA_MAIN QM, R_RESC_MAIN RM, R_USER_GROUP UG, R_USER_MAIN UM2 where QM.resc_id = RM.resc_id AND (QM.user_id = UG.group_user_id and UM2.user_name = ? and UM2.zone_name = ? and UG.user_id = UM2.user_id )) UNION ( select distinct QM.user_id, RM.resc_name, QM.quota_limit, QM.quota_over, QM.resc_id from R_QUOTA_MAIN QM, R_USER_GROUP UG, R_USER_MAIN UM2, R_RESC_MAIN RM where QM.resc_id = '0' AND (QM.user_id = UG.group_user_id and UM2.user_name = ? and UM2.zone_name = ? and UG.user_id = UM2.user_id)) UNION ( select distinct QM.user_id, RM.resc_name, QM.quota_limit, QM.quota_over, QM.resc_id from R_QUOTA_MAIN QM, R_USER_MAIN UM, R_RESC_MAIN RM WHERE (QM.resc_id = RM.resc_id or QM.resc_id = '0') AND (QM.user_id = UM.user_id and UM.user_name = ? and UM.zone_name = ? )) order by quota_over DESC";
+    // Fetches all resource and total quotas for the given user (accounting for the user's group as well).
+    // clang-format off
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+    char quotaQuery1[] =
+        // Fetch all group resource quotas for a user.
+        // Notice that UM2 is the user and is linked to UG to look up group membership.
+          "(SELECT DISTINCT QM.user_id, "
+                           "RM.resc_name, "
+                           "QM.quota_limit, "
+                           "QM.quota_over, "
+                           "QM.resc_id "
+           "FROM R_QUOTA_MAIN QM, "
+                "R_RESC_MAIN RM, "
+                "R_USER_GROUP UG, "
+                "R_USER_MAIN UM2 "
+           "WHERE QM.resc_id = RM.resc_id "
+             "AND (QM.user_id = UG.group_user_id "
+                  "AND UM2.user_name = ? "
+                  "AND UM2.zone_name = ? "
+                  "AND UG.user_id = UM2.user_id)) "
+        "UNION "
+        // Fetch all group total quotas for a user.
+          "(SELECT DISTINCT QM.user_id, "
+                           "RM.resc_name, "
+                           "QM.quota_limit, "
+                           "QM.quota_over, "
+                           "QM.resc_id "
+           "FROM R_QUOTA_MAIN QM, "
+                "R_USER_GROUP UG, "
+                "R_USER_MAIN UM2, "
+                "R_RESC_MAIN RM "
+           "WHERE QM.resc_id = '0' "
+             "AND (QM.user_id = UG.group_user_id "
+                  "AND UM2.user_name = ? "
+                  "AND UM2.zone_name = ? "
+                  "AND UG.user_id = UM2.user_id)) "
+        "UNION "
+        // Fetch all user quotas for a particular user.
+        // Eventually can be removed - only group quotas can be set since 5.0.
+          "(SELECT DISTINCT QM.user_id, "
+                           "RM.resc_name, "
+                           "QM.quota_limit, "
+                           "QM.quota_over, "
+                           "QM.resc_id "
+           "FROM R_QUOTA_MAIN QM, "
+                "R_USER_MAIN UM, "
+                "R_RESC_MAIN RM "
+           "WHERE (QM.resc_id = RM.resc_id "
+                  "OR QM.resc_id = '0') "
+             "AND (QM.user_id = UM.user_id "
+                  "AND UM.user_name = ? "
+                  "AND UM.zone_name = ?)) "
+        "ORDER BY quota_over ASC";
 
-    char quotaQuery2[] = "( select distinct QM.user_id, RM.resc_name, QM.quota_limit, QM.quota_over, QM.resc_id from R_QUOTA_MAIN QM, R_RESC_MAIN RM, R_USER_GROUP UG, R_USER_MAIN UM2 where QM.resc_id = RM.resc_id AND RM.resc_name = ? AND (QM.user_id = UG.group_user_id and UM2.user_name = ? and UM2.zone_name = ? and UG.user_id = UM2.user_id )) UNION ( select distinct QM.user_id, RM.resc_name, QM.quota_limit, QM.quota_over, QM.resc_id from R_QUOTA_MAIN QM, R_USER_GROUP UG, R_USER_MAIN UM2, R_RESC_MAIN RM where QM.resc_id = '0' AND RM.resc_name = ? AND (QM.user_id = UG.group_user_id and UM2.user_name = ? and UM2.zone_name = ? and UG.user_id = UM2.user_id)) UNION ( select distinct QM.user_id, RM.resc_name, QM.quota_limit, QM.quota_over, QM.resc_id from R_QUOTA_MAIN QM, R_USER_MAIN UM, R_RESC_MAIN RM WHERE (QM.resc_id = RM.resc_id or QM.resc_id = '0') AND RM.resc_name = ? AND (QM.user_id = UM.user_id and UM.user_name = ? and UM.zone_name = ? )) order by quota_over DESC";
-
+    // Fetches both resource quotas for the given COL_R_RESC_NAME and total quotas for the given user
+    // (accounting for the user's group as well).
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+    char quotaQuery2[] =
+        // Fetch all group resource quotas for a user and a particular resource.
+        // (Note the RM.resc_name = ? condition)
+          "(SELECT DISTINCT QM.user_id, "
+                           "RM.resc_name, "
+                           "QM.quota_limit, "
+                           "QM.quota_over, "
+                           "QM.resc_id "
+           "FROM R_QUOTA_MAIN QM, "
+                "R_RESC_MAIN RM, "
+                "R_USER_GROUP UG, "
+                "R_USER_MAIN UM2 "
+           "WHERE QM.resc_id = RM.resc_id "
+             "AND RM.resc_name = ? "
+             "AND (QM.user_id = UG.group_user_id "
+                  "AND UM2.user_name = ? "
+                  "AND UM2.zone_name = ? "
+                  "AND UG.user_id = UM2.user_id)) "
+        "UNION "
+        // Fetch all total quotas for a user and a particular resource.
+        // Note that this seems like it should always return 0 rows, but due to there being
+        // no join condition between QM.resc_id and RM.resc_id, this will indiscriminately return all
+        // total quotas for the group.
+          "(SELECT DISTINCT QM.user_id, "
+                           "RM.resc_name, "
+                           "QM.quota_limit, "
+                           "QM.quota_over, "
+                           "QM.resc_id "
+           "FROM R_QUOTA_MAIN QM, "
+                "R_USER_GROUP UG, "
+                "R_USER_MAIN UM2, "
+                "R_RESC_MAIN RM "
+           "WHERE QM.resc_id = '0' "
+             "AND RM.resc_name = ? "
+             "AND (QM.user_id = UG.group_user_id "
+                  "AND UM2.user_name = ? "
+                  "AND UM2.zone_name = ? "
+                  "AND UG.user_id = UM2.user_id)) "
+        "UNION "
+        // Fetch all user quotas for a user and a particular resource.
+        // Eventually can be removed - only group quotas can be set since 5.0.
+          "(SELECT DISTINCT QM.user_id, "
+                           "RM.resc_name, "
+                           "QM.quota_limit, "
+                           "QM.quota_over, "
+                           "QM.resc_id "
+           "FROM R_QUOTA_MAIN QM, "
+                "R_USER_MAIN UM, "
+                "R_RESC_MAIN RM "
+           "WHERE (QM.resc_id = RM.resc_id "
+                  "OR QM.resc_id = '0') "
+             "AND RM.resc_name = ? "
+             "AND (QM.user_id = UM.user_id "
+                  "AND UM.user_name = ? "
+                  "AND UM.zone_name = ?)) "
+        "ORDER BY quota_over ASC";
+    // clang-format on
     int i, valid = 0;
     int cllCounter = cllBindVarCount;
 

--- a/scripts/irods/test/test_quotas.py
+++ b/scripts/irods/test/test_quotas.py
@@ -72,7 +72,7 @@ class Test_Quotas(resource_suite.ResourceBase, unittest.TestCase):
                         lib.make_file(filename_2, 1024, contents='arbitrary')
                         cmd = 'iput -R {0} {1}'.format(self.testresc, filename_2) # should fail
                         self.admin.assert_icommand(cmd.split(), 'STDERR_SINGLELINE', 'SYS_RESC_QUOTA_EXCEEDED')
-                        cmd = 'istream write nopes'
+                        cmd = 'istream -R {0} write nopes'.format(self.testresc)
                         self.admin.assert_icommand(cmd.split(), 'STDERR', 'Error: Cannot open data object.', input='some data')
                         cmd = 'iadmin {0} {1} {2} 0'.format(quotatype[0], quotatype[1], quotaresc) # remove quota
                         self.admin.assert_icommand(cmd.split())
@@ -226,5 +226,55 @@ class Test_Quotas(resource_suite.ResourceBase, unittest.TestCase):
         finally:
             self.admin.run_icommand(['irm', '-f', f'{file_name}_case_40', f'{file_name}_case_41', f'{file_name}_case_42', f'{file_name}_case_42a'])
             self.admin.run_icommand(['iadmin', 'rmresc', resc_name])
+            self.admin.run_icommand(['iadmin', 'rmgroup', f'{group_name}_1'])
+            IrodsController().reload_configuration()
+
+    def test_single_resource_quota_violation_does_not_affect_other_resources__issue_8758(self):
+        pep_map = {
+            'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent('''
+                acRescQuotaPolicy {
+                    msiSetRescQuotaPolicy("on");
+                }
+            '''),
+            'irods_rule_engine_plugin-python': textwrap.dedent('''
+                def acRescQuotaPolicy(rule_args, callback, rei):
+                    callback.msiSetRescQuotaPolicy('on')
+            ''')
+        }
+
+        try:
+            with temporary_core_file() as core:
+                core.add_rule(pep_map[self.plugin_name])
+                IrodsController().reload_configuration()
+
+                group_name = 'test_group_issue_8758'
+                file_name = 'test_file_issue_8758'
+                resc_name = 'ufs0_quota_issue_8758'
+                other_resc_name = 'ufs1_quota_issue_8758'
+                lib.make_file(os.path.join(self.quota_user.local_session_dir, file_name), 4096, contents='arbitrary')
+                lib.create_ufs_resource(self.admin, resc_name)
+                lib.create_ufs_resource(self.admin, other_resc_name)
+
+                self.admin.assert_icommand(['iadmin', 'mkgroup', f'{group_name}_1'])
+                self.admin.assert_icommand(['iadmin', 'sgq', f'{group_name}_1', resc_name, '1000'])
+
+                self.admin.assert_icommand(['iadmin', 'atg', f'{group_name}_1', self.quota_user.username])
+
+                self.quota_user.assert_icommand(['iput', '-R', self.testresc, os.path.join(self.quota_user.local_session_dir, file_name)])
+
+                self.quota_user.assert_icommand(['icp', '-R', resc_name, file_name, f'{file_name}_on_{resc_name}'])
+                self.admin.assert_icommand(['iadmin', 'cu'])
+                self.admin.assert_icommand(['iadmin', 'lq'], 'STDOUT', ['\nquota_over: 3096\n'])
+
+                # Should pass and be unaffected by the other quota violation
+                self.quota_user.assert_icommand(['icp', '-R', other_resc_name, file_name, f'{file_name}_on_{other_resc_name}'])
+
+                self.admin.assert_icommand(['iadmin', 'cu'])
+                self.admin.assert_icommand(['iadmin', 'lq'], 'STDOUT', ['\nquota_over: 3096\n'])
+
+        finally:
+            self.admin.run_icommand(['irm', '-f', f'{file_name}_on_{other_resc_name}', f'{file_name}_on_{resc_name}'])
+            self.admin.run_icommand(['iadmin', 'rmresc', resc_name])
+            self.admin.run_icommand(['iadmin', 'rmresc', other_resc_name])
             self.admin.run_icommand(['iadmin', 'rmgroup', f'{group_name}_1'])
             IrodsController().reload_configuration()


### PR DESCRIPTION
Turns out, the quota system has been the victim of a lot of strange assumptions for the many years it's been here.

https://github.com/irods/irods/blob/7902cadf9e4ac9fcb317135d4a46dc81cb5b76a8/plugins/database/src/general_query.cpp#L1748-L1750

For starters, the quota query pair in `general_query.cpp` fetch all quotas from the database, regardless of which one is used. The only difference is that the second query it will only exclude irrelevant resource quotas (but will still fetch all total quotas as well)

It seems that we have been assuming that the first query only fetches total quotas, and the second only fetches resource quotas; this is untrue. The first query will fetch all queries (and it is done whenever a resource name is not provided).

Secondly, the code previously only checked the first row of the output. This was intended to check for the largest overrun (given the previous queries are `ORDER BY quota_over DESC`) but this instead actually checks the lowest overrun. This is because the linked list is constructed "traditionally" with the first element of the output being put at the **tail** of the list.

https://github.com/irods/irods/blob/7902cadf9e4ac9fcb317135d4a46dc81cb5b76a8/server/api/src/rsGetRescQuota.cpp#L160-L171

This is the real reason that https://github.com/irods/irods/issues/4089 point 1 occurred: the existence of another quota would shadow the total quota.

My fix in https://github.com/irods/irods/commit/8e5f20fbe3bbf21b845575e8497c12dcbad82a7e actually resolved this, although I didn't know it at the time, since I didn't know the full nature of these queries. Since the resource query (the second quota query) also fetched total quotas, it would simultaneously enforce the total quota, which masked this assumption completely.

Finally, as a fun note, the `istream` test on line 75 relied on this bug being present: it doesn't specify a resource to `istream` to, so it uses the default one, meaning that it only passed if this bug is here!

Pending a proper test case and a full test suite run. This passes `test_quotas` right now.

As a side note, I could rewrite this to work as it originally intended by reversing the linked list generation (or doing `ORDER BY quota_over ASC`) and then removing both of the linear searches in `rsGetRescQuota.cpp` which would be a little more performant. Maybe that would be preferable?