### PR TITLE
[8763] Defaulting byteorder in to_bytes to big.

### DIFF
--- a/scripts/irods/lib.py
+++ b/scripts/irods/lib.py
@@ -892,4 +892,6 @@ def calculate_crc64_nvme(data: bytes, initial_crc = 0):
             else:
                 crc >>= 1
 
-    return (crc ^ 0xFFFFFFFFFFFFFFFF).to_bytes(8) # Final XOR with all ones and return bytes 
+    # Byteorder defaults to 'big' in some versions of Python but not all.  Setting this
+    # to 'big' so it's consistent with CRC64NVMEStrategy.cpp.
+    return (crc ^ 0xFFFFFFFFFFFFFFFF).to_bytes(8, byteorder='big') # Final XOR with all ones and return bytes


### PR DESCRIPTION
The error described in #8763 was reproduced and the fix for this was verified against Ubuntu 22.04.

Also note that this setting is consistent with the default for `to_bytes` in newer versions of Python.  It is also consistent with the C++ CRC64/NVME code as shown below.

 https://github.com/irods/irods/blob/7902cadf9e4ac9fcb317135d4a46dc81cb5b76a8/lib/hasher/src/CRC64NVMEStrategy.cpp#L86-L90