### PR TITLE
[8756] Skip CRC64/NVME tests while in topology. (main)

### DIFF
--- a/scripts/irods/test/resource_suite.py
+++ b/scripts/irods/test/resource_suite.py
@@ -497,6 +497,7 @@ class ResourceSuite(ResourceBase):
         if os.path.exists(datafilename):
             os.unlink(datafilename)
 
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "TODO(#6835): Requires support for modifying configuration of remote servers")
     def test_server_side_calculates_crc64nvme_checksum_on_put_operation__issue_8554(self):
         file1 = f'{inspect.currentframe().f_code.co_name}_f1'
         file1_size = 2*1024
@@ -532,6 +533,7 @@ class ResourceSuite(ResourceBase):
             lib.remove_file_if_exists(file1)
             IrodsController().reload_configuration()
 
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "TODO(#6835): Requires support for modifying configuration of remote servers")
     def test_client_side_and_server_side_verify_crc64nvme_checksums_on_put_operation__issue_8554(self):
         file1 = f'{inspect.currentframe().f_code.co_name}_f1'
         file1_size = 2*1024

--- a/scripts/irods/test/test_ichksum.py
+++ b/scripts/irods/test/test_ichksum.py
@@ -574,6 +574,7 @@ C- {5}:
             os.unlink(local_file)
             self.admin.assert_icommand(['irm', '-f', object_name])
 
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "TODO(#6835): Requires support for modifying configuration of remote servers")
     def test_ichksum_with_crc64nvme__issue_8554(self):
         file1 = f'{inspect.currentframe().f_code.co_name}_f1'
         file1_size = 2*1024


### PR DESCRIPTION
These tests change the default_hash_scheme to "crc64nvme" in server_config.json on the server that is running the test. In some configurations the actual resource written to is not the same as the server where the test is running. This means that the hash scheme won't match what the test is expecting.

Since we have no way to updated the server configuration on all servers, these tests will now be skipped when running in topology.