### PR TITLE
[#8229] Deprecate `msiDataObjPut` (4-3-stable)

### DIFF
--- a/doxygen/microservices.cpp
+++ b/doxygen/microservices.cpp
@@ -36,7 +36,7 @@
   - #msiDataObjRepl - Replicate a data object
   - #msiDataObjCopy - Copy a data object
   - #msiDataObjGet - Get a data object
-  - #msiDataObjPut - Put a data object
+  - #msiDataObjPut -(Deprecated) Put a data object
   - #msiDataObjChksum - Checksum a data object
   - #msiDataObjPhymv - Move a data object from one resource to another
   - #msiDataObjRename - Rename a data object

--- a/server/re/include/irods/reAction.hpp
+++ b/server/re/include/irods/reAction.hpp
@@ -177,7 +177,10 @@ namespace irods
         table_[ "msiSetKeyValuePairsToObj" ] = new irods::ms_table_entry( "msiSetKeyValuePairsToObj", 3, std::function<int(msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiSetKeyValuePairsToObj ) );
         table_[ "msiExtractTemplateMDFromBuf" ] = new irods::ms_table_entry( "msiExtractTemplateMDFromBuf", 3, std::function<int(msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiExtractTemplateMDFromBuf ) );
         table_[ "msiReadMDTemplateIntoTagStruct" ] = new irods::ms_table_entry( "msiReadMDTemplateIntoTagStruct", 2, std::function<int(msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiReadMDTemplateIntoTagStruct ) );
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         table_[ "msiDataObjPut" ] = new irods::ms_table_entry( "msiDataObjPut", 4, std::function<int(msParam_t*,msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiDataObjPut ) );
+#pragma GCC diagnostic pop
         table_[ "msiDataObjGet" ] = new irods::ms_table_entry( "msiDataObjGet", 3, std::function<int(msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiDataObjGet ) );
         table_[ "msiDataObjChksum" ] = new irods::ms_table_entry( "msiDataObjChksum", 3, std::function<int(msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiDataObjChksum ) );
         table_[ "msiDataObjPhymv" ] = new irods::ms_table_entry( "msiDataObjPhymv", 6, std::function<int(msParam_t*,msParam_t*,msParam_t*,msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiDataObjPhymv ) );

--- a/server/re/include/irods/reDataObjOpr.hpp
+++ b/server/re/include/irods/reDataObjOpr.hpp
@@ -37,9 +37,11 @@ msiDataObjRepl( msParam_t *inpParam1, msParam_t *inpParam2,
 int
 msiDataObjCopy( msParam_t *inpParam1, msParam_t *inpParam2,
                 msParam_t *inpParam3, msParam_t *outParam, ruleExecInfo_t *rei );
-int
-msiDataObjPut( msParam_t *inpParam1, msParam_t *inpParam2,
-               msParam_t *inpParam3, msParam_t *outParam, ruleExecInfo_t *rei );
+[[deprecated]] int msiDataObjPut(msParam_t* inpParam1,
+                                 msParam_t* inpParam2,
+                                 msParam_t* inpParam3,
+                                 msParam_t* outParam,
+                                 ruleExecInfo_t* rei);
 int
 msiDataObjGet( msParam_t *inpParam1, msParam_t *inpParam2,
                msParam_t *outParam, ruleExecInfo_t *rei );

--- a/server/re/src/reDataObjOpr.cpp
+++ b/server/re/src/reDataObjOpr.cpp
@@ -1225,6 +1225,8 @@ msiDataObjCopy( msParam_t *inpParam1, msParam_t *inpParam2,
  * \brief This microservice requests the client to call a rcDataObjPut API
  *   as part of a workflow execution.
  *
+ * \deprecated Deprecated in 4.3.5.
+ *
  * \module core
  *
  * \since pre-2.1


### PR DESCRIPTION
The only test suite which uses `msiDataObjPut` is test_all_rules.py _(due to the `test/rules/*.r` files in the icommands repo)_.

Will run that to make sure things are still good.