### PR TITLE
[#8789] Add password_reuse_previous option for pam generated passwords (main)

### DIFF
--- a/lib/core/include/irods/irods_configuration_keywords.hpp
+++ b/lib/core/include/irods/irods_configuration_keywords.hpp
@@ -9,6 +9,7 @@ namespace irods
     extern const char* const KW_CFG_PAM_PASSWORD_MIN_TIME;
     extern const char* const KW_CFG_PAM_PASSWORD_MAX_TIME;
     extern const char* const KW_CFG_PAM_PASSWORD_EXTEND_LIFETIME;
+    extern const char* const KW_CFG_PAM_PASSWORD_REUSE_PREVIOUS;
 
     extern const char* const KW_CFG_DB_TECHNOLOGY;
     extern const char* const KW_CFG_DB_HOST;

--- a/lib/core/src/irods_configuration_keywords.cpp
+++ b/lib/core/src/irods_configuration_keywords.cpp
@@ -8,6 +8,7 @@ namespace irods
     const char* const KW_CFG_PAM_PASSWORD_MIN_TIME{"password_min_time"};
     const char* const KW_CFG_PAM_PASSWORD_MAX_TIME{"password_max_time"};
     const char* const KW_CFG_PAM_PASSWORD_EXTEND_LIFETIME{"password_extend_lifetime"};
+    const char* const KW_CFG_PAM_PASSWORD_REUSE_PREVIOUS{"password_reuse_previous"};
 
     const char* const KW_CFG_DB_TECHNOLOGY{"technology"};
     const char* const KW_CFG_DB_HOST{"host"};

--- a/scripts/irods/database_upgrade.py
+++ b/scripts/irods/database_upgrade.py
@@ -250,6 +250,8 @@ def run_update(irods_config, cursor, is_upgrade):
         else:
             database_connect.execute_sql_statement(cursor, "alter table R_USER_SESSION_KEY add column salt varchar(32);")
 
+        # pam password reuse setting
+        database_connect.execute_sql_statement(cursor, "insert into R_GRID_CONFIGURATION values ('authentication', 'password_reuse_previous', '1');")
     else:
         raise IrodsError('Upgrade to schema version %d is unsupported.' % (new_schema_version))
 


### PR DESCRIPTION
Add the pam_reuse_previous option to be able to disable reuse of previously generated temporary passwords. This is useful when server administrators want to implement proper session timeouts across multiple client machines.

E.g. suppose a user has two devices (work-laptop and hpc-cluster) and authenticates on Monday on hpc-cluster with pam_interactive and a ttl of 7 days. On Wednesday the user authenticates on work-laptop with a ttl of 1 day.

With the default settings (password_extend_lifetime = 1, password_reuse_previous = 1), the session on hpc-cluster will terminate on Thursday instead of next Monday (what the user would expect).

With the already existing option password_extend_lifetime set to 0, the user will get a session on work-laptop that is actually valid until next Monday instead of the expected TTL of 1 day.

With the new option password_reuse_previous = 0, each device will get its own generated native password, and own ttl.

I know you're implemented new session tokens for the upcoming release. Probably pam_interactive and pam_password flows will use the session tokens at some point (see #8746), but as using the session tokens currently requires to use another authentication scheme, adopting this might only be possible after a longer adoption period (all clients need an update). If this is true, we need to patch the current behaviour too to be able to adopt pam_interactive now.