### PR TITLE
[#7128] clang-tidy tweaks for mtime update unit test

### DIFF
--- a/unit_tests/src/test_replica_open_and_close.cpp
+++ b/unit_tests/src/test_replica_open_and_close.cpp
@@ -252,14 +252,16 @@ TEST_CASE("test mtime changes on open and close replica without writing to it")
         std::strncpy(static_cast<char*>(info.objPath), path.c_str(), MAX_NAME_LEN - 1);
         info.replNum = 0;
 
-        auto [kvp, lm] = irods::experimental::make_key_value_proxy();
-        kvp[REPL_STATUS_KW] = std::to_string(STALE_REPLICA);
-        kvp[ADMIN_KW] = "";
+        KeyValPair kvp{};
+        addKeyVal(&kvp, REPL_STATUS_KW, std::to_string(STALE_REPLICA).c_str());
+        addKeyVal(&kvp, ADMIN_KW, "");
 
-        mod_meta_inp.regParam = kvp.get();
+        mod_meta_inp.regParam = &kvp;
         mod_meta_inp.dataObjInfo = &info;
 
-        REQUIRE(0 == rcModDataObjMeta(comm, &mod_meta_inp));
+        static_cast<void>(rcModDataObjMeta(comm, &mod_meta_inp));
+
+        clearKeyVal(&kvp);
     }};
 
     // Create an empty data object.
@@ -372,6 +374,7 @@ TEST_CASE("test mtime changes on open and close replica without writing to it")
     SECTION("O_WRONLY with O_TRUNC updates mtime")
     {
         // Open replica with O_WRONLY and O_TRUNC flags so that the replica gets truncated.
+        // NOLINTNEXTLINE(hicpp-signed-bitwise)
         input.openFlags = O_WRONLY | O_TRUNC;
         // NOLINTNEXTLINE(readability-identifier-length)
         const auto fd = rc_replica_open(comm, &input, &json_output);


### PR DESCRIPTION
In service of #7128

Discovered when working on the cherry-pick in https://github.com/irods/irods/pull/8803

Modified unit test passes