### PR TITLE
[#8808] DataObjOpen: Rework update to replica access table (4-3-stable)

### DIFF
--- a/server/api/src/rsDataObjOpen.cpp
+++ b/server/api/src/rsDataObjOpen.cpp
@@ -518,8 +518,7 @@ namespace
 
             constexpr auto uo = update_operation::create;
             if (const auto rat_ec = update_replica_access_table(uo, l1_index, registered_replica, replica_token);
-                rat_ec < 0)
-            {
+                rat_ec < 0) {
                 irods::log(LOG_ERROR, fmt::format(
                     "[{}:{}] - [error occurred while updating replica access table] "
                     "[error_code=[{}], path=[{}], hierarchy=[{}]]",


### PR DESCRIPTION
Addresses #8808

Cherry-picked from https://github.com/irods/irods/pull/8818

Leaving this in draft for now because we may wish to discuss whether or not to put this in 4.3.5.