### PR TITLE
[#8834] Use `irods::authentication::scheme_name` instead of string literals (main)

### DIFF
--- a/lib/core/include/irods/authentication_plugin_framework.hpp
+++ b/lib/core/include/irods/authentication_plugin_framework.hpp
@@ -189,7 +189,7 @@ namespace irods::authentication
             json req{_ctx};
             json resp;
 
-            req["scheme"] = scheme;
+            req[irods::authentication::scheme_name] = scheme;
             req[irods::authentication::next_operation] = *next_operation;
 
             while (true) {

--- a/plugins/api/src/authenticate.cpp
+++ b/plugins/api/src/authenticate.cpp
@@ -56,7 +56,7 @@ namespace
         try {
             auto req  = to_json(bb_req);
             std::unique_ptr<auth::authentication_base> auth{
-                auth::resolve_authentication_plugin(get<std::string>("scheme", req), "server")};
+                auth::resolve_authentication_plugin(get<std::string>(auth::scheme_name, req), "server")};
             auto opr  = get<std::string>(auth::next_operation, req);
             auto resp = auth->call(*comm, opr, req);
 

--- a/plugins/authentication/src/native.cpp
+++ b/plugins/authentication/src/native.cpp
@@ -408,8 +408,8 @@ namespace irods::authentication
                             // Now that the limited password is recorded in the auth file, we need to authenticate with
                             // the limited password to ensure that things are working. Call the start operation - the
                             // limited password recorded in the irodsA file will be used.
-                            return nlohmann::json{
-                                {"scheme", scheme_name}, {irods_auth::next_operation, AUTH_CLIENT_START}};
+                            return nlohmann::json{{irods_auth::scheme_name, scheme_name},
+                                                  {irods_auth::next_operation, AUTH_CLIENT_START}};
                         }
                     }
                     catch (const std::invalid_argument& e) {


### PR DESCRIPTION
Addresses #8834