### PR TITLE
[#8839] Avoid brace-initialization when constructing json objects with other json objects (main)

### DIFF
--- a/lib/core/include/irods/authentication_plugin_framework.hpp
+++ b/lib/core/include/irods/authentication_plugin_framework.hpp
@@ -186,7 +186,7 @@ namespace irods::authentication
 
             const std::string* next_operation = &irods::AUTH_CLIENT_START;
 
-            json req{_ctx};
+            json req(_ctx);
             json resp;
 
             req[irods::authentication::scheme_name] = scheme;

--- a/plugins/authentication/src/irods.cpp
+++ b/plugins/authentication/src/irods.cpp
@@ -119,7 +119,7 @@ namespace irods::authentication
       private:
         auto auth_client_start(rcComm_t& comm, const json& req) -> nlohmann::json override
         {
-            json resp{req};
+            json resp(req);
             resp[user_name_kw] = comm.proxyUser.userName;
             resp[zone_name_kw] = comm.proxyUser.rodsZone;
             resp[irods_auth::next_operation] = client_init_auth_with_server;
@@ -128,7 +128,7 @@ namespace irods::authentication
 
         static auto client_init_auth_with_server_op(RcComm& _comm, const nlohmann::json& _request) -> nlohmann::json
         {
-            nlohmann::json svr_req{_request};
+            nlohmann::json svr_req(_request);
             svr_req[irods_auth::next_operation] = server_prepare_auth_check;
             auto resp = irods_auth::request(_comm, svr_req);
             resp[irods_auth::next_operation] = client_prepare_auth_check;
@@ -139,7 +139,7 @@ namespace irods::authentication
             -> nlohmann::json
         {
             irods_auth::throw_if_request_message_is_missing_key(_request, {user_name_kw, zone_name_kw});
-            nlohmann::json resp{_request};
+            nlohmann::json resp(_request);
             const auto force_prompt = _request.find(irods_auth::force_password_prompt);
             if (_request.end() != force_prompt && force_prompt->get<bool>()) {
                 fmt::print("Enter your iRODS password:");
@@ -186,7 +186,7 @@ namespace irods::authentication
         static auto client_auth_with_password_op(RcComm& _comm, const nlohmann::json& _request) -> nlohmann::json
         {
             irods_auth::throw_if_request_message_is_missing_key(_request, {user_name_kw, zone_name_kw, password_kw});
-            nlohmann::json svr_req{_request};
+            nlohmann::json svr_req(_request);
             svr_req[irods_auth::next_operation] = server_auth_with_password;
             auto resp = irods_auth::request(_comm, svr_req);
             resp[irods_auth::next_operation] = client_auth_with_session_token;
@@ -197,7 +197,7 @@ namespace irods::authentication
         {
             irods_auth::throw_if_request_message_is_missing_key(
                 _request, {user_name_kw, zone_name_kw, session_token_kw});
-            nlohmann::json svr_req{_request};
+            nlohmann::json svr_req(_request);
             svr_req[irods_auth::next_operation] = server_auth_with_session_token;
             auto resp = irods_auth::request(_comm, svr_req);
             if (const auto record_auth_file_iter = _request.find(irods_auth::record_auth_file);
@@ -213,7 +213,7 @@ namespace irods::authentication
 #ifdef RODS_SERVER
         static auto server_prepare_auth_check_op(RsComm& _comm, const nlohmann::json& _request) -> nlohmann::json
         {
-            nlohmann::json resp{_request};
+            nlohmann::json resp(_request);
             if (nullptr != _comm.auth_scheme) {
                 // NOLINTNEXTLINE(cppcoreguidelines-no-malloc, cppcoreguidelines-owning-memory)
                 std::free(_comm.auth_scheme);
@@ -349,7 +349,7 @@ namespace irods::authentication
 
             // Remove the password from the payload so that it's not sent back across the network unnecessarily, and add
             // the new session token so that the client side can use it to authenticate.
-            nlohmann::json resp{_request};
+            nlohmann::json resp(_request);
             resp.erase(password_kw);
             resp[session_token_kw] = token;
             log_auth::trace("{}: check complete for user [{}#{}]", __func__, user_name, zone_name);
@@ -428,7 +428,7 @@ namespace irods::authentication
 
             // Remove the session token from the response payload so that it is not communicated across the network
             // unnecessarily. The session token was included with the request, so the client should already have it.
-            nlohmann::json resp{_request};
+            nlohmann::json resp(_request);
             resp.erase(session_token_kw);
             return resp;
         } // server_auth_with_session_token_op

--- a/plugins/authentication/src/native.cpp
+++ b/plugins/authentication/src/native.cpp
@@ -161,7 +161,7 @@ namespace irods::authentication
     private:
         json auth_client_start(rcComm_t& comm, const json& req)
         {
-            json resp{req};
+            json resp(req);
             resp[irods_auth::next_operation] = AUTH_CLIENT_AUTH_REQUEST;
             resp["user_name"] = comm.proxyUser.userName;
             resp["zone_name"] = comm.proxyUser.rodsZone;
@@ -175,7 +175,7 @@ namespace irods::authentication
                 req, {"user_name", "zone_name", "request_result"}
             );
 
-            json resp{req};
+            json resp(req);
 
             auto request_result = req.at("request_result").get<std::string>();
             request_result.resize(CHALLENGE_LEN);
@@ -322,7 +322,7 @@ namespace irods::authentication
 
         json native_auth_client_request(rcComm_t& comm, const json& req)
         {
-            json svr_req{req};
+            json svr_req(req);
 
             // Do not transmit the password in the request to the server if it was supplied by the client application.
             // This plugin does not require secure communications, so we cannot transmit the password in the clear.
@@ -352,7 +352,7 @@ namespace irods::authentication
                 req, {"digest", "user_name", "zone_name"}
             );
 
-            json svr_req{req};
+            json svr_req(req);
 
             // Do not transmit the password in the request to the server if it was supplied by the client application.
             // This plugin does not require secure communications, so we cannot transmit the password in the clear.
@@ -438,7 +438,7 @@ namespace irods::authentication
 #ifdef RODS_SERVER
         json native_auth_agent_request(rsComm_t& comm, const json& req)
         {
-            json resp{req};
+            json resp(req);
 
             char buf[CHALLENGE_LEN + 2]{};
             get64RandomBytes( buf );
@@ -521,7 +521,7 @@ namespace irods::authentication
                 THROW(status, "rcAuthCheck failed.");
             }
 
-            json resp{req};
+            json resp(req);
 
             // Do we need to consider remote zones here?
             if (LOCAL_HOST != rodsServerHost->localFlag) {

--- a/plugins/authentication/src/pam_password.cpp
+++ b/plugins/authentication/src/pam_password.cpp
@@ -153,7 +153,7 @@ namespace irods::authentication
                       "is configured to require TLS in order to prevent leaking sensitive user information.");
             }
 
-            json resp{req};
+            json resp(req);
             resp["user_name"] = comm.proxyUser.userName;
             resp["zone_name"] = comm.proxyUser.rodsZone;
 
@@ -200,7 +200,7 @@ namespace irods::authentication
                       "is configured to require TLS in order to prevent leaking sensitive user information.");
             }
 
-            json svr_req{req};
+            json svr_req(req);
 
             svr_req[irods_auth::next_operation] = AUTH_AGENT_AUTH_REQUEST;
 
@@ -277,7 +277,7 @@ namespace irods::authentication
                 return irods_auth::request(*host->conn, req);
             }
 
-            json resp{req};
+            json resp(req);
 
             // This operation asserts that the key exists in the request above, so we know that it is there.
             const auto password_iter = resp.find(irods::AUTH_PASSWORD_KEY);

--- a/plugins/rule_engines/src/cpp_default_policy.cpp
+++ b/plugins/rule_engines/src/cpp_default_policy.cpp
@@ -1127,7 +1127,7 @@ irods::error exec_rule_expression(
     }
 
     try {
-        json r{json::parse(_rule_text)};
+        json r(json::parse(_rule_text));
 
         if(!r.contains("policy_to_invoke")) {
             return ERROR(SYS_NOT_SUPPORTED,


### PR DESCRIPTION
Addresses #8839

This covers every instance I could find. There may be other instances, particularly in member initializer lists. 