### PR TITLE
[#8272] Deprecate macros for advisory lock API (4-3-stable)

### DIFF
--- a/lib/api/include/irods/dataObjLock.h
+++ b/lib/api/include/irods/dataObjLock.h
@@ -1,9 +1,11 @@
-#ifndef DATA_OBJ_LOCK_H__
-#define DATA_OBJ_LOCK_H__
+#ifndef IRODS_DATA_OBJ_LOCK_H
+#define IRODS_DATA_OBJ_LOCK_H
 
 #include "irods/rcConnect.h"
 #include "irods/objInfo.h"
 #include "irods/dataObjInpOut.h"
+
+// All macros defined by this header file are deprecated as of 4.3.5.
 
 // lock type definition
 #define READ_LOCK_TYPE   "readLockType"
@@ -37,5 +39,4 @@ extern "C"
 __attribute__((deprecated("Logical locking now manages access to data objects.")))
 int rcDataObjUnlock( rcComm_t *conn, dataObjInp_t *dataObjInp );
 
-
-#endif
+#endif // IRODS_DATA_OBJ_LOCK_H

--- a/lib/api/src/rcDataObjGet.cpp
+++ b/lib/api/src/rcDataObjGet.cpp
@@ -63,7 +63,7 @@
  *    \n RBUDP_SEND_RATE_KW - (Deprecated) the number of RBUDP packet to send per second
  *          The default is 600000.
  *    \n RBUDP_PACK_SIZE_KW - (Deprecated) the size of RBUDP packet. The default is 8192.
- *    \n LOCK_TYPE_KW - set advisory lock type. valid value - WRITE_LOCK_TYPE.
+ *    \n LOCK_TYPE_KW - (Deprecated) set advisory lock type. valid value - WRITE_LOCK_TYPE.
  * \param[in] locFilePath - the path of the local file to download. This path
  *           can be a relative path.
  *

--- a/lib/api/src/rcDataObjOpen.cpp
+++ b/lib/api/src/rcDataObjOpen.cpp
@@ -43,7 +43,7 @@
  *    \n DATA_TYPE_KW - the data type of the data object.
  *    \n RESC_NAME_KW - The resource of the data object to open.
  *    \n REPL_NUM_KW - the replica number of the copy to open.
- *    \n LOCK_TYPE_KW - set advisory lock type. valid values - WRITE_LOCK_TYPE or READ_LOCK_TYPE.
+ *    \n LOCK_TYPE_KW - (Deprecated) set advisory lock type. valid values - WRITE_LOCK_TYPE or READ_LOCK_TYPE.
  *
  * \return integer
  * \retval an opened object descriptor on success

--- a/lib/api/src/rcDataObjPut.cpp
+++ b/lib/api/src/rcDataObjPut.cpp
@@ -68,7 +68,7 @@
  *    \n RBUDP_SEND_RATE_KW - (Deprecated) the number of RBUDP packet to send per second
  *          The default is 600000.
  *    \n RBUDP_PACK_SIZE_KW - (Deprecated) the size of RBUDP packet. The default is 8192.
- *    \n LOCK_TYPE_KW - set advisory lock type. valid value - WRITE_LOCK_TYPE.
+ *    \n LOCK_TYPE_KW - (Deprecated) set advisory lock type. valid value - WRITE_LOCK_TYPE.
  * \param[in] locFilePath - the path of the local file to upload. This path
  *           can be a relative path.
  *

--- a/lib/api/src/rcDataObjRepl.cpp
+++ b/lib/api/src/rcDataObjRepl.cpp
@@ -56,7 +56,7 @@
  *    \n RBUDP_SEND_RATE_KW - (Deprecated) the number of RBUDP packet to send per second
  *          The default is 600000.
  *    \n RBUDP_PACK_SIZE_KW - (Deprecated) the size of RBUDP packet. The default is 8192.
- *    \n LOCK_TYPE_KW - set advisory lock type. valid value - READ_LOCK_TYPE.
+ *    \n LOCK_TYPE_KW - (Deprecated) set advisory lock type. valid value - READ_LOCK_TYPE.
  *
  * \return integer
  * \retval 0 on success

--- a/lib/core/include/irods/rodsKeyWdDef.h
+++ b/lib/core/include/irods/rodsKeyWdDef.h
@@ -123,13 +123,18 @@
 #define STALE_ALL_INTERMEDIATE_REPLICAS_KW          "staleAllIntermediateReplicas"
 #define SOURCE_L1_DESC_KW                           "sourceL1Desc"
 
-// =-=-=-=-=-=-=-
-// JMC - backport 4599
-#define LOCK_TYPE_KW                                "lockType"      /* valid values are READ_LOCK_TYPE
-* WRITE_LOCK_TYPE and UNLOCK_TYPE */
-#define LOCK_CMD_KW                                 "lockCmd"       /* valid values are SET_LOCK_WAIT_CMD,
-* SET_LOCK_CMD and GET_LOCK_CMD */
-#define LOCK_FD_KW                                  "lockFd"        /* Lock file desc for unlock */
+// Valid values are READ_LOCK_TYPE WRITE_LOCK_TYPE and UNLOCK_TYPE.
+// Deprecated as of 4.3.5.
+#define LOCK_TYPE_KW                                "lockType"
+
+// Valid values are SET_LOCK_WAIT_CMD, SET_LOCK_CMD and GET_LOCK_CMD.
+// Deprecated as of 4.3.5.
+#define LOCK_CMD_KW                                 "lockCmd"
+
+// Lock file desc for unlock.
+// Deprecated as of 4.3.5.
+#define LOCK_FD_KW                                  "lockFd"
+
 #define MAX_SUB_FILE_KW                             "maxSubFile" /* max number of files for tar file bundles */
 #define MAX_BUNDLE_SIZE_KW                          "maxBunSize" /* max size of a tar bundle in Gbs */
 #define NO_STAGING_KW                               "noStaging"


### PR DESCRIPTION
Companion PR: https://github.com/irods/irods_client_icommands/pull/605