### PR TITLE
[#8857] Fix memory leaks stemming from `clearMsParam` (4-3-stable)

### DIFF
--- a/lib/core/include/irods/msParam.h
+++ b/lib/core/include/irods/msParam.h
@@ -130,11 +130,38 @@ extern "C" {
 
 int
 resetMsParam( msParam_t *msParam );
-int
-clearMsParam( msParam_t *msParam, int freeStruct );
-int
-addMsParam( msParamArray_t *msParamArray, const char *label,
-            const char *packInstruct, void *inOutStruct, bytesBuf_t *inpOutBuf );
+
+/// Deallocates memory referenced by members of a MsParam.
+///
+/// This function does not deallocate memory referenced by KeyValPairs.
+///
+/// \param[in] msParam    The pointer to a MsParam to deallocate.
+/// \param[in] freeStruct Indicates whether the memory pointed to by MsParam::inOutStruct should be deallocated.
+///
+/// \returns An integer indicating the status of the operation.
+/// \retval 0        On success.
+/// \retval non-zero On failure.
+int clearMsParam(msParam_t* msParam, int freeStruct);
+
+/// Deallocates memory referenced by members of a MsParam.
+///
+/// Unlike clearMsParam(MsParam*, int), this function deallocates memory referenced by all data members,
+/// including KeyValPairs.
+///
+/// \param[in] msParam The pointer to a MsParam to deallocate.
+///
+/// \returns An integer indicating the status of the operation.
+/// \retval 0        On success.
+/// \retval non-zero On failure.
+///
+/// \since 4.3.5
+int clearMsParamFull(msParam_t* _msParam);
+
+int addMsParam(msParamArray_t* msParamArray,
+               const char* label,
+               const char* packInstruct,
+               void* inOutStruct,
+               bytesBuf_t* inpOutBuf);
 int
 addIntParamToArray( msParamArray_t *msParamArray, char *label, int inpInt );
 int
@@ -167,8 +194,33 @@ int
 printMsParam( msParamArray_t *msParamArray );
 int
 writeMsParam( char *buf, int len, msParam_t *msParam );
-int
-clearMsParamArray( msParamArray_t *msParamArray, int freeStruct );
+
+/// Deallocates memory referenced by members of a MsParamArray.
+///
+/// This function does not deallocate memory referenced by KeyValPairs.
+///
+/// \param[in] msParamArray The pointer to a MsParamArray to deallocate.
+/// \param[in] freeStruct   Indicates whether the memory pointed to by MsParam::inOutStruct should be deallocated.
+///
+/// \returns An integer indicating the status of the operation.
+/// \retval 0        On success.
+/// \retval non-zero On failure.
+int clearMsParamArray(msParamArray_t* msParamArray, int freeStruct);
+
+/// Deallocates memory referenced by members of a MsParamArray.
+///
+/// Unlike clearMsParamArray(MsParamArray*, int), this function deallocates memory referenced by all data members,
+/// including KeyValPairs.
+///
+/// \param[in] msParamArray The pointer to a MsParamArray to deallocate.
+///
+/// \returns An integer indicating the status of the operation.
+/// \retval 0        On success.
+/// \retval non-zero On failure.
+///
+/// \since 4.3.5
+int clearMsParamArrayFull(msParamArray_t* _msParamArray);
+
 void
 fillIntInMsParam( msParam_t *msParam, const int myInt );
 void

--- a/server/api/src/rsExecRuleExpression.cpp
+++ b/server/api/src/rsExecRuleExpression.cpp
@@ -27,7 +27,7 @@ int rsExecRuleExpression(RsComm* _comm, ExecRuleExpression* _exec_rule)
     ruleExecInfoAndArg_t* rei_and_arg = nullptr;
     irods::at_scope_exit free_rei_struct{[&rei_and_arg] {
         if (rei_and_arg) {
-            freeRuleExecInfoStruct(rei_and_arg->rei, (FREE_MS_PARAM | FREE_DOINP));
+            freeRuleExecInfoStructFull(rei_and_arg->rei);
             std::free(rei_and_arg);
         }
     }};

--- a/server/api/src/rsRuleExecSubmit.cpp
+++ b/server/api/src/rsRuleExecSubmit.cpp
@@ -47,7 +47,7 @@ namespace
         ruleExecInfoAndArg_t* rei_info{};
         irods::at_scope_exit free_rei_info{[&rei_info] {
             if (rei_info) {
-                freeRuleExecInfoStruct(rei_info->rei, (FREE_MS_PARAM | FREE_DOINP));
+                freeRuleExecInfoStructFull(rei_info->rei);
                 std::free(rei_info);
             }
         }};

--- a/server/re/include/irods/irods_re_structs.hpp
+++ b/server/re/include/irods/irods_re_structs.hpp
@@ -102,11 +102,57 @@ unpackReiAndArg( RsComm *rsComm, ruleExecInfoAndArg_t **reiAndArg,
 
 int copyRuleExecInfo( ruleExecInfo_t *from, ruleExecInfo_t *to );
 
+/// Deallocates memory pointed to by a ruleExecInfo_t*.
+///
+/// This function does not deallocate memory referenced by KeyValPairs.
+///
+/// \param[in] rs                    The pointer to a ruleExecInfo_t to deallocate.
+/// \param[in] freeSpecialStructFlag \parblock A bitmask indicating whether to deallocate
+/// memory owned by the DataObjInp member and/or MsParamArray data. Bitmask values include:
+/// - FREE_MS_PARAM: Deallocate the \p msParamArray member variable.
+/// - FREE_DOINP: Deallocate the \p doinp member variable.
+/// \endparblock
+///
+/// \returns An integer indicating the status of the operation.
+/// \retval 0        On success.
+/// \retval non-zero On failure.
 int freeRuleExecInfoStruct( ruleExecInfo_t *rs, int freeSpecialStructFlag );
 
 int zeroRuleExecInfoStruct( ruleExecInfo_t *rei );
 
+/// Deallocates memory pointed to by members of a ruleExecInfo_t.
+///
+/// This function does not deallocate memory referenced by KeyValPairs.
+///
+/// \param[in] rs                    The pointer to a ruleExecInfo_t to deallocate.
+/// \param[in] freeSpecialStructFlag \parblock A bitmask indicating whether to deallocate
+/// memory owned by the DataObjInp member and/or MsParamArray data. Bitmask values include:
+/// - FREE_MS_PARAM: Deallocate the \p msParamArray member variable.
+/// - FREE_DOINP: Deallocate the \p doinp member variable.
+/// \endparblock
+///
+/// \returns An integer indicating the status of the operation.
+/// \retval 0        On success.
+/// \retval non-zero On failure.
 int freeRuleExecInfoInternals( ruleExecInfo_t *rs, int freeSpecialStructFlag );
+
+/// Deallocates all memory pointed to by a ruleExecInfo_t*.
+///
+/// Unlike freeRuleExecInfoStruct(ruleExecInfo_t*, int), this function deallocates memory referenced by all data
+/// members, including KeyValPairs.
+///
+/// \since 4.3.5
+void freeRuleExecInfoStructFull(ruleExecInfo_t* _rs);
+
+/// Deallocates memory pointed to by members of a ruleExecInfo_t.
+///
+/// Unlike freeRuleExecInfoInternals(ruleExecInfo_t*, int), this function deallocates memory referenced by all data
+/// members, including KeyValPairs.
+///
+/// The object pointed to by \p rs is never deallocated.
+///
+/// \since 4.3.5
+void freeRuleExecInfoInternalsFull(ruleExecInfo_t* _rs);
 
 int copyDataObjInfo( dataObjInfo_t *from, dataObjInfo_t *to );
 

--- a/server/re/src/reStruct.cpp
+++ b/server/re/src/reStruct.cpp
@@ -1,4 +1,5 @@
 #include "irods/irods_re_structs.hpp"
+#include "irods/msParam.h"
 #include "irods/rcMisc.h"
 #include "irods/objMetaOpr.hpp"
 #include "irods/resource.hpp"
@@ -96,6 +97,7 @@ freeRuleExecInfoStruct( ruleExecInfo_t *rs, int freeSpecialStructFlag ) {
     free( rs );
     return 0;
 }
+
 int
 freeRuleExecInfoInternals( ruleExecInfo_t *rs, int freeSpecialStructFlag ) {
     if ( rs->msParamArray != NULL && ( freeSpecialStructFlag & FREE_MS_PARAM ) > 0 ) {
@@ -132,6 +134,59 @@ freeRuleExecInfoInternals( ruleExecInfo_t *rs, int freeSpecialStructFlag ) {
     }
     return 0;
 }
+
+// NOLINTNEXTLINE(misc-no-recursion)
+void freeRuleExecInfoStructFull(ruleExecInfo_t* _rs)
+{
+    freeRuleExecInfoInternalsFull(_rs);
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+    std::free(_rs);
+} // freeRuleExecInfoStructFull
+
+// NOLINTNEXTLINE(misc-no-recursion)
+void freeRuleExecInfoInternalsFull(ruleExecInfo_t* _rs)
+{
+    if (nullptr != _rs->msParamArray) {
+        clearMsParamArrayFull(_rs->msParamArray);
+        // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+        std::free(_rs->msParamArray);
+    }
+
+    if (nullptr != _rs->doinp) {
+        clearDataObjInp(_rs->doinp);
+        // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
+        free(_rs->doinp);
+    }
+
+    if (nullptr != _rs->doi) {
+        freeAllDataObjInfo(_rs->doi);
+    }
+
+    if (nullptr != _rs->uoic) {
+        freeUserInfo(_rs->uoic);
+    }
+
+    if (nullptr != _rs->uoip) {
+        freeUserInfo(_rs->uoip);
+    }
+
+    if (nullptr != _rs->coi) {
+        freeCollInfo(_rs->coi);
+    }
+
+    if (nullptr != _rs->uoio) {
+        freeUserInfo(_rs->uoio);
+    }
+
+    if (nullptr != _rs->condInputData) {
+        clearKeyVal(_rs->condInputData);
+        freeKeyValPairStruct(_rs->condInputData);
+    }
+
+    if (nullptr != _rs->next) {
+        freeRuleExecInfoStructFull(_rs->next);
+    }
+} // freeRuleExecInfoInternalsFull
 
 int
 copyDataObjInfo( dataObjInfo_t *from, dataObjInfo_t *to ) {


### PR DESCRIPTION
The base commit of this PR has passed unit, core, and PREP tests. I've confirmed that the memory leaks for `rsExecRuleExpression` and `rsRuleExecSubmit` are fixed.

The second commit is temporary. It is there to make the polishing effort more visible - i.e. show that there are no changes in the behavior of the new functions.

Will squash once approved.