### PR TITLE
[#8861] Fix memory leak in Hasher (main)

### DIFF
--- a/lib/hasher/include/irods/ADLER32Strategy.hpp
+++ b/lib/hasher/include/irods/ADLER32Strategy.hpp
@@ -22,6 +22,7 @@ namespace irods {
             error update( const std::string& data, boost::any& context ) const override;
             error digest( std::string& messageDigest, boost::any& context ) const override;
             bool isChecksum( const std::string& ) const override;
+            void free_context(boost::any& _context) const override;
 
             /// Produce a digest in string form based on the provided options.
             ///

--- a/lib/hasher/include/irods/CRC64NVMEStrategy.hpp
+++ b/lib/hasher/include/irods/CRC64NVMEStrategy.hpp
@@ -31,6 +31,7 @@ namespace irods
         error update(const std::string&, boost::any& context) const override;
         error digest(std::string& messageDigest, boost::any& context) const override;
         bool isChecksum(const std::string&) const override;
+        void free_context(boost::any& _context) const override;
 
         /// Produce a digest in string form based on the provided options.
         ///

--- a/lib/hasher/include/irods/HashStrategy.hpp
+++ b/lib/hasher/include/irods/HashStrategy.hpp
@@ -24,6 +24,7 @@ namespace irods {
             virtual error update( const std::string&, boost::any& context ) const = 0;
             virtual error digest( std::string& messageDigest, boost::any& context ) const = 0;
             virtual bool isChecksum( const std::string& ) const = 0;
+            virtual void free_context(boost::any& _context) const = 0;
 
             /// Produce a digest in string form based on the provided options.
             ///

--- a/lib/hasher/include/irods/Hasher.hpp
+++ b/lib/hasher/include/irods/Hasher.hpp
@@ -22,7 +22,12 @@ namespace irods {
     class Hasher {
         public:
             Hasher() : _strategy( NULL ) {}
-
+            ~Hasher()
+            {
+                if (nullptr != _strategy) {
+                    _strategy->free_context(_context);
+                }
+            }
             error init( const HashStrategy* );
             error update( const std::string& );
             error digest( std::string& messageDigest );

--- a/lib/hasher/include/irods/MD5Strategy.hpp
+++ b/lib/hasher/include/irods/MD5Strategy.hpp
@@ -22,6 +22,7 @@ namespace irods {
             error update( const std::string&, boost::any& context ) const override;
             error digest( std::string& messageDigest, boost::any& context ) const override;
             bool isChecksum( const std::string& ) const override;
+            void free_context(boost::any& _context) const override;
 
             /// Produce a digest in string form based on the provided options.
             ///

--- a/lib/hasher/include/irods/SHA1Strategy.hpp
+++ b/lib/hasher/include/irods/SHA1Strategy.hpp
@@ -22,6 +22,7 @@ namespace irods {
             error update( const std::string& data, boost::any& context ) const override;
             error digest( std::string& messageDigest, boost::any& context ) const override;
             bool isChecksum( const std::string& ) const override;
+            void free_context(boost::any& _context) const override;
 
             /// Produce a digest in string form based on the provided options.
             ///

--- a/lib/hasher/include/irods/SHA256Strategy.hpp
+++ b/lib/hasher/include/irods/SHA256Strategy.hpp
@@ -22,6 +22,7 @@ namespace irods {
             error update( const std::string& data, boost::any& context ) const override;
             error digest( std::string& messageDigest, boost::any& context ) const override;
             bool isChecksum( const std::string& ) const override;
+            void free_context(boost::any& _context) const override;
 
             /// Produce a digest in string form based on the provided options.
             ///

--- a/lib/hasher/include/irods/SHA512Strategy.hpp
+++ b/lib/hasher/include/irods/SHA512Strategy.hpp
@@ -22,6 +22,7 @@ namespace irods {
             error update( const std::string& data, boost::any& context ) const override;
             error digest( std::string& messageDigest, boost::any& context ) const override;
             bool isChecksum( const std::string& ) const override;
+            void free_context(boost::any& _context) const override;
 
             /// Produce a digest in string form based on the provided options.
             ///

--- a/lib/hasher/src/ADLER32Strategy.cpp
+++ b/lib/hasher/src/ADLER32Strategy.cpp
@@ -99,4 +99,6 @@ namespace irods {
     {
         return ADLER32_CHKSUM_PREFIX;
     } // ADLER32Strategy::checksum_prefix
+
+    void ADLER32Strategy::free_context(boost::any& context) const {}
 }; // namespace irods

--- a/lib/hasher/src/CRC64NVMEStrategy.cpp
+++ b/lib/hasher/src/CRC64NVMEStrategy.cpp
@@ -126,4 +126,6 @@ namespace irods
     {
         return CRC64NVME_CHKSUM_PREFIX;
     } // CRC64NVMEStrategy::checksum_prefix
+
+    void CRC64NVMEStrategy::free_context(boost::any& context) const {}
 } // namespace irods

--- a/lib/hasher/src/MD5Strategy.cpp
+++ b/lib/hasher/src/MD5Strategy.cpp
@@ -105,4 +105,15 @@ namespace irods {
     {
         return MD5_CHKSUM_PREFIX;
     } // MD5Strategy::checksum_prefix
+
+    void MD5Strategy::free_context(boost::any& _context) const
+    {
+        try {
+            EVP_MD_CTX* context = boost::any_cast<EVP_MD_CTX*>(_context);
+            EVP_MD_CTX_free(context);
+            _context = nullptr;
+        }
+        catch (const boost::bad_any_cast& _e) {
+        }
+    }
 } // namespace irods

--- a/lib/hasher/src/SHA1Strategy.cpp
+++ b/lib/hasher/src/SHA1Strategy.cpp
@@ -111,4 +111,15 @@ namespace irods {
     {
         return SHA1_CHKSUM_PREFIX;
     } // SHA1Strategy::checksum_prefix
+
+    void SHA1Strategy::free_context(boost::any& _context) const
+    {
+        try {
+            EVP_MD_CTX* context = boost::any_cast<EVP_MD_CTX*>(_context);
+            EVP_MD_CTX_free(context);
+            _context = nullptr;
+        }
+        catch (const boost::bad_any_cast& _e) {
+        }
+    }
 }; // namespace irods

--- a/lib/hasher/src/SHA256Strategy.cpp
+++ b/lib/hasher/src/SHA256Strategy.cpp
@@ -112,4 +112,15 @@ namespace irods {
     {
         return SHA256_CHKSUM_PREFIX;
     } // SHA256Strategy::checksum_prefix
+
+    void SHA256Strategy::free_context(boost::any& _context) const
+    {
+        try {
+            EVP_MD_CTX* context = boost::any_cast<EVP_MD_CTX*>(_context);
+            EVP_MD_CTX_free(context);
+            _context = nullptr;
+        }
+        catch (const boost::bad_any_cast& _e) {
+        }
+    }
 }; // namespace irods

--- a/lib/hasher/src/SHA512Strategy.cpp
+++ b/lib/hasher/src/SHA512Strategy.cpp
@@ -111,4 +111,15 @@ namespace irods {
     {
         return SHA512_CHKSUM_PREFIX;
     } // SHA512Strategy::checksum_prefix
+
+    void SHA512Strategy::free_context(boost::any& _context) const
+    {
+        try {
+            EVP_MD_CTX* context = boost::any_cast<EVP_MD_CTX*>(_context);
+            EVP_MD_CTX_free(context);
+            _context = nullptr;
+        }
+        catch (const boost::bad_any_cast& _e) {
+        }
+    }
 }; // namespace irods


### PR DESCRIPTION
Issue quick link: #8861.

Hasher now has a destructor that cleans up the context used for the given hash strategy.