### PR TITLE
Add configuration for zone key signing hash scheme 

### DIFF
--- a/lib/core/include/irods/irods_client_server_negotiation.hpp
+++ b/lib/core/include/irods/irods_client_server_negotiation.hpp
@@ -95,9 +95,11 @@ namespace irods
     /// \param[in] _zone_key The zone key to sign.
     /// \param[in] _encryption_key The encryption key to use for signing the zone key.
     /// \param[out] _signed_zone_key The encrypted and hashed zone key.
-    auto sign_server_sid(const std::string& _zone_key,
-                         const std::string& _encryption_key,
-                         std::string&       _signed_zone_key) -> irods::error;
+    ///
+    /// \deprecated Deprecated in 5.1.0. Use \p sign_zone_key instead.
+    [[deprecated("Use sign_zone_key instead.")]] auto sign_server_sid(const std::string& _zone_key,
+                                                                      const std::string& _encryption_key,
+                                                                      std::string& _signed_zone_key) -> irods::error;
 
     /// \brief Sign the zone key using the provided encryption key and hash scheme.
     ///
@@ -115,7 +117,9 @@ namespace irods
                        std::string& _signed_zone_key) -> irods::error;
 
     /// \brief check the incoming signed zone_key against local and remote zone_keys
-    auto check_sent_sid(const std::string& _zone_key) -> irods::error;
+    ///
+    /// \deprecated Deprecated in 5.1.0.
+    [[deprecated]] auto check_sent_sid(const std::string& _zone_key) -> irods::error;
 
     /// \brief Return whether the configured negotiation_key meets a set of requirements.
     ///

--- a/lib/core/include/irods/irods_client_server_negotiation.hpp
+++ b/lib/core/include/irods/irods_client_server_negotiation.hpp
@@ -90,11 +90,29 @@ namespace irods
         irods::network_object_ptr,        // socket
         boost::shared_ptr< cs_neg_t >& ); // message payload
 
-    /// =-=-=-=-=-=-=-
-    /// @brief given a buffer encrypt and hash it for negotiation
+    /// \brief Given a buffer, encrypt and hash it for negotiation.
+    ///
+    /// \param[in] _zone_key The zone key to sign.
+    /// \param[in] _encryption_key The encryption key to use for signing the zone key.
+    /// \param[out] _signed_zone_key The encrypted and hashed zone key.
     auto sign_server_sid(const std::string& _zone_key,
                          const std::string& _encryption_key,
                          std::string&       _signed_zone_key) -> irods::error;
+
+    /// \brief Sign the zone key using the provided encryption key and hash scheme.
+    ///
+    /// \param[in] _zone_key The zone key to sign.
+    /// \param[in] _encryption_key The encryption key to use for signing the zone key.
+    /// \param[in] _zone_key_signing_hash_scheme The \p irods::Hasher scheme name to use to hash the encrypted buffer.
+    /// \param[out] _signed_zone_key The encrypted and hashed zone key.
+    ///
+    /// \return irods::error Describing any errors which occurred while signing the zone key.
+    ///
+    /// \since 5.1.0
+    auto sign_zone_key(const std::string& _zone_key,
+                       const std::string& _encryption_key,
+                       const std::string& _zone_key_signing_hash_scheme,
+                       std::string& _signed_zone_key) -> irods::error;
 
     /// \brief check the incoming signed zone_key against local and remote zone_keys
     auto check_sent_sid(const std::string& _zone_key) -> irods::error;

--- a/lib/core/include/irods/irods_configuration_keywords.hpp
+++ b/lib/core/include/irods/irods_configuration_keywords.hpp
@@ -212,6 +212,8 @@ namespace irods
     extern const char* const KW_CFG_CONNECTION_POOL_REFRESH_TIME;
 
     extern const char* const KW_CFG_USER_PASSWORD_STORAGE_MODE;
+
+    extern const char* const KW_CFG_ZONE_KEY_SIGNING_HASH_SCHEME;
 } // namespace irods
 
 #endif // IRODS_CONFIGURATION_KEYWORDS_HPP

--- a/lib/core/src/irods_client_negotiation.cpp
+++ b/lib/core/src/irods_client_negotiation.cpp
@@ -9,7 +9,6 @@
 #include "irods/irods_buffer_encryption.hpp"
 #include "irods/irods_hasher_factory.hpp"
 #include "irods/irods_configuration_parser.hpp"
-#include "irods/MD5Strategy.hpp"
 #include "irods/rcGlobalExtern.h"
 #include "irods/sockComm.h"
 #include "irods/sockCommNetworkInterface.hpp"
@@ -26,6 +25,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <map>
+#include <optional>
 #include <regex>
 #include <vector>
 
@@ -35,28 +35,21 @@ extern const packInstruct_t RodsPackTable[];
 
 namespace irods
 {
-    auto negotiation_key_is_valid(const std::string_view _key) -> bool
-    {
-        static const auto negotiation_key_regex = std::regex{R"_(^[A-Za-z0-9_]+$)_"};
+    extern const std::string MD5_NAME;
+} // namespace irods
 
-        return _key.length() == negotiation_key_length_in_bytes &&
-            std::regex_match(_key.data(), negotiation_key_regex);
-    } // negotiation_key_is_valid
-
-    /// =-=-=-=-=-=-=-
-    /// @brief given a property map and the target host name decide between a federated key and a local key
-    auto determine_negotiation_key(const std::string& _host_name) -> std::string
+namespace
+{
+    auto get_federation_property(const std::string& _host_name, const std::string& _key) -> std::optional<std::string>
     {
         try {
             const auto& federation_list = irods::get_server_property<const nlohmann::json&>(irods::KW_CFG_FEDERATION);
             for (const auto& item : federation_list) {
-                const auto e = std::cend(item);
                 const auto provider_hosts = item.find(irods::KW_CFG_CATALOG_PROVIDER_HOSTS);
-                const auto negotiation_key = item.find(irods::KW_CFG_NEGOTIATION_KEY);
-                if (e == provider_hosts || e == negotiation_key) {
-                    irods::log(LOG_WARNING,
-                               fmt::format("[{}] federation entry missing required properties - check configuration",
-                                           __func__));
+                const auto desired_value = item.find(_key);
+                if (std::cend(item) == provider_hosts || std::cend(item) == desired_value) {
+                    // The federation entry either doesn't have a provider_hosts entry or is missing the requested
+                    // property. In either case, just skip it.
                     continue;
                 }
 
@@ -68,15 +61,51 @@ namespace irods
                                 });
 
                 if (hostname_in_provider_hosts_list) {
-                    return negotiation_key->get<std::string>();
+                    return desired_value->get<std::string>();
                 }
             }
         }
         catch (const irods::exception&) {
         }
+        return std::nullopt;
+    } // get_federation_property
 
-        // if not, it must be in our zone
-        return irods::get_server_property<std::string>(KW_CFG_NEGOTIATION_KEY);
+    auto determine_hash_scheme(const std::string& _host_name) -> std::string
+    {
+        const auto& key = irods::KW_CFG_ZONE_KEY_SIGNING_HASH_SCHEME;
+
+        // First, look for a hash scheme in the federation list in case this is a federated zone server.
+        if (auto federation_hash_scheme = get_federation_property(_host_name, key); federation_hash_scheme) {
+            return std::move(federation_hash_scheme.value());
+        }
+
+        // If this is not a federated zone, use the local zone configuration.
+        try {
+            return irods::get_server_property<std::string>(key);
+        }
+        catch (...) {
+            // If the property does not exist, default to MD5 to match historical behavior.
+            return irods::MD5_NAME;
+        }
+    } // determine_hash_scheme
+} // anonymous namespace
+
+namespace irods
+{
+    auto negotiation_key_is_valid(const std::string_view _key) -> bool
+    {
+        static const auto negotiation_key_regex = std::regex{R"_(^[A-Za-z0-9_]+$)_"};
+
+        return _key.length() == negotiation_key_length_in_bytes && std::regex_match(_key.data(), negotiation_key_regex);
+    } // negotiation_key_is_valid
+
+    /// =-=-=-=-=-=-=-
+    /// @brief given a property map and the target host name decide between a federated key and a local key
+    auto determine_negotiation_key(const std::string& _host_name) -> std::string
+    {
+        const auto& key = irods::KW_CFG_NEGOTIATION_KEY;
+        const auto federation_property = get_federation_property(_host_name, key);
+        return (federation_property) ? federation_property.value() : irods::get_server_property<std::string>(key);
     } // determine_negotiation_key
 
     auto sign_zone_key(const std::string& _zone_key,
@@ -333,13 +362,15 @@ namespace irods
         // it showing that we are a trusted agent and not a pure client (e.g. icommands, jargon, etc).
         if (AGENT_PT == ProcessType || SERVER_PT == ProcessType) {
             try {
-                boost::optional<std::string> zone_key;
-                try {
-                    zone_key.reset(irods::get_server_property<std::string>(irods::KW_CFG_ZONE_KEY));
+                const auto config_handle{irods::server_properties::instance().map()};
+                const auto& config{config_handle.get_json()};
+
+                const auto zone_key_iter = config.find(irods::KW_CFG_ZONE_KEY);
+                if (config.end() == zone_key_iter) {
+                    THROW(CONFIGURATION_ERROR,
+                          fmt::format("Server configuration missing [{}] property.", irods::KW_CFG_ZONE_KEY));
                 }
-                catch (const irods::exception&) {
-                    zone_key.reset(irods::get_server_property<std::string>(LOCAL_ZONE_SID_KW));
-                }
+                const auto& zone_key = zone_key_iter->get_ref<const std::string&>();
 
                 const std::string neg_key = determine_negotiation_key(_host_name);
                 if (!negotiation_key_is_valid(neg_key)) {
@@ -353,9 +384,10 @@ namespace irods
                         __func__, __LINE__));
                 }
 
+                const auto hash_scheme = determine_hash_scheme(_host_name);
+
                 std::string signed_zone_key;
-                if (const auto err = sign_server_sid(*zone_key, neg_key, signed_zone_key);
-                    !err.ok()) {
+                if (const auto err = sign_zone_key(zone_key, neg_key, hash_scheme, signed_zone_key); !err.ok()) {
                     // Even if the signing of the zone_key fails, we continue because the
                     // other side of the connection will reject any further communications
                     // due to the missing keyword. This will result in a clean disconnect.
@@ -588,4 +620,3 @@ namespace irods
         return SUCCESS();
     } // read_client_server_negotiation_message
 } // namespace irods
-

--- a/lib/core/src/irods_client_negotiation.cpp
+++ b/lib/core/src/irods_client_negotiation.cpp
@@ -1,5 +1,7 @@
 #include "irods/irods_client_server_negotiation.hpp"
 
+#include "irods/Hasher.hpp"
+#include "irods/hash_types.hpp"
 #include "irods/irods_stacktrace.hpp"
 #include "irods/irods_exception.hpp"
 #include "irods/irods_server_properties.hpp"
@@ -77,12 +79,17 @@ namespace irods
         return irods::get_server_property<std::string>(KW_CFG_NEGOTIATION_KEY);
     } // determine_negotiation_key
 
-    error sign_server_sid(const std::string& _zone_key,
-                          const std::string& _encryption_key,
-                          std::string&       _signed_zone_key)
+    auto sign_zone_key(const std::string& _zone_key,
+                       const std::string& _encryption_key,
+                       const std::string& _zone_key_signing_hash_scheme,
+                       std::string& _signed_zone_key) -> error
     {
-        if (_encryption_key.empty()) {
-            return ERROR(CLIENT_NEGOTIATION_ERROR, "encryption key for signing is empty");
+        if (_zone_key.empty()) {
+            return ERROR(CLIENT_NEGOTIATION_ERROR, "zone key to sign is invalid");
+        }
+
+        if (!negotiation_key_is_valid(_encryption_key)) {
+            return ERROR(CLIENT_NEGOTIATION_ERROR, "encryption key for signing is invalid");
         }
 
         irods::buffer_crypt::array_t key;
@@ -99,8 +106,10 @@ namespace irods
             return PASS(err);
         }
 
+        const auto& hash_scheme = _zone_key_signing_hash_scheme;
+
         Hasher hasher;
-        if (const auto err = getHasher(MD5_NAME, hasher); !err.ok()) {
+        if (const auto err = getHasher(hash_scheme, hasher); !err.ok()) {
             return PASS(err);
         }
         if (const auto err = hasher.update(std::string(reinterpret_cast<char*>(out_buf.data()), out_buf.size()));
@@ -108,11 +117,20 @@ namespace irods
         {
             return PASS(err);
         }
-        if (const auto err = hasher.digest(_signed_zone_key); !err.ok()) {
+        static constexpr auto opts =
+            irods::hash::options{.output_mode = irods::hash::output_mode::hex_string, .include_checksum_prefix = false};
+        if (const auto err = hasher.digest(opts, _signed_zone_key); !err.ok()) {
             return PASS(err);
         }
 
         return SUCCESS();
+    } // sign_zone_key
+
+    auto sign_server_sid(const std::string& _zone_key,
+                         const std::string& _encryption_key,
+                         std::string& _signed_zone_key) -> error
+    {
+        return sign_zone_key(_zone_key, _encryption_key, MD5_NAME, _signed_zone_key);
     } // sign_server_sid
 
     /// =-=-=-=-=-=-=-

--- a/lib/core/src/irods_configuration_keywords.cpp
+++ b/lib/core/src/irods_configuration_keywords.cpp
@@ -203,5 +203,7 @@ namespace irods
     const char* const KW_CFG_CONNECTION_POOL_REFRESH_TIME{"connection_pool_refresh_time_in_seconds"};
 
     const char* const KW_CFG_USER_PASSWORD_STORAGE_MODE{"user_password_storage_mode"};
+
+    const char* const KW_CFG_ZONE_KEY_SIGNING_HASH_SCHEME{"zone_key_signing_hash_scheme"};
 } // namespace irods
 

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -334,12 +334,13 @@ namespace
         if (const auto err = hasher.update(fmt::format("{}{}", _salt, _token)); !err.ok()) {
             THROW(err.code(), err.result());
         }
+        static constexpr auto opts = irods::hash::options{
+            .output_mode = irods::hash::output_mode::base64_encoded_string, .include_checksum_prefix = false};
         std::string digest;
-        if (const auto err = hasher.digest(digest); !err.ok()) {
+        if (const auto err = hasher.digest(opts, digest); !err.ok()) {
             THROW(err.code(), err.result());
         }
-        // The SHA256Strategy adds a "sha2:" prefix - let's chop that off.
-        return digest.substr(std::strlen(SHA256_CHKSUM_PREFIX));
+        return digest;
     } // hash_session_token
 } // anonymous namespace
 

--- a/schemas/configuration/v5/server_config.json.in
+++ b/schemas/configuration/v5/server_config.json.in
@@ -228,6 +228,13 @@
                         "pattern": "^[A-Za-z0-9_]+$",
                         "maxLength": 49
                     },
+                    "zone_key_signing_hash_scheme": {
+                        "type": "enum",
+                        "enum": [
+                            "md5",
+                            "sha256"
+                        ]
+                    },
                     "zone_name": {
                         "type": "string",
                         "pattern": "^[A-Za-z0-9_\\.]+$",
@@ -402,6 +409,13 @@
             "type": "string",
             "pattern": "^[A-Za-z0-9_]+$",
             "maxLength": 49
+        },
+        "zone_key_signing_hash_scheme": {
+            "type": "enum",
+            "enum": [
+                "md5",
+                "sha256"
+            ]
         },
         "zone_name": {
             "type": "string",

--- a/scripts/irods/test/test_federation.py
+++ b/scripts/irods/test/test_federation.py
@@ -1167,6 +1167,43 @@ OUTPUT ruleExecOut
 		finally:
 			IrodsController().reload_configuration()
 
+	def test_mismatched_zone_key_signing_hash_schemes_result_in_ZONE_KEY_SIGNATURE_MISMATCH(self):
+		import json
+
+		user = self.user_sessions[0]
+		remote_zone = self.config['remote_zone']
+		local_zone = self.config['local_zone']
+		remote_home_collection = os.path.join('/{}'.format(remote_zone), 'home', '#'.join([user.username, local_zone]))
+
+		# Control case: Make sure we can list the contents in the remote zone...
+		user.assert_icommand(['ils', '-l', remote_home_collection], 'STDOUT')
+
+		# Get the current server configuration so we can make changes
+		server_config_filename = paths.server_config_path()
+		with open(server_config_filename) as f:
+			svr_cfg = json.load(f)
+
+		# The default value is "md5", so this test will fail if this is ever changed to "sha256".
+		svr_cfg['federation'][0]['zone_key_signing_hash_scheme'] = 'sha256'
+
+		new_server_config = json.dumps(svr_cfg, sort_keys=True, indent=4, separators=(',', ': '))
+
+		try:
+			with lib.file_backed_up(server_config_filename):
+				# Repave the existing server_config.json. It will be restored when we leave this 'with' block.
+				with open(server_config_filename, 'w') as f:
+					f.write(new_server_config)
+
+				# Reloading the configuration will succeed because the configuration can be validated. However, the
+				# server cannot be used because it will not be able to connect to the catalog service provider.
+				IrodsController().reload_configuration()
+
+				# Demonstrate that the local server cannot connect to the remote server.
+				user.assert_icommand(
+					['ils', '-l', remote_home_collection], 'STDERR', "cannot get status: ZONE_KEY_SIGNATURE_MISMATCH")
+
+		finally:
+			IrodsController().reload_configuration()
 
 	def test_remove_data_object_in_collection_with_read_permissions__issue_6428(self):
 		def get_collection_mtime(session, collection_path):

--- a/scripts/irods/test/test_negotiation.py
+++ b/scripts/irods/test/test_negotiation.py
@@ -138,13 +138,18 @@ class test_server_authentication__issue_2295(unittest.TestCase):
 
     @unittest.skipUnless(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER,
                          'expected behavior manifests only in server-to-server communications')
-    def test_zone_keys_mismatch_on_consumer(self):
+    def test_zone_keys_mismatch_on_consumer_causes_failure_to_connect_to_provider(self):
         self.do_signed_zone_key_mismatch_test_on_consumer("zone_key", "TEMPORARY______KEY")
 
     @unittest.skipUnless(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER,
                          'expected behavior manifests only in server-to-server communications')
-    def test_negotiation_keys_mismatch_on_consumer(self):
+    def test_negotiation_keys_mismatch_on_consumer_causes_failure_to_connect_to_provider(self):
         self.do_signed_zone_key_mismatch_test_on_consumer("negotiation_key", "32_byte____________________key__")
+
+    @unittest.skipUnless(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER,
+                         'expected behavior manifests only in server-to-server communications')
+    def test_hash_scheme_mismatch_on_consumer_causes_failure_to_connect_to_provider(self):
+        self.do_signed_zone_key_mismatch_test_on_consumer("zone_key_signing_hash_scheme", "sha256")
 
     def do_signed_zone_key_mismatch_test_on_provider(self, configuration_key, configuration_value):
         logical_path = f"{self.admin.session_collection}/do_signed_zone_key_mismatch_test_on_provider"
@@ -168,7 +173,7 @@ class test_server_authentication__issue_2295(unittest.TestCase):
                 # Attempting to reload the configuration will succeed, but reaching other servers will fail.
                 IrodsController().reload_configuration()
 
-                # Try to stream a file to a catalog consumer and fail because its signed zone key should differ.
+                # Try to stream a file to a catalog consumer and fail because signed zone key should differ.
                 self.admin.assert_icommand(
                     ['istream', "-R", self.consumer2_resc, "write", logical_path],
                     "STDERR", expected_output, input=content)
@@ -185,3 +190,6 @@ class test_server_authentication__issue_2295(unittest.TestCase):
 
     def test_negotiation_keys_mismatch_on_provider_causes_failure_to_connect_to_consumer(self):
         self.do_signed_zone_key_mismatch_test_on_provider("negotiation_key", "32_byte_negotiation_key_mismatch")
+
+    def test_hash_scheme_mismatch_on_provider_causes_failure_to_connect_to_consumer(self):
+        self.do_signed_zone_key_mismatch_test_on_provider("zone_key_signing_hash_scheme", "sha256")

--- a/scripts/irods/test/test_negotiation.py
+++ b/scripts/irods/test/test_negotiation.py
@@ -1,11 +1,5 @@
-import sys
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
 import json
+import unittest
 
 from . import session
 from .. import lib
@@ -89,3 +83,105 @@ class test_invalid_negotiation_keys(unittest.TestCase):
     def test_negotiation_key_with_invalid_characters(self):
         """Test client-server negotiation when negotiation_key contains invalid characters."""
         self.do_negotiation_key_test('32_byte_server_negotiation_key!!')
+
+
+class test_server_authentication__issue_2295(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.admin = session.mkuser_and_return_session('rodsadmin', 'otherrods', 'rods', lib.get_hostname())
+
+        self.provider_resc = "provider_resc"
+        lib.create_ufs_resource(self.admin, self.provider_resc, hostname=test.settings.ICAT_HOSTNAME)
+        self.consumer1_resc = "consumer1_resc"
+        lib.create_ufs_resource(self.admin, self.consumer1_resc, hostname=test.settings.HOSTNAME_1)
+        self.consumer2_resc = "consumer2_resc"
+        lib.create_ufs_resource(self.admin, self.consumer2_resc, hostname=test.settings.HOSTNAME_2)
+
+    @classmethod
+    def tearDownClass(self):
+        with session.make_session_for_existing_admin() as admin_session:
+            admin_session.run_icommand(['iadmin', 'rmresc', self.provider_resc])
+            admin_session.run_icommand(['iadmin', 'rmresc', self.consumer1_resc])
+            admin_session.run_icommand(['iadmin', 'rmresc', self.consumer2_resc])
+
+            self.admin.__exit__()
+            admin_session.assert_icommand(['iadmin', 'rmuser', self.admin.username])
+
+    def do_signed_zone_key_mismatch_test_on_consumer(self, configuration_key, configuration_value):
+        try:
+            with open(paths.server_config_path()) as f:
+                svr_cfg = json.load(f)
+
+            svr_cfg[configuration_key] = configuration_value
+
+            new_server_config = json.dumps(svr_cfg, sort_keys=True, indent=4, separators=(',', ': '))
+
+            with lib.file_backed_up(paths.server_config_path()):
+                with open(paths.server_config_path(), 'w') as f:
+                    f.write(new_server_config)
+
+                # Show that the server is still responsive.
+                self.admin.assert_icommand(['ils'], 'STDOUT', [self.admin.session_collection])
+
+                # Attempting to reload the configuration will succeed, but reaching the provider will fail.
+                IrodsController().reload_configuration()
+
+                # Show that the catalog provider can no longer be reached.
+                self.admin.assert_icommand(['ils'], 'STDERR', '-147000 ZONE_KEY_SIGNATURE_MISMATCH')
+
+        finally:
+            # Reload configuration since configuration has been restored.
+            IrodsController().reload_configuration()
+
+            # Show that the server is still responsive.
+            self.admin.assert_icommand(['ils'], 'STDOUT', [self.admin.session_collection])
+
+    @unittest.skipUnless(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER,
+                         'expected behavior manifests only in server-to-server communications')
+    def test_zone_keys_mismatch_on_consumer(self):
+        self.do_signed_zone_key_mismatch_test_on_consumer("zone_key", "TEMPORARY______KEY")
+
+    @unittest.skipUnless(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER,
+                         'expected behavior manifests only in server-to-server communications')
+    def test_negotiation_keys_mismatch_on_consumer(self):
+        self.do_signed_zone_key_mismatch_test_on_consumer("negotiation_key", "32_byte____________________key__")
+
+    def do_signed_zone_key_mismatch_test_on_provider(self, configuration_key, configuration_value):
+        logical_path = f"{self.admin.session_collection}/do_signed_zone_key_mismatch_test_on_provider"
+        content = "content!"
+        if test.settings.TOPOLOGY_FROM_RESOURCE_SERVER:
+            expected_output = 'ZONE_KEY_SIGNATURE_MISMATCH'
+        else:
+            expected_output = 'Error: Cannot open data object.'
+        try:
+            with open(paths.server_config_path()) as f:
+                svr_cfg = json.load(f)
+
+            svr_cfg[configuration_key] = configuration_value
+
+            new_server_config = json.dumps(svr_cfg, sort_keys=True, indent=4, separators=(',', ': '))
+
+            with lib.file_backed_up(paths.server_config_path()):
+                with open(paths.server_config_path(), 'w') as f:
+                    f.write(new_server_config)
+
+                # Attempting to reload the configuration will succeed, but reaching other servers will fail.
+                IrodsController().reload_configuration()
+
+                # Try to stream a file to a catalog consumer and fail because its signed zone key should differ.
+                self.admin.assert_icommand(
+                    ['istream', "-R", self.consumer2_resc, "write", logical_path],
+                    "STDERR", expected_output, input=content)
+
+        finally:
+            # Reload configuration since configuration has been restored.
+            IrodsController().reload_configuration()
+
+            # Remove the data object just in case it was created.
+            self.admin.assert_icommand(['irm', "-f", logical_path])
+
+    def test_zone_keys_mismatch_on_provider_causes_failure_to_connect_to_consumer(self):
+        self.do_signed_zone_key_mismatch_test_on_provider("zone_key", "zone_key_mismatch")
+
+    def test_negotiation_keys_mismatch_on_provider_causes_failure_to_connect_to_consumer(self):
+        self.do_signed_zone_key_mismatch_test_on_provider("negotiation_key", "32_byte_negotiation_key_mismatch")

--- a/server/core/include/irods/rsGlobalExtern.hpp
+++ b/server/core/include/irods/rsGlobalExtern.hpp
@@ -78,7 +78,11 @@ extern int IcatConnState;
 extern specCollCache_t *SpecCollCacheHead;
 
 extern char localSID[MAX_PASSWORD_LEN];
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 extern irods::lookup_table <std::pair <std::string, std::string> > remote_SID_key_map; // remote zone SIDs and negotiation keys
+#pragma GCC diagnostic pop
 
 /* quota for all resources for this user in bytes */
 extern rodsLong_t GlobalQuotaLimit; /* quota for all resources for this user */

--- a/server/core/src/initServer.cpp
+++ b/server/core/src/initServer.cpp
@@ -50,11 +50,21 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <vector>
+#include <fstream>
 #include <set>
 #include <string>
 #include <string_view>
-#include <fstream>
+#include <tuple>
+#include <vector>
+
+namespace irods
+{
+    extern const std::string MD5_NAME;
+
+    // Map of remote zones to a tuple of zone key, negotiation key, and signing hash scheme. For server negotiation.
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    extern irods::lookup_table<std::tuple<std::string, std::string, std::string>> zone_key_map;
+} // namespace irods
 
 namespace
 {
@@ -283,62 +293,37 @@ int initRcatServerHostByFile()
         }
     }
 
-    // try for new federation config
-    try {
-        for (const auto& federation : irods::get_server_property<const nlohmann::json&>(irods::KW_CFG_FEDERATION)) {
-            try {
-                try {
-                    const auto& fed_zone_key             = federation.at(irods::KW_CFG_ZONE_KEY).get_ref<const std::string&>();
-                    const auto& fed_zone_name            = federation.at(irods::KW_CFG_ZONE_NAME).get_ref<const std::string&>();
-                    const auto& fed_zone_negotiation_key = federation.at(irods::KW_CFG_NEGOTIATION_KEY).get_ref<const std::string&>();
+    // Look for federation configuration, and if it's not there, we're done. Issue a warning, though.
+    const auto config_handle{irods::server_properties::instance().map()};
+    const auto& config{config_handle.get_json()};
+    const auto federation_iter = config.find(irods::KW_CFG_FEDERATION);
+    if (config.cend() == federation_iter) {
+        log_agent::warn("{}: Server federation configuration was not found.", __func__);
+        return 0;
+    }
 
-                    // store in remote_SID_key_map
-                    remote_SID_key_map[fed_zone_name] = std::make_pair(fed_zone_key, fed_zone_negotiation_key);
-                }
-                catch (boost::bad_any_cast&) {
-                    rodsLog(LOG_ERROR, "initRcatServerHostByFile - failed to cast federation entry to string");
-                    continue;
-                }
-                catch (const std::out_of_range&) {
-                    rodsLog(LOG_ERROR, "%s - federation object did not contain required keys", __PRETTY_FUNCTION__);
-                    continue;
-                }
-            }
-            catch (const boost::bad_any_cast&) {
-                rodsLog(LOG_ERROR, "%s - failed to cast array member to federation object", __PRETTY_FUNCTION__);
-                continue;
-            }
+    // Iterate over all of the federated zones and get the zone key information for server authentication.
+    for (const auto& federation : federation_iter->get_ref<const nlohmann::json::array_t&>()) {
+        try {
+            const auto& zone_name = federation.at(irods::KW_CFG_ZONE_NAME).get_ref<const std::string&>();
+            const auto& zone_key = federation.at(irods::KW_CFG_ZONE_KEY).get_ref<const std::string&>();
+            const auto& negotiation_key = federation.at(irods::KW_CFG_NEGOTIATION_KEY).get_ref<const std::string&>();
+            remote_SID_key_map[zone_name] = std::make_pair(zone_key, negotiation_key);
+
+            const auto hash_scheme_iter = federation.find(irods::KW_CFG_ZONE_KEY_SIGNING_HASH_SCHEME);
+            const auto& hash_scheme = (federation.end() != hash_scheme_iter)
+                                          ? hash_scheme_iter->get_ref<const std::string&>()
+                                          : irods::MD5_NAME;
+            irods::zone_key_map[zone_name] = std::make_tuple(zone_key, negotiation_key, hash_scheme);
+        }
+        catch (const std::exception& e) {
+            log_agent::error("{}: Error in server federation configuration: {}", __func__, e.what());
+            continue;
         }
     }
-    catch (const irods::exception&) {
-        // try the old remote sid config
-        try {
-            for (const auto& rem_sid : irods::get_server_property<std::vector<std::string>>(REMOTE_ZONE_SID_KW)) {
-                // legacy format should be zone_name-SID
-                const size_t pos = rem_sid.find("-");
-                if (pos == std::string::npos) {
-                    rodsLog(LOG_ERROR, "initRcatServerHostByFile - Unable to parse remote SID %s", rem_sid.c_str());
-                }
-                else {
-                    // store in remote_SID_key_map
-                    std::string fed_zone_name = rem_sid.substr(0, pos);
-                    std::string fed_zone_key = rem_sid.substr(pos + 1);
-                    // use our negotiation key for the old configuration
-                    try {
-                        const auto& neg_key = irods::get_server_property<const std::string>(irods::KW_CFG_NEGOTIATION_KEY);
-                        remote_SID_key_map[fed_zone_name] = std::make_pair(fed_zone_key, neg_key);
-                    }
-                    catch (const irods::exception& e) {
-                        irods::log(irods::error(e));
-                        return e.code();
-                    }
-                }
-            }
-        } catch (const irods::exception&) {}
-    } // else
 
     return 0;
-}
+} // initRcatServerHostByFile
 
 int
 initZone( rsComm_t *rsComm ) {

--- a/server/core/src/initServer.cpp
+++ b/server/core/src/initServer.cpp
@@ -308,7 +308,10 @@ int initRcatServerHostByFile()
             const auto& zone_name = federation.at(irods::KW_CFG_ZONE_NAME).get_ref<const std::string&>();
             const auto& zone_key = federation.at(irods::KW_CFG_ZONE_KEY).get_ref<const std::string&>();
             const auto& negotiation_key = federation.at(irods::KW_CFG_NEGOTIATION_KEY).get_ref<const std::string&>();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             remote_SID_key_map[zone_name] = std::make_pair(zone_key, negotiation_key);
+#pragma GCC diagnostic pop
 
             const auto hash_scheme_iter = federation.find(irods::KW_CFG_ZONE_KEY_SIGNING_HASH_SCHEME);
             const auto& hash_scheme = (federation.end() != hash_scheme_iter)

--- a/server/core/src/irods_server_globals.cpp
+++ b/server/core/src/irods_server_globals.cpp
@@ -56,7 +56,10 @@ specCollCache_t *SpecCollCacheHead = NULL;
 /* Server Authentication information */
 
 char localSID[MAX_PASSWORD_LEN]; /* Local Zone Servers ID string */
-irods::lookup_table <std::pair <std::string, std::string> > remote_SID_key_map; // remote zone SIDs and negotiation keys
+
+// remote zone SIDs and negotiation keys
+[[deprecated("Use irods::zone_key_map intead.")]] irods::lookup_table<std::pair<std::string, std::string>>
+    remote_SID_key_map; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 /* quota for all resources for this user in bytes */
 rodsLong_t GlobalQuotaLimit;    /* quota for all resources for this user */

--- a/server/core/src/irods_server_negotiation.cpp
+++ b/server/core/src/irods_server_negotiation.cpp
@@ -1,18 +1,86 @@
-// =-=-=-=-=-=-=-
-#include "irods/initServer.hpp"
 #include "irods/irods_client_server_negotiation.hpp"
+
+#include "irods/initServer.hpp"
 #include "irods/irods_configuration_keywords.hpp"
 #include "irods/irods_kvp_string_parser.hpp"
+#include "irods/irods_logger.hpp"
 #include "irods/irods_server_properties.hpp"
-
-// =-=-=-=-=-=-=-
-// irods includes
 #include "irods/rodsDef.h"
 #include "irods/rsGlobalExtern.hpp"
 
 #include <list>
+#include <string>
 
 #include <fmt/format.h>
+
+namespace irods
+{
+    extern const std::string MD5_NAME;
+
+    // Map of remote zones to a tuple of zone key, negotiation key, and signing hash scheme
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    irods::lookup_table<std::tuple<std::string, std::string, std::string>> zone_key_map;
+} // namespace irods
+
+namespace
+{
+    using log_server = irods::experimental::log::server;
+
+    auto check_sent_zone_key(const std::string& _zone_key) -> irods::error
+    {
+        if (_zone_key.empty()) {
+            return ERROR(SYS_INVALID_INPUT_PARAM, "incoming zone_key is empty");
+        }
+
+        // Check local zone keys for a match with the sent zone key.
+        try {
+            const auto config_handle{irods::server_properties::instance().map()};
+            const auto& config{config_handle.get_json()};
+
+            const auto& neg_key = config.at(irods::KW_CFG_NEGOTIATION_KEY).get_ref<const std::string&>();
+            if (!irods::negotiation_key_is_valid(neg_key)) {
+                log_server::warn("{}: negotiation_key in server_config is invalid", __func__);
+            }
+
+            const auto& zone_key = config.at(irods::KW_CFG_ZONE_KEY).get_ref<const std::string&>();
+
+            const auto hash_scheme_iter = config.find(irods::KW_CFG_ZONE_KEY_SIGNING_HASH_SCHEME);
+            const auto& hash_scheme =
+                (config.end() != hash_scheme_iter) ? hash_scheme_iter->get_ref<const std::string&>() : irods::MD5_NAME;
+
+            std::string signed_zone_key;
+            if (const auto err = irods::sign_zone_key(zone_key, neg_key, hash_scheme, signed_zone_key); !err.ok()) {
+                return PASS(err);
+            }
+
+            if (_zone_key == signed_zone_key) {
+                log_server::trace("{}: Signed zone_key matches input signed zone_key", __func__);
+                return SUCCESS();
+            }
+        }
+        catch (const irods::exception& e) {
+            log_server::error(
+                "{}: Error occurred while while checking signed zone key: {}", __func__, e.client_display_what());
+            return {e};
+        }
+
+        // Check zone and negotiation keys defined for remote zones (i.e. federation) for a match.
+        for (const auto& entry : irods::zone_key_map) {
+            const auto& [zone_key, neg_key, hash_scheme] = entry.second;
+
+            std::string signed_zone_key;
+            if (const auto err = irods::sign_zone_key(zone_key, neg_key, hash_scheme, signed_zone_key); !err.ok()) {
+                return PASS(err);
+            }
+
+            if (_zone_key == signed_zone_key) {
+                return SUCCESS();
+            }
+        }
+
+        return ERROR(ZONE_KEY_SIGNATURE_MISMATCH, "signed zone_keys do not match");
+    } // check_sent_zone_key
+} // anonymous namespace
 
 namespace irods
 {
@@ -149,7 +217,7 @@ namespace irods
                     // Make sure that the zone_key was signed using the correct negotiation_key
                     // and matches the signed zone_key for this zone. If it does not match, the
                     // server should end communications.
-                    if (const auto err = check_sent_sid(zone_key); !err.ok()) {
+                    if (const auto err = check_sent_zone_key(zone_key); !err.ok()) {
                         return err;
                     }
 

--- a/server/core/src/irods_server_negotiation.cpp
+++ b/server/core/src/irods_server_negotiation.cpp
@@ -84,6 +84,8 @@ namespace
 
 namespace irods
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     error check_sent_sid(const std::string& _zone_key)
     {
         if (_zone_key.empty()) {
@@ -133,10 +135,8 @@ namespace irods
 
         return ERROR(ZONE_KEY_SIGNATURE_MISMATCH, "signed zone_keys do not match");
     } // check_sent_sid
+#pragma GCC diagnostic pop
 
-
-/// =-=-=-=-=-=-=-
-/// @brief function which manages the TLS and Auth negotiations with the client
     error client_server_negotiation_for_server(irods::network_object_ptr _ptr,
                                                std::string& _result,
                                                bool _require_cs_neg,

--- a/unit_tests/src/test_client_server_negotiation.cpp
+++ b/unit_tests/src/test_client_server_negotiation.cpp
@@ -28,3 +28,38 @@ TEST_CASE("negotiation_key_is_valid")
     // Leading underscore makes the string 32 bytes long, couldn't find any others to use.
     CHECK(!irods::negotiation_key_is_valid("_`~!@#$%^&*()-+=[{}]|;:',<>.?/\"\\"));
 }
+
+TEST_CASE("sign_zone_key")
+{
+    constexpr const char* zone_key = "zone_key_1";
+    constexpr const char* encryption_key = "32_BYTE_SERVER_NEGOTIATION_KEY__";
+
+    std::string signed_zone_key;
+
+    constexpr const char* default_hash_scheme = "md5";
+
+    // Invalid zone key
+    CHECK(!irods::sign_zone_key("", encryption_key, default_hash_scheme, signed_zone_key).ok());
+
+    // Invalid encryption keys
+    CHECK(!irods::sign_zone_key(zone_key, "", default_hash_scheme, signed_zone_key).ok());
+    CHECK(
+        !irods::sign_zone_key(zone_key, "31_BYTE_SERVER_NEGOTIATION_KEY_", default_hash_scheme, signed_zone_key).ok());
+
+    // Invalid hash scheme
+    CHECK(!irods::sign_zone_key(zone_key, encryption_key, "", signed_zone_key).ok());
+    CHECK(!irods::sign_zone_key(zone_key, encryption_key, "jimbo", signed_zone_key).ok());
+
+    // md5
+    CHECK(irods::sign_zone_key(zone_key, encryption_key, default_hash_scheme, signed_zone_key).ok());
+    CHECK("ff2443be8ca197d5ecc2dc360244444e" == signed_zone_key);
+
+    // sha256
+    CHECK(irods::sign_zone_key(zone_key, encryption_key, "sha256", signed_zone_key).ok());
+    CHECK("f9456c64c904cf104e5a436e06c274807b102fabe2e2b485fba1d3253df33d62" == signed_zone_key);
+
+    // sha512
+    CHECK(irods::sign_zone_key(zone_key, encryption_key, "sha512", signed_zone_key).ok());
+    CHECK("7e2e38e24fd02f252b14a6fcd855c63d07b263b360f936b783e64bd56744f1c148a51d8388cd78b23883b132ccc8ef9de1856e8d2d3b"
+          "123ce841d111d56a815a" == signed_zone_key);
+}

--- a/unit_tests/src/test_client_server_negotiation.cpp
+++ b/unit_tests/src/test_client_server_negotiation.cpp
@@ -39,16 +39,16 @@ TEST_CASE("sign_zone_key")
     constexpr const char* default_hash_scheme = "md5";
 
     // Invalid zone key
-    CHECK(!irods::sign_zone_key("", encryption_key, default_hash_scheme, signed_zone_key).ok());
+    CHECK_FALSE(irods::sign_zone_key("", encryption_key, default_hash_scheme, signed_zone_key).ok());
 
     // Invalid encryption keys
-    CHECK(!irods::sign_zone_key(zone_key, "", default_hash_scheme, signed_zone_key).ok());
-    CHECK(
-        !irods::sign_zone_key(zone_key, "31_BYTE_SERVER_NEGOTIATION_KEY_", default_hash_scheme, signed_zone_key).ok());
+    CHECK_FALSE(irods::sign_zone_key(zone_key, "", default_hash_scheme, signed_zone_key).ok());
+    CHECK_FALSE(
+        irods::sign_zone_key(zone_key, "31_BYTE_SERVER_NEGOTIATION_KEY_", default_hash_scheme, signed_zone_key).ok());
 
     // Invalid hash scheme
-    CHECK(!irods::sign_zone_key(zone_key, encryption_key, "", signed_zone_key).ok());
-    CHECK(!irods::sign_zone_key(zone_key, encryption_key, "jimbo", signed_zone_key).ok());
+    CHECK_FALSE(irods::sign_zone_key(zone_key, encryption_key, "", signed_zone_key).ok());
+    CHECK_FALSE(irods::sign_zone_key(zone_key, encryption_key, "jimbo", signed_zone_key).ok());
 
     // md5
     CHECK(irods::sign_zone_key(zone_key, encryption_key, default_hash_scheme, signed_zone_key).ok());


### PR DESCRIPTION
Addresses #2295
In service of #3403
Addresses #5948

Without https://github.com/irods/irods/issues/6835, we can't add any automated testing for modifying configs on both ends of a server authentication conversation. I've done some manual testing and confirmed that sha256 on both servers works for both a topology and in federation. I'd like to do a little more testing to be sure, but I think this is in a decent spot.

Passing tests:
- [x] unit tests
- [x] topology-on-provider (test_negotiation)
- [x] topology-on-consumer (test_negotiation)
- [x] federation (new test only)