### PR TITLE
[#8748] Make user_password_storage_mode a grid configuration 

### DIFF
--- a/clients/icommands/src/iadmin.cpp
+++ b/clients/icommands/src/iadmin.cpp
@@ -2616,6 +2616,7 @@ usage( char *subOpt ) {
                                             "authentication   password_max_time",
                                             "authentication   password_min_time",
                                             "authentication   password_reuse_previous",
+                                            "authentication   password_storage_mode",
                                             "authentication   token_lifetime_in_seconds",
                                             ""};
 
@@ -2644,6 +2645,7 @@ usage( char *subOpt ) {
                                             "authentication   password_max_time",
                                             "authentication   password_min_time",
                                             "authentication   password_reuse_previous",
+                                            "authentication   password_storage_mode",
                                             "authentication   token_lifetime_in_seconds",
                                             "database         schema_version",
                                             "delay_server     leader",

--- a/lib/core/include/irods/irods_configuration_keywords.hpp
+++ b/lib/core/include/irods/irods_configuration_keywords.hpp
@@ -211,8 +211,6 @@ namespace irods
 
     extern const char* const KW_CFG_CONNECTION_POOL_REFRESH_TIME;
 
-    extern const char* const KW_CFG_USER_PASSWORD_STORAGE_MODE;
-
     extern const char* const KW_CFG_ZONE_KEY_SIGNING_HASH_SCHEME;
 } // namespace irods
 

--- a/lib/core/src/irods_configuration_keywords.cpp
+++ b/lib/core/src/irods_configuration_keywords.cpp
@@ -202,8 +202,6 @@ namespace irods
 
     const char* const KW_CFG_CONNECTION_POOL_REFRESH_TIME{"connection_pool_refresh_time_in_seconds"};
 
-    const char* const KW_CFG_USER_PASSWORD_STORAGE_MODE{"user_password_storage_mode"};
-
     const char* const KW_CFG_ZONE_KEY_SIGNING_HASH_SCHEME{"zone_key_signing_hash_scheme"};
 } // namespace irods
 

--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -324,6 +324,62 @@ namespace
         return SUCCESS();
     } // get_token_lifetime_configuration
 
+    auto get_password_storage_mode_configuration(std::string& _out) -> irods::error
+    {
+        constexpr auto max_size_for_option_value = 2700;
+        constexpr auto default_password_storage_mode = "legacy";
+        constexpr const char* config_namespace = "authentication";
+        constexpr const char* config_option_name = "password_storage_mode";
+
+        std::array<char, max_size_for_option_value + 1> password_storage_mode_str{};
+        std::vector<std::string> bindVars{config_namespace, config_option_name};
+
+        // The cValSize parameter eventually is used in a call to sprintf, so at most cValSize - 1 characters are
+        // printed to the buffer. This ensures that the string will be null terminated.
+        const int status = cmlGetStringValueFromSql(
+            "select option_value from R_GRID_CONFIGURATION where namespace = ? and option_name = ?",
+            password_storage_mode_str.data(),
+            password_storage_mode_str.size(),
+            bindVars,
+            &icss);
+
+        if (status < 0) {
+            if (CAT_NO_ROWS_FOUND == status) {
+                _out = default_password_storage_mode;
+                log_db::warn("{}: Could not find entry in R_GRID_CONFIGURATION matching namespace:[{}] and "
+                             "option:[{}]. Using default value [{}].",
+                             __func__,
+                             config_namespace,
+                             config_option_name,
+                             _out);
+                return SUCCESS();
+            }
+            log_db::error("{}: cmlGetStringValueFromSql failure: {}", __func__, status);
+            return ERROR(status, "Failed to get auth token lifetime configuration.");
+        }
+
+        constexpr std::array<std::string_view, 3> modes{"legacy", "hashed", "both"};
+        const auto password_storage_mode_is_valid =
+            std::any_of(modes.begin(), modes.end(), [&password_storage_mode_str](const auto& mode) {
+                return mode == password_storage_mode_str.data();
+            });
+        if (!password_storage_mode_is_valid) {
+            _out = default_password_storage_mode;
+            log_db::warn("{}: Invalid R_GRID_CONFIGURATION value. namespace:[{}], option:[{}], value:[{}]. Using "
+                         "default value [{}]",
+                         __func__,
+                         config_namespace,
+                         config_option_name,
+                         password_storage_mode_str.data(),
+                         _out);
+        }
+        else {
+            _out = password_storage_mode_str.data();
+        }
+
+        return SUCCESS();
+    } // get_password_storage_mode_configuration
+
     // Computes SHA256 hash of the provided token and salt.
     auto hash_session_token(const std::string& _token, const std::string& _salt) -> std::string
     {
@@ -7280,17 +7336,14 @@ irods::error db_mod_user_op(
             return ERROR( status2, "icatApplyRule failed" );
         }
 
-        const auto config_handle{irods::server_properties::instance().map()};
-        const auto& config{config_handle.get_json()};
-        auto store_hashed_password = false;
-        auto store_scrambled_password = true;
-        if (const auto password_storage_mode_iter = config.find(irods::KW_CFG_USER_PASSWORD_STORAGE_MODE);
-            config.end() != password_storage_mode_iter)
-        {
-            const auto& password_storage_mode = password_storage_mode_iter->get_ref<const std::string&>();
-            store_scrambled_password = (password_storage_mode != "hashed");
-            store_hashed_password = (password_storage_mode != "legacy");
+        // Get the password storage mode configuration.
+        std::string password_storage_mode;
+        if (const auto err = get_password_storage_mode_configuration(password_storage_mode); !err.ok()) {
+            return err;
         }
+        // If the password_storage_mode configuration is an invalid value, it defaults to "legacy".
+        const auto store_scrambled_password = (password_storage_mode != "hashed");
+        const auto store_hashed_password = (password_storage_mode != "legacy");
 
         if (store_hashed_password) {
             try {

--- a/schemas/configuration/v5/server_config.json.in
+++ b/schemas/configuration/v5/server_config.json.in
@@ -393,14 +393,6 @@
                 "verify_server"
             ]
         },
-        "user_password_storage_mode": {
-            "type": "enum",
-            "enum": [
-                "legacy",
-                "hashed",
-                "both"
-            ]
-        },
         "zone_auth_scheme" : {
             "type": "string",
             "maxLength": 63

--- a/scripts/irods/database_upgrade.py
+++ b/scripts/irods/database_upgrade.py
@@ -285,6 +285,9 @@ def run_update(irods_config, cursor, is_upgrade):
                     ");"
             )
 
+        # password storage mode setting
+        database_connect.execute_sql_statement(cursor, "insert into R_GRID_CONFIGURATION values ('authentication', 'password_storage_mode', 'legacy');")
+
     else:
         raise IrodsError('Upgrade to schema version %d is unsupported.' % (new_schema_version))
 

--- a/scripts/irods/test/test_iadmin.py
+++ b/scripts/irods/test/test_iadmin.py
@@ -3076,50 +3076,54 @@ class test_moduser_remove_password__issue_2899(unittest.TestCase):
     def test_moduser_remove_password_for_user_with_a_legacy_password(self):
         native_password = "native_password"
         irods_password = "irods_password"
+
+        namespace = 'authentication'
+        option_name = 'password_storage_mode'
+        original_password_storage_mode = self.admin.assert_icommand(
+            ['iadmin', 'get_grid_configuration', namespace, option_name], 'STDOUT')[1].strip()
+
         try:
-            config = IrodsConfig()
-            with lib.file_backed_up(paths.server_config_path()):
-                with self.subTest("native password only is not affected by remove_password"):
-                    # Configure the password storage mode to legacy, just in case.
-                    config.server_config["user_password_storage_mode"] = "legacy"
-                    lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-                    IrodsController(config).reload_configuration()
+            with self.subTest("native password only is not affected by remove_password"):
+                # Configure the password storage mode to legacy, just in case.
+                self.admin.assert_icommand(['iadmin', 'set_grid_configuration', namespace, option_name, "legacy"])
+                IrodsController().reload_configuration()
 
-                    # Set the user's password for native authentication.
-                    self.admin.assert_icommand(
-                        ['iadmin', 'moduser', self.test_user.username, "password", native_password])
-                    self.assertTrue(self.user_has_native_password())
+                # Set the user's password for native authentication.
+                self.admin.assert_icommand(
+                    ['iadmin', 'moduser', self.test_user.username, "password", native_password])
+                self.assertTrue(self.user_has_native_password())
 
-                    # Now run remove_password, to no effect (and no errors). The user should still be able use native
-                    # authentication.
-                    self.admin.assert_icommand(
-                        ["iadmin", "moduser", self.test_user.username, "remove_password"], desired_rc=0)
-                    self.assertTrue(self.user_has_native_password())
+                # Now run remove_password, to no effect (and no errors). The user should still be able use native
+                # authentication.
+                self.admin.assert_icommand(
+                    ["iadmin", "moduser", self.test_user.username, "remove_password"], desired_rc=0)
+                self.assertTrue(self.user_has_native_password())
 
-                with self.subTest("irods and native passwords set is only affected by remove_password for irods auth"):
-                    # Configure the password storage mode to hashed so that setting the password updates the irods
-                    # password and not the native password.
-                    config.server_config["user_password_storage_mode"] = "hashed"
-                    lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-                    IrodsController(config).reload_configuration()
+            with self.subTest("irods and native passwords set is only affected by remove_password for irods auth"):
+                # Configure the password storage mode to hashed so that setting the password updates the irods
+                # password and not the native password.
+                self.admin.assert_icommand(['iadmin', 'set_grid_configuration', namespace, option_name, "hashed"])
+                IrodsController().reload_configuration()
 
-                    # Ensure that the user does not have a password for use with irods authentication.
-                    self.assertFalse(self.user_has_irods_password())
+                # Ensure that the user does not have a password for use with irods authentication.
+                self.assertFalse(self.user_has_irods_password())
 
-                    # Set the user's password for irods authentication and confirm that the user has passwords set for
-                    # both the irods and native authentication schemes.
-                    self.admin.assert_icommand(
-                        ['iadmin', 'moduser', self.test_user.username, "password", irods_password, "no-scramble"])
-                    self.assertTrue(self.user_has_native_password())
-                    self.assertTrue(self.user_has_irods_password())
+                # Set the user's password for irods authentication and confirm that the user has passwords set for
+                # both the irods and native authentication schemes.
+                self.admin.assert_icommand(
+                    ['iadmin', 'moduser', self.test_user.username, "password", irods_password, "no-scramble"])
+                self.assertTrue(self.user_has_native_password())
+                self.assertTrue(self.user_has_irods_password())
 
-                    # Now run remove_password. The user should only have a password set for native authentication again.
-                    self.admin.assert_icommand(
-                        ["iadmin", "moduser", self.test_user.username, "remove_password"], desired_rc=0)
-                    self.assertTrue(self.user_has_native_password())
-                    self.assertFalse(self.user_has_irods_password())
+                # Now run remove_password. The user should only have a password set for native authentication again.
+                self.admin.assert_icommand(
+                    ["iadmin", "moduser", self.test_user.username, "remove_password"], desired_rc=0)
+                self.assertTrue(self.user_has_native_password())
+                self.assertFalse(self.user_has_irods_password())
 
         finally:
+            self.admin.assert_icommand(
+                ['iadmin', 'set_grid_configuration', namespace, option_name, original_password_storage_mode])
             IrodsController().reload_configuration()
 
     def test_moduser_remove_password_for_authenticated_user_results_in_an_error__issue_8747(self):

--- a/scripts/irods/test/test_session_tokens.py
+++ b/scripts/irods/test/test_session_tokens.py
@@ -30,15 +30,18 @@ class test_session_token_lifetime_configuration(unittest.TestCase):
 			server_config['plugin_configuration']['authentication']['irods'] = {
 				'insecure_mode': True
 			}
-		server_config["user_password_storage_mode"] = "both"
 		lib.update_json_file_from_dict(paths.server_config_path(), server_config)
+		with session.make_session_for_existing_admin() as admin_session:
+			cls.original_password_storage_mode = admin_session.assert_icommand(
+				['iadmin', 'get_grid_configuration', "authentication", "password_storage_mode"], 'STDOUT')[1].strip()
+			admin_session.assert_icommand(['iadmin', 'set_grid_configuration', "authentication", "password_storage_mode", "both"])
 		IrodsController().reload_configuration()
 
 		# Create an admin user / session for all the tests so we don't have to keep making sessions for each test.
 		cls.admin = session.mkuser_and_return_session("rodsadmin", "otherrods", "rods", lib.get_hostname())
 
 		# Create a test user and set the user's password. This should allow for authenticating both with native and
-		# irods auth schemes due to the user_password_storage_mode configuration being set to "both" above.
+		# irods auth schemes due to the password_storage_mode configuration being set to "both" above.
 		cls.test_user = session.mkuser_and_return_session("rodsuser", "bilbo", "baggins", lib.get_hostname())
 
 		# Change the user's authentication scheme to irods authentication because that's what all of these tests use.
@@ -49,6 +52,8 @@ class test_session_token_lifetime_configuration(unittest.TestCase):
 	def tearDownClass(cls):
 		# Restore the original server configuration if necessary.
 		shutil.copyfile(cls.server_config_backup, paths.server_config_path())
+		cls.admin.assert_icommand(
+			['iadmin', 'set_grid_configuration', "authentication", "password_storage_mode", cls.original_password_storage_mode])
 		IrodsController().reload_configuration()
 
 		# Exit the test admin and test user session and remove the user. Have to authenticate using native
@@ -119,10 +124,13 @@ class test_password_authentication_returning_session_tokens(unittest.TestCase):
 			server_config['plugin_configuration']['authentication']['irods'] = {
 				'insecure_mode': True
 			}
-		server_config["user_password_storage_mode"] = "both"
 		lib.update_json_file_from_dict(paths.server_config_path(), server_config)
 
 		# Set the grid configuration to the desired value and reload configuration.
+		self.original_password_storage_mode = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', "authentication", "password_storage_mode"], 'STDOUT')[1].strip()
+		self.admin.assert_icommand(['iadmin', 'set_grid_configuration', "authentication", "password_storage_mode", "both"])
+
 		self.original_token_lifetime = self.admin.assert_icommand(
 			["iadmin", "get_grid_configuration", self.configuration_namespace, self.configuration_option_name], "STDOUT")[1].strip()
 		self.admin.assert_icommand(
@@ -130,7 +138,7 @@ class test_password_authentication_returning_session_tokens(unittest.TestCase):
 		IrodsController().reload_configuration()
 
 		# Create a test user and set the user's password. This should allow for authenticating both with native and
-		# irods auth schemes due to the user_password_storage_mode configuration being set to "both" above.
+		# irods auth schemes due to the password_storage_mode configuration being set to "both" above.
 		self.test_rodsadmin = session.mkuser_and_return_session(
 			"rodsadmin", "test_rodsadmin", "rodsadminpass", lib.get_hostname())
 		self.test_rodsuser = session.mkuser_and_return_session(
@@ -150,6 +158,8 @@ class test_password_authentication_returning_session_tokens(unittest.TestCase):
 		shutil.copyfile(self.server_config_backup, paths.server_config_path())
 		self.admin.assert_icommand(
 			["iadmin", "set_grid_configuration", self.configuration_namespace, self.configuration_option_name, self.original_token_lifetime])
+		self.admin.assert_icommand(
+			['iadmin', 'set_grid_configuration', "authentication", "password_storage_mode", self.original_password_storage_mode])
 		IrodsController().reload_configuration()
 
 		# Exit test user sessions and remove the users. Have to re-authenticate because the users may not have
@@ -274,12 +284,14 @@ class test_remove_session_tokens(unittest.TestCase):
 		shutil.copyfile(paths.server_config_path(), self.server_config_backup)
 		with open(paths.server_config_path()) as f:
 			server_config = json.load(f)
-		server_config["user_password_storage_mode"] = "both"
 		# Configure insecure mode for irods authentication scheme if the tests are not being run with TLS enabled.
 		if False == test.settings.USE_SSL:
 			server_config['plugin_configuration']['authentication']['irods'] = {'insecure_mode': True}
 		# Update the server configuration and reload the configuration.
 		lib.update_json_file_from_dict(paths.server_config_path(), server_config)
+		self.original_password_storage_mode = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', "authentication", "password_storage_mode"], 'STDOUT')[1].strip()
+		self.admin.assert_icommand(['iadmin', 'set_grid_configuration', "authentication", "password_storage_mode", "both"])
 
 		# Configure the session token lifetime to something short so we can test in a reasonable amount of time.
 		self.token_lifetime_value = 5
@@ -312,6 +324,8 @@ class test_remove_session_tokens(unittest.TestCase):
 	def tearDownClass(self):
 		# Restore the original server configuration.
 		shutil.copyfile(self.server_config_backup, paths.server_config_path())
+		self.admin.assert_icommand(
+			['iadmin', 'set_grid_configuration', "authentication", "password_storage_mode", self.original_password_storage_mode])
 		IrodsController().reload_configuration()
 
 		# Exit the test admin and test user session and remove the user. Have to authenticate using native

--- a/scripts/irods/test/test_setting_user_password.py
+++ b/scripts/irods/test/test_setting_user_password.py
@@ -14,12 +14,10 @@ from ..controller import IrodsController
 from ..exceptions import IrodsError
 
 
-def configure_password_storage_mode(value):
-	# Update server config and reload configuration.
-	config = IrodsConfig()
-	config.server_config["user_password_storage_mode"] = value
-	lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-	IrodsController(config).reload_configuration()
+def configure_password_storage_mode(admin_session, value):
+	admin_session.assert_icommand(
+		["iadmin", "set_grid_configuration", "authentication", "password_storage_mode", value])
+	IrodsController().reload_configuration()
 
 
 def authenticate_with_scheme(user_session, scheme_name, password, should_fail=False):
@@ -90,12 +88,14 @@ class test_modifying_user_password(unittest.TestCase):
 		self.admin.assert_icommand(["iadmin", "rmuser", self.test_user.username])
 
 	def test_config_legacy_sets_password_for_native_scheme_but_not_irods_scheme(self):
-		config = IrodsConfig()
-		with lib.file_backed_up(config.server_config_path):
-			# Update server config and reload configuration.
-			config.server_config["user_password_storage_mode"] = "legacy"
-			lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-			IrodsController(config).reload_configuration()
+		namespace = 'authentication'
+		option_name = 'password_storage_mode'
+		original_password_storage_mode = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', namespace, option_name], 'STDOUT')[1].strip()
+		try:
+			# Update grid config and reload configuration.
+			self.admin.assert_icommand(['iadmin', 'set_grid_configuration', namespace, option_name, "legacy"])
+			IrodsController().reload_configuration()
 
 			# Set user password and send in scrambled form. This should set the user's password in R_USER_PASSWORD
 			# but not R_USER_CREDENTIALS.
@@ -125,15 +125,20 @@ class test_modifying_user_password(unittest.TestCase):
 				authenticate_with_scheme(self.test_user, "irods", should_fail=True, password=scrambled_password)
 				authenticate_with_scheme(self.test_user, "irods", should_fail=True, password=non_scrambled_password)
 
-		IrodsController().reload_configuration()
+		finally:
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', namespace, option_name, original_password_storage_mode])
+			IrodsController().reload_configuration()
 
 	def test_config_hashed_sets_password_for_irods_scheme_but_not_native_scheme(self):
-		config = IrodsConfig()
-		with lib.file_backed_up(config.server_config_path):
-			# Update server config and reload configuration.
-			config.server_config["user_password_storage_mode"] = "hashed"
-			lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-			IrodsController(config).reload_configuration()
+		namespace = 'authentication'
+		option_name = 'password_storage_mode'
+		original_password_storage_mode = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', namespace, option_name], 'STDOUT')[1].strip()
+		try:
+			# Update grid config and reload configuration.
+			self.admin.assert_icommand(['iadmin', 'set_grid_configuration', namespace, option_name, "hashed"])
+			IrodsController().reload_configuration()
 
 			# Set user password and send in scrambled form. This should set the user's password in R_USER_CREDENTIALS
 			# but not R_USER_PASSWORD.
@@ -163,15 +168,20 @@ class test_modifying_user_password(unittest.TestCase):
 				authenticate_with_scheme(self.test_user, "irods", should_fail=True, password=scrambled_password)
 				authenticate_with_scheme(self.test_user, "irods", should_fail=False, password=non_scrambled_password)
 
-		IrodsController().reload_configuration()
+		finally:
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', namespace, option_name, original_password_storage_mode])
+			IrodsController().reload_configuration()
 
 	def test_config_sets_password_for_both_native_and_irods_schemes(self):
-		config = IrodsConfig()
-		with lib.file_backed_up(config.server_config_path):
-			# Update server config and reload configuration.
-			config.server_config["user_password_storage_mode"] = "both"
-			lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-			IrodsController(config).reload_configuration()
+		namespace = 'authentication'
+		option_name = 'password_storage_mode'
+		original_password_storage_mode = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', namespace, option_name], 'STDOUT')[1].strip()
+		try:
+			# Update grid config and reload configuration.
+			self.admin.assert_icommand(['iadmin', 'set_grid_configuration', namespace, option_name, "both"])
+			IrodsController().reload_configuration()
 
 			# Set user password and send in scrambled form. This should set the user's password in R_USER_PASSWORD
 			# and also R_USER_CREDENTIALS.
@@ -201,15 +211,20 @@ class test_modifying_user_password(unittest.TestCase):
 				authenticate_with_scheme(self.test_user, "irods", should_fail=True, password=scrambled_password)
 				authenticate_with_scheme(self.test_user, "irods", should_fail=False, password=non_scrambled_password)
 
-		IrodsController().reload_configuration()
+		finally:
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', namespace, option_name, original_password_storage_mode])
+			IrodsController().reload_configuration()
 
 	def test_config_both_with_long_passwords(self):
-		config = IrodsConfig()
-		with lib.file_backed_up(config.server_config_path):
-			# Update server config and reload configuration.
-			config.server_config["user_password_storage_mode"] = "both"
-			lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-			IrodsController(config).reload_configuration()
+		namespace = 'authentication'
+		option_name = 'password_storage_mode'
+		original_password_storage_mode = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', namespace, option_name], 'STDOUT')[1].strip()
+		try:
+			# Update grid config and reload configuration.
+			self.admin.assert_icommand(['iadmin', 'set_grid_configuration', namespace, option_name, "both"])
+			IrodsController().reload_configuration()
 
 			# Set user password to a very long string (257 characters) and try to send it in scrambled form.
 			long_password = "1234567_" * 32 + "z"
@@ -238,15 +253,20 @@ class test_modifying_user_password(unittest.TestCase):
 				# Authenticate with irods scheme - should fail.
 				authenticate_with_scheme(self.test_user, "irods", should_fail=True, password=long_password)
 
-		IrodsController().reload_configuration()
+		finally:
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', namespace, option_name, original_password_storage_mode])
+			IrodsController().reload_configuration()
 
 	def test_config_legacy_with_long_passwords(self):
-		config = IrodsConfig()
-		with lib.file_backed_up(config.server_config_path):
-			# Update server config and reload configuration.
-			config.server_config["user_password_storage_mode"] = "legacy"
-			lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-			IrodsController(config).reload_configuration()
+		namespace = 'authentication'
+		option_name = 'password_storage_mode'
+		original_password_storage_mode = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', namespace, option_name], 'STDOUT')[1].strip()
+		try:
+			# Update grid config and reload configuration.
+			self.admin.assert_icommand(['iadmin', 'set_grid_configuration', namespace, option_name, "legacy"])
+			IrodsController().reload_configuration()
 
 			# Set user password to a very long string (257 characters) and try to send it in scrambled form.
 			long_password = "1234567_" * 32 + "z"
@@ -275,16 +295,21 @@ class test_modifying_user_password(unittest.TestCase):
 				# Authenticate with irods scheme - should fail.
 				authenticate_with_scheme(self.test_user, "irods", should_fail=True, password=long_password)
 
-		IrodsController().reload_configuration()
+		finally:
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', namespace, option_name, original_password_storage_mode])
+			IrodsController().reload_configuration()
 
 	@unittest.skip("TODO(#8730): This test fails because we cannot handle passwords over 42 characters.")
 	def test_config_hashed_with_long_passwords(self):
-		config = IrodsConfig()
-		with lib.file_backed_up(config.server_config_path):
-			# Update server config and reload configuration.
-			config.server_config["user_password_storage_mode"] = "hashed"
-			lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-			IrodsController(config).reload_configuration()
+		namespace = 'authentication'
+		option_name = 'password_storage_mode'
+		original_password_storage_mode = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', namespace, option_name], 'STDOUT')[1].strip()
+		try:
+			# Update grid config and reload configuration.
+			self.admin.assert_icommand(['iadmin', 'set_grid_configuration', namespace, option_name, "hashed"])
+			IrodsController().reload_configuration()
 
 			# Set user password to a very long string (257 characters) and try to send it in scrambled form.
 			long_password = "1234567_" * 32 + "z"
@@ -312,13 +337,19 @@ class test_modifying_user_password(unittest.TestCase):
 				# Authenticate with irods scheme - should succeed.
 				authenticate_with_scheme(self.test_user, "irods", should_fail=False, password=long_password)
 
-		IrodsController().reload_configuration()
+		finally:
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', namespace, option_name, original_password_storage_mode])
+			IrodsController().reload_configuration()
 
 
 @unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, "Must configure catalog provider for these tests.")
 class test_igroupadmin_mkuser(unittest.TestCase):
 	@classmethod
 	def setUpClass(self):
+		# Create an admin user / session for all the tests so we don't have to keep making it for each test.
+		self.admin = session.mkuser_and_return_session("rodsadmin", "otherrods", "rods", lib.get_hostname())
+
 		# Create a groupadmin user / session for all the tests so we don't have to keep making it for each test.
 		self.groupadmin = session.mkuser_and_return_session("groupadmin", "grouper", "gpass", lib.get_hostname())
 
@@ -345,10 +376,12 @@ class test_igroupadmin_mkuser(unittest.TestCase):
 			shutil.copyfile(self.server_config_backup, paths.server_config_path())
 			IrodsController().reload_configuration()
 
-		# Exit the test admin session and remove the user.
+		# Exit the test admin sessions and remove the users.
+		self.admin.__exit__()
 		self.groupadmin.__exit__()
 		with session.make_session_for_existing_admin() as admin_session:
 			admin_session.run_icommand(["iadmin", "rmuser", self.groupadmin.username])
+			admin_session.run_icommand(["iadmin", "rmuser", self.admin.username])
 
 	def tearDown(self):
 		# Exit the test user session and remove the user, if the user was created.
@@ -357,12 +390,14 @@ class test_igroupadmin_mkuser(unittest.TestCase):
 				admin_session.run_icommand(["iadmin", "rmuser", self.test_user_name])
 
 	def test_config_legacy_sets_password_for_native_scheme_but_not_irods_scheme(self):
-		config = IrodsConfig()
-		with lib.file_backed_up(config.server_config_path):
-			# Update server config and reload configuration.
-			config.server_config["user_password_storage_mode"] = "legacy"
-			lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-			IrodsController(config).reload_configuration()
+		namespace = 'authentication'
+		option_name = 'password_storage_mode'
+		original_password_storage_mode = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', namespace, option_name], 'STDOUT')[1].strip()
+		try:
+			# Update grid config and reload configuration.
+			self.admin.assert_icommand(['iadmin', 'set_grid_configuration', namespace, option_name, "legacy"])
+			IrodsController().reload_configuration()
 
 			# Set user password and send in scrambled form. This should set the user's password in R_USER_PASSWORD
 			# but not R_USER_CREDENTIALS.
@@ -404,15 +439,20 @@ class test_igroupadmin_mkuser(unittest.TestCase):
 				authenticate_with_scheme(test_user, "irods", should_fail=True, password=scrambled_password)
 				authenticate_with_scheme(test_user, "irods", should_fail=True, password=non_scrambled_password)
 
-		IrodsController().reload_configuration()
+		finally:
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', namespace, option_name, original_password_storage_mode])
+			IrodsController().reload_configuration()
 
 	def test_config_hashed_sets_password_for_irods_scheme_but_not_native_scheme(self):
-		config = IrodsConfig()
-		with lib.file_backed_up(config.server_config_path):
-			# Update server config and reload configuration.
-			config.server_config["user_password_storage_mode"] = "hashed"
-			lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-			IrodsController(config).reload_configuration()
+		namespace = 'authentication'
+		option_name = 'password_storage_mode'
+		original_password_storage_mode = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', namespace, option_name], 'STDOUT')[1].strip()
+		try:
+			# Update grid config and reload configuration.
+			self.admin.assert_icommand(['iadmin', 'set_grid_configuration', namespace, option_name, "hashed"])
+			IrodsController().reload_configuration()
 
 			# Set user password and send in scrambled form. This should set the user's password in R_USER_CREDENTIALS
 			# but not R_USER_PASSWORD.
@@ -454,15 +494,20 @@ class test_igroupadmin_mkuser(unittest.TestCase):
 				authenticate_with_scheme(test_user, "irods", should_fail=True, password=scrambled_password)
 				authenticate_with_scheme(test_user, "irods", should_fail=False, password=non_scrambled_password)
 
-		IrodsController().reload_configuration()
+		finally:
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', namespace, option_name, original_password_storage_mode])
+			IrodsController().reload_configuration()
 
 	def test_config_sets_password_for_both_native_and_irods_schemes(self):
-		config = IrodsConfig()
-		with lib.file_backed_up(config.server_config_path):
-			# Update server config and reload configuration.
-			config.server_config["user_password_storage_mode"] = "both"
-			lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-			IrodsController(config).reload_configuration()
+		namespace = 'authentication'
+		option_name = 'password_storage_mode'
+		original_password_storage_mode = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', namespace, option_name], 'STDOUT')[1].strip()
+		try:
+			# Update grid config and reload configuration.
+			self.admin.assert_icommand(['iadmin', 'set_grid_configuration', namespace, option_name, "both"])
+			IrodsController().reload_configuration()
 
 			# Set user password and send in scrambled form. This should set the user's password in R_USER_PASSWORD
 			# and also R_USER_CREDENTIALS.
@@ -504,30 +549,13 @@ class test_igroupadmin_mkuser(unittest.TestCase):
 				authenticate_with_scheme(test_user, "irods", should_fail=True, password=scrambled_password)
 				authenticate_with_scheme(test_user, "irods", should_fail=False, password=non_scrambled_password)
 
-		IrodsController().reload_configuration()
+		finally:
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', namespace, option_name, original_password_storage_mode])
+			IrodsController().reload_configuration()
 
 
 class test_invalid_configurations_and_options(unittest.TestCase):
-	@unittest.skipIf(test.settings.TOPOLOGY_FROM_RESOURCE_SERVER, "Must configure catalog provider for this test.")
-	def test_invalid_password_storage_mode_value_causes_configuration_reload_to_fail(self):
-		# A test to see what the server does when the configuration is an invalid value cannot be created because the
-		# server validates the configuration before starting. The invalid configuration causes the validation to fail
-		# and so the configuration does not reload. If we could test this, we would expect setting user passwords to
-		# fail for all cases and return an error because the configuration cannot direct what should happen.
-		config = IrodsConfig()
-		with lib.file_backed_up(config.server_config_path):
-			# Update server config and reload configuration. This should cause an error.
-			invalid_config = "banana"
-			config.server_config["user_password_storage_mode"] = invalid_config
-			lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-			res = subprocess.run(['irodsServer', '-c'], capture_output=True, text=True)
-			self.assertNotEqual(res.returncode, 0)
-			self.assertIn('"valid": false', res.stderr)
-			self.assertIn('"instanceLocation": "/user_password_storage_mode"', res.stderr)
-			self.assertIn(f'"error": "\'{invalid_config}\' is not a valid enum value."', res.stderr)
-
-		IrodsController().reload_configuration()
-
 	def test_igroupadmin_mkuser_no_scramble_option_requires_optional_zone_to_be_specified(self):
 		user_name = "nobody"
 		with session.make_session_for_existing_admin() as admin_session:
@@ -548,12 +576,15 @@ class ipasswd_test_base(unittest.TestCase):
 		shutil.copyfile(paths.server_config_path(), cls.server_config_backup)
 		with open(paths.server_config_path()) as f:
 			server_config = json.load(f)
-		server_config["user_password_storage_mode"] = cls.password_storage_mode
 		# Configure insecure mode for irods authentication scheme if the tests are not being run with TLS enabled.
 		if False == test.settings.USE_SSL:
 			server_config['plugin_configuration']['authentication']['irods'] = {'insecure_mode': True}
 		# Update the server configuration and reload the configuration.
 		lib.update_json_file_from_dict(paths.server_config_path(), server_config)
+		cls.original_password_storage_mode = cls.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', "authentication", "password_storage_mode"], 'STDOUT')[1].strip()
+		cls.admin.assert_icommand(
+			['iadmin', 'set_grid_configuration', "authentication", "password_storage_mode", cls.password_storage_mode])
 		IrodsController().reload_configuration()
 
 		cls.old_password = "old_password"
@@ -564,6 +595,8 @@ class ipasswd_test_base(unittest.TestCase):
 	def tearDownClass(cls):
 		# Restore the original server configuration.
 		shutil.copyfile(cls.server_config_backup, paths.server_config_path())
+		cls.admin.assert_icommand(
+			['iadmin', 'set_grid_configuration', "authentication", "password_storage_mode", cls.original_password_storage_mode])
 		IrodsController().reload_configuration()
 
 		# Exit the test admin session and remove the user.
@@ -582,6 +615,9 @@ class ipasswd_test_base(unittest.TestCase):
 		# Exit the test user session and remove the user.
 		self.test_user.__exit__()
 		self.admin.assert_icommand(["iadmin", "rmuser", self.test_user.username])
+		# Set the password storage mode back to whatever is required for this test class as it may have changed.
+		self.admin.assert_icommand(
+			['iadmin', 'set_grid_configuration', "authentication", "password_storage_mode", self.password_storage_mode])
 		IrodsController().reload_configuration()
 
 	def configure_user_session_auth_scheme(self, auth_scheme):
@@ -601,7 +637,7 @@ class test_ipasswd_with_both_passwords_set(ipasswd_test_base):
 	def test_password_storage_mode_legacy_and_auth_scheme_native(self):
 		# Case 1
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("legacy")
+			configure_password_storage_mode(self.admin, "legacy")
 			self.configure_user_session_auth_scheme("native")
 
 			# Change password using native credentials to authenticate.
@@ -616,7 +652,7 @@ class test_ipasswd_with_both_passwords_set(ipasswd_test_base):
 	def test_password_storage_mode_legacy_and_auth_scheme_irods(self):
 		# Case 2
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("legacy")
+			configure_password_storage_mode(self.admin, "legacy")
 			self.configure_user_session_auth_scheme("irods")
 
 			# Change password using irods credentials to authenticate. Note: --no-scramble option is required in
@@ -634,7 +670,7 @@ class test_ipasswd_with_both_passwords_set(ipasswd_test_base):
 	def test_password_storage_mode_hashed_and_auth_scheme_native(self):
 		# Case 3
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("hashed")
+			configure_password_storage_mode(self.admin, "hashed")
 			self.configure_user_session_auth_scheme("native")
 
 			# Change password using native credentials to authenticate.
@@ -649,7 +685,7 @@ class test_ipasswd_with_both_passwords_set(ipasswd_test_base):
 	def test_password_storage_mode_hashed_and_auth_scheme_irods(self):
 		# Case 4
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("hashed")
+			configure_password_storage_mode(self.admin, "hashed")
 			self.configure_user_session_auth_scheme("irods")
 
 			# Change password using irods credentials to authenticate. Note: --no-scramble option is required in
@@ -667,7 +703,7 @@ class test_ipasswd_with_both_passwords_set(ipasswd_test_base):
 	def test_password_storage_mode_both_and_auth_scheme_native(self):
 		# Case 5
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("both")
+			configure_password_storage_mode(self.admin, "both")
 			self.configure_user_session_auth_scheme("native")
 
 			# Change password using native credentials to authenticate.
@@ -682,7 +718,7 @@ class test_ipasswd_with_both_passwords_set(ipasswd_test_base):
 	def test_password_storage_mode_both_and_auth_scheme_irods(self):
 		# Case 6
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("both")
+			configure_password_storage_mode(self.admin, "both")
 			self.configure_user_session_auth_scheme("irods")
 
 			# Change password using irods credentials to authenticate. Note: --no-scramble option is required in
@@ -706,7 +742,7 @@ class test_ipasswd_with_only_native_password_set(ipasswd_test_base):
 	def test_password_storage_mode_legacy_and_auth_scheme_native(self):
 		# Case 7
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("legacy")
+			configure_password_storage_mode(self.admin, "legacy")
 			self.configure_user_session_auth_scheme("native")
 
 			# Change password using native credentials to authenticate.
@@ -721,7 +757,7 @@ class test_ipasswd_with_only_native_password_set(ipasswd_test_base):
 	def test_password_storage_mode_legacy_and_auth_scheme_irods(self):
 		# Case 8
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("legacy")
+			configure_password_storage_mode(self.admin, "legacy")
 			self.configure_user_session_auth_scheme("irods")
 
 			# Attempt changing password using irods credentials and fail to authenticate. No irods password is set.
@@ -740,7 +776,7 @@ class test_ipasswd_with_only_native_password_set(ipasswd_test_base):
 	def test_password_storage_mode_hashed_and_auth_scheme_native(self):
 		# Case 9
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("hashed")
+			configure_password_storage_mode(self.admin, "hashed")
 			self.configure_user_session_auth_scheme("native")
 
 			# Change password using native credentials to authenticate.
@@ -755,7 +791,7 @@ class test_ipasswd_with_only_native_password_set(ipasswd_test_base):
 	def test_password_storage_mode_hashed_and_auth_scheme_irods(self):
 		# Case 10
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("hashed")
+			configure_password_storage_mode(self.admin, "hashed")
 			self.configure_user_session_auth_scheme("irods")
 
 			# Attempt changing password using irods credentials and fail to authenticate. No irods password is set.
@@ -774,7 +810,7 @@ class test_ipasswd_with_only_native_password_set(ipasswd_test_base):
 	def test_password_storage_mode_both_and_auth_scheme_native(self):
 		# Case 11
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("both")
+			configure_password_storage_mode(self.admin, "both")
 			self.configure_user_session_auth_scheme("native")
 
 			# Change password using native credentials to authenticate.
@@ -789,7 +825,7 @@ class test_ipasswd_with_only_native_password_set(ipasswd_test_base):
 	def test_password_storage_mode_both_and_auth_scheme_irods(self):
 		# Case 12
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("both")
+			configure_password_storage_mode(self.admin, "both")
 			self.configure_user_session_auth_scheme("irods")
 
 			# Attempt changing password using irods credentials and fail to authenticate. No irods password is set.
@@ -814,7 +850,7 @@ class test_ipasswd_with_only_irods_password_set(ipasswd_test_base):
 	def test_password_storage_mode_legacy_and_auth_scheme_native(self):
 		# Case 13
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("legacy")
+			configure_password_storage_mode(self.admin, "legacy")
 			self.configure_user_session_auth_scheme("native")
 
 			# Attempt changing password using native credentials and fail to authenticate. No native password is set.
@@ -830,7 +866,7 @@ class test_ipasswd_with_only_irods_password_set(ipasswd_test_base):
 	def test_password_storage_mode_legacy_and_auth_scheme_irods(self):
 		# Case 14
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("legacy")
+			configure_password_storage_mode(self.admin, "legacy")
 			self.configure_user_session_auth_scheme("irods")
 
 			# Change password using irods credentials to authenticate. Note: --no-scramble option is required in
@@ -848,7 +884,7 @@ class test_ipasswd_with_only_irods_password_set(ipasswd_test_base):
 	def test_password_storage_mode_hashed_and_auth_scheme_native(self):
 		# Case 15
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("hashed")
+			configure_password_storage_mode(self.admin, "hashed")
 			self.configure_user_session_auth_scheme("native")
 
 			# Attempt changing password using native credentials and fail to authenticate. No native password is set.
@@ -864,7 +900,7 @@ class test_ipasswd_with_only_irods_password_set(ipasswd_test_base):
 	def test_password_storage_mode_hashed_and_auth_scheme_irods(self):
 		# Case 16
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("hashed")
+			configure_password_storage_mode(self.admin, "hashed")
 			self.configure_user_session_auth_scheme("irods")
 
 			# Change password using irods credentials to authenticate. Note: --no-scramble option is required in
@@ -882,7 +918,7 @@ class test_ipasswd_with_only_irods_password_set(ipasswd_test_base):
 	def test_password_storage_mode_both_and_auth_scheme_native(self):
 		# Case 17
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("both")
+			configure_password_storage_mode(self.admin, "both")
 			self.configure_user_session_auth_scheme("native")
 
 			# Attempt changing password using native credentials and fail to authenticate. No native password is set.
@@ -898,7 +934,7 @@ class test_ipasswd_with_only_irods_password_set(ipasswd_test_base):
 	def test_password_storage_mode_both_and_auth_scheme_irods(self):
 		# Case 18
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("both")
+			configure_password_storage_mode(self.admin, "both")
 			self.configure_user_session_auth_scheme("irods")
 
 			# Change password using irods credentials to authenticate. Note: --no-scramble option is required in
@@ -918,7 +954,7 @@ class test_ipasswd_with_only_irods_password_set(ipasswd_test_base):
 		# scheme rather than authenticating with a session token.
 		irods_auth_password_prompt = "Enter your iRODS password:"
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("hashed")
+			configure_password_storage_mode(self.admin, "hashed")
 			self.configure_user_session_auth_scheme("irods")
 
 			# Authenticate the user so that we have a session token.
@@ -990,7 +1026,7 @@ class test_ipasswd_with_no_password_set(unittest.TestCase):
 	def test_password_storage_mode_legacy_auth_scheme_native(self):
 		# Case 19
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("legacy")
+			configure_password_storage_mode(self.admin, "legacy")
 			self.configure_user_session_auth_scheme("native")
 
 			# Attempt changing password using native credentials and fail to authenticate. No native password is set.
@@ -1006,7 +1042,7 @@ class test_ipasswd_with_no_password_set(unittest.TestCase):
 	def test_password_storage_mode_legacy_auth_scheme_irods(self):
 		# Case 20
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("legacy")
+			configure_password_storage_mode(self.admin, "legacy")
 			self.configure_user_session_auth_scheme("irods")
 
 			# Attempt changing password using irods credentials and fail to authenticate. No irods password is set.
@@ -1025,7 +1061,7 @@ class test_ipasswd_with_no_password_set(unittest.TestCase):
 	def test_password_storage_mode_hashed_auth_scheme_native(self):
 		# Case 21
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("hashed")
+			configure_password_storage_mode(self.admin, "hashed")
 			self.configure_user_session_auth_scheme("native")
 
 			# Attempt changing password using native credentials and fail to authenticate. No native password is set.
@@ -1041,7 +1077,7 @@ class test_ipasswd_with_no_password_set(unittest.TestCase):
 	def test_password_storage_mode_hashed_auth_scheme_irods(self):
 		# Case 22
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("hashed")
+			configure_password_storage_mode(self.admin, "hashed")
 			self.configure_user_session_auth_scheme("irods")
 
 			# Attempt changing password using irods credentials and fail to authenticate. No irods password is set.
@@ -1060,7 +1096,7 @@ class test_ipasswd_with_no_password_set(unittest.TestCase):
 	def test_password_storage_mode_both_auth_scheme_native(self):
 		# Case 23
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("both")
+			configure_password_storage_mode(self.admin, "both")
 			self.configure_user_session_auth_scheme("native")
 
 			# Attempt changing password using native credentials and fail to authenticate. No native password is set.
@@ -1076,7 +1112,7 @@ class test_ipasswd_with_no_password_set(unittest.TestCase):
 	def test_password_storage_mode_both_auth_scheme_irods(self):
 		# Case 24
 		with lib.file_backed_up(paths.server_config_path()):
-			configure_password_storage_mode("both")
+			configure_password_storage_mode(self.admin, "both")
 			self.configure_user_session_auth_scheme("irods")
 
 			# Attempt changing password using irods credentials and fail to authenticate. No irods password is set.


### PR DESCRIPTION
In service of #8748

Passing tests:
- [x] unit tests
- [x] core tests