### PR TITLE
[#8729] Fix R_USER_CREDENTIALS / R_USER_SESSION_KEY for new install

### DIFF
--- a/plugins/database/src/icatSysTables.sql.pp.in
+++ b/plugins/database/src/icatSysTables.sql.pp.in
@@ -106,7 +106,7 @@ create table R_RULE_EXEC ( rule_exec_id INT64TYPE not null, rule_name varchar(27
 
 create table R_USER_GROUP ( group_user_id INT64TYPE not null, user_id INT64TYPE not null, create_ts varchar(32), modify_ts varchar(32)) ;
 
-create table R_USER_SESSION_KEY ( user_id INT64TYPE not null, session_key varchar(1000) not null, session_info varchar(1000) , auth_scheme varchar(250) not null, session_expiry_ts varchar(32) not null, create_ts varchar(32), modify_ts varchar(32)) ;
+create table R_USER_SESSION_KEY ( user_id INT64TYPE not null, session_key varchar(1000) not null, session_info varchar(1000) , auth_scheme varchar(250) not null, session_expiry_ts varchar(32) not null, create_ts varchar(32), modify_ts varchar(32), salt varchar(32)) ;
 
 create table R_USER_PASSWORD ( user_id INT64TYPE not null, rcat_password varchar(250) not null, pass_expiry_ts varchar(32) not null, create_ts varchar(32), modify_ts varchar(32)) ;
 
@@ -153,6 +153,8 @@ create table R_TICKET_ALLOWED_USERS ( ticket_id INT64TYPE not null, user_name va
 create table R_TICKET_ALLOWED_GROUPS ( ticket_id INT64TYPE not null, group_name varchar(250) not null);
 
 create table R_GRID_CONFIGURATION ( namespace varchar(2700), option_name varchar(2700), option_value varchar(2700));
+
+create table R_USER_CREDENTIALS (user_id INT64TYPE, hashed_password varchar(2700), salt varchar(32), hashing_algorithm varchar(250), hashing_parameters varchar(2700), create_time varchar(32), modify_time varchar(32), expiration_time varchar(32));
 
 #ifdef mysql
 

--- a/scripts/irods/database_upgrade.py
+++ b/scripts/irods/database_upgrade.py
@@ -245,45 +245,47 @@ def run_update(irods_config, cursor, is_upgrade):
         database_connect.execute_sql_statement(cursor, "insert into R_GRID_CONFIGURATION values ('authentication', 'token_lifetime_in_seconds', '1209600');")
 
         # Add new column to R_USER_SESSION_KEY for storing salts.
-        if "oracle" == irods_config.catalog_database_type:
-            database_connect.execute_sql_statement(cursor, "alter table R_USER_SESSION_KEY add (salt varchar2(32));")
-        else:
-            database_connect.execute_sql_statement(cursor, "alter table R_USER_SESSION_KEY add column salt varchar(32);")
+        if is_upgrade:
+            if "oracle" == irods_config.catalog_database_type:
+                database_connect.execute_sql_statement(cursor, "alter table R_USER_SESSION_KEY add (salt varchar2(32));")
+            else:
+                database_connect.execute_sql_statement(cursor, "alter table R_USER_SESSION_KEY add column salt varchar(32);")
 
         # pam password reuse setting
         database_connect.execute_sql_statement(cursor, "insert into R_GRID_CONFIGURATION values ('authentication', 'password_reuse_previous', '1');")
 
         # Add R_USER_CREDENTIALS table.
-        if "oracle" == irods_config.catalog_database_type:
-            database_connect.execute_sql_statement(
-                cursor,
-                "create table R_USER_CREDENTIALS"
-                    "("
-                        "user_id "           "integer, "
-                        "hashed_password "   "varchar(2700), "
-                        "salt "              "varchar(32), "
-                        "hashing_algorithm " "varchar(250), "
-                        "hashing_parameters ""varchar(2700), "
-                        "create_time "       "varchar(32), "
-                        "modify_time "       "varchar(32), "
-                        "expiration_time "   "varchar(32)"
-                    ");"
-            )
-        else:
-            database_connect.execute_sql_statement(
-                cursor,
-                "create table R_USER_CREDENTIALS"
-                    "("
-                        "user_id "           "bigint, "
-                        "hashed_password "   "varchar(2700), "
-                        "salt "              "varchar(32), "
-                        "hashing_algorithm " "varchar(250), "
-                        "hashing_parameters ""varchar(2700), "
-                        "create_time "       "varchar(32), "
-                        "modify_time "       "varchar(32), "
-                        "expiration_time "   "varchar(32)"
-                    ");"
-            )
+        if is_upgrade:
+            if "oracle" == irods_config.catalog_database_type:
+                database_connect.execute_sql_statement(
+                    cursor,
+                    "create table R_USER_CREDENTIALS"
+                        "("
+                            "user_id "           "integer, "
+                            "hashed_password "   "varchar(2700), "
+                            "salt "              "varchar(32), "
+                            "hashing_algorithm " "varchar(250), "
+                            "hashing_parameters ""varchar(2700), "
+                            "create_time "       "varchar(32), "
+                            "modify_time "       "varchar(32), "
+                            "expiration_time "   "varchar(32)"
+                        ");"
+                )
+            else:
+                database_connect.execute_sql_statement(
+                    cursor,
+                    "create table R_USER_CREDENTIALS"
+                        "("
+                            "user_id "           "bigint, "
+                            "hashed_password "   "varchar(2700), "
+                            "salt "              "varchar(32), "
+                            "hashing_algorithm " "varchar(250), "
+                            "hashing_parameters ""varchar(2700), "
+                            "create_time "       "varchar(32), "
+                            "modify_time "       "varchar(32), "
+                            "expiration_time "   "varchar(32)"
+                        ");"
+                )
 
         # password storage mode setting
         database_connect.execute_sql_statement(cursor, "insert into R_GRID_CONFIGURATION values ('authentication', 'password_storage_mode', 'legacy');")


### PR DESCRIPTION
In service of #8729

While the other efforts of #8729 can be done through post-hoc script modifications, this change must be done as part of a release (specifically, 5.1.0, if we want it). So, this is being proposed in its own PR.

Passing tests:
- [x] unit tests (postgres)
- [x] unit tests (mysql)
- [x] core tests after upgrade (postgres)
- [x] core tests after upgrade (mysql)