### PR TITLE
Add support for TLS and irods auth in setup_irods.py

### DIFF
--- a/scripts/irods/configuration.py
+++ b/scripts/irods/configuration.py
@@ -191,21 +191,43 @@ class IrodsConfig(object):
 
     @property
     def admin_password(self):
-        if not os.path.exists(os.path.dirname(paths.password_file_path())):
-            return None
-        with open(paths.password_file_path(), 'rt') as f:
-            return decode(f.read())
+        auth_scheme = self.server_config.get("zone_auth_scheme", "native")
+        if "native" == auth_scheme:
+            if not os.path.exists(os.path.dirname(paths.password_file_path())):
+                return None
+            with open(paths.password_file_path(), 'rt') as f:
+                return decode(f.read())
+        return self._admin_password
 
     @admin_password.setter
     def admin_password(self, value):
         l = logging.getLogger(__name__)
-        if not os.path.exists(os.path.dirname(paths.password_file_path())):
-            os.makedirs(os.path.dirname(paths.password_file_path()), mode=0o700)
+        self._admin_password = value
+        auth_scheme = self.server_config.get("zone_auth_scheme", "native")
+        if "native" == auth_scheme:
+            if not os.path.exists(os.path.dirname(paths.password_file_path())):
+                os.makedirs(os.path.dirname(paths.password_file_path()), mode=0o700)
+            mtime = int(time.time())
+            with open(paths.password_file_path(), 'wt') as f:
+                l.debug('Writing password file %s', f.name)
+                print(encode(value, mtime=mtime), end='', file=f)
+            os.utime(paths.password_file_path(), (mtime, mtime))
+
+    @property
+    def admin_session_token(self):
+        return self._session_token
+
+    @admin_session_token.setter
+    def admin_session_token(self, value):
+        l = logging.getLogger(__name__)
+        self._session_token = value
+        if not os.path.exists(os.path.dirname(paths.service_account_session_token_file_path())):
+            os.makedirs(os.path.dirname(paths.service_account_session_token_file_path()), mode=0o600)
         mtime = int(time.time())
-        with open(paths.password_file_path(), 'wt') as f:
-            l.debug('Writing password file %s', f.name)
-            print(encode(value, mtime=mtime), end='', file=f)
-        os.utime(paths.password_file_path(), (mtime, mtime))
+        with open(paths.service_account_session_token_file_path(), 'wt') as f:
+            l.debug('Writing session token to file: [%s]', f.name)
+            print(value, end='', file=f)
+        os.utime(paths.service_account_session_token_file_path(), (mtime, mtime))
 
     def commit(self, config_dict, path, clear_cache=True, make_backup=False):
         l = logging.getLogger(__name__)
@@ -274,6 +296,10 @@ class IrodsConfig(object):
     @property
     def password_file_path(self):
         return paths.password_file_path()
+
+    @property
+    def session_token_file_path(self):
+        return paths.service_account_session_token_file_path()
 
     @property
     def log_directory(self):

--- a/scripts/irods/database_connect.py
+++ b/scripts/irods/database_connect.py
@@ -432,8 +432,8 @@ def setup_database_values(irods_config, cursor=None, default_resource_directory=
         }
         params = hashing_parameters["parameters"]
         derived_key = hashlib.scrypt(
-            irods_config.admin_password.encode(),
-            salt=salt.encode(),
+            irods_config.admin_password.encode("utf-8"),
+            salt=salt.encode("utf-8"),
             n=params["N"],
             r=params["r"],
             p=params["p"],
@@ -456,7 +456,7 @@ def setup_database_values(irods_config, cursor=None, default_resource_directory=
         irods_config.admin_session_token = str(uuid.uuid4())
         salted_token = salt + irods_config.admin_session_token
         # Hash it and base64-encode it so that it can be represented in the catalog.
-        hashed_session_token = base64.b64encode(hashlib.sha256(salted_token.encode()).digest()).decode("utf-8")
+        hashed_session_token = base64.b64encode(hashlib.sha256(salted_token.encode("utf-8")).digest()).decode("utf-8")
         execute_sql_statement(cursor,
                 "insert into R_USER_SESSION_KEY (user_id, session_key, auth_scheme, session_expiry_ts, create_ts, modify_ts, salt) values (?, ?, ?, ?, ?, ?, ?);",
                 admin_user_id,

--- a/scripts/irods/database_connect.py
+++ b/scripts/irods/database_connect.py
@@ -1,14 +1,19 @@
 from __future__ import print_function
 
+import base64
+import hashlib
 import itertools
 import json
 import logging
 import os
 import pprint
+import random
 import shutil
+import string
 import sys
 import tempfile
 import time
+import uuid
 
 from . import lib
 from . import password_obfuscation
@@ -412,15 +417,66 @@ def setup_database_values(irods_config, cursor=None, default_resource_directory=
             timestamp)
 
     #password
-    scrambled_password = password_obfuscation.scramble(irods_config.admin_password,
-            key=irods_config.server_config.get('environment_variables', {}).get('IRODS_DATABASE_USER_PASSWORD_SALT', None))
-    execute_sql_statement(cursor,
-            "insert into R_USER_PASSWORD values (?,?,'9999-12-31-23.59.00',?,?);",
-            admin_user_id,
-            scrambled_password,
-            timestamp,
-            timestamp,
-            log_params=False)
+    auth_scheme = irods_config.server_config.get("zone_auth_scheme", "native")
+    if "irods" == auth_scheme:
+        # Derive a key from the provided password.
+        salt = ''.join(random.choices(string.ascii_letters + string.digits, k=16))
+        hashing_parameters = {
+            "algorithm": "scrypt",
+            "parameters": {
+                "N": 16384,
+                "r": 8,
+                "p": 1,
+                "key_length": 64
+            }
+        }
+        params = hashing_parameters["parameters"]
+        derived_key = hashlib.scrypt(
+            irods_config.admin_password.encode(),
+            salt=salt.encode(),
+            n=params["N"],
+            r=params["r"],
+            p=params["p"],
+            dklen=params["key_length"]
+        )
+        # base64-encode the derived key so that it can be represented in the catalog.
+        hashed_password = base64.b64encode(derived_key).decode("utf-8")
+        execute_sql_statement(cursor,
+                "insert into R_USER_CREDENTIALS (user_id, hashed_password, salt, hashing_algorithm, hashing_parameters, create_time, modify_time) values (?, ?, ?, ?, ?, ?, ?);",
+                admin_user_id,
+                hashed_password,
+                salt,
+                hashing_parameters["algorithm"],
+                json.dumps(hashing_parameters),
+                timestamp,
+                timestamp,
+                log_params=False)
+        # And generate a session token to use later.
+        salt = ''.join(random.choices(string.ascii_letters + string.digits, k=16))
+        irods_config.admin_session_token = str(uuid.uuid4())
+        salted_token = salt + irods_config.admin_session_token
+        # Hash it and base64-encode it so that it can be represented in the catalog.
+        hashed_session_token = base64.b64encode(hashlib.sha256(salted_token.encode()).digest()).decode("utf-8")
+        execute_sql_statement(cursor,
+                "insert into R_USER_SESSION_KEY (user_id, session_key, auth_scheme, session_expiry_ts, create_ts, modify_ts, salt) values (?, ?, ?, ?, ?, ?, ?);",
+                admin_user_id,
+                hashed_session_token,
+                irods_config.server_config["zone_auth_scheme"],
+                '{0:011d}'.format(99999999999),
+                timestamp,
+                timestamp,
+                salt,
+                log_params=False)
+    else:
+        scrambled_password = password_obfuscation.scramble(irods_config.admin_password,
+                key=irods_config.server_config.get('environment_variables', {}).get('IRODS_DATABASE_USER_PASSWORD_SALT', None))
+        execute_sql_statement(cursor,
+                "insert into R_USER_PASSWORD values (?,?,'9999-12-31-23.59.00',?,?);",
+                admin_user_id,
+                scrambled_password,
+                timestamp,
+                timestamp,
+                log_params=False)
 
     #collections
     system_collections = [

--- a/scripts/irods/database_connect.py
+++ b/scripts/irods/database_connect.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import pprint
-import random
+import secrets
 import shutil
 import string
 import sys
@@ -420,7 +420,7 @@ def setup_database_values(irods_config, cursor=None, default_resource_directory=
     auth_scheme = irods_config.server_config.get("zone_auth_scheme", "native")
     if "irods" == auth_scheme:
         # Derive a key from the provided password.
-        salt = ''.join(random.choices(string.ascii_letters + string.digits, k=16))
+        salt = ''.join([secrets.choice(string.ascii_letters + string.digits) for _ in range(16)])
         hashing_parameters = {
             "algorithm": "scrypt",
             "parameters": {
@@ -452,7 +452,7 @@ def setup_database_values(irods_config, cursor=None, default_resource_directory=
                 timestamp,
                 log_params=False)
         # And generate a session token to use later.
-        salt = ''.join(random.choices(string.ascii_letters + string.digits, k=16))
+        salt = ''.join([secrets.choice(string.ascii_letters + string.digits) for _ in range(16)])
         irods_config.admin_session_token = str(uuid.uuid4())
         salted_token = salt + irods_config.admin_session_token
         # Hash it and base64-encode it so that it can be represented in the catalog.

--- a/scripts/irods/database_upgrade.py
+++ b/scripts/irods/database_upgrade.py
@@ -288,7 +288,8 @@ def run_update(irods_config, cursor, is_upgrade):
                 )
 
         # password storage mode setting
-        database_connect.execute_sql_statement(cursor, "insert into R_GRID_CONFIGURATION values ('authentication', 'password_storage_mode', 'legacy');")
+        password_storage_mode = "hashed" if "irods" == irods_config.server_config.get("zone_auth_scheme", "native") else "legacy"
+        database_connect.execute_sql_statement(cursor, f"insert into R_GRID_CONFIGURATION values ('authentication', 'password_storage_mode', '{password_storage_mode}');")
 
     else:
         raise IrodsError('Upgrade to schema version %d is unsupported.' % (new_schema_version))

--- a/scripts/irods/paths.py
+++ b/scripts/irods/paths.py
@@ -284,6 +284,16 @@ def _password_file_path():
 def password_file_path():
     return str(_password_file_path())
 
+
+# TODO: cache this if we start caching _userconf_directory()
+def _service_account_session_token_file_path():
+    return _userconf_directory() / '.irods_secrets'
+
+
+def service_account_session_token_file_path():
+    return str(_service_account_session_token_file_path())
+
+
 # TODO: consider renaming to convey that this is specifically the service account's environment file
 # TODO: cache this if we start caching _userconf_directory()
 def _default_client_environment_path():

--- a/scripts/irods/setup_options.py
+++ b/scripts/irods/setup_options.py
@@ -32,4 +32,8 @@ def add_options(parser):
                         'where a file is put to the default resource. '
                         'Helpful when setting up an iRODS server in a zone '
                         'where no default resource exists.')
+    parser.add_argument('--tls',
+                        dest='prompt_tls', action='store_true',
+                        help='Prompt for TLS configuration. Default configuration is no TLS. '
+                             'This option has no effect with --json_configuration_file.')
     start_options.add_options(parser)

--- a/scripts/irods/setup_options.py
+++ b/scripts/irods/setup_options.py
@@ -36,4 +36,9 @@ def add_options(parser):
                         dest='prompt_tls', action='store_true',
                         help='Prompt for TLS configuration. Default configuration is no TLS. '
                              'This option has no effect with --json_configuration_file.')
+    parser.add_argument('--auth-scheme',
+                        dest='auth_scheme', choices=['native', 'irods'],
+                        help='Prompt for zone authentication scheme. Default scheme used is "native". '
+                             'Using "irods" auth scheme implies --tls. This option has no effect with '
+                             '--json_configuration_file.')
     start_options.add_options(parser)

--- a/scripts/setup_irods.py
+++ b/scripts/setup_irods.py
@@ -569,6 +569,7 @@ def setup_client_environment(irods_config):
     service_account_dict = {
         'schema_name': 'service_account_environment',
         'schema_version': 'v5',
+        'irods_authentication_scheme': irods_config.server_config['zone_auth_scheme'],
         'irods_host': irods_config.server_config['host'],
         'irods_port': irods_config.server_config['zone_port'],
         'irods_default_resource': irods_config.server_config['default_resource_name'],
@@ -626,6 +627,11 @@ def main():
         irods_config.injected_environment['irodsReconnect'] = ''
     if args.prompt_tls:
         optional_prompts.append("tls")
+    if args.auth_scheme:
+        irods_config.server_config['zone_auth_scheme'] = args.auth_scheme
+        # Auth schemes which require TLS will automatically prompt for TLS configuration.
+        if not args.prompt_tls and args.auth_scheme in ["irods", "pam_password", "pam"]:
+            optional_prompts.append("tls")
 
     try:
         setup_server(irods_config,

--- a/scripts/setup_irods.py
+++ b/scripts/setup_irods.py
@@ -157,7 +157,7 @@ def setup_server(irods_config, json_configuration_file=None, test_mode=False, op
 
     # Update core.re to reflect configured TLS. This is done here because unattended installations will not use the TLS
     # setup function.
-    if "CS_NEG_REQUIRE" == irods_config.server_config.get("client_server_policy", "CS_NEG_REFUSE"):
+    if "tls_server" in irods_config.server_config:
         acPreConnect_rule_to_replace = 'acPreConnect(*OUT) { *OUT="CS_NEG_REFUSE"; }'
         acPreConnect_rule_replacement = 'acPreConnect(*OUT) { *OUT="CS_NEG_REQUIRE"; }'
         replace_in_file(core_re_path, acPreConnect_rule_to_replace, acPreConnect_rule_replacement)

--- a/scripts/setup_irods.py
+++ b/scripts/setup_irods.py
@@ -70,7 +70,7 @@ except:
     print('The pyodbc module is required for setup of catalog service providers.', file=sys.stderr)
 
 
-def setup_server(irods_config, json_configuration_file=None, test_mode=False, optional_prompts=[]):
+def setup_server(irods_config, json_configuration_file=None, test_mode=False, optional_prompts=None):
     l = logging.getLogger(__name__)
 
     optional_setup_funcs = {
@@ -130,7 +130,7 @@ def setup_server(irods_config, json_configuration_file=None, test_mode=False, op
         # default resource
         default_resource_name, default_resource_directory = setup_storage(irods_config)
         # Go through any optional setup prompted by setup script options.
-        for prompt_name in optional_prompts:
+        for prompt_name in optional_prompts or []:
             if (setup_func := optional_setup_funcs.get(prompt_name)) is None:
                 l.warning(f"No setup function found for optional prompt '{prompt_name}'. Skipping.")
                 continue

--- a/scripts/setup_irods.py
+++ b/scripts/setup_irods.py
@@ -463,7 +463,7 @@ def setup_tls(irods_config):
             f'Diffie-Hellman parameters file: {irods_config.server_config["tls_server"].get("dh_params_file")}\n'
             f'CA certificate file:            {irods_config.server_config["tls_client"].get("ca_certificate_file", "")}\n'
             f'CA certificate path:            {irods_config.server_config["tls_client"].get("ca_certificate_path", "")}\n'
-            f'Client verify server level:     {irods_config.server_config["tls_client"].get("verify_server")}\n'
+            f'Certificate verification level: {irods_config.server_config["tls_client"].get("verify_server")}\n'
             '-------------------------------------------------------------\n\n'
             'Please confirm'
         )

--- a/scripts/setup_irods.py
+++ b/scripts/setup_irods.py
@@ -69,8 +69,13 @@ except:
     print('WARNING: pyodbc module could not be imported.', file=sys.stderr)
     print('The pyodbc module is required for setup of catalog service providers.', file=sys.stderr)
 
-def setup_server(irods_config, json_configuration_file=None, test_mode=False):
+
+def setup_server(irods_config, json_configuration_file=None, test_mode=False, optional_prompts=[]):
     l = logging.getLogger(__name__)
+
+    optional_setup_funcs = {
+        "tls": setup_tls
+    }
 
     if json_configuration_file is not None:
         with open(json_configuration_file) as f:
@@ -124,6 +129,12 @@ def setup_server(irods_config, json_configuration_file=None, test_mode=False):
             database_interface.setup_database_config(irods_config)
         # default resource
         default_resource_name, default_resource_directory = setup_storage(irods_config)
+        # Go through any optional setup prompted by setup script options.
+        for prompt_name in optional_prompts:
+            if (setup_func := optional_setup_funcs.get(prompt_name)) is None:
+                l.warning(f"No setup function found for optional prompt '{prompt_name}'. Skipping.")
+                continue
+            setup_func(irods_config)
         # server config
         setup_server_config(irods_config)
         # client environment and password
@@ -142,6 +153,15 @@ def setup_server(irods_config, json_configuration_file=None, test_mode=False):
         if not os.path.exists(path):
             shutil.copyfile(irods.paths.get_template_filepath(path), path)
 
+    core_re_path = os.path.join(irods_config.core_re_directory, 'core.re')
+
+    # Update core.re to reflect configured TLS. This is done here because unattended installations will not use the TLS
+    # setup function.
+    if "CS_NEG_REQUIRE" == irods_config.server_config.get("client_server_policy", "CS_NEG_REFUSE"):
+        acPreConnect_rule_to_replace = 'acPreConnect(*OUT) { *OUT="CS_NEG_REFUSE"; }'
+        acPreConnect_rule_replacement = 'acPreConnect(*OUT) { *OUT="CS_NEG_REQUIRE"; }'
+        replace_in_file(core_re_path, acPreConnect_rule_to_replace, acPreConnect_rule_replacement)
+
     l.info(irods.lib.get_header('Starting iRODS...'))
     controller = IrodsController(irods_config)
     controller.start()
@@ -154,7 +174,6 @@ def setup_server(irods_config, json_configuration_file=None, test_mode=False):
         irods.lib.execute_command(['iadmin', 'mkresc', default_resource_name, 'unixfilesystem', ':'.join([irods.lib.get_hostname(), default_resource_directory]), ''])
 
     # update core.re with default resource
-    core_re_path = os.path.join(irods_config.core_re_directory, 'core.re')
     replace_in_file(core_re_path, 'demoResc', default_resource_name)
 
     # Restart the server in case core.re changed.
@@ -380,6 +399,83 @@ def setup_storage(irods_config):
 
     return (resource_name, resource_vault_path)
 
+
+def setup_tls(irods_config):
+    l = logging.getLogger(__name__)
+    l.info(irods.lib.get_header('Setting up TLS'))
+
+    while True:
+        # TLS configuration for incoming connections.
+        if "tls_server" not in irods_config.server_config:
+            irods_config.server_config["tls_server"] = {}
+
+        default_certificate_chain_file = irods_config.server_config["tls_server"].get("certificate_chain_file")
+        irods_config.server_config["tls_server"]['certificate_chain_file'] = irods.lib.default_prompt(
+            "Path to server's certificate chain file",
+            default=[default_certificate_chain_file] if default_certificate_chain_file else None,
+            input_filter=irods.lib.character_count_filter(minimum=1, field='Certificate chain file'))
+
+        default_certificate_key_file = irods_config.server_config["tls_server"].get("certificate_key_file")
+        irods_config.server_config["tls_server"]['certificate_key_file'] = irods.lib.default_prompt(
+            "Path to server's certificate key file",
+            default=[default_certificate_key_file] if default_certificate_key_file else None,
+            input_filter=irods.lib.character_count_filter(minimum=1, field='Certificate key file'))
+
+        default_dh_params_file = irods_config.server_config["tls_server"].get("dh_params_file")
+        irods_config.server_config["tls_server"]['dh_params_file'] = irods.lib.default_prompt(
+            "Path to Diffie-Hellman parameter file",
+            default=[default_dh_params_file] if default_dh_params_file else None,
+            input_filter=irods.lib.character_count_filter(minimum=1, field='Diffie-Hellman params file'))
+
+        # TLS configuration for outgoing connections (server-to-server).
+        if "tls_client" not in irods_config.server_config:
+            irods_config.server_config["tls_client"] = {}
+
+        default_ca_certificate_file = irods_config.server_config["tls_client"].get('ca_certificate_file')
+        client_ca_certificate_file = irods.lib.default_prompt(
+            "Path to CA certificate file",
+            default=[default_ca_certificate_file] if default_ca_certificate_file else None)
+
+        default_ca_certificate_path = irods_config.server_config["tls_client"].get('ca_certificate_path')
+        client_ca_certificate_path = irods.lib.default_prompt(
+            "Path to CA certificates directory",
+            default=[default_ca_certificate_path] if default_ca_certificate_path else None)
+
+        default_verify_server = irods_config.server_config["tls_client"].get('verify_server') or "cert"
+        verify_server_levels = ["hostname", "cert", "none"]
+        client_verify_server = irods.lib.default_prompt(
+            "Certificate verification level",
+            default=verify_server_levels,
+            previous=verify_server_levels.index(default_verify_server) + 1,
+            input_filter=irods.lib.set_filter(verify_server_levels, field='Verify server'))
+
+        if client_ca_certificate_file:
+            irods_config.server_config["tls_client"]['ca_certificate_file'] = client_ca_certificate_file
+        if client_ca_certificate_path:
+            irods_config.server_config["tls_client"]['ca_certificate_path'] = client_ca_certificate_path
+        irods_config.server_config["tls_client"]['verify_server'] = client_verify_server
+
+        confirmation_message = (
+            '\n'
+            '-------------------------------------------------------------\n'
+            f'Certificate chain file:         {irods_config.server_config["tls_server"].get("certificate_chain_file")}\n'
+            f'Certificate key file:           {irods_config.server_config["tls_server"].get("certificate_key_file")}\n'
+            f'Diffie-Hellman parameters file: {irods_config.server_config["tls_server"].get("dh_params_file")}\n'
+            f'CA certificate file:            {irods_config.server_config["tls_client"].get("ca_certificate_file", "")}\n'
+            f'CA certificate path:            {irods_config.server_config["tls_client"].get("ca_certificate_path", "")}\n'
+            f'Client verify server level:     {irods_config.server_config["tls_client"].get("verify_server")}\n'
+            '-------------------------------------------------------------\n\n'
+            'Please confirm'
+        )
+
+        if irods.lib.default_prompt(confirmation_message, default=['yes']) in ['', 'y', 'Y', 'yes', 'YES']:
+            break
+
+    irods_config.server_config["client_server_policy"] = "CS_NEG_REQUIRE"
+
+    irods_config.commit(irods_config.server_config, irods_config.server_config_path, clear_cache=False)
+
+
 def setup_server_config(irods_config):
     l = logging.getLogger(__name__)
     l.info(irods.lib.get_header('Configuring the server options'))
@@ -492,6 +588,10 @@ def setup_client_environment(irods_config):
         'irods_transfer_buffer_size_for_parallel_transfer_in_megabytes': irods_config.server_config['advanced_settings']['transfer_buffer_size_for_parallel_transfer_in_megabytes'],
         'irods_connection_pool_refresh_time_in_seconds': irods_config.server_config['connection_pool_refresh_time_in_seconds']
     }
+    if tls_client_config := irods_config.server_config.get("tls_client"):
+        service_account_dict["irods_ssl_ca_certificate_file"] = tls_client_config["ca_certificate_file"]
+        service_account_dict["irods_ssl_verify_server"] = tls_client_config["verify_server"]
+
     if not os.path.exists(os.path.dirname(irods_config.client_environment_path)):
         os.makedirs(os.path.dirname(irods_config.client_environment_path), mode=0o700)
     irods_config.commit(service_account_dict, irods_config.client_environment_path, clear_cache=False)
@@ -505,6 +605,7 @@ def main():
     args = parse_arguments()
 
     irods_config = IrodsConfig()
+    optional_prompts = []
 
     irods.log.register_file_handler(irods_config.setup_log_path)
     if None != args.verbose and args.verbose > 0:
@@ -523,11 +624,14 @@ def main():
         irods_config.injected_environment['reServerOption'] = args.rule_engine_server_options
     if args.server_reconnect_flag:
         irods_config.injected_environment['irodsReconnect'] = ''
+    if args.prompt_tls:
+        optional_prompts.append("tls")
 
     try:
         setup_server(irods_config,
                      json_configuration_file=args.json_configuration_file,
-                     test_mode=args.test_mode)
+                     test_mode=args.test_mode,
+                     optional_prompts=optional_prompts)
     except IrodsError:
         l.error('Error encountered running setup_irods:\n', exc_info=True)
         l.info('Exiting...')


### PR DESCRIPTION
Addresses #7717
Addresses #8729

There are 2-by-2 things being added here:
 - Choice of auth scheme and TLS (2)
 - Script prompts or unattended install (2)

We don't really have tests for the setup script, so I've just been doing manual tests. We cannot run our test suite with irods authentication (see https://github.com/irods/irods/issues/6785). So that leaves us with TLS using unattended install vs not-unattended install.

In order to run said tests, changes need to be made in the testing environment, the PR for which I will open/link later.