### PR TITLE
Fix boot time tracking / Do not allow server to start if launched by incorrect user (main)

### DIFF
--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -2235,9 +2235,11 @@ class Test_Resource_CompoundWithUnivmss(ChunkyDevTest, ResourceSuite, unittest.T
 
             # TODO(#8935): Remove this line when the default for "escape_single_quotes" changes in iRODS 6.
             with self.subTest('iput fails when path contains single quotes and escape_single_quotes not enabled'):
-                self.user0.assert_icommand(['iput', file_path], 'STDERR', ['-550000 UNIV_MSS_SYNCTOARCH_ERR'])
+                self.user0.assert_icommand(['iput', '-R', 'demoResc', file_path], 'STDERR', [r'-550\d{3} UNIV_MSS_SYNCTOARCH_ERR'], use_regex=True)
                 self.assertEqual(lib.get_replica_status_for_resource(self.user0, logical_path, 'archiveResc'), '0')
-                self.user0.assert_icommand(['irm', '-f', filename], 'STDERR', ['-552000 UNIV_MSS_UNLINK_ERR'])
+                # We check the first three digits of the error code because the last three digits can change
+                # due to the inclusion of errno.
+                self.user0.assert_icommand(['irm', '-f', filename], 'STDERR', [r'-552\d{3} UNIV_MSS_UNLINK_ERR'], use_regex=True)
 
             # TODO(#8935): Remove this line when the default for "escape_single_quotes" changes in iRODS 6.
             self.admin.assert_icommand(['iadmin', 'modresc', 'archiveResc', 'context', 'script=univMSSInterface.sh;escape_single_quotes=1;'])
@@ -2249,7 +2251,7 @@ class Test_Resource_CompoundWithUnivmss(ChunkyDevTest, ResourceSuite, unittest.T
             with self.subTest('Sync-to-Archive - iput'):
                 # Create a new data object. The bug normally produces an error here. This should succeed
                 # now that single quotes are escaped.
-                self.user0.assert_icommand(['iput', file_path])
+                self.user0.assert_icommand(['iput', '-R', 'demoResc', file_path])
 
                 # Verify that all replicas are good.
                 self.assertEqual(lib.get_replica_status_for_resource(self.user0, logical_path, 'cacheResc'), '1')
@@ -2258,21 +2260,37 @@ class Test_Resource_CompoundWithUnivmss(ChunkyDevTest, ResourceSuite, unittest.T
                 # Remove the data object for the next subtest.
                 self.user0.assert_icommand(['irm', '-f', filename])
 
-            with self.subTest('Sync-to-Archive - itouch'):
-                self.user0.assert_icommand(['itouch', filename])
+            # Skip this itouch case when running in a topology from a catalog consumer.
+            #
+            # itouch does not support targeting the root of a resource hierarchy containing one or
+            # more child resources. It can only be used to target leaf resources.
+            #
+            # This subtest must be run from a catalog provider for the following reasons:
+            # - The default resource of the catalog provider is demoResc (i.e the compound resource)
+            # - Running itouch without specifying a leaf resource results in the connected server using its default resource
+            if not test.settings.TOPOLOGY_FROM_RESOURCE_SERVER:
+                with self.subTest('Sync-to-Archive - itouch + default resource for provider'):
+                    self.user0.assert_icommand(['itouch', filename])
+                    self.assertEqual(lib.get_replica_status_for_resource(self.user0, logical_path, 'cacheResc'), '1')
+                    self.assertEqual(lib.get_replica_status_for_resource(self.user0, logical_path, 'archiveResc'), '1')
+                    self.user0.assert_icommand(['irm', '-f', filename])
+
+            with self.subTest('Sync-to-Archive - itouch + rebalance'):
+                self.user0.assert_icommand(['itouch', '-R', 'cacheResc', filename])
+                self.admin.assert_icommand(['iadmin', 'modresc', 'demoResc', 'rebalance'])
                 self.assertEqual(lib.get_replica_status_for_resource(self.user0, logical_path, 'cacheResc'), '1')
                 self.assertEqual(lib.get_replica_status_for_resource(self.user0, logical_path, 'archiveResc'), '1')
                 self.user0.assert_icommand(['irm', '-f', filename])
 
             with self.subTest('Sync-to-Archive - istream write'):
-                self.user0.assert_icommand(['istream', 'write', filename], input='data')
+                self.user0.assert_icommand(['istream', 'write', '-R', 'demoResc', filename], input='data')
                 self.assertEqual(lib.get_replica_status_for_resource(self.user0, logical_path, 'cacheResc'), '1')
                 self.assertEqual(lib.get_replica_status_for_resource(self.user0, logical_path, 'archiveResc'), '1')
                 self.user0.assert_icommand(['irm', '-f', filename])
 
             # These subtests verify the stage-to-cache functionality behaves as expected.
             with self.subTest('Stage-to-Cache - iget'):
-                self.user0.assert_icommand(['itouch', filename])
+                self.user0.assert_icommand(['iput', '-R', 'demoResc', file_path])
                 self.user0.assert_icommand(['itrim', '-N1', '-n0', filename], 'STDOUT', ['data objects trimmed = 1.'])
                 self.user0.assert_icommand(['iget', filename, '-'], 'STDOUT')
                 self.assertEqual(lib.get_replica_status_for_resource(self.user0, logical_path, 'cacheResc'), '1')
@@ -2288,16 +2306,16 @@ class Test_Resource_CompoundWithUnivmss(ChunkyDevTest, ResourceSuite, unittest.T
                 self.user0.assert_icommand(['itrim', '-N1', '-n2', filename], 'STDOUT', ['data objects trimmed = 1.'])
 
                 # Show that we must use the force flag to overwrite the data object.
-                self.user0.assert_icommand(['iput', file_path], 'STDERR', ['-312000 OVERWRITE_WITHOUT_FORCE_FLAG'])
+                self.user0.assert_icommand(['iput', '-R', 'demoResc', file_path], 'STDERR', ['-312000 OVERWRITE_WITHOUT_FORCE_FLAG'])
 
-                self.user0.assert_icommand(['iput', '-f', file_path], 'STDOUT')
+                self.user0.assert_icommand(['iput', '-f', '-R', 'demoResc', file_path], 'STDOUT')
                 self.assertEqual(lib.get_replica_status_for_resource(self.user0, logical_path, 'cacheResc'), '1')
                 self.assertEqual(lib.get_replica_status_for_resource(self.user0, logical_path, 'archiveResc'), '1')
 
             # This subtest is specifically about renaming data objects.
             with self.subTest('Rename'):
                 self.user0.assert_icommand(['irm', '-f', filename])
-                self.user0.assert_icommand(['itouch', filename])
+                self.user0.assert_icommand(['iput', '-R', 'demoResc', file_path])
                 self.assertEqual(lib.get_replica_status_for_resource(self.user0, logical_path, 'cacheResc'), '1')
                 self.assertEqual(lib.get_replica_status_for_resource(self.user0, logical_path, 'archiveResc'), '1')
 

--- a/server/main_server/src/main.cpp
+++ b/server/main_server/src/main.cpp
@@ -22,6 +22,7 @@
 #include "irods/rcGlobalExtern.h" // For ProcessType
 #include "irods/rcMisc.h"
 #include "irods/rodsClient.h"
+#include "irods/rodsDef.h"
 #include "irods/rodsErrorTable.h"
 #include "irods/rodsLog.h"
 #include "irods/update_replica_access_time.h"
@@ -133,6 +134,7 @@ namespace
     auto print_usage() -> void;
     auto print_version_info() -> void;
 
+    auto set_boot_time_as_environment_variable() -> void;
     auto validate_configuration() -> bool;
     auto daemonize() -> void;
     auto create_pid_file(const std::string& _pid_file) -> int;
@@ -166,7 +168,7 @@ namespace
 
 auto main(int _argc, char* _argv[]) -> int
 {
-    [[maybe_unused]] const auto boot_time = std::chrono::system_clock::now();
+    set_boot_time_as_environment_variable();
 
     bool write_to_stdout = false;
     bool enable_test_mode = false;
@@ -440,6 +442,28 @@ Signals:
         fmt::print(
             "irodsServer v{}.{}.{}-{}\n", IRODS_VERSION_MAJOR, IRODS_VERSION_MINOR, IRODS_VERSION_PATCHLEVEL, commit);
     } // print_version_info
+
+    // This function is meant to be called before the logger is initialized.
+    auto set_boot_time_as_environment_variable() -> void
+    {
+        try {
+            using std::chrono::duration_cast;
+            using std::chrono::seconds;
+            using std::chrono::system_clock;
+
+            const auto now = duration_cast<seconds>(system_clock::now().time_since_epoch());
+            const auto now_string = std::to_string(now.count());
+
+            // Set the boot time as an environment variable so that rsGetMiscSvrInfo can report it
+            // to the client. If there's a failure, notify the administrator and continue the boot process.
+            if (setenv(SERVER_BOOT_TIME, now_string.c_str(), 1) != 0) {
+                fmt::print(stderr, "Warning: Failed to set server boot time as an environment variable.\n");
+            }
+        }
+        catch (const std::exception& e) {
+            fmt::print(stderr, "Error: Caught exception while setting server boot time as an environment variable: {}\n", e.what());
+        }
+    } // set_boot_time_as_environment_variable
 
     auto validate_configuration() -> bool
     {

--- a/server/main_server/src/main.cpp
+++ b/server/main_server/src/main.cpp
@@ -235,7 +235,6 @@ auto main(int _argc, char* _argv[]) -> int
         }
 
         if (create_pid_file(pid_file) != 0) {
-            fmt::print(stderr, "Error: could not create PID file [{}].\n", pid_file);
             return 1;
         }
     }
@@ -661,7 +660,7 @@ Signals:
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-signed-bitwise)
         const auto fd = open(_pid_file.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
         if (fd == -1) {
-            fmt::print("Could not open PID file.\n");
+            fmt::print(stderr, "Error: Could not open PID file.\n");
             return 1;
         }
 
@@ -669,7 +668,7 @@ Signals:
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
         const auto flags = fcntl(fd, F_GETFD);
         if (flags == -1) {
-            fmt::print("Could not retrieve open flags for PID file.\n");
+            fmt::print(stderr, "Error: Could not retrieve open flags for PID file.\n");
             return 1;
         }
 
@@ -678,7 +677,7 @@ Signals:
         // Keep in mind that record locks are NOT inherited by forked child processes.
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-signed-bitwise)
         if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1) {
-            fmt::print("Could not set FD_CLOEXEC on PID file.\n");
+            fmt::print(stderr, "Error: Could not set FD_CLOEXEC on PID file.\n");
             return 1;
         }
 
@@ -695,21 +694,22 @@ Signals:
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
         if (fcntl(fd, F_SETLK, &input) == -1) {
             if (EAGAIN == errno || EACCES == errno) {
-                fmt::print("Could not acquire write lock for PID file. Another instance "
-                           "could be running already.\n");
+                fmt::print(
+                    stderr,
+                    "Error: Could not acquire write lock for PID file. Another instance could be running already.\n");
                 return 1;
             }
         }
 
         if (ftruncate(fd, 0) == -1) {
-            fmt::print("Could not truncate PID file's contents.\n");
+            fmt::print(stderr, "Error: Could not truncate PID file's contents.\n");
             return 1;
         }
 
         const auto contents = fmt::format("{}\n", getpid());
         // NOLINTNEXTLINE(google-runtime-int)
         if (write(fd, contents.data(), contents.size()) != static_cast<long>(contents.size())) {
-            fmt::print("Could not write PID to PID file.\n");
+            fmt::print(stderr, "Error: Could not write PID to PID file.\n");
             return 1;
         }
 

--- a/server/main_server/src/main.cpp
+++ b/server/main_server/src/main.cpp
@@ -135,6 +135,8 @@ namespace
     auto print_version_info() -> void;
 
     auto set_boot_time_as_environment_variable() -> void;
+    auto terminate_if_launched_with_root_privileges() -> void;
+    auto warn_if_launched_by_non_owner() -> void;
     auto validate_configuration() -> bool;
     auto daemonize() -> void;
     auto create_pid_file(const std::string& _pid_file) -> int;
@@ -207,6 +209,9 @@ auto main(int _argc, char* _argv[]) -> int
             return 0;
         }
 
+        terminate_if_launched_with_root_privileges();
+        warn_if_launched_by_non_owner();
+
         if (vm.count("validate-config") > 0) {
             return validate_configuration() ? 0 : 1;
         }
@@ -251,6 +256,13 @@ auto main(int _argc, char* _argv[]) -> int
         rodsLogSqlReq(0);
 
         init_logger(getpid(), write_to_stdout, enable_test_mode);
+
+        log_server::info("{}: Server launched by real UID=[{}], real GID=[{}], effective UID=[{}], effective GID=[{}].",
+                         __func__,
+                         getuid(),
+                         getgid(),
+                         geteuid(),
+                         getegid());
 
         // Setting up signal handlers here removes the need for reacting to shutdown signals
         // such as SIGINT and SIGTERM during the startup sequence.
@@ -461,9 +473,47 @@ Signals:
             }
         }
         catch (const std::exception& e) {
-            fmt::print(stderr, "Error: Caught exception while setting server boot time as an environment variable: {}\n", e.what());
+            fmt::print(stderr,
+                       "Error: Caught exception while setting server boot time as an environment variable: {}\n",
+                       e.what());
         }
     } // set_boot_time_as_environment_variable
+
+    // This function is meant to be called before the logger is initialized.
+    auto terminate_if_launched_with_root_privileges() -> void
+    {
+        if (geteuid() == 0) {
+            fmt::print(stderr, "Warning: Launching server with root privileges is not allowed. Exiting.\n");
+            std::exit(1);
+        }
+
+        // Guard against setuid-related security vulnerabilities.
+        if (getuid() != geteuid()) {
+            fmt::print(
+                stderr, "Warning: Real UID [{}] and effective UID [{}] must match. Exiting.\n", getuid(), geteuid());
+            std::exit(1);
+        }
+    } // terminate_if_launched_with_root_privileges
+
+    // This function is meant to be called before the logger is initialized.
+    auto warn_if_launched_by_non_owner() -> void
+    {
+        const auto home_dir = irods::get_irods_home_directory();
+        struct stat stat_info; // NOLINT(cppcoreguidelines-pro-type-member-init)
+        if (stat(home_dir.c_str(), &stat_info) != 0) {
+            fmt::print(stderr, "Error: stat failed: errno=[{}], path=[{}] -- Exiting.\n", errno, home_dir.c_str());
+            return;
+        }
+
+        if (!S_ISDIR(stat_info.st_mode)) {
+            fmt::print(
+                stderr, "Warning: [{}] must be the home directory of the service account user.\n", home_dir.c_str());
+        }
+
+        if (const auto uid = getuid(); uid != stat_info.st_uid) {
+            fmt::print(stderr, "Warning: Server launched by UID [{}]. Expected UID [{}].\n", uid, stat_info.st_uid);
+        }
+    } // warn_if_launched_by_non_owner
 
     auto validate_configuration() -> bool
     {


### PR DESCRIPTION
I've verified that only the user identified in /etc/irods/service_account.config is able to start the server.

I still need to check non-package install and service manager cases. There's also a couple error cases which I need to determine how to handle.