### PR TITLE
[#8951] Deprecate `PUBLIC_USER_NAME` and `PUBLIC_USER_AUTH` macros (main)

### DIFF
--- a/lib/core/include/irods/rodsDef.h
+++ b/lib/core/include/irods/rodsDef.h
@@ -110,7 +110,7 @@
 #define IRODS_TO_IRODS          "IRODS_TO_IRODS"
 #define IRODS_TO_COLLECTION     "IRODS_TO_COLLECTION"
 
-/* definition for public user */
+/* definition for public user. Deprecated in 5.1.0. */
 #define PUBLIC_USER_NAME        "public"
 
 /* definition for anonymous user */

--- a/lib/core/include/irods/rodsUser.h
+++ b/lib/core/include/irods/rodsUser.h
@@ -17,7 +17,7 @@
 /* REMOTE or LOCAL refers to the Zone */
 /* priv or not indicates whether the user is iRODS Admin: privileged */
 #define NO_USER_AUTH            0       /* not authenticated yet */
-#define PUBLIC_USER_AUTH        1       /* not authenticated yet */
+#define PUBLIC_USER_AUTH        1       /* not authenticated yet. Deprecated in 5.1.0. */
 #define REMOTE_USER_AUTH        2       /* authenticated as remote user */
 #define LOCAL_USER_AUTH         3       /* authenticated as local user */
 // Authenticated as a privileged remote user. This authentication level is reserved for iRODS


### PR DESCRIPTION
No functional changes to the code. Updated comments on macros only.

Ignoring clang-format since it would require formatting other lines. Wrapping the entire block in `// clang-format off/on` doesn't feel correct either.