### PR TITLE
[#8638,#8956] Warn user about incompatible icommands / Check for nullptr (main)

### DIFF
--- a/clients/icommands/src/iadmin.cpp
+++ b/clients/icommands/src/iadmin.cpp
@@ -1925,6 +1925,8 @@ main( int argc, char **argv ) {
 
     const auto disconnect = irods::at_scope_exit{[] { rcDisconnect(Conn); }};
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     status = utils::authenticate_client(Conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(Conn->rError, stderr);

--- a/clients/icommands/src/iapitest.cpp
+++ b/clients/icommands/src/iapitest.cpp
@@ -65,6 +65,8 @@ main( int argc, char** argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     // =-=-=-=-=-=-=-
     // initialize pluggable api table
     irods::pack_entry_table& pk_tbl = irods::get_pack_table();

--- a/clients/icommands/src/ibun.cpp
+++ b/clients/icommands/src/ibun.cpp
@@ -75,6 +75,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/icd.cpp
+++ b/clients/icommands/src/icd.cpp
@@ -71,6 +71,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     status = utils::authenticate_client(Conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(Conn->rError, stderr);

--- a/clients/icommands/src/ichksum.cpp
+++ b/clients/icommands/src/ichksum.cpp
@@ -72,6 +72,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/ichmod.cpp
+++ b/clients/icommands/src/ichmod.cpp
@@ -72,6 +72,8 @@ main( int argc, char **argv ) {
         return 5;
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/iclienthints.cpp
+++ b/clients/icommands/src/iclienthints.cpp
@@ -75,6 +75,8 @@ main( int _argc, char** argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     // =-=-=-=-=-=-=-
     // initialize pluggable api table
     irods::pack_entry_table& pk_tbl = irods::get_pack_table();

--- a/clients/icommands/src/icp.cpp
+++ b/clients/icommands/src/icp.cpp
@@ -82,6 +82,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/ifsck.cpp
+++ b/clients/icommands/src/ifsck.cpp
@@ -98,6 +98,8 @@ main( int argc, char **argv ) {
         return 2;
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     if ( strcmp( myEnv.rodsUserName, PUBLIC_USER_NAME ) != 0 ) {
         status = utils::authenticate_client(conn, myEnv);
         if ( status != 0 ) {

--- a/clients/icommands/src/iget.cpp
+++ b/clients/icommands/src/iget.cpp
@@ -74,6 +74,8 @@ main( int argc, char **argv ) {
         return 2;
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     if ( strcmp( myEnv.rodsUserName, PUBLIC_USER_NAME ) != 0 ) {
         status = utils::authenticate_client(conn, myEnv);
         if ( status != 0 ) {

--- a/clients/icommands/src/igroupadmin.cpp
+++ b/clients/icommands/src/igroupadmin.cpp
@@ -427,6 +427,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     status = utils::authenticate_client(Conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(Conn->rError, stderr);

--- a/clients/icommands/src/iinit.cpp
+++ b/clients/icommands/src/iinit.cpp
@@ -384,6 +384,8 @@ int main( int argc, char **argv )
         return 2;
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     auto ctx = nlohmann::json{{irods::AUTH_TTL_KEY, std::to_string(ttl)},
                               {ia::record_auth_file, true},
                               {ia::force_password_prompt, true},

--- a/clients/icommands/src/ils.cpp
+++ b/clients/icommands/src/ils.cpp
@@ -70,6 +70,9 @@ main( int argc, char **argv ) {
     if ( conn == NULL ) {
         exit( 2 );
     }
+
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     // =-=-=-=-=-=-=-
     // initialize pluggable api table
     irods::api_entry_table&  api_tbl = irods::get_client_api_table();

--- a/clients/icommands/src/ilsresc.cpp
+++ b/clients/icommands/src/ilsresc.cpp
@@ -513,6 +513,8 @@ main( int argc, char **argv ) {
             return 2;
         }
 
+        utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
         status = utils::authenticate_client(Conn, myEnv);
         if ( status != 0 ) {
             print_error_stack_to_file(Conn->rError, stderr);

--- a/clients/icommands/src/imcoll.cpp
+++ b/clients/icommands/src/imcoll.cpp
@@ -97,6 +97,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/imeta.cpp
+++ b/clients/icommands/src/imeta.cpp
@@ -1915,6 +1915,8 @@ int main( int argc, const char **argv )
 
     const auto disconnect = irods::at_scope_exit{[] { rcDisconnect(Conn); }};
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     if (utils::authenticate_client(Conn, myEnv) != 0) {
         print_error_stack_to_file(Conn->rError, stderr);
         return 3;

--- a/clients/icommands/src/imiscsvrinfo.cpp
+++ b/clients/icommands/src/imiscsvrinfo.cpp
@@ -1,3 +1,5 @@
+#include "utility.hpp"
+
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/packStruct.h>
@@ -56,6 +58,8 @@ main( int argc, char **argv ) {
     if ( Conn == NULL ) {
         exit( 2 );
     }
+
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
 
     if (const auto vers = irods::to_version(Conn->svrVersion->relVersion); vers && *vers < irods::version{4, 3, 4}) {
         // iRODS 4.3.3 and earlier do not support the certinfo member variable. This if-branch

--- a/clients/icommands/src/imkdir.cpp
+++ b/clients/icommands/src/imkdir.cpp
@@ -65,6 +65,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/imv.cpp
+++ b/clients/icommands/src/imv.cpp
@@ -72,6 +72,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/ipasswd.cpp
+++ b/clients/icommands/src/ipasswd.cpp
@@ -93,6 +93,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     // If --no-scramble was specified, make sure the UserAdmin API of the connected server actually supports the
     // feature. If not, exit with an error. The password will not be usable if it is set with this option and the
     // server does not support this feature.

--- a/clients/icommands/src/iphymv.cpp
+++ b/clients/icommands/src/iphymv.cpp
@@ -75,6 +75,8 @@ main( int argc, char **argv ) {
         return 2;
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         // Failed to authenticate as the configured user

--- a/clients/icommands/src/ips.cpp
+++ b/clients/icommands/src/ips.cpp
@@ -64,6 +64,8 @@ main( int argc, char **argv ) {
         return 2;
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     if ( strcmp( myEnv.rodsUserName, PUBLIC_USER_NAME ) != 0 ) {
         status = utils::authenticate_client(conn, myEnv);
         if ( status != 0 ) {

--- a/clients/icommands/src/iput.cpp
+++ b/clients/icommands/src/iput.cpp
@@ -82,6 +82,8 @@ main( int argc, char **argv ) {
         return 2;
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/iqdel.cpp
+++ b/clients/icommands/src/iqdel.cpp
@@ -96,6 +96,8 @@ main( int argc, char **argv ) {
 
     const auto disconnect = irods::at_scope_exit{[] { rcDisconnect(Conn); }};
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     status = utils::authenticate_client(Conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(Conn->rError, stderr);

--- a/clients/icommands/src/iqmod.cpp
+++ b/clients/icommands/src/iqmod.cpp
@@ -100,6 +100,8 @@ main( int argc, char **argv ) {
 
     const auto disconnect = irods::at_scope_exit{[] { rcDisconnect(Conn); }};
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     status = utils::authenticate_client(Conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(Conn->rError, stderr);

--- a/clients/icommands/src/iqstat.cpp
+++ b/clients/icommands/src/iqstat.cpp
@@ -175,6 +175,8 @@ main( int argc, char **argv ) {
     Conn = rcConnect( myEnv.rodsHost, myEnv.rodsPort, myEnv.rodsUserName,
                       myEnv.rodsZone, 0, &errMsg );
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     status = utils::authenticate_client(Conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(Conn->rError, stderr);

--- a/clients/icommands/src/iqstat.cpp
+++ b/clients/icommands/src/iqstat.cpp
@@ -174,6 +174,9 @@ main( int argc, char **argv ) {
 
     Conn = rcConnect( myEnv.rodsHost, myEnv.rodsPort, myEnv.rodsUserName,
                       myEnv.rodsZone, 0, &errMsg );
+    if (nullptr == Conn) {
+        return 2;
+    }
 
     utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
 

--- a/clients/icommands/src/iquery.cpp
+++ b/clients/icommands/src/iquery.cpp
@@ -1,3 +1,5 @@
+#include "utility.hpp"
+
 #include <irods/client_connection.hpp>
 #include <irods/genquery2.h>
 #include <irods/irods_at_scope_exit.hpp>
@@ -93,6 +95,9 @@ int main(int _argc, char* _argv[]) // NOLINT(modernize-use-trailing-return-type)
         }};
 
         auto* conn_ptr = static_cast<RcComm*>(conn);
+
+        utils::warn_if_connected_to_potentially_incompatible_server(*conn_ptr);
+
         const auto ec = rc_genquery2(conn_ptr, &input, &output);
         if (ec < 0) {
             fmt::print(stderr, "error: {}\n", ec);

--- a/clients/icommands/src/iquest.cpp
+++ b/clients/icommands/src/iquest.cpp
@@ -386,6 +386,8 @@ main( int argc, char **argv ) {
 
     const auto disconnect = irods::at_scope_exit{[conn] { rcDisconnect(conn); }};
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/iquota.cpp
+++ b/clients/icommands/src/iquota.cpp
@@ -537,6 +537,8 @@ main( int argc, char **argv ) {
 
     const auto disconnect = irods::at_scope_exit{[] { rcDisconnect(Conn); }};
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     status = utils::authenticate_client(Conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(Conn->rError, stderr);

--- a/clients/icommands/src/ireg.cpp
+++ b/clients/icommands/src/ireg.cpp
@@ -82,6 +82,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/irepl.cpp
+++ b/clients/icommands/src/irepl.cpp
@@ -84,6 +84,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/irm.cpp
+++ b/clients/icommands/src/irm.cpp
@@ -72,6 +72,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/irmdir.cpp
+++ b/clients/icommands/src/irmdir.cpp
@@ -123,6 +123,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     status = utils::authenticate_client(Conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(Conn->rError, stderr);

--- a/clients/icommands/src/irmtrash.cpp
+++ b/clients/icommands/src/irmtrash.cpp
@@ -70,6 +70,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/irsync.cpp
+++ b/clients/icommands/src/irsync.cpp
@@ -112,6 +112,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/irule.cpp
+++ b/clients/icommands/src/irule.cpp
@@ -180,6 +180,10 @@ main( int argc, char **argv ) {
 
     load_client_api_plugins();
 
+    // Keeps warn_if_connected_to_potentially_incompatible_server from being invoked
+    // more than once.
+    bool print_incompatibility_warning = true;
+
     /* Don't need to parse parameters if just listing available rule_engine_instances */
     if ( argsMap.count( "available" ) ) {
         /* add key val for listing available rule engine instances */
@@ -206,7 +210,7 @@ main( int argc, char **argv ) {
                 exit( 10 );
             }
 
-            /* if the input file name starts with "i:", the get the file from iRODS server */
+            // If the input file name starts with "i:", get the file from the iRODS server.
             if ( !strncmp( fileName, "i:", 2 ) ) {
                 status = getRodsEnv( &myEnv );
 
@@ -221,6 +225,9 @@ main( int argc, char **argv ) {
                 if ( conn == NULL ) {
                     exit( 2 );
                 }
+
+                utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+                print_incompatibility_warning = false;
 
                 status = utils::authenticate_client(conn, myEnv);
                 if ( status != 0 ) {
@@ -450,6 +457,12 @@ main( int argc, char **argv ) {
             rodsLogError( LOG_ERROR, errMsg.status, "rcConnect failure %s",
                           errMsg.msg );
             exit( 2 );
+        }
+
+        if (print_incompatibility_warning) {
+            // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
+            print_incompatibility_warning = false;
+            utils::warn_if_connected_to_potentially_incompatible_server(*conn);
         }
 
         status = utils::authenticate_client(conn, myEnv);

--- a/clients/icommands/src/iscan.cpp
+++ b/clients/icommands/src/iscan.cpp
@@ -68,6 +68,8 @@ main( int argc, char **argv ) {
         return 2;
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     if ( strcmp( myEnv.rodsUserName, PUBLIC_USER_NAME ) != 0 ) {
         status = utils::authenticate_client(conn, myEnv);
         if ( status != 0 ) {

--- a/clients/icommands/src/istream.cpp
+++ b/clients/icommands/src/istream.cpp
@@ -88,6 +88,8 @@ int main(int argc, char* argv[])
 
         irods::experimental::client_connection conn;
 
+        utils::warn_if_connected_to_potentially_incompatible_server(static_cast<RcComm&>(conn));
+
         irods::at_scope_exit print_errors_on_exit{[&conn] {
             printErrorStack(static_cast<rcComm_t*>(conn)->rError);
         }};

--- a/clients/icommands/src/isysmeta.cpp
+++ b/clients/icommands/src/isysmeta.cpp
@@ -374,6 +374,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     status = utils::authenticate_client(Conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(Conn->rError, stderr);

--- a/clients/icommands/src/iticket.cpp
+++ b/clients/icommands/src/iticket.cpp
@@ -894,6 +894,8 @@ main( int argc, char **argv ) {
 
     const auto disconnect = irods::at_scope_exit{[] { rcDisconnect(Conn); }};
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     status = utils::authenticate_client(Conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(Conn->rError, stderr);

--- a/clients/icommands/src/itouch.cpp
+++ b/clients/icommands/src/itouch.cpp
@@ -73,6 +73,8 @@ int main(int _argc, char* _argv[])
         irods::experimental::client_connection comm;
         RcComm& comm_ref = comm;
 
+        utils::warn_if_connected_to_potentially_incompatible_server(comm_ref);
+
         if (const auto ec = rc_touch(&comm_ref, json_input.data()); ec < 0) {
             printErrorStack(comm_ref.rError);
             return 1;

--- a/clients/icommands/src/itree.cpp
+++ b/clients/icommands/src/itree.cpp
@@ -1,3 +1,5 @@
+#include "utility.hpp"
+
 #include <irods/rodsClient.h>
 #include <irods/client_connection.hpp>
 #include <irods/irods_client_api_table.hpp>
@@ -124,6 +126,8 @@ int main(int argc, char** argv){
         auto path = correct_path(vm, env);
         load_client_api_plugins();
         irods::experimental::client_connection conn;
+
+        utils::warn_if_connected_to_potentially_incompatible_server(static_cast<RcComm&>(conn));
 
         if (!fs::client::is_collection(conn, path)) {
             std::cerr << "Error: The specified path does not refer to a collection.\n";

--- a/clients/icommands/src/itree.cpp
+++ b/clients/icommands/src/itree.cpp
@@ -26,7 +26,6 @@
 namespace po   = boost::program_options;
 namespace fs   = irods::experimental::filesystem;
 namespace ix   = irods::experimental;
-namespace json = nlohmann;
 
 using pattern_matcher = std::variant<int,               // no option specified
                                      std::string,       // glob-style pattern specified
@@ -39,7 +38,7 @@ auto print_dir(const fs::path&,
 
 auto correct_path(const po::variables_map&, rodsEnv&) -> fs::path;
 auto print_usage() -> void;
-auto get_json(const fs::path&, const po::variables_map&, ix::client_connection&, unsigned int depth) -> json::json;
+auto get_json(const fs::path&, const po::variables_map&, ix::client_connection&, unsigned int depth) -> nlohmann::json;
 auto contains_pattern(const pattern_matcher& pm) -> bool;
 
 // ANSI escape numbers. For setting the colors.
@@ -136,9 +135,9 @@ int main(int argc, char** argv){
 
         if (vm["json"].as<bool>() || vm["uppercase_json_deprecated"].as<bool>()) {
             auto value = get_json(path, vm, conn, vm["depth"].as<int>() );
-            json::json top;
+            nlohmann::json top;
             top.push_back(value);
-            json::json report = {{"type","report"}, {"collections",collections},{"data_objects",objects}};
+            nlohmann::json report = {{"type", "report"}, {"collections", collections}, {"data_objects", objects}};
 
             if (vm["size"].as<bool>()) {
                 report["size"] = total_size;
@@ -347,8 +346,9 @@ auto correct_path(const po::variables_map& pm, rodsEnv& env) -> fs::path {
 }
 
 auto print_usage() -> void {
+    // clang-format off
     fmt::print(
-        R"_(itree - List contents of collections in a tree-like format.
+R"_(itree - List contents of collections in a tree-like format.
 
 Usage: itree [OPTION]... COLLECTION
 
@@ -382,11 +382,13 @@ Options:
   -x, --regex-extended-syntax
                   Enable extended syntax for regular expressions.
 )_");
+    // clang-format on
 
     printReleaseInfo("itree");
 }
 
-auto contents_size(const json::json& value) -> std::uintmax_t {
+auto contents_size(const nlohmann::json& value) -> std::uintmax_t
+{
     std::uintmax_t total = 0;
     for(const auto& child : value["contents"]) {
         total += child["size"].get<std::uintmax_t>();
@@ -394,22 +396,24 @@ auto contents_size(const json::json& value) -> std::uintmax_t {
     return total;
 }
 
-auto get_json(const fs::path& path, const po::variables_map& vm, ix::client_connection& conn, unsigned int depth ) -> json::json  {
+auto get_json(const fs::path& path, const po::variables_map& vm, ix::client_connection& conn, unsigned int depth)
+    -> nlohmann::json
+{
     auto fsiter = fs::client::collection_iterator(conn, path);
-    json::json value;
+    nlohmann::json value;
     value["type"] = "collection";
     if( vm["fullpath"].as<bool>() || path.object_name().string().empty() ) {
         value["name"] = path;
     } else {
         value["name"] = path.object_name();
     }
-    value["contents"] = json::json::value_t::array;
+    value["contents"] = nlohmann::json::value_t::array;
     if( depth == 0 ) {
         return value;
     }
     for(const auto& object: fsiter) {
         if( object.is_collection() ) {
-            json::json sub_coll;
+            nlohmann::json sub_coll;
             sub_coll = get_json(object.path(), vm, conn, depth - 1);
             value["contents"].emplace_back(std::move(sub_coll));
             collections++;
@@ -417,7 +421,7 @@ auto get_json(const fs::path& path, const po::variables_map& vm, ix::client_conn
             if(  vm["collections-only"].as<bool>() || !object_matches(object) ) {
                 continue;
             }
-            json::json data_object;
+            nlohmann::json data_object;
             if( vm["fullpath"].as<bool>() ){
                 data_object["name"] = object.path();
             } else {
@@ -429,9 +433,9 @@ auto get_json(const fs::path& path, const po::variables_map& vm, ix::client_conn
                 data_object["size"] = object.data_size();
             }
             if( vm.count("acl") ) {
-                json::json permissions;
+                nlohmann::json permissions;
                 for ( auto& perm : object.status().permissions() ) {
-                    json::json permission;
+                    nlohmann::json permission;
                     permission["bearer_name"] = perm.name;
                     permission["zone"] = perm.zone;
                     permission["access_level"] = permission_type_string(perm.prms);

--- a/clients/icommands/src/itrim.cpp
+++ b/clients/icommands/src/itrim.cpp
@@ -74,6 +74,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/iunreg.cpp
+++ b/clients/icommands/src/iunreg.cpp
@@ -75,6 +75,8 @@ main( int argc, char **argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     status = utils::authenticate_client(conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(conn->rError, stderr);

--- a/clients/icommands/src/iuserinfo.cpp
+++ b/clients/icommands/src/iuserinfo.cpp
@@ -145,6 +145,8 @@ main( int argc, char **argv ) {
 
     const auto disconnect = irods::at_scope_exit{[] { rcDisconnect(Conn); }};
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*Conn);
+
     status = utils::authenticate_client(Conn, myEnv);
     if ( status != 0 ) {
         print_error_stack_to_file(Conn->rError, stderr);

--- a/clients/icommands/src/izonereport.cpp
+++ b/clients/icommands/src/izonereport.cpp
@@ -80,6 +80,8 @@ main( int _argc, char** argv ) {
         exit( 2 );
     }
 
+    utils::warn_if_connected_to_potentially_incompatible_server(*conn);
+
     // =-=-=-=-=-=-=-
     // initialize pluggable api table
     irods::pack_entry_table& pk_tbl = irods::get_pack_table();

--- a/clients/icommands/src/utility.hpp
+++ b/clients/icommands/src/utility.hpp
@@ -22,7 +22,7 @@ namespace utils
         // Setting this environment variable is required so that "ips" can display
         // the command name alongside the connection information.
         if (setenv(SP_OPTION, _display_name.data(), /* overwrite */ 1)) {
-            std::cout << "Warning: Could not set environment variable [spOption] for ips.";
+            std::cout << "Warning: Could not set environment variable [spOption] for ips.\n";
         }
     }
 

--- a/clients/icommands/src/utility.hpp
+++ b/clients/icommands/src/utility.hpp
@@ -33,16 +33,19 @@ namespace utils
         return ia::authenticate_client(*_comm, ctx);
     } // authenticate_client
 
-    inline auto option_specified(std::string_view _option, int argc, char** argv) -> bool
+    inline auto option_specified(std::string_view _option, int _argc, char** _argv) -> bool
     {
-        for (int arg = 0; arg < argc; ++arg) {
-            if (!argv[arg]) {
+        for (int arg = 0; arg < _argc; ++arg) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            if (!_argv[arg]) {
                 continue;
             }
 
-            if (_option == argv[arg]) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            if (_option == _argv[arg]) {
                 // parseCmdLineOpt is EVIL and requires this. Please don't ask why.
-                argv[arg] = "-Z";
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                _argv[arg] = "-Z";
                 return true;
             }
         }
@@ -88,4 +91,3 @@ namespace utils
 } // namespace utils
 
 #endif // IRODS_ICOMMANDS_UTILITY_HPP
-

--- a/clients/icommands/src/utility.hpp
+++ b/clients/icommands/src/utility.hpp
@@ -3,13 +3,17 @@
 
 #include <irods/authentication_plugin_framework.hpp>
 #include <irods/getRodsEnv.h>
+#include <irods/irods_version.h>
 #include <irods/rodsDef.h>
+#include <irods/version.hpp>
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
 
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <string_view>
-
-#include <nlohmann/json.hpp>
 
 namespace utils
 {
@@ -45,6 +49,42 @@ namespace utils
 
         return false;
     } // option_specified
+
+    // Prints a warning to stderr if the major version number of the iCommands does
+    // not match the major version number of the connected server.
+    //
+    // Prints a warning to stderr if the version of the server cannot be determined.
+    // It is recommended that the user verify they are connecting to a trusted server
+    // before proceeding.
+    //
+    // Setting the following environment variable to 0 causes the warning message to
+    // be suppressed.
+    //
+    //     ICOMMANDS_DETECT_SERVER_VERSION_MISMATCH
+    //
+    inline auto warn_if_connected_to_potentially_incompatible_server(const RcComm& _comm) -> void
+    {
+        // If not defined or explicitly set to 0, return immediately.
+        const char* env_var = std::getenv("ICOMMANDS_DETECT_SERVER_VERSION_MISMATCH");
+        if (env_var != nullptr && std::strncmp(env_var, "0", 1) == 0) {
+            return;
+        }
+
+        const auto server_version = irods::to_version(_comm.svrVersion->relVersion);
+        if (!server_version) {
+            fmt::print(stderr,
+                       "Warning: Could not determine server version. Make sure you are connected to a trusted iRODS "
+                       "server.\n\n");
+        }
+        else if (server_version->major != IRODS_VERSION_MAJOR) {
+            fmt::print(stderr,
+                       "Warning: Major version number mismatch detected between iCommands and server.\n\n"
+                       "   iCommands   : {}\n"
+                       "   iRODS server: {}\n\n",
+                       IRODS_VERSION_MAJOR,
+                       server_version->major);
+        }
+    } // warn_if_connected_to_potentially_incompatible_server
 } // namespace utils
 
 #endif // IRODS_ICOMMANDS_UTILITY_HPP

--- a/lib/core/src/rcMisc.cpp
+++ b/lib/core/src/rcMisc.cpp
@@ -4930,7 +4930,7 @@ void set_ips_display_name(const char* _display_name)
     // Setting this environment variable is required so that "ips" can display
     // the command name alongside the connection information.
     if (setenv(SP_OPTION, _display_name, /* overwrite */ 1)) {
-        std::cout << "Warning: Could not set environment variable [spOption] for ips.";
+        std::cout << "Warning: Could not set environment variable [spOption] for ips.\n";
     }
 } // set_ips_display_name
 


### PR DESCRIPTION
Here's a real example of what users will see with this initial implementation.

```
$ ils
Warning: Major version number mismatch detected between iCommands and server!

   iCommands major version number   : 5
   iRODS server major version number: 4

To avoid compatibility issues, use an iCommands installation which matches the server's major version number.
/tempZone/home/kory:
```

TODOs:
- [x] Confirm all icommands report the warning when connected to an iRODS 4 server
- [x] Confirm environment variable disables warning for one iCommand
- [x] Run unit tests
- [x] Run core tests