### PR TITLE
[#8980] Reject relative paths to PID file on server startup (main)

### DIFF
--- a/clients/icommands/src/istream.cpp
+++ b/clients/icommands/src/istream.cpp
@@ -118,45 +118,56 @@ int main(int argc, char* argv[])
 
 auto usage() -> void
 {
-    std::cout << "Usage: istream read [-R RESC_NAME] [-o INTEGER] [-c INTEGER] LOGICAL_PATH\n"
-                 "Usage: istream read [-n REPLICA_NUMBER] [-o INTEGER] [-c INTEGER] LOGICAL_PATH\n"
-                 "Usage: istream write [-R RESC_NAME] [-k] [-o INTEGER] [-c INTEGER] [--no-trunc] [-a] LOGICAL_PATH\n"
-                 "Usage: istream write [-n REPLICA_NUMBER] [-k] [-o INTEGER] [-c INTEGER] [--no-trunc] [-a] LOGICAL_PATH\n"
-                 "\n"
-                 "Streams bytes to/from iRODS via stdin/stdout.\n"
-                 "Reads bytes from the target data object and prints them to stdout.\n"
-                 "Writes bytes from stdin to the target data object.\n"
-                 "\n"
-                 "Writing to a non-existent data object will create it by default.\n"
-                 "Writing to an existing data object always truncates it.  Truncation can be\n"
-                 "disabled by passing --no-trunc.  However, using --no-trunc disables creation\n"
-                 "of data objects.\n"
-                 "\n"
-                 "If the client-side of the connection is interrupted before the data object\n"
-                 "is closed, then the catalog will not be updated and the data object will have\n"
-                 "a replica status of intermediate or stale.  Information such as data object\n"
-                 "size and checksum will not be available.\n"
-                 "\n"
-                 "If the target data object does not reside on the connected server, istream\n"
-                 "will not attempt to redirect to the server hosting the replica.  Traffic will\n"
-                 "always flow through the connected server.\n"
-                 "\n"
-                 "Options:\n"
-                 "-R, --resource  The root resource to read from or write to.  Cannot be used\n"
-                 "                with --replica.\n"
-                 "-n, --replica   The replica number of the replica to read from or write to.\n"
-                 "                Replica numbers cannot be used to create new data objects.\n"
-                 "                Cannot be used with --resource.\n"
-                 "-o, --offset    The number of bytes to skip within the data object before\n"
-                 "                reading/writing.  Value must be positive.  Defaults to zero.\n"
-                 "-c, --count     The number of bytes to read/write.  Value must be positive.\n"
-                 "                Defaults to all bytes.\n"
-                 "-a, --append    Appends bytes read from stdin to the data object.  Implies\n"
-                 "                --no-trunc.\n"
-                 "    --no-trunc  Does not truncate the data object.  Disables creation of data\n"
-                 "                objects.  Ignored by write operations when --append is set.\n"
-                 "-k, --checksum  Compute checksum.\n"
-                 "-h, --help      Prints this message\n";
+    std::cout << R"__(istream - Read from or write to a data object
+
+Usage: istream read [-R RESOURCE_NAME] [-o INTEGER] [-c INTEGER] LOGICAL_PATH
+Usage: istream read [-n REPLICA_NUMBER] [-o INTEGER] [-c INTEGER] LOGICAL_PATH
+Usage: istream write [-R RESOURCE_NAME] [-k] [-o INTEGER] [-c INTEGER] [--no-trunc] [-a] LOGICAL_PATH
+Usage: istream write [-n REPLICA_NUMBER] [-k] [-o INTEGER] [-c INTEGER] [--no-trunc] [-a] LOGICAL_PATH
+
+Streams bytes to/from iRODS via stdin/stdout.
+Reads bytes from the target data object and prints them to stdout.
+Writes bytes from stdin to the target data object.
+
+Writing to a non-existent data object will create it by default.
+Writing to an existing data object always truncates it. Truncation can be
+disabled by passing --no-trunc. However, using --no-trunc disables creation
+of data objects.
+
+If the client-side of the connection is interrupted before the data object
+is closed, then the catalog will not be updated and the data object will have
+a replica status of intermediate or stale. Information such as data object
+size and checksum will not be available.
+
+If the target data object does not reside on the connected server, istream
+will not attempt to redirect to the server hosting the replica. Traffic will
+always flow through the connected server.
+
+Mandatory arguments to long options are mandatory for short options too.
+
+Options:
+ -R, --resource=RESOURCE_NAME
+               The root resource to read from or write to. Cannot be used
+               with --replica.
+ -n, --replica=REPLICA_NUMBER
+               The replica number of the replica to read from or write to.
+               Replica numbers cannot be used to create new data objects.
+               Cannot be used with --resource.
+ -o, --offset=INTEGER
+               The number of bytes to skip within the data object before
+               reading/writing. Value must be positive. Defaults to zero.
+ -c, --count=INTEGER
+               The number of bytes to read/write. Value must be positive.
+               Defaults to all bytes.
+ -a, --append  Appends bytes read from stdin to the data object. Implies
+               --no-trunc.
+     --no-trunc
+               Does not truncate the data object. Disables creation of data
+               objects. Ignored by write operations when --append is set.
+ -k, --checksum
+               Compute checksum.
+ -h, --help    Prints this message
+)__";
 
     printReleaseInfo("istream");
 }

--- a/clients/icommands/src/itouch.cpp
+++ b/clients/icommands/src/itouch.cpp
@@ -116,10 +116,12 @@ Mandatory arguments to long options are mandatory for short options too.
 
 Options:
   -c, --no-create  Do not create a data object.
-  -n, --replica    The replica number of the replica to update.  This
+  -n, --replica=REPLICA_NUMBER
+                   The replica number of the replica to update. This
                    option applies to data objects only. Cannot be used
                    with -R.
-  -R, --resource   The leaf resource that contains the replica to update.
+  -R, --resource=RESOURCE_NAME
+                   The leaf resource that contains the replica to update.
                    This option applies to data objects only. If the data
                    object does not exist and this option is used, the
                    replica will be created on the resource specified.

--- a/scripts/irods/test/test_misc.py
+++ b/scripts/irods/test/test_misc.py
@@ -1,8 +1,11 @@
 import os
+import psutil
+import signal
 import subprocess
 import sys
 import tempfile
 import textwrap
+import time
 import unittest
 
 from datetime import datetime, timedelta
@@ -600,6 +603,112 @@ class Test_Misc(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 
 
         finally:
             IrodsController().reload_configuration()
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, 'Only requires a single server')
+    def test_server_rejects_relative_paths_to_pid_file__issue_8980(self):
+        pid_file_paths = [
+            'irods_issue_8980.pid',
+            './irods_issue_8980.pid',
+            'log/irods_issue_8980.pid',
+            '',
+        ]
+
+        for pid_path in pid_file_paths:
+            res = subprocess.run(['irodsServer', '-p', pid_path, '-t'], capture_output=True, text=True)
+            self.assertNotEqual(res.returncode, 0)
+            self.assertIn(f'Error: PID file path must be absolute: [{pid_path}]\n', res.stderr)
+
+        for pid_path in pid_file_paths:
+            res = subprocess.run(['irodsServer', '-p', pid_path, '--stdout', '-t'], capture_output=True, text=True)
+            self.assertNotEqual(res.returncode, 0)
+            self.assertIn(f'Error: PID file path must be absolute: [{pid_path}]\n', res.stderr)
+
+        for pid_path in pid_file_paths:
+            res = subprocess.run(['irodsServer', '-p', pid_path, '-t', '-d'], capture_output=True, text=True)
+            self.assertNotEqual(res.returncode, 0)
+            self.assertIn(f'Error: PID file path must be absolute: [{pid_path}]\n', res.stderr)
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, 'Only requires a single server')
+    def test_server_can_be_launched_with_different_pid_file__issue_8980(self):
+        controller = IrodsController()
+
+        def pid_file_exists(file, max_attempts=30):
+            for _ in range(max_attempts):
+                if os.path.exists(file):
+                    return True
+                time.sleep(1)
+            return False
+
+        # This function relies on the "controller" variable.
+        def wait_for_server_to_start(max_attempts=30):
+            for _ in range(max_attempts):
+                if controller.is_server_listening_for_client_requests():
+                    return True
+                time.sleep(1)
+            return False
+
+        try:
+            # Stop the server so that the test can launch it with a different PID file.
+            # This avoids address-in-use issues, etc.
+            controller.stop()
+
+            # Test launching the server in the foreground with a custom PID file.
+            #
+            # "start_new_session" is used to make sure the server is launched under a different
+            # process group/session. Not doing this results in signals like SIGUSR1 (used by the server)
+            # being sent to this test, causing it to be interrupted and exiting.
+            pid_file_path = f'{paths.irods_directory()}/irods_server_foreground_issue_8980.pid'
+            proc = subprocess.Popen(['irodsServer', '-p', pid_file_path, '-t'], start_new_session=True)
+            try:
+                # Wait for the server to open the listening socket. This guarantees that the
+                # server has completed initialization of signal handlers. This MUST be done before
+                # sending signals to the the server process.
+                self.assertTrue(wait_for_server_to_start())
+                self.assertTrue(pid_file_exists(pid_file_path))
+
+            finally:
+                proc.terminate()
+                self.assertEqual(proc.wait(), 0)
+
+            # Test launching the server as a daemon with a custom PID file.
+            pid_file_path = f'{paths.irods_directory()}/irods_server_daemon_issue_8980.pid'
+            proc = subprocess.Popen(['irodsServer', '-p', pid_file_path, '-t', '-d'], start_new_session=True)
+            try:
+                self.assertEqual(proc.wait(), 0) # Wait for the server to daemonize.
+                self.assertTrue(wait_for_server_to_start())
+                self.assertTrue(pid_file_exists(pid_file_path))
+
+            finally:
+                # Terminate the server.
+                with open(pid_file_path) as f:
+                    pid_number = int(f.readline().strip())
+                self.assertGreater(pid_number, 0)
+                os.kill(pid_number, signal.SIGTERM)
+
+                # Make sure the server is shut down. We only know this if os.kill() raises an exception
+                # or the process is identified as a zombie.
+                server_is_shutdown = False
+                try:
+                    proc = psutil.Process(pid_number)
+                    for _ in range(30):
+                        os.kill(pid_number, 0) # We want this to raise an exception.
+                        time.sleep(1)
+
+                        # If the process is a zombie, that means this test is probably running in an
+                        # environment without an init-like process. This is perfectly acceptable for test
+                        # purposes as it indicates the process has exited.
+                        if proc.status() == psutil.STATUS_ZOMBIE:
+                            server_is_shutdown = True
+                            break
+
+                except (ProcessLookupError, PermissionError, psutil.NoSuchProcess):
+                    # This exception block will be triggered if the OS cannot find a PID matching
+                    # the target PID or the user does not have permission to send the target PID signals.
+                    server_is_shutdown = True
+                self.assertTrue(server_is_shutdown)
+
+        finally:
+            controller.start(test_mode=True);
 
 
 class test_server_side_libraries(unittest.TestCase):

--- a/server/main_server/src/main.cpp
+++ b/server/main_server/src/main.cpp
@@ -220,6 +220,15 @@ auto main(int _argc, char* _argv[]) -> int
             return 1;
         }
 
+        auto pid_file = irods::get_irods_runstate_directory() / "irods/irods-server.pid";
+        if (const auto iter = vm.find("pid-file"); std::end(vm) != iter) {
+            pid_file = iter->second.as<std::string>();
+            if (pid_file.is_relative()) {
+                fmt::print(stderr, "Error: PID file path must be absolute: [{}]\n", pid_file.c_str());
+                return 1;
+            }
+        }
+
         if (vm.count("daemonize") > 0) {
             if (write_to_stdout) {
                 fmt::print(stderr, "Error: --daemonize and --stdout are incompatible.\n");
@@ -229,12 +238,7 @@ auto main(int _argc, char* _argv[]) -> int
             daemonize();
         }
 
-        std::string pid_file = (irods::get_irods_runstate_directory() / "irods/irods-server.pid").string();
-        if (const auto iter = vm.find("pid-file"); std::end(vm) != iter) {
-            pid_file = std::move(iter->second.as<std::string>());
-        }
-
-        if (create_pid_file(pid_file) != 0) {
+        if (create_pid_file(pid_file.c_str()) != 0) {
             return 1;
         }
     }


### PR DESCRIPTION
~Working on failed assertion. Putting in draft until that is fixed.~

New tests pass in isolation and when run with other test suites. No need to run the full test suite for this since the code changes apply to startup logic and help text.

This is now ready.