### PR TITLE
[#8917] Extend customization options for random scheme vault path policy (main)

### DIFF
--- a/doxygen/microservices.cpp
+++ b/doxygen/microservices.cpp
@@ -156,7 +156,9 @@
   - #msiSetDataObjPreferredResc - Specifies the preferred copy to use, if the data has multiple copies
   - #msiSetDataObjAvoidResc - Specifies the copy to avoid
   - #msiSetGraftPathScheme - Sets the scheme for composing the physical path in the vault to GRAFT_PATH
-  - #msiSetRandomScheme - Sets the the scheme for composing the physical path in the vault to RANDOM
+  - #msiSetRandomScheme - Sets the scheme for composing the physical path in the vault to RANDOM
+  - #msi_set_random_scheme_style - Sets the style used when composing a randomly-generated physical path in the vault
+  - #msi_set_random_scheme_suffix_length - Sets the length of the suffix style used when composing a randomly-generated physical path in the vault
   - #msiSetNumThreads - specify the parameters for determining the number of threads to use for data transfer
   - #msiNoChkFilePathPerm - Does not check file path permission when registering a file
   - #msiSetChkFilePathPerm - Sets the check type for file path permission check when registering a file

--- a/packaging/core.re.template
+++ b/packaging/core.re.template
@@ -292,11 +292,43 @@ acSetChkFilePathPerm {msiSetChkFilePathPerm("disallowPathReg"); }
 #      The advantage with the RANDOM scheme is renaming operations (imv, irm)
 #      are much faster because there is no need to rename the
 #      corresponding physical path.
+#
+#    msi_set_random_scheme_style(style) - Set the random scheme style.
+#      This microservice allows administrators to change how physical paths are
+#      generated. The effects of this microservice are not applied unless the
+#      vault path policy is set to the random scheme.
+#
+#      This microservice has no effect if invoked outside of acSetVaultPathPolicy()
+#      or an error occurs.
+#
+#      Styles:
+#        - 0: Default style, i.e. <vault_root>/<int>/<int>/<filename>.<epoch_seconds>
+#        - 1: Append random characters, i.e. <vault_root>/<int>/<int>/<filename>.<epoch_seconds>.<random_characters>
+#
+#      A style of 1 results in 5 randomly generated alphanumeric characters
+#      being appended to the physical path. Attempting to set the value to anything
+#      other than 0 or 1 will result in an error.
+#
+#      See msi_set_random_scheme_suffix_length() for information about changing
+#      the length of the generated suffix string.
+#
+#    msi_set_random_scheme_suffix_length(length) - Set the random scheme suffix
+#      length.
+#
+#      The effects of this microservice are not applied unless the random scheme
+#      style is set to 1.
+#
+#      This microservice has no effect if invoked outside of acSetVaultPathPolicy()
+#      or an error occurs.
+#
+#      The length must satisfy the range [1, 32]. Failing to satisfy this requirement
+#      will result in an error.
+#
 # This default is GRAFT_PATH scheme with addUserName == yes and trimDirCnt == 1.
 # Note : if trimDirCnt is greater than 1, the home or trash entry will be
 # taken out.
-# acSetVaultPathPolicy {msiSetRandomScheme; }
-acSetVaultPathPolicy {msiSetGraftPathScheme("no","1"); }
+# acSetVaultPathPolicy { msiSetRandomScheme; msi_set_random_scheme_style(0); msi_set_random_scheme_suffix_length(5); }
+acSetVaultPathPolicy { msiSetGraftPathScheme("no","1"); }
 #
 # 18) acPreProcForCollCreate - This is the PreProcessing rule for creating
 # a collection. Currently there is no function written specifically

--- a/scripts/irods/test/session.py
+++ b/scripts/irods/test/session.py
@@ -292,6 +292,9 @@ class IrodsSession(object):
                             self.username,
                             self._session_id)
 
+    def get_session_id(self):
+        return self._session_id
+
 # Two-way mapping of the new (json) and old iRODS environment setting names
 json_env_map = {'irods_host': 'irodsHost',
         'irods_port': 'irodsPort',

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import getpass
 import json
 import os
@@ -1809,6 +1808,138 @@ OUTPUT ruleExecOut
 
         finally:
             IrodsController().reload_configuration()
+
+    def test_vault_path_random_scheme_customization_options__issue_8917(self):
+        # This function assumes acSetVaultPathPolicy()'s entire definition is on one line.
+        # The test will fail if that assumption is broken.
+        def replace_acSetVaultPathPolicyPEP(filepath, replacement_string):
+            with open(filepath) as f:
+                lines = f.readlines()
+
+            new_content = []
+            for line in lines:
+                if line.startswith('acSetVaultPathPolicy'):
+                    new_content.append(replacement_string)
+                else:
+                    new_content.append(line)
+
+            with open(filepath, 'w') as f:
+                f.writelines(new_content)
+
+        def do_test(style, expected_output, suffix_length=None, expect_error=False):
+            if isinstance(suffix_length, int):
+                pep_map = {
+                    'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent(f'''\
+                        acSetVaultPathPolicy()
+                        {{
+                            msiSetRandomScheme();
+                            msi_set_random_scheme_style({style});
+                            msi_set_random_scheme_suffix_length({suffix_length});
+                        }}
+                        '''),
+                    'irods_rule_engine_plugin-python': textwrap.dedent(f'''\
+                        def acSetVaultPathPolicy(rule_args, callback, rei):
+                            callback.msiSetRandomScheme()
+                            callback.msi_set_random_scheme_style({style})
+                            callback.msi_set_random_scheme_suffix_length({suffix_length});
+                        ''')
+                }
+            else:
+                pep_map = {
+                    'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent(f'''\
+                        acSetVaultPathPolicy()
+                        {{
+                            msiSetRandomScheme();
+                            msi_set_random_scheme_style({style});
+                        }}
+                        '''),
+                    'irods_rule_engine_plugin-python': textwrap.dedent(f'''\
+                        def acSetVaultPathPolicy(rule_args, callback, rei):
+                            callback.msiSetRandomScheme()
+                            callback.msi_set_random_scheme_style({style})
+                        ''')
+                }
+
+            try:
+                with temporary_core_file() as core:
+                    replace_acSetVaultPathPolicyPEP(core.filepath, pep_map[plugin_name])
+                    IrodsController().reload_configuration()
+
+                    data_object = f'{self.user0.session_collection}/issue_8917-{style}'
+                    if expect_error:
+                        with tempfile.NamedTemporaryFile(suffix='.issue_8917.txt', delete=True) as tf:
+                            self.user0.assert_icommand(['iput', tf.name, data_object], 'STDERR', expected_output)
+                        self.assertFalse(lib.replica_exists(self.user0, data_object, 0))
+                    else:
+                        try:
+                            self.user0.assert_icommand(['itouch', data_object])
+                            self.user0.assert_icommand(['ils', '-L', data_object], 'STDOUT', expected_output, use_regex=True)
+
+                        finally:
+                            self.user0.assert_icommand(['irm', '-f', data_object])
+
+            finally:
+                IrodsController().reload_configuration()
+
+        # Make sure we don't change existing behavior. This is the backward compatibility case.
+        do_test(0, [r'.+/\d+/\d+/.+\..{10,}$'])
+
+        # Appends 5 random bytes between ascii '0' and 'z' inclusive. This also verifies
+        # the default suffix length is 5.
+        do_test(1, [r'.+/\d+/\d+/.+[.].{10,}[.].{5}$'])
+
+        # Show that the suffix length can be any value as long as it's within the range [1, 32].
+        for suffix_length in [1, 3, 12, 32]:
+            with self.subTest(f'good suffix length: [{suffix_length}]'):
+                do_test(1, [fr'.+/\d+/\d+/.+[.].{{10,}}[.].{{{suffix_length}}}$'], suffix_length)
+
+        # Show that an invalid style results in an error.
+        for style in [-1, 2]:
+            with self.subTest(f'invalid style: [{style}]'):
+                do_test(style, ['-130000 SYS_INVALID_INPUT_PARAM'], expect_error=True)
+
+        # Show that an invalid suffix length results in an error.
+        for suffix_length in [-7, 0, 33]:
+            with self.subTest(f'invalid suffix length: [{suffix_length}]'):
+                do_test(1, ['-130000 SYS_INVALID_INPUT_PARAM'], suffix_length, expect_error=True)
+
+    @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Only applicable to the NREP')
+    def test_irule_cannot_modify_the_random_scheme_via_acSetVaultPathPolicy__issue_8917(self):
+        data_object = f'{self.user0.session_collection}/issue_8917_irule.txt'
+        rule_file_path = f'{self.user0.local_session_dir}/issue_8917_irule.r'
+
+        # The following policy should not have any effect on the physical path generated
+        # via the call to msi_touch().
+        #
+        # NOTE: The first rule is treated as the main rule. Other rules can be provided and
+        # invoked from the first rule.
+        with open(rule_file_path, 'w') as f:
+            f.write(textwrap.dedent(f'''\
+                do_test
+                {{
+                    msi_touch('{{"logical_path": "{data_object}"}}');
+                }}
+
+                acSetVaultPathPolicy()
+                {{
+                    msiSetRandomScheme();
+                    msi_set_random_scheme_style(1);
+                    msi_set_random_scheme_suffix_length(10);
+                }}
+
+                INPUT null
+                OUTPUT ruleExecOut
+            '''))
+
+        # This should result in the creation of a new data object.
+        plugin_instance = plugin_name + '-instance'
+        self.user0.assert_icommand(['irule', '-r', plugin_instance, '-F', rule_file_path])
+        self.assertTrue(lib.replica_exists(self.user0, data_object, 0))
+
+        # Show the physical path of the data object matches what we'd expect when the
+        # random scheme isn't enabled.
+        data_path = lib.get_replica_full_row(self.user0, data_object, 0)['DATA_PATH']
+        self.assertEqual(data_path, f'/var/lib/irods/Vault/home/{self.user0.username}/{self.user0.get_session_id()}/{os.path.basename(data_object)}')
 
 class Test_msiDataObjRepl_checksum_keywords(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 'apass')]), unittest.TestCase):
     global plugin_name

--- a/server/core/CMakeLists.txt
+++ b/server/core/CMakeLists.txt
@@ -137,6 +137,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/server_utilities.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/specColl.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/user_validation_utilities.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/vault_path_policy.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/irods/voting.hpp"
 )
 

--- a/server/core/include/irods/vault_path_policy.hpp
+++ b/server/core/include/irods/vault_path_policy.hpp
@@ -1,0 +1,17 @@
+#ifndef IRODS_VAULT_PATH_POLICY_HPP
+#define IRODS_VAULT_PATH_POLICY_HPP
+
+/// \file
+
+namespace irods::vault_path_policy
+{
+    // Keywords used by the random scheme microservices and vault path policy.
+    inline constexpr const char* random_scheme_style = "random_scheme_style";
+    inline constexpr const char* random_scheme_suffix_length = "random_scheme_suffix_length";
+
+    // Default values used by the random scheme microservices and vault path policy.
+    inline constexpr int random_scheme_config_default_style = 0;
+    inline constexpr int random_scheme_config_default_suffix_length = 5;
+} // namespace irods::vault_path_policy
+
+#endif // IRODS_VAULT_PATH_POLICY_HPP

--- a/server/core/src/physPath.cpp
+++ b/server/core/src/physPath.cpp
@@ -1,17 +1,28 @@
+#include "irods/physPath.hpp"
+
 #include "irods/collCreate.h"
 #include "irods/collection.hpp"
 #include "irods/dataObjClose.h"
 #include "irods/dataObjOpr.hpp"
 #include "irods/fileChksum.h"
 #include "irods/genQuery.h"
+#include "irods/irods_at_scope_exit.hpp"
+#include "irods/irods_get_full_path_for_config_file.hpp"
+#include "irods/irods_hierarchy_parser.hpp"
+#include "irods/irods_log.hpp"
+#include "irods/irods_logger.hpp"
+#include "irods/irods_random.hpp"
+#include "irods/irods_resource_backport.hpp"
+#include "irods/irods_server_properties.hpp"
+#include "irods/irods_stacktrace.hpp"
 #include "irods/modDataObjMeta.h"
 #include "irods/objMetaOpr.hpp"
-#include "irods/physPath.hpp"
 #include "irods/rcGlobalExtern.h"
 #include "irods/rcMisc.h"
+#include "irods/reSysDataObjOpr.hpp"
+#include "irods/replica_proxy.hpp"
 #include "irods/resource.hpp"
 #include "irods/rodsConnect.h"
-#include "irods/rodsDef.h"
 #include "irods/rodsDef.h"
 #include "irods/rodsPath.h"
 #include "irods/rsCollCreate.hpp"
@@ -23,22 +34,53 @@
 #include "irods/rsGlobalExtern.hpp"
 #include "irods/rsModDataObjMeta.hpp"
 #include "irods/rsObjStat.hpp"
-#include "irods/irods_at_scope_exit.hpp"
-#include "irods/irods_get_full_path_for_config_file.hpp"
-#include "irods/irods_hierarchy_parser.hpp"
-#include "irods/irods_log.hpp"
-#include "irods/irods_random.hpp"
-#include "irods/irods_resource_backport.hpp"
-#include "irods/irods_server_properties.hpp"
-#include "irods/irods_stacktrace.hpp"
-#include "irods/replica_proxy.hpp"
+#include "irods/vault_path_policy.hpp"
 
 #include <fmt/format.h>
 
 #include <unistd.h> // JMC - backport 4598
 #include <fcntl.h> // JMC - backport 4598
 
+#include <cstdint>
 #include <cstring>
+#include <ctime>
+
+namespace
+{
+    namespace ir = irods::experimental::replica;
+    namespace ivpp = irods::vault_path_policy;
+
+    using log_agent = irods::experimental::log::agent;
+
+    namespace detail
+    {
+        // The following variables support extensions to the random scheme vault path policy.
+        // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+        int random_scheme_style = ivpp::random_scheme_config_default_style;
+        int random_scheme_suffix_length = ivpp::random_scheme_config_default_suffix_length;
+        // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+        // Returns the random scheme style if set in the REI. Otherwise, the default is returned.
+        auto get_random_scheme_style(RuleExecInfo& _rei) -> int
+        {
+            auto* msp = getMsParamByLabel(&_rei.inOutMsParamArray, ivpp::random_scheme_style);
+            if (!msp) {
+                return ivpp::random_scheme_config_default_style;
+            }
+            return *static_cast<int*>(msp->inOutStruct);
+        } // get_random_scheme_style
+
+        // Returns the random scheme suffix length if set in the REI. Otherwise, the default is returned.
+        auto get_random_scheme_suffix_length(RuleExecInfo& _rei) -> int
+        {
+            auto* msp = getMsParamByLabel(&_rei.inOutMsParamArray, ivpp::random_scheme_suffix_length);
+            if (!msp) {
+                return ivpp::random_scheme_config_default_suffix_length;
+            }
+            return *static_cast<int*>(msp->inOutStruct);
+        } // get_random_scheme_suffix_length
+    } // namespace detail
+} // anonymous namespace
 
 int getLeafRescPathName(const std::string& _resc_hier, std::string& _ret_string);
 
@@ -49,11 +91,6 @@ int chkAndHandleOrphanFile(
     char *filePath,
     const char *_resc_name,
     int replStatus);
-
-namespace
-{
-    namespace ir = irods::experimental::replica;
-} // anonymous namespace
 
 namespace irods
 {
@@ -259,7 +296,6 @@ int
 getVaultPathPolicy( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
                     vaultPathPolicy_t *outVaultPathPolicy ) {
     ruleExecInfo_t rei;
-    msParam_t *msParam;
     int status;
 
     if ( outVaultPathPolicy == NULL || dataObjInfo == NULL || rsComm == NULL ) {
@@ -285,8 +321,15 @@ getVaultPathPolicy( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
         return status;
     }
 
-    if ( ( msParam = getMsParamByLabel( &rei.inOutMsParamArray,
-                                        VAULT_PATH_POLICY ) ) == NULL ) {
+    // This is horrible, but it must be done here to avoid giving non-rodsadmin users
+    // the ability to modify server-side configuration options for the random scheme.
+    //
+    // This limits modification of the random scheme configuration options to acSetVaultPathPolicy().
+    detail::random_scheme_style = detail::get_random_scheme_style(rei);
+    detail::random_scheme_suffix_length = detail::get_random_scheme_suffix_length(rei);
+
+    auto* msParam = getMsParamByLabel(&rei.inOutMsParamArray, VAULT_PATH_POLICY);
+    if (nullptr == msParam) {
         /* use the default */
         outVaultPathPolicy->scheme = DEF_VAULT_PATH_SCHEME;
         outVaultPathPolicy->addUserName = DEF_ADD_USER_FLAG;
@@ -326,9 +369,37 @@ setPathForRandomScheme( char *objPath, const char *vaultPath, char *userName,
         return status;
     }
 
-    snprintf( outPath, MAX_NAME_LEN,
-              "%s/%s/%d/%d/%s.%d", vaultPath, userName, dir1, dir2,
-              logicalFileName, ( uint ) time( NULL ) );
+    log_agent::debug("{}: Random scheme: style=[{}], suffix length=[{}]",
+                     __func__,
+                     detail::random_scheme_style,
+                     detail::random_scheme_suffix_length);
+
+    if (detail::random_scheme_style == 1) {
+        const auto rnd_str =
+            irods::generate_random_alphanumeric_string(static_cast<std::int16_t>(detail::random_scheme_suffix_length));
+        std::snprintf(outPath,
+                      MAX_NAME_LEN,
+                      "%s/%s/%d/%d/%s.%d.%s",
+                      vaultPath,
+                      userName,
+                      dir1,
+                      dir2,
+                      logicalFileName,
+                      static_cast<unsigned int>(std::time(nullptr)),
+                      rnd_str.c_str());
+    }
+    else {
+        std::snprintf(outPath,
+                      MAX_NAME_LEN,
+                      "%s/%s/%d/%d/%s.%d",
+                      vaultPath,
+                      userName,
+                      dir1,
+                      dir2,
+                      logicalFileName,
+                      static_cast<unsigned int>(std::time(nullptr)));
+    }
+
     return 0;
 }
 

--- a/server/core/src/physPath.cpp
+++ b/server/core/src/physPath.cpp
@@ -277,6 +277,7 @@ getVaultPathPolicy( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
     status = applyRule( "acSetVaultPathPolicy", NULL, &rei, NO_SAVE_REI );
     clearKeyVal(rei.condInputData);
     free(rei.condInputData);
+    rei.condInputData = nullptr;
     if ( status < 0 ) {
         rodsLog( LOG_ERROR,
                  "getVaultPathPolicy: rule acSetVaultPathPolicy error, status = %d",

--- a/server/re/include/irods/reAction.hpp
+++ b/server/re/include/irods/reAction.hpp
@@ -158,6 +158,7 @@ int msiTakeThreeArgumentsAndDoNothing(msParam_t *arg1, msParam_t *arg2, msParam_
 namespace irods
 {
     // clang-format off
+    // NOLINTBEGIN(cppcoreguidelines-owning-memory)
 
     // =-=-=-=-=-=-=-
     // implementation of the microservice table class, which initializes the table during the ctor
@@ -258,6 +259,8 @@ namespace irods
         table_[ "msiExecCmd" ] = new irods::ms_table_entry( "msiExecCmd", 6, std::function<int(msParam_t*,msParam_t*,msParam_t*,msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiExecCmd ) );
         table_[ "msiSetGraftPathScheme" ] = new irods::ms_table_entry( "msiSetGraftPathScheme", 2, std::function<int(msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiSetGraftPathScheme ) );
         table_[ "msiSetRandomScheme" ] = new irods::ms_table_entry( "msiSetRandomScheme", 0, std::function<int(ruleExecInfo_t*)>( msiSetRandomScheme ) );
+        table_[ "msi_set_random_scheme_style" ] = new irods::ms_table_entry("msi_set_random_scheme_style", 1, std::function<int(msParam_t*, ruleExecInfo_t*)>(msi_set_random_scheme_style));
+        table_[ "msi_set_random_scheme_suffix_length" ] = new irods::ms_table_entry("msi_set_random_scheme_suffix_length", 1, std::function<int(msParam_t*, ruleExecInfo_t*)>(msi_set_random_scheme_suffix_length));
         table_[ "msiCheckHostAccessControl" ] = new irods::ms_table_entry( "msiCheckHostAccessControl", 0, std::function<int(ruleExecInfo_t*)>( msiCheckHostAccessControl ) );
         table_[ "msiGetIcatTime" ] = new irods::ms_table_entry( "msiGetIcatTime", 2, std::function<int(msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiGetIcatTime ) );
         table_[ "msiGetTaggedValueFromString" ] = new irods::ms_table_entry( "msiGetTaggedValueFromString", 3, std::function<int(msParam_t*,msParam_t*,msParam_t*,ruleExecInfo_t*)>( msiGetTaggedValueFromString ) );
@@ -289,6 +292,7 @@ namespace irods
         table_["msi_genquery2_free"] = new irods::ms_table_entry("msi_genquery2_free", 1, std::function<int(msParam_t*, ruleExecInfo_t*)>(msi_genquery2_free));
     }; // ms_table::ms_table
 
+    // NOLINTEND(cppcoreguidelines-owning-memory)
     // clang-format on
 
     // =-=-=-=-=-=-=-

--- a/server/re/include/irods/reSysDataObjOpr.hpp
+++ b/server/re/include/irods/reSysDataObjOpr.hpp
@@ -1,6 +1,8 @@
 #ifndef IRODS_RE_SYS_DATA_OBJ_OPR_HPP
 #define IRODS_RE_SYS_DATA_OBJ_OPR_HPP
 
+/// \file
+
 #include "irods/rods.h"
 #include "irods/objMetaOpr.hpp"
 #include "irods/dataObjRepl.h"
@@ -38,6 +40,54 @@ msiSetGraftPathScheme( msParam_t *xaddUserName, msParam_t *xtrimDirCnt,
                        ruleExecInfo_t *rei );
 int
 msiSetRandomScheme( ruleExecInfo_t *rei );
+
+/// Sets the random scheme style.
+///
+/// This microservice allows administrators to change how physical paths are generated. The effects of
+/// this microservice are not applied unless the vault path policy is set to the random scheme.
+///
+/// This microservice has no effect if invoked outside of acSetVaultPathPolicy() or an error occurs.
+///
+/// Styles:
+/// - 0: Default style, i.e. <vault_root>/<int>/<int>/<filename>.<epoch_seconds>
+/// - 1: Append random characters, i.e. <vault_root>/<int>/<int>/<filename>.<epoch_seconds>.<random_characters>
+///
+/// \param[in] _style \parblock The new style of the randomly-generated string. A value of 1 results
+///                   in 5 randomly generated alphanumeric characters being appended to the physical
+///                   path. Attempting to set the value to anything other than 0 or 1 will result in
+///                   an error. See #msi_set_random_scheme_suffix_length for information about changing
+///                   the length of the generated suffix string.
+///                   \endparblock
+/// \param[in] _rei   A pointer to a #RuleExecInfo object. The execution information. Hidden within
+///                   the iRODS Rule Language.
+///
+/// \returns An integer indicating the status of the operation.
+/// \retval  0 On success.
+/// \retval <0 On failure.
+///
+/// \since 5.1.0
+int msi_set_random_scheme_style(MsParam* _style, ruleExecInfo_t* _rei);
+
+/// Sets the random scheme suffix length.
+///
+/// The effects of this microservice are not applied unless the random scheme style is set to 1.
+/// See #msi_set_random_scheme_style for more information.
+///
+/// This microservice has no effect if invoked outside of acSetVaultPathPolicy() or an error occurs.
+///
+/// \param[in] _suffix_length The new length of the randomly-generated string. The value must
+///                           satisfy the range [1, 32]. Failing to satisfy this requirement will
+///                           result in an error.
+/// \param[in] _rei           A pointer to a #RuleExecInfo object. The execution information. Hidden
+///                           within the iRODS Rule Language.
+///
+/// \returns An integer indicating the status of the operation.
+/// \retval  0 On success.
+/// \retval <0 On failure.
+///
+/// \since 5.1.0
+int msi_set_random_scheme_suffix_length(MsParam* _suffix_length, ruleExecInfo_t* _rei);
+
 int
 msiSetRescQuotaPolicy( msParam_t *xflag, ruleExecInfo_t *rei );
 

--- a/server/re/src/reSysDataObjOpr.cpp
+++ b/server/re/src/reSysDataObjOpr.cpp
@@ -1,21 +1,36 @@
 /// \file
 
-#include "irods/rcMisc.h"
 #include "irods/reSysDataObjOpr.hpp"
+
+#include "irods/apiNumber.h"
+#include "irods/dataObjOpr.hpp"
 #include "irods/genQuery.h"
 #include "irods/getRescQuota.h"
-#include "irods/dataObjOpr.hpp"
-#include "irods/resource.hpp"
-#include "irods/physPath.hpp"
-#include "irods/rsGenQuery.hpp"
-#include "irods/rsModDataObjMeta.hpp"
-#include "irods/rsDataObjRepl.hpp"
-#include "irods/apiNumber.h"
 #include "irods/irodsDelayServer.hpp"
+#include "irods/irods_logger.hpp"
 #include "irods/irods_resource_backport.hpp"
 #include "irods/irods_server_api_table.hpp"
 #include "irods/irods_server_properties.hpp"
-#include "irods/irods_logger.hpp"
+#include "irods/msParam.h"
+#include "irods/msi_preconditions.hpp"
+#include "irods/physPath.hpp"
+#include "irods/rcMisc.h"
+#include "irods/resource.hpp"
+#include "irods/rodsDef.h"
+#include "irods/rodsErrorTable.h"
+#include "irods/rsDataObjRepl.hpp"
+#include "irods/rsGenQuery.hpp"
+#include "irods/rsModDataObjMeta.hpp"
+#include "irods/vault_path_policy.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <initializer_list>
+
+namespace
+{
+    using log_msi = irods::experimental::log::microservice;
+} // anonymous namespace
 
 /**
  * \fn msiSetDefaultResc (msParam_t *xdefaultRescList, msParam_t *xoptionStr, ruleExecInfo_t *rei)
@@ -1111,6 +1126,106 @@ msiSetRandomScheme( ruleExecInfo_t *rei ) {
     }
     return 0;
 }
+
+auto msi_set_random_scheme_style(MsParam* _style, ruleExecInfo_t* _rei) -> int
+{
+    _rei->status = 0;
+
+    if (!_style) {
+        log_msi::error("Invalid argument: Expected valid pointer for [_style] parameter. Received nullptr.");
+        _rei->status = INVALID_INPUT_ARGUMENT_NULL_POINTER;
+        return INVALID_INPUT_ARGUMENT_NULL_POINTER;
+    }
+
+    if (!_style->type) {
+        log_msi::error("Invalid argument: Expected valid pointer for [_style->type] parameter. Received nullptr.");
+        _rei->status = INVALID_INPUT_ARGUMENT_NULL_POINTER;
+        return INVALID_INPUT_ARGUMENT_NULL_POINTER;
+    }
+
+    if (std::strncmp(_style->type, INT_MS_T, std::strlen(INT_MS_T)) != 0) {
+        log_msi::error("Invalid argument: Expected integer for [_style->type] parameter. Received [{}].", _style->type);
+        _rei->status = SYS_INVALID_INPUT_PARAM;
+        return SYS_INVALID_INPUT_PARAM;
+    }
+
+    if (!_style->inOutStruct) {
+        log_msi::error(
+            "Invalid argument: Expected valid pointer for [_style->inOutStruct] parameter. Received nullptr.");
+        _rei->status = INVALID_INPUT_ARGUMENT_NULL_POINTER;
+        return INVALID_INPUT_ARGUMENT_NULL_POINTER;
+    }
+
+    const auto new_style = *static_cast<int*>(_style->inOutStruct);
+    if (new_style < 0 || new_style > 1) {
+        log_msi::error("{}: Invalid style [{}] for vault path scheme. Expected 0 or 1.", __func__, new_style);
+        _rei->status = SYS_INVALID_INPUT_PARAM;
+        return _rei->status;
+    }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-no-malloc)
+    auto* style = static_cast<int*>(std::malloc(sizeof(int)));
+    *style = new_style;
+    addMsParam(&_rei->inOutMsParamArray,
+               irods::vault_path_policy::random_scheme_style,
+               INT_MS_T,
+               static_cast<void*>(style),
+               nullptr);
+
+    return 0;
+} // msi_set_random_scheme_style
+
+auto msi_set_random_scheme_suffix_length(MsParam* _suffix_length, ruleExecInfo_t* _rei) -> int
+{
+    _rei->status = 0;
+
+    if (!_suffix_length) {
+        log_msi::error("Invalid argument: Expected valid pointer for [_suffix_length] parameter. Received nullptr.");
+        _rei->status = INVALID_INPUT_ARGUMENT_NULL_POINTER;
+        return INVALID_INPUT_ARGUMENT_NULL_POINTER;
+    }
+
+    if (!_suffix_length->type) {
+        log_msi::error(
+            "Invalid argument: Expected valid pointer for [_suffix_length->type] parameter. Received nullptr.");
+        _rei->status = INVALID_INPUT_ARGUMENT_NULL_POINTER;
+        return INVALID_INPUT_ARGUMENT_NULL_POINTER;
+    }
+
+    if (std::strncmp(_suffix_length->type, INT_MS_T, std::strlen(INT_MS_T)) != 0) {
+        log_msi::error("Invalid argument: Expected integer for [_suffix_length->type] parameter. Received [{}].",
+                       _suffix_length->type);
+        _rei->status = SYS_INVALID_INPUT_PARAM;
+        return SYS_INVALID_INPUT_PARAM;
+    }
+
+    if (!_suffix_length->inOutStruct) {
+        log_msi::error(
+            "Invalid argument: Expected valid pointer for [_suffix_length->inOutStruct] parameter. Received nullptr.");
+        _rei->status = INVALID_INPUT_ARGUMENT_NULL_POINTER;
+        return INVALID_INPUT_ARGUMENT_NULL_POINTER;
+    }
+
+    const auto new_length = *static_cast<int*>(_suffix_length->inOutStruct);
+    if (new_length < 1 || new_length > 32) {
+        log_msi::error("{}: Invalid suffix length [{}] for vault path scheme. Length must satisfy the range [1, 32].",
+                       __func__,
+                       new_length);
+        _rei->status = SYS_INVALID_INPUT_PARAM;
+        return _rei->status;
+    }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-no-malloc)
+    auto* length = static_cast<int*>(std::malloc(sizeof(int)));
+    *length = new_length;
+    addMsParam(&_rei->inOutMsParamArray,
+               irods::vault_path_policy::random_scheme_suffix_length,
+               INT_MS_T,
+               static_cast<void*>(length),
+               nullptr);
+
+    return 0;
+} // msi_set_random_scheme_suffix_length
 
 /**
  * \fn msiSetRescQuotaPolicy (msParam_t *xflag, ruleExecInfo_t *rei)


### PR DESCRIPTION
All unit and core tests pass.
ASan did not report any memory leaks on creation of physical path.