### PR TITLE
[#8999] rsModDataObjMeta: Format string as timestamp for DATA_CREATE_KW (main)

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -2390,6 +2390,19 @@ irods::error db_mod_data_obj_meta_op(
                 }
             }
 
+            if (regParamNames[i] == DATA_CREATE_KW) {
+                /* if create_ts, also make sure it's in the standard time-stamp format: "%011d" */
+                if (colNames[i] == "create_ts") { /* double check*/
+                    if (strlen(theVal) < 11) {
+                        static char theVal5[20];
+                        time_t myTimeValue;
+                        myTimeValue = atoll(theVal);
+                        snprintf(theVal5, sizeof theVal5, "%011d", (int) myTimeValue);
+                        updateVals[j] = theVal5;
+                    }
+                }
+            }
+
             if(regParamNames[i] == DATA_SIZE_KW) {
                 doingDataSize = 1; /* flag to check size */
                 snprintf( dataSizeString, sizeof( dataSizeString ), "%s", theVal );

--- a/scripts/irods/test/test_iadmin.py
+++ b/scripts/irods/test/test_iadmin.py
@@ -2508,7 +2508,7 @@ class Test_Iadmin_modrepl(resource_suite.ResourceBase, unittest.TestCase):
         dumb_int = 16
         cols = {
             #"COLL_ID" : dumb_int,
-            "DATA_CREATE_TIME" : dumb_string,
+            "DATA_CREATE_TIME" : '00000000038',
             "DATA_CHECKSUM" : dumb_string,
             "DATA_EXPIRY" : '00000000016',
             #"DATA_ID" : dumb_string,

--- a/unit_tests/src/test_rc_mod_data_obj_meta.cpp
+++ b/unit_tests/src/test_rc_mod_data_obj_meta.cpp
@@ -1,12 +1,15 @@
 #include <catch2/catch_all.hpp>
 
+#include "irods_error_enum_matcher.hpp"
+#include "unit_test_utils.hpp"
+
 #include "irods/client_connection.hpp"
 #include "irods/dataObjInpOut.h"
 #include "irods/dstream.hpp"
 #include "irods/filesystem.hpp"
 #include "irods/irods_at_scope_exit.hpp"
-#include "irods_error_enum_matcher.hpp"
 #include "irods/irods_exception.hpp"
+#include "irods/irods_query.hpp"
 #include "irods/objInfo.h"
 #include "irods/rcMisc.h"
 #include "irods/replica.hpp"
@@ -14,7 +17,6 @@
 #include "irods/rodsDef.h"
 #include "irods/rodsErrorTable.h"
 #include "irods/transport/default_transport.hpp"
-#include "unit_test_utils.hpp"
 
 #include <fmt/format.h>
 
@@ -148,3 +150,55 @@ TEST_CASE("using ADMIN_KW with rcModDataObjMeta")
         }
     }
 } // rc_data_obj_repl
+
+TEST_CASE("#8999: rsModDataObjMeta formats string as timestamp for DATA_CREATE_KW")
+{
+    load_client_api_plugins();
+
+    rodsEnv env;
+    _getRodsEnv(env);
+
+    irods::experimental::client_connection conn;
+
+    const auto sandbox = fs::path{env.rodsHome} / "issue_8999";
+    if (!fs::client::exists(conn, sandbox)) {
+        REQUIRE(fs::client::create_collection(conn, sandbox));
+    }
+
+    const auto data_object = sandbox / "data_object";
+
+    const irods::at_scope_exit remove_sandbox{
+        [&conn, &sandbox] { fs::client::remove_all(conn, sandbox, fs::remove_options::no_trash); }};
+
+    // Create a new data object.
+    {
+        irods::experimental::io::client::native_transport tp{conn};
+        irods::experimental::io::odstream{tp, data_object};
+    }
+
+    // Configure the input structures to pass invalid arguments to the server.
+    DataObjInfo info{};
+    std::strncpy(info.objPath, data_object.c_str(), sizeof(DataObjInfo::objPath) - 1);
+
+    // The strings MUST be less than 11 bytes in length for the API to convert
+    // and format them as timestamps.
+    KeyValPair reg_param{};
+    addKeyVal(&reg_param, DATA_CREATE_KW, "bad_ts_0");
+    addKeyVal(&reg_param, DATA_MODIFY_KW, "bad_ts_1");
+    addKeyVal(&reg_param, DATA_ACCESS_TIME_KW, "bad_ts_2");
+
+    ModDataObjMetaInp input{&info, &reg_param};
+    REQUIRE(rcModDataObjMeta(static_cast<RcComm*>(conn), &input) == 0);
+
+    // Show that the server handles create time just like the other time fields.
+    const auto query_str = fmt::format(
+        "select DATA_CREATE_TIME, DATA_MODIFY_TIME, DATA_ACCESS_TIME where COLL_NAME = '{}' and DATA_NAME = '{}'",
+        sandbox.c_str(),
+        data_object.object_name().c_str());
+    constexpr const char* expected_ts = "00000000000";
+    for (auto&& row : irods::query{static_cast<RcComm*>(conn), query_str}) {
+        CHECK(expected_ts == row[0]);
+        CHECK(expected_ts == row[1]);
+        CHECK(expected_ts == row[2]);
+    }
+}


### PR DESCRIPTION
Confirmed the new test passes at the bench.

Will run the unit tests and core tests next.

Will open an issue about the 11 byte limit.