### PR TITLE
[8994] Add primary key to logical quota table (main)

### DIFF
--- a/scripts/irods/database_upgrade.py
+++ b/scripts/irods/database_upgrade.py
@@ -299,7 +299,7 @@ def run_update(irods_config, cursor, is_upgrade):
         bigint_type = bigint_for_db.get(irods_config.catalog_database_type, "bigint")
 
         # Add table for logical quotas
-        database_connect.execute_sql_statement(cursor, f"create table R_LOGICAL_QUOTA_MAIN (coll_id {bigint_type}, max_bytes {bigint_type}, max_objects {bigint_type}, over_bytes {bigint_type}, over_objects {bigint_type}, modify_ts varchar(32));")
+        database_connect.execute_sql_statement(cursor, f"create table R_LOGICAL_QUOTA_MAIN (coll_id {bigint_type} primary key, max_bytes {bigint_type}, max_objects {bigint_type}, over_bytes {bigint_type}, over_objects {bigint_type}, modify_ts varchar(32));")
 
         # Add grid configuration setting for toggling logical quota enforcement
         database_connect.execute_sql_statement(cursor, "insert into R_GRID_CONFIGURATION values ('logical_quotas', 'enabled', '0');")


### PR DESCRIPTION
After doing some research, it looks like adding this should yield some minor performance gains that won't be visible in most cases.

From what I can tell, adding a primary key essentially cuts linear searches on the table down as long as you're searching by the key (or index). This matters when updating an existing logical quota (`UPDATE...WHERE...`) and when deleting logical quotas (`delete...where...`). That seems enough to make this change worth it.

Tested by running the core test `test_logical_quotas` across multiple DBMSes (maria10.11, maria11.4, maria11.8, my8.0, my8.4, pg14, pg16, pg17) and it passes.