### PR TITLE
[#8994] Add primary key to R_USER_CREDENTIALS (main)

### DIFF
--- a/plugins/database/src/icatSysTables.sql.pp.in
+++ b/plugins/database/src/icatSysTables.sql.pp.in
@@ -154,7 +154,7 @@ create table R_TICKET_ALLOWED_GROUPS ( ticket_id INT64TYPE not null, group_name 
 
 create table R_GRID_CONFIGURATION ( namespace varchar(2700), option_name varchar(2700), option_value varchar(2700));
 
-create table R_USER_CREDENTIALS (user_id INT64TYPE, hashed_password varchar(2700), salt varchar(32), hashing_algorithm varchar(250), hashing_parameters varchar(2700), create_time varchar(32), modify_time varchar(32), expiration_time varchar(32));
+create table R_USER_CREDENTIALS (user_id INT64TYPE primary key, hashed_password varchar(2700), salt varchar(32), hashing_algorithm varchar(250), hashing_parameters varchar(2700), create_time varchar(32), modify_time varchar(32), expiration_time varchar(32));
 
 #ifdef mysql
 

--- a/scripts/irods/database_upgrade.py
+++ b/scripts/irods/database_upgrade.py
@@ -254,39 +254,6 @@ def run_update(irods_config, cursor, is_upgrade):
         # pam password reuse setting
         database_connect.execute_sql_statement(cursor, "insert into R_GRID_CONFIGURATION values ('authentication', 'password_reuse_previous', '1');")
 
-        # Add R_USER_CREDENTIALS table.
-        if is_upgrade:
-            if "oracle" == irods_config.catalog_database_type:
-                database_connect.execute_sql_statement(
-                    cursor,
-                    "create table R_USER_CREDENTIALS"
-                        "("
-                            "user_id "           "integer, "
-                            "hashed_password "   "varchar(2700), "
-                            "salt "              "varchar(32), "
-                            "hashing_algorithm " "varchar(250), "
-                            "hashing_parameters ""varchar(2700), "
-                            "create_time "       "varchar(32), "
-                            "modify_time "       "varchar(32), "
-                            "expiration_time "   "varchar(32)"
-                        ");"
-                )
-            else:
-                database_connect.execute_sql_statement(
-                    cursor,
-                    "create table R_USER_CREDENTIALS"
-                        "("
-                            "user_id "           "bigint, "
-                            "hashed_password "   "varchar(2700), "
-                            "salt "              "varchar(32), "
-                            "hashing_algorithm " "varchar(250), "
-                            "hashing_parameters ""varchar(2700), "
-                            "create_time "       "varchar(32), "
-                            "modify_time "       "varchar(32), "
-                            "expiration_time "   "varchar(32)"
-                        ");"
-                )
-
         # password storage mode setting
         database_connect.execute_sql_statement(cursor, "insert into R_GRID_CONFIGURATION values ('authentication', 'password_storage_mode', 'legacy');")
 
@@ -297,6 +264,23 @@ def run_update(irods_config, cursor, is_upgrade):
         }
 
         bigint_type = bigint_for_db.get(irods_config.catalog_database_type, "bigint")
+
+        # Add R_USER_CREDENTIALS table.
+        if is_upgrade:
+            database_connect.execute_sql_statement(
+                cursor,
+                "create table R_USER_CREDENTIALS"
+                    "("
+                        "user_id "           f"{bigint_type} primary key, "
+                        "hashed_password "    "varchar(2700), "
+                        "salt "               "varchar(32), "
+                        "hashing_algorithm "  "varchar(250), "
+                        "hashing_parameters " "varchar(2700), "
+                        "create_time "        "varchar(32), "
+                        "modify_time "        "varchar(32), "
+                        "expiration_time "    "varchar(32)"
+                    ");"
+            )
 
         # Add table for logical quotas
         database_connect.execute_sql_statement(cursor, f"create table R_LOGICAL_QUOTA_MAIN (coll_id {bigint_type} primary key, max_bytes {bigint_type}, max_objects {bigint_type}, over_bytes {bigint_type}, over_objects {bigint_type}, modify_ts varchar(32));")


### PR DESCRIPTION
In service of #8994

See bottom line for primary key (`psql`):
```
ICAT=# \d r_user_credentials
                       Table "public.r_user_credentials"
       Column       |          Type           | Collation | Nullable | Default 
--------------------+-------------------------+-----------+----------+---------
 user_id            | bigint                  |           | not null | 
 hashed_password    | character varying(2700) |           |          | 
 salt               | character varying(32)   |           |          | 
 hashing_algorithm  | character varying(250)  |           |          | 
 hashing_parameters | character varying(2700) |           |          | 
 create_time        | character varying(32)   |           |          | 
 modify_time        | character varying(32)   |           |          | 
 expiration_time    | character varying(32)   |           |          | 
Indexes:
    "r_user_credentials_pkey" PRIMARY KEY, btree (user_id)
```

Running `test_session_keys` and `test_setting_user_password` with the following DBs:
- [x] mariadb-10.11
- [x] mariadb-11.4 
- [x] mariadb-11.8 
- [x] mysql-8.0 
- [x] mysql-8.4 
- [x] postgres-14 
- [x] postgres-16 
- [x] postgres-17

Also need to do an upgrade test.

Will take out of draft when testing completes.