### PR TITLE
[#9016] GenQuery2: Preserve query semantics when generating SQL (main)

### DIFF
--- a/scripts/irods/test/test_iquery.py
+++ b/scripts/irods/test/test_iquery.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import unittest
 
@@ -994,3 +995,66 @@ class Test_IQuery(session.make_sessions_mixin(rodsadmins, rodsusers), unittest.T
 
             finally:
                 self.admin.assert_icommand(['imeta', 'rm', '-u', self.user.username, attr_n, attr_v, attr_u])
+
+    def test_genquery2_preserves_query_semantics_when_generating_sql__issue_9016(self):
+        group = 'issue_9016_group'
+        other_rodsuser = 'issue_9016_bob'
+
+        group_home_collection = f'/{self.user.zone_name}/home/{group}'
+        data_object_1 = f'{group_home_collection}/file1.txt'
+        data_object_2 = f'{group_home_collection}/file2.txt'
+
+        try:
+            # Create a rodsuser.
+            self.admin.assert_icommand(['iadmin', 'mkuser', other_rodsuser, 'rodsuser'])
+
+            # Create a group and add three users to it.
+            self.admin.assert_icommand(['iadmin', 'mkgroup', group])
+            self.admin.assert_icommand(['iadmin', 'atg', group, self.admin.username])
+            self.admin.assert_icommand(['iadmin', 'atg', group, self.user.username])
+            self.admin.assert_icommand(['iadmin', 'atg', group, other_rodsuser])
+
+            # Create a data object and grant one of the rodsusers "own" permissions.
+            self.admin.assert_icommand(['itouch', data_object_1])
+            self.admin.assert_icommand(['ichmod', 'own', self.user.username, data_object_1])
+
+            # Create a second data object and grant the other rodsusers "own" permissions.
+            self.admin.assert_icommand(['itouch', data_object_2])
+            self.admin.assert_icommand(['ichmod', 'own', other_rodsuser, data_object_2])
+
+            # Verify the permissions are in place. This set of assertions are mainly for debugging purposes.
+            group_perm = f'ACL - g:{group}#{self.user.zone_name}:own'
+            self.admin.assert_icommand(['ils', '-Ad', group_home_collection], 'STDOUT', [group_perm])
+
+            admin_perm = f'{self.admin.qualified_username}:own'
+            user_perm = f'{self.user.qualified_username}:own'
+            self.admin.assert_icommand(['ils', '-A', data_object_1], 'STDOUT', [admin_perm, user_perm])
+
+            user_perm = f'{self.user.qualified_username}:own'
+            self.admin.assert_icommand(['ils', '-A', data_object_2], 'STDOUT', [admin_perm, f'{other_rodsuser}#{self.user.zone_name}:own'])
+
+            self.user.assert_icommand(['ils', '-Ad', group_home_collection], 'STDOUT', [group_perm])
+            self.admin.assert_icommand(['ils', '-A', data_object_1], 'STDOUT', [admin_perm, user_perm])
+
+            # Show GenQuery2 returns only the data objects which the invoking user is allowed to access.
+            #
+            # The GenQuery2 parser must wrap client-provided conditions in parentheses to maintain the intent
+            # of the GenQuery2 string. The parentheses guarantee that SQL precedence rules for logical operators
+            # do not change the meaning of the GenQuery2 string. This primarily applies to situations where the
+            # parser decides to insert additional conditions into the generated SQL.
+            _, out, err = self.user.assert_icommand(
+                ['iquery', f"select distinct COLL_NAME, DATA_NAME where COLL_NAME = '{group_home_collection}' or COLL_NAME like '{group_home_collection}/%'"], 'STDOUT')
+            self.assertEqual(out.strip(), json.dumps([[group_home_collection, os.path.basename(data_object_1)]], separators=(',', ':')))
+            self.assertEqual(len(err), 0)
+
+            # Show that changing the order of the conditions does not affect the outcome.
+            _, out, err = self.user.assert_icommand(
+                ['iquery', f"select distinct COLL_NAME, DATA_NAME where COLL_NAME like '{group_home_collection}/%' or COLL_NAME = '{group_home_collection}'"], 'STDOUT')
+            self.assertEqual(out.strip(), json.dumps([[group_home_collection, os.path.basename(data_object_1)]], separators=(',', ':')))
+            self.assertEqual(len(err), 0)
+
+        finally:
+            self.admin.run_icommand(['irm', '-f', data_object_1])
+            self.admin.run_icommand(['irm', '-f', data_object_2])
+            self.admin.run_icommand(['iadmin', 'rmgroup', group])
+            self.admin.run_icommand(['iadmin', 'rmuser', other_rodsuser])

--- a/server/genquery2/src/genquery2_sql.cpp
+++ b/server/genquery2/src/genquery2_sql.cpp
@@ -565,7 +565,11 @@ namespace
             condition_clause_prefix = "where";
         }
         else {
-            sql += fmt::format(" where {}", _conditions);
+            // Wrap the client conditions in parentheses to maintain the intent of the GenQuery2 string.
+            // The parentheses guarantee that SQL precedence rules for logical operators (e.g. SQL-AND)
+            // do not change the meaning of the GenQuery2 string. This primarily applies to situations
+            // where the parser decides to insert additional conditions to enforce permissions.
+            sql += fmt::format(" where ({})", _conditions);
             condition_clause_prefix = "and";
         }
 


### PR DESCRIPTION
Catch2 unit tests and core tests pass.