### PR TITLE
[#7074] Prevent crash on invalid rule input (main)

### DIFF
--- a/plugins/rule_engines/irods_rule_language/src/parser.cpp
+++ b/plugins/rule_engines/irods_rule_language/src/parser.cpp
@@ -255,8 +255,16 @@ Token* nextTokenRuleGen( Pointer* e, ParserContext *context, int rulegen, int pa
                 }
             }
             else if ( pathLiteral && ch == '/' ) { /* path */
-                nextStringBase( e, token->text,MAX_TOKEN_TEXT_LEN, "),; \t\r\n", 0, '\\', 0, token->vars ); /* path can be used in a foreach loop or assignment, or as a function argument */
-                token->type = TK_PATH;
+                // Handle no string found case
+                // path can be used in a foreach loop or assignment, or as a function argument
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                if (-1 == nextStringBase(e, token->text, MAX_TOKEN_TEXT_LEN, "),; \t\r\n", 0, '\\', 0, token->vars)) {
+                    token->type = N_ERROR;
+                }
+                // String has been found, set the appropriate type
+                else {
+                    token->type = TK_PATH;
+                }
                 break;
             }
 

--- a/scripts/irods/test/test_irule.py
+++ b/scripts/irods/test/test_irule.py
@@ -97,3 +97,21 @@ class Test_Irule(ResourceBase, unittest.TestCase):
         _, err, rc = self.admin.run_icommand(['irule', '-r', 'irods_rule_engine_plugin-irods_rule_language-instance', 'msiStrToBytesBuf("potato",*Buf); writeBytesBuf("/bad/path", *Buf);', 'null', 'null'])
         self.assertIn('-310000 USER_FILE_DOES_NOT_EXIST', err)
         self.assertNotEqual(rc, 0)
+
+    @unittest.skipUnless(plugin_name == 'irods_rule_engine_plugin-irods_rule_language', 'only applicable for irods_rule_language REP')
+    def test_irule_does_not_crash_agent_on_bad_input__issue_7074(self):
+        bad_rule = '''
+test_irule_does_not_crash_agent_on_bad_input__issue_7074 {
+    *access = 0;
+    msiCheckAccess("*logical_path", "read_object", *access);
+}
+INPUT *logical_path="/tempZone/home/alan/foo"
+OUTPUT ruleExecOut
+        '''
+        path_to_file = os.path.join(self.user0.local_session_dir, 'issue_7074.r')
+
+        with open(path_to_file, 'w') as f:
+            f.write(bad_rule)
+
+        rc, _, _ = self.user0.assert_icommand(['irule', '-F', path_to_file, '-r', 'irods_rule_engine_plugin-irods_rule_language-instance', os.path.join(self.user0.home_collection, 'thing')], 'STDERR', '-1201000 RE_PARSER_ERROR')
+        self.assertNotEqual(rc, 0)


### PR DESCRIPTION
Issue quick link: #7074

This PR prevents the iRODS agent from crashing by checking the return code from a helper function before assigning a token type.