### PR TITLE
[8975] Guard clauses for argument overflow in icmds (main)

### DIFF
--- a/clients/icommands/src/iadmin.cpp
+++ b/clients/icommands/src/iadmin.cpp
@@ -1140,6 +1140,10 @@ getInput( char *cmdToken[], int maxTokens ) {
     nTokens = 0;
     tokenFlag = 0;
     for ( i = 0; i < lenstr; i++ ) {
+        if (nTokens >= maxTokens) {
+            fprintf(stderr, "Too many command line arguments.\n");
+            return 0;
+        }
         if ( ttybuf[i] == '\n' ) {
             ttybuf[i] = '\0';
             cmdToken[nTokens++] = cpTokenStart;
@@ -1837,6 +1841,12 @@ main( int argc, char **argv ) {
     int i;
     const int maxCmdTokens = 20;
     char *cmdToken[maxCmdTokens];
+
+    if (argc - argOffset > maxCmdTokens) {
+        fprintf(stderr, "Too many command line arguments.\n");
+        return 1;
+    }
+
     for ( i = 0; i < maxCmdTokens; i++ ) {
         cmdToken[i] = "";
     }

--- a/clients/icommands/src/igroupadmin.cpp
+++ b/clients/icommands/src/igroupadmin.cpp
@@ -144,6 +144,10 @@ getInput( char *cmdToken[], int maxTokens ) {
     nTokens = 0;
     tokenFlag = 0;
     for ( i = 0; i < lenstr; i++ ) {
+        if (nTokens >= maxTokens) {
+            fprintf(stderr, "Too many command line arguments.\n");
+            return;
+        }
         if ( ttybuf[i] == '\n' ) {
             ttybuf[i] = '\0';
             cmdToken[nTokens++] = cpTokenStart;
@@ -370,6 +374,11 @@ main( int argc, char **argv ) {
     }
 
     argOffset = myRodsArgs.optind;
+
+    if (argc - argOffset > maxCmdTokens) {
+        fprintf(stderr, "Too many command line arguments.\n");
+        exit(1);
+    }
 
     status = getRodsEnv( &myEnv );
     if ( status < 0 ) {

--- a/clients/icommands/src/isysmeta.cpp
+++ b/clients/icommands/src/isysmeta.cpp
@@ -337,6 +337,11 @@ main( int argc, char **argv ) {
 
     argOffset = myRodsArgs.optind;
 
+    if (argc - argOffset > maxCmdTokens) {
+        fprintf(stderr, "Too many command line arguments.\n");
+        return 1;
+    }
+
     status = getRodsEnv( &myEnv );
     if ( status < 0 ) {
         rodsLog( LOG_ERROR, "main: getRodsEnv error. status = %d",

--- a/clients/icommands/src/iticket.cpp
+++ b/clients/icommands/src/iticket.cpp
@@ -612,6 +612,10 @@ getInput( char *cmdToken[], int maxTokens ) {
     nTokens = 0;
     tokenFlag = 0;
     for ( i = 0; i < lenstr; i++ ) {
+        if (nTokens >= maxTokens) {
+            fprintf(stderr, "Too many command line arguments.\n");
+            return;
+        }
         if ( ttybuf[i] == '\n' ) {
             ttybuf[i] = '\0';
             cmdToken[nTokens++] = cpTokenStart;
@@ -777,6 +781,11 @@ main( int argc, char **argv ) {
     }
 
     argOffset = myRodsArgs.optind;
+
+    if (argc - argOffset > maxCmdTokens) {
+        fprintf(stderr, "Too many command line arguments.\n");
+        return 1;
+    }
     if ( argOffset > 1 ) {
         if ( argOffset > 2 ) {
             if ( *argv[1] == '-' && *( argv[1] + 1 ) == 'z' ) {

--- a/scripts/irods/test/test_iadmin.py
+++ b/scripts/irods/test/test_iadmin.py
@@ -2242,6 +2242,11 @@ class Test_Iadmin(resource_suite.ResourceBase, unittest.TestCase):
         finally:
             self.admin.run_icommand(['iadmin', 'rmzone', good_zone_name])
 
+    def test_iadmin_prints_error_message_on_argument_overflow__issue_8975(self):
+        # 20 arguments is the limit
+        ec, _, _ = self.admin.assert_icommand(['iadmin', *['potato'] * 21], 'STDERR', 'Too many command line arguments.')
+        self.assertNotEqual(ec, 0)
+
 class Test_Iadmin_Resources(resource_suite.ResourceBase, unittest.TestCase):
 
     def setUp(self):

--- a/scripts/irods/test/test_igroupadmin.py
+++ b/scripts/irods/test/test_igroupadmin.py
@@ -50,6 +50,11 @@ class Test_Igroupadmin(resource_suite.ResourceBase, unittest.TestCase):
         finally :
             self.admin.assert_icommand(['iadmin', 'moduser', self.user_sessions[0].username, 'type', 'rodsuser'])
 
+    def test_igroupadmin_prints_error_message_on_argument_overflow__issue_8975(self):
+        # 20 arguments is the limit
+        ec, _, _ = self.admin.assert_icommand(['igroupadmin', *['potato'] * 21], 'STDERR', 'Too many command line arguments.')
+        self.assertNotEqual(ec, 0)
+
 
 class test_making_groups(unittest.TestCase):
     """Test making a group."""

--- a/scripts/irods/test/test_isysmeta.py
+++ b/scripts/irods/test/test_isysmeta.py
@@ -72,3 +72,8 @@ class Test_isysmeta(session.make_sessions_mixin([('otherrods', 'rods')], [('alic
         self.admin.assert_icommand("isysmeta mod testfile.txt +1h", "EMPTY")
         check_relative_expiry(seconds_ahead)
 
+    def test_isysmeta_prints_error_message_on_argument_overflow__issue_8975(self):
+        # 20 arguments is the limit
+        ec, _, _ = self.admin.assert_icommand(['isysmeta', *['potato'] * 21], 'STDERR', 'Too many command line arguments.')
+        self.assertNotEqual(ec, 0)
+

--- a/scripts/irods/test/test_iticket.py
+++ b/scripts/irods/test/test_iticket.py
@@ -1243,6 +1243,12 @@ class Test_Iticket(SessionsMixin, unittest.TestCase):
         finally:
             self.user.run_icommand(['iticket', 'delete', ticket_string])
 
+    def test_iticket_prints_error_message_on_argument_overflow__issue_8975(self):
+        # 20 arguments is the limit
+        ec, _, _ = self.admin.assert_icommand(['iticket', *['potato'] * 21], 'STDERR', 'Too many command line arguments.')
+        self.assertNotEqual(ec, 0)
+
+
 def get_modification_and_creation_time(cls, ticket_string):
     out, err, ec = cls.admin.run_icommand(['iquest', '%s...%s', "select TICKET_MODIFY_TIME, TICKET_CREATE_TIME where TICKET_STRING = '{}'".format(ticket_string)])
     cls.assertEqual(ec, 0)


### PR DESCRIPTION
Individual tests pass, but full suite hasn't been run yet.
Not entirely sure about the approach here, so taking comments. I did consider some other approaches such as just printing usage when overflowing, but I was worried that wasn't clear enough what the issue was in case a user organically ran into this.