### PR TITLE
[#8933] Prevent `ils` core dump on directory permission issues (main)

### DIFF
--- a/lib/core/src/irods_environment_properties.cpp
+++ b/lib/core/src/irods_environment_properties.cpp
@@ -13,7 +13,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/filesystem.hpp>
-
+#include <boost/system/detail/error_code.hpp>
 
 namespace irods {
     error get_json_environment_file(
@@ -86,8 +86,12 @@ namespace irods {
             return;
         }
 
-        if (!boost::filesystem::exists(json_file)) {
-            rodsLog(LOG_ERROR, "environment_properties::capture: missing environment file. should be at [%s]", json_file.c_str());
+        boost::system::error_code ec{};
+        if (!boost::filesystem::exists(json_file, ec)) {
+            rodsLog(LOG_ERROR,
+                    "environment_properties::capture: %s. Expected file at [%s].",
+                    ec.message().c_str(),
+                    json_file.c_str());
             return;
         }
 

--- a/scripts/irods/test/test_ils.py
+++ b/scripts/irods/test/test_ils.py
@@ -1,5 +1,7 @@
 import copy
 import os
+import pathlib
+import stat
 import unittest
 
 from . import session
@@ -32,6 +34,18 @@ class Test_Ils(resource_suite.ResourceBase, unittest.TestCase):
         self.admin.assert_icommand(['ils', '-l', rods_filename_1, rods_filename_2], 'STDOUT_MULTILINE', filename_1, filename_2)
         os.system('rm -f ' + filename_1)
         os.system('rm -f ' + filename_2)
+
+    def test_ils_does_not_core_dump_on_bad_file_permissions__issue_8933(self):
+        # Save original permissions
+        parent_dir = str(pathlib.Path(self.user0._environment_file_path).parent)
+
+        dir_stats = os.stat(parent_dir)
+        try:
+            os.chmod(parent_dir, 0o007)
+            self.user0.assert_icommand(['ils'], 'STDERR_SINGLELINE', 'environment_properties::capture: Permission denied.')
+        finally:
+            # Restore file permissions
+            os.chmod(parent_dir, stat.S_IMODE(dir_stats.st_mode))
 
     def test_genquery_fallback_for_collection_permissions__issue_4636(self):
         # Remove the specific query. This will cause the fallback to be used.

--- a/scripts/irods/test/test_misc.py
+++ b/scripts/irods/test/test_misc.py
@@ -363,9 +363,8 @@ class Test_Misc(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 
             self.assertIn('Enter your current iRODS password', stdout)
 
             # Check expected error exists
-            error_string = ' ERROR: environment_properties::capture: missing environment file. should be at [{}/.irods/irods_environment.json]\n'.format(
-                temp_home)
-            self.assertEqual(stderr, error_string)
+            error_string = 'Expected file at [{}/.irods/irods_environment.json].'.format(temp_home)
+            self.assertIn(error_string, stderr)
 
 
     def test_tcp_keepalive_time__issue_2533_3824(self):


### PR DESCRIPTION
Issue quick link: #8933

This PR fixes a core dump by updating the `boost::filesystem::exists(...)` function call to use a non-throwing version.