### PR TITLE
[9034] Fix bug in logical quotas calculation (main)

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -16603,11 +16603,12 @@ irods::error db_calc_logical_usage_and_quota_op(irods::plugin_context& _ctx, [[m
     }
 
     getNowStr(myTime);
-    cllBindVars[cllBindVarCount++] = myTime;
 
     // clang-format off
-    status = cmlExecuteNoAnswerSql(
 #ifdef MY_ICAT
+    cllBindVars[cllBindVarCount++] = PATH_SEPARATOR;
+    cllBindVars[cllBindVarCount++] = myTime;
+    status = cmlExecuteNoAnswerSql(
         // Update logical quota table
         "UPDATE R_LOGICAL_QUOTA_MAIN "
         // using values from:
@@ -16643,7 +16644,8 @@ irods::error db_calc_logical_usage_and_quota_op(irods::plugin_context& _ctx, [[m
                    "R_COLL_MAIN RCM1, "
                    "R_COLL_MAIN RCM2 "
               "WHERE R_DATA_MAIN.coll_id = RCM2.coll_id "
-                "AND RCM2.coll_name LIKE CONCAT(RCM1.coll_name, '%')) ranked_objs "
+                "AND (RCM2.coll_name LIKE CONCAT(RCM1.coll_name, ?, '%') "
+                     "OR RCM2.coll_name = RCM1.coll_name)) ranked_objs "
            // Only count one data object that is top-ranked.
            "WHERE ranked_objs.replica_rank = 1 "
            "GROUP BY basecoll) AS totals ON totals.basecoll = R_LOGICAL_QUOTA_MAIN.coll_id "
@@ -16654,6 +16656,9 @@ irods::error db_calc_logical_usage_and_quota_op(irods::plugin_context& _ctx, [[m
             "over_objects = SIGN(max_objects)*SIGN(max_objects)*(COALESCE(obj_total, 0) - max_objects), "
             "modify_ts = ?",
 #else
+    cllBindVars[cllBindVarCount++] = myTime;
+    cllBindVars[cllBindVarCount++] = PATH_SEPARATOR;
+    status = cmlExecuteNoAnswerSql(
         "UPDATE R_LOGICAL_QUOTA_MAIN "
         "SET (over_bytes, "
              "over_objects, "
@@ -16681,7 +16686,8 @@ irods::error db_calc_logical_usage_and_quota_op(irods::plugin_context& _ctx, [[m
                    "R_COLL_MAIN RCM2 "
               "WHERE R_DATA_MAIN.coll_id = RCM2.coll_id "
                 "AND RCM1.coll_id = R_LOGICAL_QUOTA_MAIN.coll_id "
-                "AND RCM2.coll_name LIKE RCM1.coll_name || '%') AS ranked_objs "
+                "AND (RCM2.coll_name LIKE (RCM1.coll_name || ? || '%') "
+                     "OR RCM2.coll_name = RCM1.coll_name)) AS ranked_objs "
            "WHERE ranked_objs.replica_rank = 1)",
 #endif
      &icss);

--- a/scripts/irods/test/test_logical_quotas.py
+++ b/scripts/irods/test/test_logical_quotas.py
@@ -4207,3 +4207,86 @@ class Test_Logical_Quotas(
             )
 
             self.admin.assert_icommand(["iadmin", "rmzone", zone_name])
+
+    def test_logical_quotas_do_not_count_similarly_prefixed_collections__issue_9034(self):
+        file_name = "test_logical_quota_similar_name"
+        file_path = os.path.join(self.quota_user.local_session_dir, file_name)
+        subcoll_path = f"{self.quota_user.session_collection}/subcoll"
+        uncounted_subcoll_path = f"{self.quota_user.session_collection}/subcollsimilar"
+        file_size = 4096
+        max_bytes = 10000
+        lib.make_file(
+            file_path,
+            file_size,
+            contents="arbitrary",
+        )
+        try:
+            self.quota_user.assert_icommand(["imkdir", subcoll_path])
+            self.quota_user.assert_icommand(["imkdir", uncounted_subcoll_path])
+
+            self.admin.assert_icommand(
+                [
+                    "iadmin",
+                    "set_logical_quota",
+                    subcoll_path,
+                    "bytes",
+                    str(max_bytes),
+                ]
+            )
+            _, out, _ = self.admin.assert_icommand(
+                ["iadmin", "list_logical_quotas"], "STDOUT_SINGLELINE", subcoll_path
+            )
+
+            self.assertTrue(
+                (
+                    self.llq_output_template
+                    % (
+                        subcoll_path,
+                        str(max_bytes),
+                        "<unset>",
+                        str(-max_bytes),
+                        "<unenforced>",
+                    )
+                )
+                in out
+            )
+
+            self.quota_user.assert_icommand(
+                [
+                    "iput",
+                    file_path,
+                    f"{uncounted_subcoll_path}/{file_name}",
+                ]
+            )
+
+            self.admin.assert_icommand(["iadmin", "calculate_logical_usage"])
+
+            _, out, _ = self.admin.assert_icommand(
+                ["iadmin", "list_logical_quotas"], "STDOUT_SINGLELINE", subcoll_path
+            )
+
+            # Should remain unchanged.
+            self.assertTrue(
+                (
+                    self.llq_output_template
+                    % (
+                        subcoll_path,
+                        str(max_bytes),
+                        "<unset>",
+                        str(-max_bytes),
+                        "<unenforced>",
+                    )
+                )
+                in out
+            )
+
+        finally:
+            self.admin.run_icommand(
+                [
+                    "iadmin",
+                    "set_logical_quota",
+                    subcoll_path,
+                    "0",
+                    "0",
+                ]
+            )


### PR DESCRIPTION
Had worked on this for so long, but didn't realize this was an issue until now...oops.
`test_logical_quotas` passes on all our tested DBMSes.
Furthermore, the test has been demonstrated to capture the issue: it fails without the `cpp` changes, and passes with.

Since this system is so new and basically doesn't interact with anything, this is a pretty good indicator that these changes are OK. I can, however, run the full suite just to make sure nothing was overlooked.

Taking comments.