### PR TITLE
[9039] Add a new style (2) without filename to msiSetRandomScheme.

### DIFF
--- a/packaging/core.re.template
+++ b/packaging/core.re.template
@@ -304,10 +304,11 @@ acSetChkFilePathPerm {msiSetChkFilePathPerm("disallowPathReg"); }
 #      Styles:
 #        - 0: Default style, i.e. <vault_root>/<int>/<int>/<filename>.<epoch_seconds>
 #        - 1: Append random characters, i.e. <vault_root>/<int>/<int>/<filename>.<epoch_seconds>.<random_characters>
+#        - 2: Append random characters without filename, i.e. <vault_root>/<int>/<int>/<epoch_seconds>.<random_characters>
 #
-#      A style of 1 results in 5 randomly generated alphanumeric characters
+#      A style of 1 or 2 results in 5 randomly generated alphanumeric characters
 #      being appended to the physical path. Attempting to set the value to anything
-#      other than 0 or 1 will result in an error.
+#      other than 0, 1, or 2 will result in an error.
 #
 #      See msi_set_random_scheme_suffix_length() for information about changing
 #      the length of the generated suffix string.
@@ -316,7 +317,7 @@ acSetChkFilePathPerm {msiSetChkFilePathPerm("disallowPathReg"); }
 #      length.
 #
 #      The effects of this microservice are not applied unless the random scheme
-#      style is set to 1.
+#      style is set to 1 or 2.
 #
 #      This microservice has no effect if invoked outside of acSetVaultPathPolicy()
 #      or an error occurs.

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -1892,9 +1892,11 @@ OUTPUT ruleExecOut
         for suffix_length in [1, 3, 12, 32]:
             with self.subTest(f'good suffix length: [{suffix_length}]'):
                 do_test(1, [fr'.+/\d+/\d+/.+[.].{{10,}}[.].{{{suffix_length}}}$'], suffix_length)
+                # Style 2: like style 1 but filename removed.
+                do_test(2, [fr'.+/\d+/\d+/\d+[.].{{{suffix_length}}}$'], suffix_length)
 
         # Show that an invalid style results in an error.
-        for style in [-1, 2]:
+        for style in [-1, 3]:
             with self.subTest(f'invalid style: [{style}]'):
                 do_test(style, ['-130000 SYS_INVALID_INPUT_PARAM'], expect_error=True)
 

--- a/server/core/src/physPath.cpp
+++ b/server/core/src/physPath.cpp
@@ -388,6 +388,19 @@ setPathForRandomScheme( char *objPath, const char *vaultPath, char *userName,
                       static_cast<unsigned int>(std::time(nullptr)),
                       rnd_str.c_str());
     }
+    else if (detail::random_scheme_style == 2) {
+        const auto rnd_str =
+            irods::generate_random_alphanumeric_string(static_cast<std::int16_t>(detail::random_scheme_suffix_length));
+        std::snprintf(outPath,
+                      MAX_NAME_LEN,
+                      "%s/%s/%d/%d/%d.%s",
+                      vaultPath,
+                      userName,
+                      dir1,
+                      dir2,
+                      static_cast<unsigned int>(std::time(nullptr)),
+                      rnd_str.c_str());
+    }
     else {
         std::snprintf(outPath,
                       MAX_NAME_LEN,

--- a/server/re/include/irods/reSysDataObjOpr.hpp
+++ b/server/re/include/irods/reSysDataObjOpr.hpp
@@ -51,10 +51,11 @@ msiSetRandomScheme( ruleExecInfo_t *rei );
 /// Styles:
 /// - 0: Default style, i.e. <vault_root>/<int>/<int>/<filename>.<epoch_seconds>
 /// - 1: Append random characters, i.e. <vault_root>/<int>/<int>/<filename>.<epoch_seconds>.<random_characters>
+/// - 2: Append random characters without filename, i.e. <vault_root>/<int>/<int>/<epoch_seconds>.<random_characters>
 ///
-/// \param[in] _style \parblock The new style of the randomly-generated string. A value of 1 results
+/// \param[in] _style \parblock The new style of the randomly-generated string. A value of 1 or 2 results
 ///                   in 5 randomly generated alphanumeric characters being appended to the physical
-///                   path. Attempting to set the value to anything other than 0 or 1 will result in
+///                   path. Attempting to set the value to anything other than 0, 1, or 2 will result in
 ///                   an error. See #msi_random_scheme_set_suffix_length for information about changing
 ///                   the length of the generated suffix string.
 ///                   \endparblock
@@ -70,7 +71,7 @@ int msi_random_scheme_set_style(MsParam* _style, ruleExecInfo_t* _rei);
 
 /// Sets the random scheme suffix length.
 ///
-/// The effects of this microservice are not applied unless the random scheme style is set to 1.
+/// The effects of this microservice are not applied unless the random scheme style is set to 1 or 2.
 /// See #msi_random_scheme_set_style for more information.
 ///
 /// This microservice has no effect if invoked outside of acSetVaultPathPolicy() or an error occurs.

--- a/server/re/src/reSysDataObjOpr.cpp
+++ b/server/re/src/reSysDataObjOpr.cpp
@@ -1157,8 +1157,8 @@ auto msi_random_scheme_set_style(MsParam* _style, ruleExecInfo_t* _rei) -> int
     }
 
     const auto new_style = *static_cast<int*>(_style->inOutStruct);
-    if (new_style < 0 || new_style > 1) {
-        log_msi::error("{}: Invalid style [{}] for vault path scheme. Expected 0 or 1.", __func__, new_style);
+    if (new_style < 0 || new_style > 2) {
+        log_msi::error("{}: Invalid style [{}] for vault path scheme. Expected 0, 1, or 2.", __func__, new_style);
         _rei->status = SYS_INVALID_INPUT_PARAM;
         return _rei->status;
     }


### PR DESCRIPTION
It generates a physical path of the form:
<vault_root>/<int>/<int>/<epoch_seconds>.<random_characters>

Inspired by style 1, only remove the filename.

This increases abstraction between the logical and physical layers by completely removing the original filename from the physical path.