### PR TITLE
[#8974] Update `logPsgError(...)` to log errors in readable text (main)

### DIFF
--- a/plugins/database/src/low_level_odbc.cpp
+++ b/plugins/database/src/low_level_odbc.cpp
@@ -146,7 +146,8 @@ logPsgError( HENV henv, HDBC hdbc, HSTMT hstmt, int dbType ) {
                 errorVal = CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME;
             }
         }
-        log_sql::info("{}: SQLState: {}; SQLCODE: {}; SQL Error message: {}", __func__, sqlstate, sqlcode, psgErrorMsg);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        log_sql::info("{}: SQLState: {}; SQLCODE: {}; SQL Error message: {}", __func__, sqlstate, sqlcode, reinterpret_cast<char*>(psgErrorMsg));
     }
     return errorVal;
 }


### PR DESCRIPTION
Issue quick link: #8974

This PR allows for the SQL error message to be printed in readable text instead of being a literal `unsigned char` array dump.

---

The fix was manually tested by changing the following query to have a typo (`limiter` instead of `limit`): https://github.com/irods/irods/blob/94877a2eac9c66ae3da4bde89d6fc28109124f36/plugins/database/src/db_plugin.cpp#L13865-L13873

The SQL error reported in `log_message` now has readable text:
```json
{
  "log_category": "sql",
  "log_level": "info",
  "log_message": "logPsgError: SQLState: [52, 50, 54, 48, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]; SQLCODE: 1; SQL Error message: ERROR: syntax error at or near \"limiter\";\nError while executing the query",
  "request_api_name": "GENERAL_ADMIN_AN",
  "request_api_number": 701,
  "request_api_version": "d",
  "request_client_user": "otherrods",
  "request_host": "172.20.0.3",
  "request_proxy_user": "otherrods",
  "request_release_version": "rods5.0.90",
  "server_host": "6781cc447052",
  "server_pid": 1295164,
  "server_timestamp": "2026-08-06T19:13:43.204Z",
  "server_type": "agent",
  "server_zone": "tempZone"
}
```