### PR TITLE
[9050] Fix overcounting bug with LIKE wildcards in coll names (main)

### DIFF
--- a/plugins/database/src/db_plugin.cpp
+++ b/plugins/database/src/db_plugin.cpp
@@ -16644,7 +16644,9 @@ irods::error db_calc_logical_usage_and_quota_op(irods::plugin_context& _ctx, [[m
                    "R_COLL_MAIN RCM1, "
                    "R_COLL_MAIN RCM2 "
               "WHERE R_DATA_MAIN.coll_id = RCM2.coll_id "
-                "AND (RCM2.coll_name LIKE CONCAT(RCM1.coll_name, ?, '%') "
+                // Escape all LIKE wildcards from the coll name by replacing them out.
+                // MySQL only: backslashes are escape characters by default, so they need to be doubled.
+                "AND (RCM2.coll_name LIKE CONCAT(REPLACE(REPLACE(REPLACE(RCM1.coll_name, '\\\\', '\\\\\\\\'), '%', '\\\\%'), '_', '\\\\_'), ?, '%') ESCAPE '\\\\' "
                      "OR RCM2.coll_name = RCM1.coll_name)) ranked_objs "
            // Only count one data object that is top-ranked.
            "WHERE ranked_objs.replica_rank = 1 "
@@ -16686,7 +16688,7 @@ irods::error db_calc_logical_usage_and_quota_op(irods::plugin_context& _ctx, [[m
                    "R_COLL_MAIN RCM2 "
               "WHERE R_DATA_MAIN.coll_id = RCM2.coll_id "
                 "AND RCM1.coll_id = R_LOGICAL_QUOTA_MAIN.coll_id "
-                "AND (RCM2.coll_name LIKE (RCM1.coll_name || ? || '%') "
+                "AND (RCM2.coll_name LIKE (REPLACE(REPLACE(REPLACE(RCM1.coll_name, '\\', '\\\\'), '%', '\\%'), '_', '\\_') || ? || '%') ESCAPE '\\' "
                      "OR RCM2.coll_name = RCM1.coll_name)) AS ranked_objs "
            "WHERE ranked_objs.replica_rank = 1)",
 #endif

--- a/scripts/irods/test/test_logical_quotas.py
+++ b/scripts/irods/test/test_logical_quotas.py
@@ -4290,3 +4290,171 @@ class Test_Logical_Quotas(
                     "0",
                 ]
             )
+
+
+    def test_logical_quotas_do_not_overcount_collections_with_like_wildcards__issue_9050(self):
+        file_name = "test_logical_quota_like_wildcards"
+        file_path = os.path.join(self.quota_user.local_session_dir, file_name)
+
+        # The failure that this test guards against is as follows:
+        # With a quota set on .../%potato, logical quotas will count data objects
+        # whose collection path matches .../%potato/%
+        # This means a data object like .../badpotato/obj will not be counted, but
+        # .../badpotato/inner/obj will be, since obj's enclosing collection name
+        # matches the pattern. (.../badpotato/inner matches .../%potato/%)
+        subcoll_path = f"{self.quota_user.session_collection}/%potato"
+        other_subcoll_path = f"{self.quota_user.session_collection}/_tomato"
+        uncounted_subcoll_path = f"{self.quota_user.session_collection}/badpotato"
+        other_uncounted_subcoll_path = f"{self.quota_user.session_collection}/btomato"
+
+        deep_subcoll = f"inner"
+
+        file_size = 4096
+        max_bytes = 10000
+        max_objects = 10000
+        lib.make_file(
+            file_path,
+            file_size,
+            contents="arbitrary",
+        )
+        try:
+            self.quota_user.assert_icommand(["imkdir", subcoll_path])
+            self.quota_user.assert_icommand(["imkdir", other_subcoll_path])
+            self.quota_user.assert_icommand(["imkdir", uncounted_subcoll_path])
+            self.quota_user.assert_icommand(["imkdir", other_uncounted_subcoll_path])
+
+            self.quota_user.assert_icommand(["imkdir", f"{other_uncounted_subcoll_path}/{deep_subcoll}"])
+            self.quota_user.assert_icommand(["imkdir", f"{uncounted_subcoll_path}/{deep_subcoll}"])
+
+            self.admin.assert_icommand(
+                [
+                    "iadmin",
+                    "set_logical_quota",
+                    subcoll_path,
+                    str(max_bytes),
+                    str(max_objects),
+                ]
+            )
+            _, out, _ = self.admin.assert_icommand(
+                ["iadmin", "list_logical_quotas"], "STDOUT_SINGLELINE", subcoll_path
+            )
+
+            self.assertTrue(
+                (
+                    self.llq_output_template
+                    % (
+                        subcoll_path,
+                        str(max_bytes),
+                        str(max_objects),
+                        str(-max_bytes),
+                        str(-max_objects),
+                    )
+                )
+                in out
+            )
+
+            self.admin.assert_icommand(
+                [
+                    "iadmin",
+                    "set_logical_quota",
+                    other_subcoll_path,
+                    str(max_bytes),
+                    str(max_objects),
+                ]
+            )
+            _, out, _ = self.admin.assert_icommand(
+                ["iadmin", "list_logical_quotas"], "STDOUT_SINGLELINE", subcoll_path
+            )
+
+            self.assertTrue(
+                (
+                    self.llq_output_template
+                    % (
+                        other_subcoll_path,
+                        str(max_bytes),
+                        str(max_objects),
+                        str(-max_bytes),
+                        str(-max_objects),
+                    )
+                )
+                in out
+            )
+
+            self.quota_user.assert_icommand(
+                [
+                    "iput",
+                    file_path,
+                    f"{uncounted_subcoll_path}/{deep_subcoll}/{file_name}",
+                ]
+            )
+
+            self.admin.assert_icommand(["iadmin", "calculate_logical_usage"])
+
+            _, out, _ = self.admin.assert_icommand(
+                ["iadmin", "list_logical_quotas"], "STDOUT_SINGLELINE", subcoll_path
+            )
+
+            # Should remain unchanged.
+            self.assertTrue(
+                (
+                    self.llq_output_template
+                    % (
+                        subcoll_path,
+                        str(max_bytes),
+                        str(max_objects),
+                        str(-max_bytes),
+                        str(-max_objects),
+                    )
+                )
+                in out
+            )
+
+            self.quota_user.assert_icommand(
+                [
+                    "iput",
+                    file_path,
+                    f"{other_uncounted_subcoll_path}/{deep_subcoll}/{file_name}",
+                ]
+            )
+
+            self.admin.assert_icommand(["iadmin", "calculate_logical_usage"])
+
+            _, out, _ = self.admin.assert_icommand(
+                ["iadmin", "list_logical_quotas"], "STDOUT_SINGLELINE", other_subcoll_path
+            )
+
+            # Should remain unchanged.
+            self.assertTrue(
+                (
+                    self.llq_output_template
+                    % (
+                        other_subcoll_path,
+                        str(max_bytes),
+                        str(max_objects),
+                        str(-max_bytes),
+                        str(-max_objects),
+                    )
+                )
+                in out
+            )
+
+        finally:
+            self.admin.run_icommand(
+                [
+                    "iadmin",
+                    "set_logical_quota",
+                    subcoll_path,
+                    "0",
+                    "0",
+                ]
+            )
+
+            self.admin.run_icommand(
+                [
+                    "iadmin",
+                    "set_logical_quota",
+                    other_subcoll_path,
+                    "0",
+                    "0",
+                ]
+            )


### PR DESCRIPTION
Seems to work as intended.

Ran the new test in a before/after style against one DBMS. As expected, it failed before and succeeded after.

Ran `test_logical_quotas` for all DBMSes we test against, and all pass.

Taking comments.