### PR TITLE
9062.m move physical path construction policy to a per-resource configuration (main)

### DIFF
--- a/doxygen/microservices.cpp
+++ b/doxygen/microservices.cpp
@@ -155,10 +155,10 @@
   - #msiSetNoDirectRescInp - Sets a list of resources that cannot be used by a normal user directly
   - #msiSetDataObjPreferredResc - Specifies the preferred copy to use, if the data has multiple copies
   - #msiSetDataObjAvoidResc - Specifies the copy to avoid
-  - #msiSetGraftPathScheme - Sets the scheme for composing the physical path in the vault to GRAFT_PATH
-  - #msiSetRandomScheme - Sets the scheme for composing the physical path in the vault to RANDOM
-  - #msi_random_scheme_set_style - Sets the style used when composing a randomly-generated physical path in the vault
-  - #msi_random_scheme_set_suffix_length - Sets the length of the suffix style used when composing a randomly-generated physical path in the vault
+  - #msiSetGraftPathScheme - Compatibility no-op. Use the file_naming_policy resource context key.
+  - #msiSetRandomScheme - Compatibility no-op. Use the file_naming_policy resource context key.
+  - #msi_random_scheme_set_style - Compatibility no-op. Use the random_scheme_style resource context key.
+  - #msi_random_scheme_set_suffix_length - Compatibility no-op. Use the random_scheme_suffix_length resource context key.
   - #msiSetNumThreads - specify the parameters for determining the number of threads to use for data transfer
   - #msiNoChkFilePathPerm - Does not check file path permission when registering a file
   - #msiSetChkFilePathPerm - Sets the check type for file path permission check when registering a file

--- a/file_naming_policy1.md
+++ b/file_naming_policy1.md
@@ -1,0 +1,259 @@
+# Per-Resource File Naming Policy Plan
+
+## Goal
+
+iRODS currently uses a server-wide vault path policy, normally configured via
+`acSetVaultPathPolicy`, to decide whether physical paths should follow the
+logical namespace or use a random naming scheme. This should become a
+per-resource setting so different storage resources can make independent
+decisions.
+
+The new policy is stored in each resource's context string using the key
+`file_naming_policy`.
+
+## Decisions
+
+- This is a hard cutover from `acSetVaultPathPolicy` for physical path naming.
+- If `file_naming_policy` is absent, use the shipped default behavior:
+  `consistent`.
+- Initial supported policy values are `consistent` and `random`.
+- Policy values are case-sensitive to make debugging easier.
+- Unknown policy values must log a warning and behave as `consistent`.
+- Duplicate context keys must log a warning explaining the values found and the
+  value being used.
+- Duplicate-key resolution should follow current effective behavior: the last
+  value wins.
+- Random naming options should keep the existing key names:
+  `random_scheme_style` and `random_scheme_suffix_length`.
+- Invalid random style or suffix values should log warnings and use defaults.
+- The policy must be read from the leaf resource where the replica is stored,
+  not from coordinating resources such as replication or passthru resources.
+- Upgrade/migration logic is intentionally left for a later change.
+
+## Rationale
+
+Logical paths and physical storage paths are separated in the catalog, but the
+default consistent layout keeps them in sync. Logical moves can therefore result
+in physical renames through the resource plugin. That is expensive for recursive
+collection moves.
+
+Random naming avoids the need to keep physical paths in sync with logical paths.
+Because storage resources can have different operational requirements, this
+choice should be made per resource instead of per server.
+
+The runtime implementation should be separated from upgrade behavior. Upgrade
+may later inspect the old `acSetVaultPathPolicy` intent and set
+`file_naming_policy` on each resource. That work touches migration and persisted
+administrator intent, so it should be handled independently from the runtime
+cutover.
+
+## Runtime Semantics
+
+### `consistent`
+
+- New writes use the existing consistent/graft-style physical path layout.
+- Logical data object moves physically rename replicas to keep physical paths in
+  sync.
+- Recursive collection moves continue to call physical rename for replicas on
+  consistent-policy leaf resources.
+
+### `random`
+
+- New writes use the existing random physical path layout.
+- `random_scheme_style` and `random_scheme_suffix_length` affect only new writes
+  into that resource.
+- Logical data object moves do not physically rename replicas.
+- Recursive collection moves skip physical rename for replicas on random-policy
+  leaf resources.
+
+### Existing Replicas
+
+Changing a resource's `file_naming_policy` does not rewrite existing physical
+paths. The setting affects future writes and future move/sync behavior only.
+
+For example, if an administrator changes a resource from `consistent` to
+`random`, existing consistent-looking physical paths remain as-is and will no
+longer be physically renamed on later logical moves.
+
+## Implementation Notes
+
+The main implementation area is `server/core/src/physPath.cpp`.
+
+Relevant existing behavior:
+
+- `getFilePathName()` currently calls `getVaultPathPolicy()` and chooses between
+  `setPathForGraftPathScheme()` and `setPathForRandomScheme()`.
+- `syncDataObjPhyPathS()` currently calls `getVaultPathPolicy()` and returns
+  early when the scheme is not `GRAFT_PATH_S`.
+- `syncCollPhyPath()` calls `syncDataObjPhyPathS()` for each replica found under
+  the moved collection, so the leaf-resource decision in `syncDataObjPhyPathS()`
+  is the important recursive-move optimization point.
+- `physPath.cpp` currently stores random scheme style and suffix length in
+  mutable process-global variables. Those should be removed.
+
+Suggested implementation steps:
+
+1. Add constants and enum-like helpers in or near
+   `server/core/include/irods/vault_path_policy.hpp`.
+
+   Suggested constants:
+
+   - `file_naming_policy`
+   - `file_naming_policy_consistent`
+   - `file_naming_policy_random`
+   - existing `random_scheme_style`
+   - existing `random_scheme_suffix_length`
+
+2. Add a small internal policy model in `physPath.cpp`.
+
+   Example shape:
+
+   ```cpp
+   enum class file_naming_policy
+   {
+       consistent,
+       random
+   };
+
+   struct file_naming_policy_config
+   {
+       file_naming_policy policy = file_naming_policy::consistent;
+       int random_scheme_style = irods::vault_path_policy::random_scheme_config_default_style;
+       int random_scheme_suffix_length = irods::vault_path_policy::random_scheme_config_default_suffix_length;
+   };
+   ```
+
+3. Add defensive resource-context parsing.
+
+   Requirements:
+
+   - Resolve context from the leaf resource, preferably via
+     `irods::get_resource_property<std::string>(rescId, irods::RESOURCE_CONTEXT,
+     context)`.
+   - Tolerate malformed/non-`key=value` tokens because existing context strings
+     can contain legacy/freeform values.
+   - Detect duplicate keys for the policy-related keys and log a warning showing
+     all values and the value used.
+   - Use last value wins.
+   - Do not make malformed unrelated tokens fatal.
+   - Log warnings for invalid policy, invalid style, invalid suffix length, and
+     malformed numeric values.
+
+4. Replace `getVaultPathPolicy()` usage in `getFilePathName()`.
+
+   Current logic should become policy driven:
+
+   - `consistent` calls existing `setPathForGraftPathScheme()` with the current
+     shipped defaults equivalent to `msiSetGraftPathScheme("no", "1")`.
+   - `random` calls `setPathForRandomScheme()` using the per-resource style and
+     suffix length.
+
+   The existing `getVaultPathPolicy()` function can remain for ABI/source
+   compatibility, but it should no longer control physical path generation.
+
+5. Replace `getVaultPathPolicy()` usage in `syncDataObjPhyPathS()`.
+
+   The sync decision should become:
+
+   - If policy is `consistent`, continue current sync behavior.
+   - If policy is anything else, return early before `getFilePathName()` and
+     before any `rsFileRename()` call.
+
+6. Remove mutable process-global random naming state.
+
+   `random_scheme_style` and `random_scheme_suffix_length` should be passed into
+   random path generation explicitly, most likely by changing
+   `setPathForRandomScheme()` or by adding a small wrapper.
+
+7. Preserve old symbols initially.
+
+   Leave `msiSetRandomScheme`, `msiSetGraftPathScheme`, random-scheme
+   microservices, and `getVaultPathPolicy()` in place for now. Existing rules may
+   still reference them, but they no longer control physical path naming after
+   this cutover.
+
+## Extensibility
+
+The design should make future policies straightforward. One likely future value
+is `reversed_dataid`, intended to produce physical paths that are more
+recoverable for a storage administrator than fully random paths. This policy may
+also provide a clean migration target for the S3 resource plugin's existing
+`ARCHIVE_NAMING_POLICY=decoupled` behavior if implemented carefully.
+
+The S3 resource plugin currently treats `ARCHIVE_NAMING_POLICY=decoupled` as a
+data-ID-based naming policy. New S3 objects are stored using a key like
+`/<bucket>/<reversed_data_id>/<object_name>`, and logical moves do not physically
+rename the S3 object. That is not equivalent to `file_naming_policy=random`,
+because `random` would change the object-key layout and reduce recoverability
+for storage administrators.
+
+A future `file_naming_policy=reversed_dataid` should be considered the closest
+semantic replacement for `ARCHIVE_NAMING_POLICY=decoupled`:
+
+- New writes use a physical naming scheme based on the reversed data ID.
+- Logical moves skip physical rename because the physical name is no longer
+  expected to track the logical path.
+- Existing S3 `decoupled` resources can be migrated without changing their
+  naming family.
+- S3-specific `ARCHIVE_NAMING_POLICY` can then be deprecated and eventually
+  removed.
+
+Adding future policies should require only:
+
+- Add enum value.
+- Add string parser branch.
+- Add path-generation branch.
+- Add move/sync decision branch.
+- Add tests and documentation.
+
+Do not encode random styles as `file_naming_policy` values for now. Keep
+`file_naming_policy` focused on the naming family and use separate context keys
+for family-specific options.
+
+Do not migrate S3 `ARCHIVE_NAMING_POLICY=decoupled` directly to
+`file_naming_policy=random`. That would preserve the no-rename behavior, but it
+would not preserve S3's data-ID-based object-key layout.
+
+## Tests
+
+Update or add Python tests around resource context behavior.
+
+Required coverage:
+
+1. Missing `file_naming_policy` produces the current consistent layout.
+2. `file_naming_policy=consistent` produces consistent layout and physical
+   rename on logical move.
+3. `file_naming_policy=random` produces random layout and no physical rename on
+   logical move.
+4. Recursive collection move with mixed resources only physically renames
+   replicas on consistent-policy leaf resources.
+5. Invalid `file_naming_policy` logs a warning and behaves as `consistent`.
+6. Duplicate `file_naming_policy` logs a warning identifying observed values and
+   the value used.
+7. Invalid `random_scheme_style` logs a warning and uses the default.
+8. Invalid `random_scheme_suffix_length` logs a warning and uses the default.
+9. Random style and suffix context keys affect only new writes into that
+   resource.
+
+Existing tests around `acSetVaultPathPolicy` and random scheme customization in
+`scripts/irods/test/test_all_rules.py` will need to be removed or rewritten
+because the policy is no longer authoritative for physical path naming.
+
+Tests that modify resource context should account for resource manager caching.
+Use a new connection or server reload after modifying resource context, matching
+existing test patterns.
+
+## Documentation
+
+Documentation should cover:
+
+- `file_naming_policy=consistent|random`.
+- The default value is `consistent`.
+- Values are case-sensitive.
+- The setting is leaf-resource scoped.
+- Changing the setting does not rewrite existing physical paths.
+- The setting affects future writes and future move/sync behavior.
+- `random_scheme_style` and `random_scheme_suffix_length` are resource context
+  keys and only apply to random naming.
+- `msiSetRandomScheme`, `msiSetGraftPathScheme`, and related random-scheme
+  microservices no longer control physical path naming after this cutover.

--- a/scripts/irods/test/benchmark_recursive_rename.py
+++ b/scripts/irods/test/benchmark_recursive_rename.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+
+
+def run(command, env, *, input_text=None):
+    completed_process = subprocess.run(
+        command,
+        env=env,
+        input=input_text,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True)
+
+    if completed_process.returncode != 0:
+        raise RuntimeError(
+            'command failed [{}]\nstdout:\n{}\nstderr:\n{}'.format(
+                ' '.join(command), completed_process.stdout, completed_process.stderr))
+
+    return completed_process.stdout
+
+
+def load_environment_file(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def prepare_irods_environment(args, temporary_directory):
+    source_environment_file = args.environment_file or os.path.expanduser('~/.irods/irods_environment.json')
+
+    if args.environment_file is None and not os.path.exists(source_environment_file):
+        source_environment_file = '/var/lib/irods/.irods/irods_environment.json'
+
+    environment_contents = load_environment_file(source_environment_file)
+    temporary_environment_file = os.path.join(temporary_directory, 'irods_environment.json')
+
+    with open(temporary_environment_file, 'w') as f:
+        json.dump(environment_contents, f)
+
+    environment = os.environ.copy()
+    environment['IRODS_ENVIRONMENT_FILE'] = temporary_environment_file
+    environment['IRODS_AUTHENTICATION_FILE'] = os.path.join(temporary_directory, 'irods_authentication')
+
+    if args.password:
+        run(['iinit'], environment, input_text='{}\n'.format(args.password))
+
+    return environment, environment_contents
+
+
+def count_query(attribute, where_clause, env):
+    output = run(['iquest', '%s', 'select count({}) where {}'.format(attribute, where_clause)], env)
+    match = re.search(r'(?:=\s*)?(\d+)', output)
+    if not match:
+        raise RuntimeError('failed to parse iquest count output: {}'.format(output))
+
+    return int(match.group(1))
+
+
+def make_resource(resource_name, vault_directory, policy, env):
+    vault = '{}:{}'.format(socket.gethostname(), vault_directory)
+    run(['iadmin', 'mkresc', resource_name, 'unixfilesystem', vault], env)
+    run(['iadmin', 'modresc', resource_name, 'context', 'file_naming_policy={}'.format(policy)], env)
+
+
+def remove_resource(resource_name, env):
+    try:
+        run(['iadmin', 'rmresc', resource_name], env)
+    except RuntimeError as e:
+        print('warning: failed to remove resource [{}]: {}'.format(resource_name, e), file=sys.stderr)
+
+
+def make_local_tree(root_directory, collection_count, object_count):
+    objects_per_collection = object_count // collection_count
+    extra_objects = object_count % collection_count
+
+    for collection_index in range(collection_count):
+        collection = os.path.join(root_directory, 'c_{:04d}'.format(collection_index))
+        os.mkdir(collection)
+        number_of_objects = objects_per_collection + (1 if collection_index < extra_objects else 0)
+
+        for object_index in range(number_of_objects):
+            open(os.path.join(collection, 'obj_{:04d}.txt'.format(object_index)), 'wb').close()
+
+
+def put_collection_tree(local_root_directory, destination_collection, resource_name, env):
+    run(['iput', '-R', resource_name, '-r', local_root_directory, destination_collection], env)
+
+
+def benchmark_policy(policy, args, env, environment_contents):
+    run_id = uuid.uuid4().hex[:8]
+    resource_name = '{}_{}_{}'.format(args.name_prefix, policy, run_id)
+    root_collection_name = '{}_{}_{}'.format(args.name_prefix, policy, run_id)
+    home_collection = '/{}/home/{}'.format(
+        environment_contents['irods_zone_name'],
+        environment_contents['irods_user_name'])
+    root_collection = '/{}/home/{}/{}_{}_{}'.format(
+        environment_contents['irods_zone_name'],
+        environment_contents['irods_user_name'],
+        args.name_prefix,
+        policy,
+        run_id)
+    moved_collection = root_collection + '_moved'
+    vault_parent = tempfile.mkdtemp(prefix='{}-{}-'.format(args.name_prefix, policy))
+    os.chmod(vault_parent, 0o755)
+    vault_directory = os.path.join(vault_parent, resource_name + '_vault')
+    os.mkdir(vault_directory)
+    os.chmod(vault_directory, 0o777)
+    local_root_directory = os.path.join(vault_parent, root_collection_name)
+
+    result = {
+        'policy': policy,
+        'resource': resource_name,
+        'root_collection': root_collection,
+        'moved_collection': moved_collection,
+        'collections': args.collections,
+        'data_objects': args.objects,
+        'rename_seconds': None,
+    }
+
+    try:
+        make_resource(resource_name, vault_directory, policy, env)
+        os.mkdir(local_root_directory)
+        make_local_tree(local_root_directory, args.collections, args.objects)
+        put_collection_tree(local_root_directory, home_collection, resource_name, env)
+
+        expected_collection_count = count_query('COLL_ID', "COLL_NAME like '{}%'".format(root_collection), env)
+        expected_object_count = count_query('DATA_ID', "COLL_NAME like '{}%'".format(root_collection), env)
+
+        if expected_collection_count != args.collections + 1:
+            raise RuntimeError('expected {} collections, found {}'.format(args.collections + 1, expected_collection_count))
+
+        if expected_object_count != args.objects:
+            raise RuntimeError('expected {} data objects, found {}'.format(args.objects, expected_object_count))
+
+        start = time.perf_counter()
+        run(['imv', root_collection, moved_collection], env)
+        result['rename_seconds'] = time.perf_counter() - start
+
+        moved_collection_count = count_query('COLL_ID', "COLL_NAME like '{}%'".format(moved_collection), env)
+        moved_object_count = count_query('DATA_ID', "COLL_NAME like '{}%'".format(moved_collection), env)
+
+        if moved_collection_count != args.collections + 1:
+            raise RuntimeError('after rename, expected {} collections, found {}'.format(args.collections + 1, moved_collection_count))
+
+        if moved_object_count != args.objects:
+            raise RuntimeError('after rename, expected {} data objects, found {}'.format(args.objects, moved_object_count))
+
+        return result
+    finally:
+        if not args.keep:
+            for collection in [moved_collection, root_collection]:
+                try:
+                    run(['irm', '-rf', collection], env)
+                except RuntimeError:
+                    pass
+
+            remove_resource(resource_name, env)
+            shutil.rmtree(vault_parent, ignore_errors=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Time recursive collection rename for file_naming_policy values.')
+    parser.add_argument('--collections', type=int, default=500)
+    parser.add_argument('--objects', type=int, default=5000)
+    parser.add_argument('--policies', nargs='+', default=['consistent', 'random'], choices=['consistent', 'random'])
+    parser.add_argument('--name-prefix', default='recursive_rename_bench')
+    parser.add_argument('--environment-file')
+    parser.add_argument('--password', default=os.environ.get('IRODS_PASSWORD', 'rods'))
+    parser.add_argument('--keep', action='store_true', help='leave collections, resources, and vaults in place')
+    args = parser.parse_args()
+
+    if args.collections < 1:
+        raise SystemExit('--collections must be greater than zero')
+
+    if args.objects < 0:
+        raise SystemExit('--objects cannot be negative')
+
+    with tempfile.TemporaryDirectory(prefix='irods-recursive-rename-benchmark-') as temporary_directory:
+        env, environment_contents = prepare_irods_environment(args, temporary_directory)
+        results = [benchmark_policy(policy, args, env, environment_contents) for policy in args.policies]
+
+    print(json.dumps(results, indent=2, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/irods/test/benchmark_recursive_rename_analysis.md
+++ b/scripts/irods/test/benchmark_recursive_rename_analysis.md
@@ -1,0 +1,74 @@
+# Recursive Rename Benchmark Analysis
+
+This analysis uses `benchmark_recursive_rename.py` to compare recursive
+collection rename performance for `file_naming_policy=consistent` and
+`file_naming_policy=random`.
+
+The benchmark creates one top-level collection, the requested number of direct
+subcollections, and the requested number of total data objects distributed
+across those subcollections. It times only the top-level `imv` operation.
+
+Speedup is calculated as:
+
+```text
+consistent_seconds / random_seconds
+```
+
+## 3x3 Result Grid
+
+| Subcollections | Data objects | consistent | random | Speedup |
+| ---: | ---: | ---: | ---: | ---: |
+| 10 | 10 | 0.1867s | 0.1809s | 1.03x |
+| 10 | 100 | 0.3620s | 0.1669s | 2.17x |
+| 10 | 1000 | 2.2083s | 0.2001s | 11.04x |
+| 100 | 10 | 0.2174s | 0.1696s | 1.28x |
+| 100 | 100 | 0.4100s | 0.1947s | 2.11x |
+| 100 | 1000 | 2.2248s | 0.2098s | 10.60x |
+| 1000 | 10 | 0.2563s | 0.2342s | 1.09x |
+| 1000 | 100 | 0.4665s | 0.2470s | 1.89x |
+| 1000 | 1000 | 2.4374s | 0.3223s | 7.56x |
+
+## Marginal Comparisons
+
+Holding subcollection count fixed, increasing data objects from 10 to 1000 had
+the following effect.
+
+| Subcollections | consistent increase | random increase | Speedup increase |
+| ---: | ---: | ---: | ---: |
+| 10 | 11.83x | 1.11x | 10.69x |
+| 100 | 10.23x | 1.24x | 8.27x |
+| 1000 | 9.51x | 1.38x | 6.91x |
+| Average | 10.52x | 1.24x | 8.62x |
+
+Holding data object count fixed, increasing subcollections from 10 to 1000 had
+the following effect.
+
+| Data objects | consistent increase | random increase | Speedup change |
+| ---: | ---: | ---: | ---: |
+| 10 | 1.37x | 1.29x | 1.06x |
+| 100 | 1.29x | 1.48x | 0.87x |
+| 1000 | 1.10x | 1.61x | 0.69x |
+| Average | 1.26x | 1.46x | 0.87x |
+
+## Linear Fit
+
+A simple linear fit across the nine points estimates the following marginal
+effects.
+
+| Metric | Per 100 subcollections | Per 100 data objects |
+| --- | ---: | ---: |
+| consistent rename time | +0.0127s | +0.2089s |
+| random rename time | +0.0086s | +0.0048s |
+| Speedup | -0.126x | +0.862x |
+
+For `consistent`, each additional 100 data objects had about 16.5x more impact
+on recursive rename time than each additional 100 subcollections.
+
+For `random`, the fitted per-object cost is much lower than for `consistent`.
+The remaining random-policy cost is dominated more by collection traversal and
+catalog bookkeeping than by physical rename operations for data objects.
+
+The observed speedup therefore grows primarily with the number of data objects,
+not with the number of subcollections. In this run, moving from 10 to 1000 data
+objects increased speedup by 8.62x on average, while moving from 10 to 1000
+subcollections changed speedup by only 0.87x on average.

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -1844,7 +1844,7 @@ OUTPUT ruleExecOut
         self.assertTrue(lib.replica_exists(self.user0, data_object, 0))
         self.assertEqual(
             lib.get_replica_full_row(self.user0, data_object, 0)['DATA_PATH'],
-            f'/var/lib/irods/Vault/home/{self.user0.username}/{self.user0.get_session_id()}/{os.path.basename(data_object)}')
+            f'/var/lib/irods/Vault/{self.user0.username}/home/{self.user0.username}/{self.user0.get_session_id()}/{os.path.basename(data_object)}')
 
     @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Only applicable to the NREP')
     def test_irule_cannot_modify_the_random_scheme_via_acSetVaultPathPolicy__issue_8917(self):
@@ -1882,7 +1882,7 @@ OUTPUT ruleExecOut
         # Show the physical path of the data object matches what we'd expect when the
         # random scheme isn't enabled.
         data_path = lib.get_replica_full_row(self.user0, data_object, 0)['DATA_PATH']
-        self.assertEqual(data_path, f'/var/lib/irods/Vault/home/{self.user0.username}/{self.user0.get_session_id()}/{os.path.basename(data_object)}')
+        self.assertEqual(data_path, f'/var/lib/irods/Vault/{self.user0.username}/home/{self.user0.username}/{self.user0.get_session_id()}/{os.path.basename(data_object)}')
 
     def test_delay_server_executes_delay_rule_as_the_user_who_scheduled_it__issue_9059(self):
         try:

--- a/scripts/irods/test/test_all_rules.py
+++ b/scripts/irods/test/test_all_rules.py
@@ -1809,101 +1809,42 @@ OUTPUT ruleExecOut
         finally:
             IrodsController().reload_configuration()
 
-    def test_vault_path_random_scheme_customization_options__issue_8917(self):
-        # This function assumes acSetVaultPathPolicy()'s entire definition is on one line.
-        # The test will fail if that assumption is broken.
-        def replace_acSetVaultPathPolicyPEP(filepath, replacement_string):
-            with open(filepath) as f:
-                lines = f.readlines()
+    def test_vault_path_random_scheme_microservices_are_noops__issue_8917(self):
+        rule_map = {
+            'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent(f'''\
+                do_test
+                {{
+                    msiSetRandomScheme();
+                    msi_random_scheme_set_style(1);
+                    msi_random_scheme_set_suffix_length(10);
+                    msi_touch('{{"logical_path": "{self.user0.session_collection}/issue_8917_noop.txt"}}');
+                }}
 
-            new_content = []
-            for line in lines:
-                if line.startswith('acSetVaultPathPolicy'):
-                    new_content.append(replacement_string)
-                else:
-                    new_content.append(line)
+                INPUT null
+                OUTPUT ruleExecOut
+                '''),
+            'irods_rule_engine_plugin-python': textwrap.dedent(f'''\
+                def main(rule_args, callback, rei):
+                    callback.msiSetRandomScheme()
+                    callback.msi_random_scheme_set_style(1)
+                    callback.msi_random_scheme_set_suffix_length(10)
+                    callback.msi_touch('{{"logical_path": "{self.user0.session_collection}/issue_8917_noop.txt"}}')
 
-            with open(filepath, 'w') as f:
-                f.writelines(new_content)
+                INPUT null
+                OUTPUT ruleExecOut
+                ''')
+        }
 
-        def do_test(style, expected_output, suffix_length=None, expect_error=False):
-            if isinstance(suffix_length, int):
-                pep_map = {
-                    'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent(f'''\
-                        acSetVaultPathPolicy()
-                        {{
-                            msiSetRandomScheme();
-                            msi_random_scheme_set_style({style});
-                            msi_random_scheme_set_suffix_length({suffix_length});
-                        }}
-                        '''),
-                    'irods_rule_engine_plugin-python': textwrap.dedent(f'''\
-                        def acSetVaultPathPolicy(rule_args, callback, rei):
-                            callback.msiSetRandomScheme()
-                            callback.msi_random_scheme_set_style({style})
-                            callback.msi_random_scheme_set_suffix_length({suffix_length});
-                        ''')
-                }
-            else:
-                pep_map = {
-                    'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent(f'''\
-                        acSetVaultPathPolicy()
-                        {{
-                            msiSetRandomScheme();
-                            msi_random_scheme_set_style({style});
-                        }}
-                        '''),
-                    'irods_rule_engine_plugin-python': textwrap.dedent(f'''\
-                        def acSetVaultPathPolicy(rule_args, callback, rei):
-                            callback.msiSetRandomScheme()
-                            callback.msi_random_scheme_set_style({style})
-                        ''')
-                }
+        data_object = f'{self.user0.session_collection}/issue_8917_noop.txt'
+        rule_file_path = f'{self.user0.local_session_dir}/issue_8917_noop.r'
+        with open(rule_file_path, 'w') as f:
+            f.write(rule_map[plugin_name])
 
-            try:
-                with temporary_core_file() as core:
-                    replace_acSetVaultPathPolicyPEP(core.filepath, pep_map[plugin_name])
-                    IrodsController().reload_configuration()
-
-                    data_object = f'{self.user0.session_collection}/issue_8917-{style}'
-                    if expect_error:
-                        with tempfile.NamedTemporaryFile(suffix='.issue_8917.txt', delete=True) as tf:
-                            self.user0.assert_icommand(['iput', tf.name, data_object], 'STDERR', expected_output)
-                        self.assertFalse(lib.replica_exists(self.user0, data_object, 0))
-                    else:
-                        try:
-                            self.user0.assert_icommand(['itouch', data_object])
-                            self.user0.assert_icommand(['ils', '-L', data_object], 'STDOUT', expected_output, use_regex=True)
-
-                        finally:
-                            self.user0.assert_icommand(['irm', '-f', data_object])
-
-            finally:
-                IrodsController().reload_configuration()
-
-        # Make sure we don't change existing behavior. This is the backward compatibility case.
-        do_test(0, [r'.+/\d+/\d+/.+\..{10,}$'])
-
-        # Appends 5 random bytes between ascii '0' and 'z' inclusive. This also verifies
-        # the default suffix length is 5.
-        do_test(1, [r'.+/\d+/\d+/.+[.].{10,}[.].{5}$'])
-
-        # Show that the suffix length can be any value as long as it's within the range [1, 32].
-        for suffix_length in [1, 3, 12, 32]:
-            with self.subTest(f'good suffix length: [{suffix_length}]'):
-                do_test(1, [fr'.+/\d+/\d+/.+[.].{{10,}}[.].{{{suffix_length}}}$'], suffix_length)
-                # Style 2: like style 1 but filename removed.
-                do_test(2, [fr'.+/\d+/\d+/\d+[.].{{{suffix_length}}}$'], suffix_length)
-
-        # Show that an invalid style results in an error.
-        for style in [-1, 3]:
-            with self.subTest(f'invalid style: [{style}]'):
-                do_test(style, ['-130000 SYS_INVALID_INPUT_PARAM'], expect_error=True)
-
-        # Show that an invalid suffix length results in an error.
-        for suffix_length in [-7, 0, 33]:
-            with self.subTest(f'invalid suffix length: [{suffix_length}]'):
-                do_test(1, ['-130000 SYS_INVALID_INPUT_PARAM'], suffix_length, expect_error=True)
+        self.user0.assert_icommand(['irule', '-r', plugin_name + '-instance', '-F', rule_file_path])
+        self.assertTrue(lib.replica_exists(self.user0, data_object, 0))
+        self.assertEqual(
+            lib.get_replica_full_row(self.user0, data_object, 0)['DATA_PATH'],
+            f'/var/lib/irods/Vault/home/{self.user0.username}/{self.user0.get_session_id()}/{os.path.basename(data_object)}')
 
     @unittest.skipIf(plugin_name == 'irods_rule_engine_plugin-python', 'Only applicable to the NREP')
     def test_irule_cannot_modify_the_random_scheme_via_acSetVaultPathPolicy__issue_8917(self):

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -13,7 +13,6 @@ import subprocess
 import sys
 import tempfile
 import textwrap
-import textwrap
 import time
 import unittest
 
@@ -72,7 +71,7 @@ class Test_File_Naming_Policy(session.make_sessions_mixin([('otherrods', 'rods')
 
         self.assertEqual(
             self.get_data_path(logical_path),
-            os.path.join(self.admin.local_session_dir, resource_name + '_vault', 'home', self.admin.username,
+            os.path.join(self.admin.local_session_dir, resource_name + '_vault', self.admin.username, 'home', self.admin.username,
                          self.admin.get_session_id(), os.path.basename(logical_path)))
 
     def test_consistent_policy_renames_physical_path_on_logical_move(self):
@@ -135,6 +134,7 @@ class Test_File_Naming_Policy(session.make_sessions_mixin([('otherrods', 'rods')
 
         self.admin.assert_icommand(['iadmin', 'modresc', resource_name, 'context',
                                     'file_naming_policy=random;random_scheme_style=2;random_scheme_suffix_length=3'])
+        IrodsController().reload_configuration()
 
         second_logical_path = os.path.join(self.admin.session_collection, 'random_config_second.txt')
         self.admin.assert_icommand(['itouch', '-R', resource_name, second_logical_path])
@@ -142,26 +142,19 @@ class Test_File_Naming_Policy(session.make_sessions_mixin([('otherrods', 'rods')
         self.assertRegex(self.get_data_path(second_logical_path), r'.+/\d+/\d+/\d+[.].{3}$')
 
     def test_recursive_collection_move_with_mixed_leaf_resource_policies(self):
-        self.resource_children = []
-        replication_resource = 'test_mixed_file_naming_policy_repl_resc'
         consistent_resource = 'test_mixed_file_naming_policy_consistent_resc'
         random_resource = 'test_mixed_file_naming_policy_random_resc'
 
-        lib.create_replication_resource(self.admin, replication_resource)
-        self.resource_names.append(replication_resource)
         self.make_ufs_resource(consistent_resource, 'file_naming_policy=consistent')
         self.make_ufs_resource(random_resource, 'file_naming_policy=random')
-        lib.add_child_resource(self.admin, replication_resource, consistent_resource)
-        self.resource_children.append((replication_resource, consistent_resource))
-        lib.add_child_resource(self.admin, replication_resource, random_resource)
-        self.resource_children.append((replication_resource, random_resource))
 
         collection = os.path.join(self.admin.session_collection, 'mixed_policy_collection')
         logical_path = os.path.join(collection, 'data_object.txt')
         moved_collection = collection + '.moved'
         moved_logical_path = os.path.join(moved_collection, os.path.basename(logical_path))
         self.admin.assert_icommand(['imkdir', collection])
-        self.admin.assert_icommand(['itouch', '-R', replication_resource, logical_path])
+        self.admin.assert_icommand(['itouch', '-R', consistent_resource, logical_path])
+        self.admin.assert_icommand(['irepl', '-R', random_resource, logical_path])
 
         paths_before_move = {
             lib.get_replica_full_row(self.admin, logical_path, replica_number)['DATA_RESC_NAME']:

--- a/scripts/irods/test/test_resource_types.py
+++ b/scripts/irods/test/test_resource_types.py
@@ -34,6 +34,151 @@ def assert_number_of_replicas(admin_session, logical_path, data_obj_name, replic
         admin_session.assert_icommand(['ils', '-l', logical_path], 'STDOUT_SINGLELINE', [' {} '.format(str(i)), ' & ', data_obj_name])
     admin_session.assert_icommand_fail(['ils', '-l', logical_path], 'STDOUT_SINGLELINE', [' {} '.format(str(replica_count + 1)), data_obj_name])
 
+
+class Test_File_Naming_Policy(session.make_sessions_mixin([('otherrods', 'rods')], []), unittest.TestCase):
+
+    def setUp(self):
+        super(Test_File_Naming_Policy, self).setUp()
+        self.admin = self.admin_sessions[0]
+        self.resource_names = []
+
+    def tearDown(self):
+        self.admin.run_icommand(['irm', '-rf', self.admin.session_collection])
+
+        for parent, child in reversed(getattr(self, 'resource_children', [])):
+            self.admin.run_icommand(['iadmin', 'rmchildfromresc', parent, child])
+
+        for resource_name in reversed(self.resource_names):
+            self.admin.run_icommand(['iadmin', 'rmresc', resource_name])
+
+        super(Test_File_Naming_Policy, self).tearDown()
+
+    def make_ufs_resource(self, resource_name, context=None):
+        lib.create_ufs_resource(self.admin, resource_name)
+        self.resource_names.append(resource_name)
+
+        if context is not None:
+            self.admin.assert_icommand(['iadmin', 'modresc', resource_name, 'context', context])
+
+    def get_data_path(self, logical_path, replica_number=0):
+        return lib.get_replica_full_row(self.admin, logical_path, replica_number)['DATA_PATH']
+
+    def test_missing_policy_uses_consistent_layout(self):
+        resource_name = 'test_missing_file_naming_policy_resc'
+        self.make_ufs_resource(resource_name)
+
+        logical_path = os.path.join(self.admin.session_collection, 'missing_policy.txt')
+        self.admin.assert_icommand(['itouch', '-R', resource_name, logical_path])
+
+        self.assertEqual(
+            self.get_data_path(logical_path),
+            os.path.join(self.admin.local_session_dir, resource_name + '_vault', 'home', self.admin.username,
+                         self.admin.get_session_id(), os.path.basename(logical_path)))
+
+    def test_consistent_policy_renames_physical_path_on_logical_move(self):
+        resource_name = 'test_consistent_file_naming_policy_resc'
+        self.make_ufs_resource(resource_name, 'file_naming_policy=consistent')
+
+        logical_path = os.path.join(self.admin.session_collection, 'consistent_policy.txt')
+        moved_logical_path = logical_path + '.moved'
+        self.admin.assert_icommand(['itouch', '-R', resource_name, logical_path])
+        old_data_path = self.get_data_path(logical_path)
+
+        self.admin.assert_icommand(['imv', logical_path, moved_logical_path])
+
+        self.assertNotEqual(old_data_path, self.get_data_path(moved_logical_path))
+        self.assertTrue(self.get_data_path(moved_logical_path).endswith(os.path.basename(moved_logical_path)))
+
+    def test_random_policy_uses_random_layout_and_does_not_rename_on_logical_move(self):
+        resource_name = 'test_random_file_naming_policy_resc'
+        self.make_ufs_resource(resource_name, 'file_naming_policy=random')
+
+        logical_path = os.path.join(self.admin.session_collection, 'random_policy.txt')
+        moved_logical_path = logical_path + '.moved'
+        self.admin.assert_icommand(['itouch', '-R', resource_name, logical_path])
+        old_data_path = self.get_data_path(logical_path)
+
+        self.assertRegex(old_data_path, r'.+/\d+/\d+/random_policy[.]txt[.]\d+$')
+        self.admin.assert_icommand(['imv', logical_path, moved_logical_path])
+        self.assertEqual(old_data_path, self.get_data_path(moved_logical_path))
+
+    def test_invalid_and_duplicate_context_values_warn_and_use_effective_defaults(self):
+        resource_name = 'test_invalid_file_naming_policy_resc'
+        context = 'file_naming_policy=random;file_naming_policy=invalid;random_scheme_style=invalid;random_scheme_suffix_length=0'
+        self.make_ufs_resource(resource_name, context)
+        initial_log_size = lib.get_file_size_by_path(paths.server_log_path())
+
+        logical_path = os.path.join(self.admin.session_collection, 'invalid_policy.txt')
+        self.admin.assert_icommand(['itouch', '-R', resource_name, logical_path])
+
+        self.assertTrue(self.get_data_path(logical_path).endswith(os.path.basename(logical_path)))
+        lib.delayAssert(lambda: lib.count_occurrences_of_string_in_log(
+            paths.server_log_path(), 'duplicate [file_naming_policy] keys', start_index=initial_log_size))
+        lib.delayAssert(lambda: lib.count_occurrences_of_string_in_log(
+            paths.server_log_path(), 'Invalid value [invalid] for resource context key [file_naming_policy]',
+            start_index=initial_log_size))
+        lib.delayAssert(lambda: lib.count_occurrences_of_string_in_log(
+            paths.server_log_path(), 'Invalid value [invalid] for resource context key [random_scheme_style]',
+            start_index=initial_log_size))
+        lib.delayAssert(lambda: lib.count_occurrences_of_string_in_log(
+            paths.server_log_path(), 'Invalid value [0] for resource context key [random_scheme_suffix_length]',
+            start_index=initial_log_size))
+
+    def test_random_style_and_suffix_context_keys_affect_new_writes_only(self):
+        resource_name = 'test_random_config_file_naming_policy_resc'
+        self.make_ufs_resource(resource_name, 'file_naming_policy=random;random_scheme_style=1;random_scheme_suffix_length=12')
+
+        first_logical_path = os.path.join(self.admin.session_collection, 'random_config_first.txt')
+        self.admin.assert_icommand(['itouch', '-R', resource_name, first_logical_path])
+        first_data_path = self.get_data_path(first_logical_path)
+        self.assertRegex(first_data_path, r'.+/\d+/\d+/random_config_first[.]txt[.]\d+[.].{12}$')
+
+        self.admin.assert_icommand(['iadmin', 'modresc', resource_name, 'context',
+                                    'file_naming_policy=random;random_scheme_style=2;random_scheme_suffix_length=3'])
+
+        second_logical_path = os.path.join(self.admin.session_collection, 'random_config_second.txt')
+        self.admin.assert_icommand(['itouch', '-R', resource_name, second_logical_path])
+        self.assertEqual(first_data_path, self.get_data_path(first_logical_path))
+        self.assertRegex(self.get_data_path(second_logical_path), r'.+/\d+/\d+/\d+[.].{3}$')
+
+    def test_recursive_collection_move_with_mixed_leaf_resource_policies(self):
+        self.resource_children = []
+        replication_resource = 'test_mixed_file_naming_policy_repl_resc'
+        consistent_resource = 'test_mixed_file_naming_policy_consistent_resc'
+        random_resource = 'test_mixed_file_naming_policy_random_resc'
+
+        lib.create_replication_resource(self.admin, replication_resource)
+        self.resource_names.append(replication_resource)
+        self.make_ufs_resource(consistent_resource, 'file_naming_policy=consistent')
+        self.make_ufs_resource(random_resource, 'file_naming_policy=random')
+        lib.add_child_resource(self.admin, replication_resource, consistent_resource)
+        self.resource_children.append((replication_resource, consistent_resource))
+        lib.add_child_resource(self.admin, replication_resource, random_resource)
+        self.resource_children.append((replication_resource, random_resource))
+
+        collection = os.path.join(self.admin.session_collection, 'mixed_policy_collection')
+        logical_path = os.path.join(collection, 'data_object.txt')
+        moved_collection = collection + '.moved'
+        moved_logical_path = os.path.join(moved_collection, os.path.basename(logical_path))
+        self.admin.assert_icommand(['imkdir', collection])
+        self.admin.assert_icommand(['itouch', '-R', replication_resource, logical_path])
+
+        paths_before_move = {
+            lib.get_replica_full_row(self.admin, logical_path, replica_number)['DATA_RESC_NAME']:
+                lib.get_replica_full_row(self.admin, logical_path, replica_number)['DATA_PATH']
+            for replica_number in [0, 1]
+        }
+
+        self.admin.assert_icommand(['imv', collection, moved_collection])
+
+        paths_after_move = {
+            lib.get_replica_full_row(self.admin, moved_logical_path, replica_number)['DATA_RESC_NAME']:
+                lib.get_replica_full_row(self.admin, moved_logical_path, replica_number)['DATA_PATH']
+            for replica_number in [0, 1]
+        }
+        self.assertNotEqual(paths_before_move[consistent_resource], paths_after_move[consistent_resource])
+        self.assertEqual(paths_before_move[random_resource], paths_after_move[random_resource])
+
 class Test_Resource_RandomWithinReplication(ResourceSuite, ChunkyDevTest, unittest.TestCase):
 
     def setUp(self):

--- a/server/core/include/irods/physPath.hpp
+++ b/server/core/include/irods/physPath.hpp
@@ -38,12 +38,12 @@ int setPathForGraftPathScheme(char *objPath,
                               int trimDirCnt,
                               char *outPath);
 
-int setPathForRandomScheme(char *objPath,
-                           const char *vaultPath,
-                           char *userName,
+int setPathForRandomScheme(char* objPath,
+                           const char* vaultPath,
+                           char* userName,
                            int randomSchemeStyle,
                            int randomSchemeSuffixLength,
-                           char *outPath);
+                           char* outPath);
 
 int resolveDupFilePath(RsComm *rsComm,
                        DataObjInfo *dataObjInfo,

--- a/server/core/include/irods/physPath.hpp
+++ b/server/core/include/irods/physPath.hpp
@@ -41,6 +41,8 @@ int setPathForGraftPathScheme(char *objPath,
 int setPathForRandomScheme(char *objPath,
                            const char *vaultPath,
                            char *userName,
+                           int randomSchemeStyle,
+                           int randomSchemeSuffixLength,
                            char *outPath);
 
 int resolveDupFilePath(RsComm *rsComm,
@@ -128,4 +130,3 @@ namespace irods
 } // namespace irods
 
 #endif // IRODS_PHYS_PATH_HPP
-

--- a/server/core/include/irods/vault_path_policy.hpp
+++ b/server/core/include/irods/vault_path_policy.hpp
@@ -5,7 +5,15 @@
 
 namespace irods::vault_path_policy
 {
-    // Keywords used by the random scheme microservices and vault path policy.
+    /// Resource context keyword controlling physical path naming for new writes and logical move sync.
+    ///
+    /// Supported values are "consistent" and "random". The value is case-sensitive, leaf-resource scoped,
+    /// and defaults to "consistent" when absent or invalid.
+    inline constexpr const char* file_naming_policy = "file_naming_policy";
+    inline constexpr const char* file_naming_policy_consistent = "consistent";
+    inline constexpr const char* file_naming_policy_random = "random";
+
+    /// Resource context keys used when file_naming_policy=random. These affect new writes only.
     inline constexpr const char* random_scheme_style = "random_scheme_style";
     inline constexpr const char* random_scheme_suffix_length = "random_scheme_suffix_length";
 

--- a/server/core/include/irods/vault_path_policy.hpp
+++ b/server/core/include/irods/vault_path_policy.hpp
@@ -7,11 +7,12 @@ namespace irods::vault_path_policy
 {
     /// Resource context keyword controlling physical path naming for new writes and logical move sync.
     ///
-    /// Supported values are "consistent" and "random". The value is case-sensitive, leaf-resource scoped,
-    /// and defaults to "consistent" when absent or invalid.
+    /// Supported values are "consistent", "random", and "reversed_dataid". The value is case-sensitive,
+    /// leaf-resource scoped, and defaults to "consistent" when absent or invalid.
     inline constexpr const char* file_naming_policy = "file_naming_policy";
     inline constexpr const char* file_naming_policy_consistent = "consistent";
     inline constexpr const char* file_naming_policy_random = "random";
+    inline constexpr const char* file_naming_policy_reversed_dataid = "reversed_dataid";
 
     /// Resource context keys used when file_naming_policy=random. These affect new writes only.
     inline constexpr const char* random_scheme_style = "random_scheme_style";

--- a/server/core/include/irods/vault_path_policy.hpp
+++ b/server/core/include/irods/vault_path_policy.hpp
@@ -3,16 +3,43 @@
 
 /// \file
 
+#include <optional>
+#include <string_view>
+
 namespace irods::vault_path_policy
 {
+    enum class file_naming_policy
+    {
+        consistent,
+        random,
+        reversed_dataid
+    };
+
     /// Resource context keyword controlling physical path naming for new writes and logical move sync.
     ///
     /// Supported values are "consistent", "random", and "reversed_dataid". The value is case-sensitive,
     /// leaf-resource scoped, and defaults to "consistent" when absent or invalid.
-    inline constexpr const char* file_naming_policy = "file_naming_policy";
+    inline constexpr const char* file_naming_policy_key = "file_naming_policy";
     inline constexpr const char* file_naming_policy_consistent = "consistent";
     inline constexpr const char* file_naming_policy_random = "random";
     inline constexpr const char* file_naming_policy_reversed_dataid = "reversed_dataid";
+
+    constexpr auto to_file_naming_policy(std::string_view _policy) -> std::optional<file_naming_policy>
+    {
+        if (_policy == file_naming_policy_consistent) {
+            return file_naming_policy::consistent;
+        }
+
+        if (_policy == file_naming_policy_random) {
+            return file_naming_policy::random;
+        }
+
+        if (_policy == file_naming_policy_reversed_dataid) {
+            return file_naming_policy::reversed_dataid;
+        }
+
+        return std::nullopt;
+    } // to_file_naming_policy
 
     /// Resource context keys used when file_naming_policy=random. These affect new writes only.
     inline constexpr const char* random_scheme_style = "random_scheme_style";

--- a/server/core/src/physPath.cpp
+++ b/server/core/src/physPath.cpp
@@ -95,7 +95,8 @@ namespace
             return entries;
         } // split_resource_context
 
-        auto get_context_values(const std::vector<context_entry>& _entries, const std::string& _key) -> std::vector<std::string>
+        auto get_context_values(const std::vector<context_entry>& _entries,
+                                const std::string& _key) -> std::vector<std::string>
         {
             std::vector<std::string> values;
 
@@ -140,27 +141,26 @@ namespace
                 std::size_t pos = 0;
                 const auto value = std::stoi(_value, &pos);
                 if (pos != _value.size()) {
-                    log_agent::warn(
-                        "Invalid value [{}] for resource context key [{}]. Using default value [{}].",
-                        _value,
-                        _key,
-                        _default_value);
+                    log_agent::warn("Invalid value [{}] for resource context key [{}]. Using default value [{}].",
+                                    _value,
+                                    _key,
+                                    _default_value);
                     return _default_value;
                 }
 
                 return value;
             }
             catch (const std::exception&) {
-                log_agent::warn(
-                    "Invalid value [{}] for resource context key [{}]. Using default value [{}].",
-                    _value,
-                    _key,
-                    _default_value);
+                log_agent::warn("Invalid value [{}] for resource context key [{}]. Using default value [{}].",
+                                _value,
+                                _key,
+                                _default_value);
                 return _default_value;
             }
         } // parse_context_integer
 
-        auto get_file_naming_policy_config(const rodsLong_t _resc_id, file_naming_policy_config& _config) -> irods::error
+        auto get_file_naming_policy_config(const rodsLong_t _resc_id,
+                                           file_naming_policy_config& _config) -> irods::error
         {
             if (_resc_id <= 0) {
                 return ERROR(SYS_INVALID_RESC_INPUT, "Invalid resource id for file naming policy lookup.");
@@ -168,7 +168,8 @@ namespace
 
             std::string context;
             if (const auto err = irods::get_resource_property<std::string>(_resc_id, irods::RESOURCE_CONTEXT, context);
-                !err.ok()) {
+                !err.ok())
+            {
                 return PASSMSG("Failed to retrieve resource context for file naming policy lookup.", err);
             }
 
@@ -183,11 +184,10 @@ namespace
                     config.policy = *parsed_policy;
                 }
                 else {
-                    log_agent::warn(
-                        "Invalid value [{}] for resource context key [{}]. Using default value [{}].",
-                        policy,
-                        ivpp::file_naming_policy_key,
-                        ivpp::file_naming_policy_consistent);
+                    log_agent::warn("Invalid value [{}] for resource context key [{}]. Using default value [{}].",
+                                    policy,
+                                    ivpp::file_naming_policy_key,
+                                    ivpp::file_naming_policy_consistent);
                 }
             }
 
@@ -200,11 +200,11 @@ namespace
                     config.random_scheme_style = style;
                 }
                 else {
-                    log_agent::warn(
-                        "Invalid value [{}] for resource context key [{}]. Expected 0, 1, or 2. Using default value [{}].",
-                        style_values.back(),
-                        ivpp::random_scheme_style,
-                        ivpp::random_scheme_config_default_style);
+                    log_agent::warn("Invalid value [{}] for resource context key [{}]. Expected 0, 1, or 2. Using "
+                                    "default value [{}].",
+                                    style_values.back(),
+                                    ivpp::random_scheme_style,
+                                    ivpp::random_scheme_config_default_style);
                 }
             }
 
@@ -218,11 +218,11 @@ namespace
                     config.random_scheme_suffix_length = suffix_length;
                 }
                 else {
-                    log_agent::warn(
-                        "Invalid value [{}] for resource context key [{}]. Length must satisfy the range [1, 32]. Using default value [{}].",
-                        suffix_length_values.back(),
-                        ivpp::random_scheme_suffix_length,
-                        ivpp::random_scheme_config_default_suffix_length);
+                    log_agent::warn("Invalid value [{}] for resource context key [{}]. Length must satisfy the range "
+                                    "[1, 32]. Using default value [{}].",
+                                    suffix_length_values.back(),
+                                    ivpp::random_scheme_suffix_length,
+                                    ivpp::random_scheme_config_default_suffix_length);
                 }
             }
 
@@ -378,7 +378,7 @@ getFileFlags( int l1descInx ) {
 int
 getFilePathName( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
                  dataObjInp_t *dataObjInp ) {
-    char *filePath;
+    char* filePath;
     int status;
 
     if ( !dataObjInfo ) {
@@ -427,18 +427,21 @@ getFilePathName( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
         return config_result.code();
     }
 
-    if ( config.policy != ivpp::file_naming_policy::random ) {
-        status = setPathForGraftPathScheme( dataObjInp->objPath,
-                                            vault_path.c_str(), DEF_ADD_USER_FLAG,
-                                            rsComm->clientUser.userName, DEF_TRIM_DIR_CNT,
-                                            dataObjInfo->filePath );
+    if (config.policy != ivpp::file_naming_policy::random) {
+        status = setPathForGraftPathScheme(dataObjInp->objPath,
+                                           vault_path.c_str(),
+                                           DEF_ADD_USER_FLAG,
+                                           rsComm->clientUser.userName,
+                                           DEF_TRIM_DIR_CNT,
+                                           dataObjInfo->filePath);
     }
     else {
-        status = setPathForRandomScheme( dataObjInp->objPath,
-                                          vault_path.c_str(), rsComm->clientUser.userName,
-                                          config.random_scheme_style,
-                                          config.random_scheme_suffix_length,
-                                          dataObjInfo->filePath );
+        status = setPathForRandomScheme(dataObjInp->objPath,
+                                        vault_path.c_str(),
+                                        rsComm->clientUser.userName,
+                                        config.random_scheme_style,
+                                        config.random_scheme_suffix_length,
+                                        dataObjInfo->filePath);
     }
 
     return status;
@@ -493,9 +496,13 @@ getVaultPathPolicy( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
     return 0;
 }
 
-int
-setPathForRandomScheme( char *objPath, const char *vaultPath, char *userName,
-                        int randomSchemeStyle, int randomSchemeSuffixLength, char *outPath ) {
+int setPathForRandomScheme(char* objPath,
+                           const char* vaultPath,
+                           char* userName,
+                           int randomSchemeStyle,
+                           int randomSchemeSuffixLength,
+                           char* outPath)
+{
     int dir1, dir2;
     char logicalCollName[MAX_NAME_LEN];
     char logicalFileName[MAX_NAME_LEN];
@@ -515,10 +522,8 @@ setPathForRandomScheme( char *objPath, const char *vaultPath, char *userName,
         return status;
     }
 
-    log_agent::debug("{}: Random scheme: style=[{}], suffix length=[{}]",
-                     __func__,
-                     randomSchemeStyle,
-                     randomSchemeSuffixLength);
+    log_agent::debug(
+        "{}: Random scheme: style=[{}], suffix length=[{}]", __func__, randomSchemeStyle, randomSchemeSuffixLength);
 
     if (randomSchemeStyle == 1) {
         const auto rnd_str =
@@ -1106,7 +1111,7 @@ syncDataObjPhyPathS( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
         return config_result.code();
     }
 
-    if ( config.policy != ivpp::file_naming_policy::consistent ) {
+    if (config.policy != ivpp::file_naming_policy::consistent) {
         /* no need to sync */
         return 0;
     }
@@ -1142,9 +1147,8 @@ syncDataObjPhyPathS( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
         rstrcpy( myDdataObjInp.objPath, dataObjInfo->objPath, MAX_NAME_LEN );
         int status = getFilePathName(rsComm, dataObjInfo, &myDdataObjInp);
         if (status < 0) {
-            const auto err{ERROR(status,
-                                 (boost::format("getFilePathName err for [%s]") %
-                                  dataObjInfo->objPath).str().c_str())};
+            const auto err{
+                ERROR(status, (boost::format("getFilePathName err for [%s]") % dataObjInfo->objPath).str().c_str())};
             irods::log(err);
             return err.code();
         }
@@ -1152,9 +1156,8 @@ syncDataObjPhyPathS( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
     else {
         int status = getFilePathName(rsComm, dataObjInfo, dataObjInp);
         if (status < 0) {
-            const auto err{ERROR(status,
-                                 (boost::format("getFilePathName err for [%s]") %
-                                  dataObjInfo->objPath).str().c_str())};
+            const auto err{
+                ERROR(status, (boost::format("getFilePathName err for [%s]") % dataObjInfo->objPath).str().c_str())};
             irods::log(err);
             return err.code();
         }

--- a/server/core/src/physPath.cpp
+++ b/server/core/src/physPath.cpp
@@ -57,16 +57,9 @@ namespace
 
     namespace detail
     {
-        enum class file_naming_policy
-        {
-            consistent,
-            random,
-            reversed_dataid
-        };
-
         struct file_naming_policy_config
         {
-            file_naming_policy policy = file_naming_policy::consistent;
+            ivpp::file_naming_policy policy = ivpp::file_naming_policy::consistent;
             int random_scheme_style = ivpp::random_scheme_config_default_style;
             int random_scheme_suffix_length = ivpp::random_scheme_config_default_suffix_length;
         };
@@ -182,24 +175,18 @@ namespace
             auto config = file_naming_policy_config{};
             const auto entries = split_resource_context(context);
 
-            const auto policy_values = get_context_values(entries, ivpp::file_naming_policy);
-            log_duplicate_context_key(ivpp::file_naming_policy, policy_values);
+            const auto policy_values = get_context_values(entries, ivpp::file_naming_policy_key);
+            log_duplicate_context_key(ivpp::file_naming_policy_key, policy_values);
             if (!policy_values.empty()) {
                 const auto& policy = policy_values.back();
-                if (policy == ivpp::file_naming_policy_consistent) {
-                    config.policy = file_naming_policy::consistent;
-                }
-                else if (policy == ivpp::file_naming_policy_random) {
-                    config.policy = file_naming_policy::random;
-                }
-                else if (policy == ivpp::file_naming_policy_reversed_dataid) {
-                    config.policy = file_naming_policy::reversed_dataid;
+                if (const auto parsed_policy = ivpp::to_file_naming_policy(policy); parsed_policy) {
+                    config.policy = *parsed_policy;
                 }
                 else {
                     log_agent::warn(
                         "Invalid value [{}] for resource context key [{}]. Using default value [{}].",
                         policy,
-                        ivpp::file_naming_policy,
+                        ivpp::file_naming_policy_key,
                         ivpp::file_naming_policy_consistent);
                 }
             }
@@ -440,7 +427,7 @@ getFilePathName( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
         return config_result.code();
     }
 
-    if ( config.policy != detail::file_naming_policy::random ) {
+    if ( config.policy != ivpp::file_naming_policy::random ) {
         status = setPathForGraftPathScheme( dataObjInp->objPath,
                                             vault_path.c_str(), DEF_ADD_USER_FLAG,
                                             rsComm->clientUser.userName, DEF_TRIM_DIR_CNT,
@@ -1119,7 +1106,7 @@ syncDataObjPhyPathS( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
         return config_result.code();
     }
 
-    if ( config.policy != detail::file_naming_policy::consistent ) {
+    if ( config.policy != ivpp::file_naming_policy::consistent ) {
         /* no need to sync */
         return 0;
     }

--- a/server/core/src/physPath.cpp
+++ b/server/core/src/physPath.cpp
@@ -95,8 +95,8 @@ namespace
             return entries;
         } // split_resource_context
 
-        auto get_context_values(const std::vector<context_entry>& _entries,
-                                const std::string& _key) -> std::vector<std::string>
+        auto get_context_values(const std::vector<context_entry>& _entries, const std::string& _key)
+            -> std::vector<std::string>
         {
             std::vector<std::string> values;
 
@@ -159,8 +159,8 @@ namespace
             }
         } // parse_context_integer
 
-        auto get_file_naming_policy_config(const rodsLong_t _resc_id,
-                                           file_naming_policy_config& _config) -> irods::error
+        auto get_file_naming_policy_config(const rodsLong_t _resc_id, file_naming_policy_config& _config)
+            -> irods::error
         {
             if (_resc_id <= 0) {
                 return ERROR(SYS_INVALID_RESC_INPUT, "Invalid resource id for file naming policy lookup.");

--- a/server/core/src/physPath.cpp
+++ b/server/core/src/physPath.cpp
@@ -60,7 +60,8 @@ namespace
         enum class file_naming_policy
         {
             consistent,
-            random
+            random,
+            reversed_dataid
         };
 
         struct file_naming_policy_config
@@ -190,6 +191,9 @@ namespace
                 }
                 else if (policy == ivpp::file_naming_policy_random) {
                     config.policy = file_naming_policy::random;
+                }
+                else if (policy == ivpp::file_naming_policy_reversed_dataid) {
+                    config.policy = file_naming_policy::reversed_dataid;
                 }
                 else {
                     log_agent::warn(
@@ -436,7 +440,7 @@ getFilePathName( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
         return config_result.code();
     }
 
-    if ( config.policy == detail::file_naming_policy::consistent ) {
+    if ( config.policy != detail::file_naming_policy::random ) {
         status = setPathForGraftPathScheme( dataObjInp->objPath,
                                             vault_path.c_str(), DEF_ADD_USER_FLAG,
                                             rsComm->clientUser.userName, DEF_TRIM_DIR_CNT,

--- a/server/core/src/physPath.cpp
+++ b/server/core/src/physPath.cpp
@@ -44,6 +44,9 @@
 #include <cstdint>
 #include <cstring>
 #include <ctime>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace
 {
@@ -54,31 +57,187 @@ namespace
 
     namespace detail
     {
-        // The following variables support extensions to the random scheme vault path policy.
-        // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
-        int random_scheme_style = ivpp::random_scheme_config_default_style;
-        int random_scheme_suffix_length = ivpp::random_scheme_config_default_suffix_length;
-        // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
-
-        // Returns the random scheme style if set in the REI. Otherwise, the default is returned.
-        auto get_random_scheme_style(RuleExecInfo& _rei) -> int
+        enum class file_naming_policy
         {
-            auto* msp = getMsParamByLabel(&_rei.inOutMsParamArray, ivpp::random_scheme_style);
-            if (!msp) {
-                return ivpp::random_scheme_config_default_style;
-            }
-            return *static_cast<int*>(msp->inOutStruct);
-        } // get_random_scheme_style
+            consistent,
+            random
+        };
 
-        // Returns the random scheme suffix length if set in the REI. Otherwise, the default is returned.
-        auto get_random_scheme_suffix_length(RuleExecInfo& _rei) -> int
+        struct file_naming_policy_config
         {
-            auto* msp = getMsParamByLabel(&_rei.inOutMsParamArray, ivpp::random_scheme_suffix_length);
-            if (!msp) {
-                return ivpp::random_scheme_config_default_suffix_length;
+            file_naming_policy policy = file_naming_policy::consistent;
+            int random_scheme_style = ivpp::random_scheme_config_default_style;
+            int random_scheme_suffix_length = ivpp::random_scheme_config_default_suffix_length;
+        };
+
+        struct context_entry
+        {
+            std::string key;
+            std::string value;
+        };
+
+        auto split_resource_context(const std::string& _context) -> std::vector<context_entry>
+        {
+            std::vector<context_entry> entries;
+
+            for (std::string::size_type start = 0; start <= _context.size();) {
+                const auto end = _context.find(';', start);
+                const auto token = _context.substr(start, end == std::string::npos ? std::string::npos : end - start);
+
+                if (!token.empty()) {
+                    const auto separator = token.find('=');
+                    if (separator != std::string::npos) {
+                        entries.push_back({token.substr(0, separator), token.substr(separator + 1)});
+                    }
+                }
+
+                if (end == std::string::npos) {
+                    break;
+                }
+
+                start = end + 1;
             }
-            return *static_cast<int*>(msp->inOutStruct);
-        } // get_random_scheme_suffix_length
+
+            return entries;
+        } // split_resource_context
+
+        auto get_context_values(const std::vector<context_entry>& _entries, const std::string& _key) -> std::vector<std::string>
+        {
+            std::vector<std::string> values;
+
+            for (const auto& [key, value] : _entries) {
+                if (key == _key) {
+                    values.push_back(value);
+                }
+            }
+
+            return values;
+        } // get_context_values
+
+        auto join_values(const std::vector<std::string>& _values) -> std::string
+        {
+            std::string result;
+
+            for (std::size_t i = 0; i < _values.size(); ++i) {
+                if (i > 0) {
+                    result += ", ";
+                }
+
+                result += "[" + _values[i] + "]";
+            }
+
+            return result;
+        } // join_values
+
+        auto log_duplicate_context_key(const std::string& _key, const std::vector<std::string>& _values) -> void
+        {
+            if (_values.size() > 1) {
+                log_agent::warn(
+                    "Resource context contains duplicate [{}] keys. Values found: {}. Using last value [{}].",
+                    _key,
+                    join_values(_values),
+                    _values.back());
+            }
+        } // log_duplicate_context_key
+
+        auto parse_context_integer(const std::string& _key, const std::string& _value, const int _default_value) -> int
+        {
+            try {
+                std::size_t pos = 0;
+                const auto value = std::stoi(_value, &pos);
+                if (pos != _value.size()) {
+                    log_agent::warn(
+                        "Invalid value [{}] for resource context key [{}]. Using default value [{}].",
+                        _value,
+                        _key,
+                        _default_value);
+                    return _default_value;
+                }
+
+                return value;
+            }
+            catch (const std::exception&) {
+                log_agent::warn(
+                    "Invalid value [{}] for resource context key [{}]. Using default value [{}].",
+                    _value,
+                    _key,
+                    _default_value);
+                return _default_value;
+            }
+        } // parse_context_integer
+
+        auto get_file_naming_policy_config(const rodsLong_t _resc_id, file_naming_policy_config& _config) -> irods::error
+        {
+            if (_resc_id <= 0) {
+                return ERROR(SYS_INVALID_RESC_INPUT, "Invalid resource id for file naming policy lookup.");
+            }
+
+            std::string context;
+            if (const auto err = irods::get_resource_property<std::string>(_resc_id, irods::RESOURCE_CONTEXT, context);
+                !err.ok()) {
+                return PASSMSG("Failed to retrieve resource context for file naming policy lookup.", err);
+            }
+
+            auto config = file_naming_policy_config{};
+            const auto entries = split_resource_context(context);
+
+            const auto policy_values = get_context_values(entries, ivpp::file_naming_policy);
+            log_duplicate_context_key(ivpp::file_naming_policy, policy_values);
+            if (!policy_values.empty()) {
+                const auto& policy = policy_values.back();
+                if (policy == ivpp::file_naming_policy_consistent) {
+                    config.policy = file_naming_policy::consistent;
+                }
+                else if (policy == ivpp::file_naming_policy_random) {
+                    config.policy = file_naming_policy::random;
+                }
+                else {
+                    log_agent::warn(
+                        "Invalid value [{}] for resource context key [{}]. Using default value [{}].",
+                        policy,
+                        ivpp::file_naming_policy,
+                        ivpp::file_naming_policy_consistent);
+                }
+            }
+
+            const auto style_values = get_context_values(entries, ivpp::random_scheme_style);
+            log_duplicate_context_key(ivpp::random_scheme_style, style_values);
+            if (!style_values.empty()) {
+                const auto style = parse_context_integer(
+                    ivpp::random_scheme_style, style_values.back(), ivpp::random_scheme_config_default_style);
+                if (style >= 0 && style <= 2) {
+                    config.random_scheme_style = style;
+                }
+                else {
+                    log_agent::warn(
+                        "Invalid value [{}] for resource context key [{}]. Expected 0, 1, or 2. Using default value [{}].",
+                        style_values.back(),
+                        ivpp::random_scheme_style,
+                        ivpp::random_scheme_config_default_style);
+                }
+            }
+
+            const auto suffix_length_values = get_context_values(entries, ivpp::random_scheme_suffix_length);
+            log_duplicate_context_key(ivpp::random_scheme_suffix_length, suffix_length_values);
+            if (!suffix_length_values.empty()) {
+                const auto suffix_length = parse_context_integer(ivpp::random_scheme_suffix_length,
+                                                                 suffix_length_values.back(),
+                                                                 ivpp::random_scheme_config_default_suffix_length);
+                if (suffix_length >= 1 && suffix_length <= 32) {
+                    config.random_scheme_suffix_length = suffix_length;
+                }
+                else {
+                    log_agent::warn(
+                        "Invalid value [{}] for resource context key [{}]. Length must satisfy the range [1, 32]. Using default value [{}].",
+                        suffix_length_values.back(),
+                        ivpp::random_scheme_suffix_length,
+                        ivpp::random_scheme_config_default_suffix_length);
+                }
+            }
+
+            _config = config;
+            return SUCCESS();
+        } // get_file_naming_policy_config
     } // namespace detail
 } // anonymous namespace
 
@@ -229,7 +388,6 @@ int
 getFilePathName( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
                  dataObjInp_t *dataObjInp ) {
     char *filePath;
-    vaultPathPolicy_t vaultPathPolicy;
     int status;
 
     if ( !dataObjInfo ) {
@@ -271,21 +429,25 @@ getFilePathName( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
         return status;
     }
 
-    status = getVaultPathPolicy( rsComm, dataObjInfo, &vaultPathPolicy );
-    if ( status < 0 ) {
-        return status;
+    auto config = detail::file_naming_policy_config{};
+    auto config_result = detail::get_file_naming_policy_config(dataObjInfo->rescId, config);
+    if (!config_result.ok()) {
+        irods::log(PASS(config_result));
+        return config_result.code();
     }
 
-    if ( vaultPathPolicy.scheme == GRAFT_PATH_S ) {
+    if ( config.policy == detail::file_naming_policy::consistent ) {
         status = setPathForGraftPathScheme( dataObjInp->objPath,
-                                            vault_path.c_str(), vaultPathPolicy.addUserName,
-                                            rsComm->clientUser.userName, vaultPathPolicy.trimDirCnt,
+                                            vault_path.c_str(), DEF_ADD_USER_FLAG,
+                                            rsComm->clientUser.userName, DEF_TRIM_DIR_CNT,
                                             dataObjInfo->filePath );
     }
     else {
         status = setPathForRandomScheme( dataObjInp->objPath,
-                                         vault_path.c_str(), rsComm->clientUser.userName,
-                                         dataObjInfo->filePath );
+                                          vault_path.c_str(), rsComm->clientUser.userName,
+                                          config.random_scheme_style,
+                                          config.random_scheme_suffix_length,
+                                          dataObjInfo->filePath );
     }
 
     return status;
@@ -321,13 +483,6 @@ getVaultPathPolicy( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
         return status;
     }
 
-    // This is horrible, but it must be done here to avoid giving non-rodsadmin users
-    // the ability to modify server-side configuration options for the random scheme.
-    //
-    // This limits modification of the random scheme configuration options to acSetVaultPathPolicy().
-    detail::random_scheme_style = detail::get_random_scheme_style(rei);
-    detail::random_scheme_suffix_length = detail::get_random_scheme_suffix_length(rei);
-
     auto* msParam = getMsParamByLabel(&rei.inOutMsParamArray, VAULT_PATH_POLICY);
     if (nullptr == msParam) {
         /* use the default */
@@ -349,7 +504,7 @@ getVaultPathPolicy( rsComm_t *rsComm, dataObjInfo_t *dataObjInfo,
 
 int
 setPathForRandomScheme( char *objPath, const char *vaultPath, char *userName,
-                        char *outPath ) {
+                        int randomSchemeStyle, int randomSchemeSuffixLength, char *outPath ) {
     int dir1, dir2;
     char logicalCollName[MAX_NAME_LEN];
     char logicalFileName[MAX_NAME_LEN];
@@ -371,12 +526,12 @@ setPathForRandomScheme( char *objPath, const char *vaultPath, char *userName,
 
     log_agent::debug("{}: Random scheme: style=[{}], suffix length=[{}]",
                      __func__,
-                     detail::random_scheme_style,
-                     detail::random_scheme_suffix_length);
+                     randomSchemeStyle,
+                     randomSchemeSuffixLength);
 
-    if (detail::random_scheme_style == 1) {
+    if (randomSchemeStyle == 1) {
         const auto rnd_str =
-            irods::generate_random_alphanumeric_string(static_cast<std::int16_t>(detail::random_scheme_suffix_length));
+            irods::generate_random_alphanumeric_string(static_cast<std::int16_t>(randomSchemeSuffixLength));
         std::snprintf(outPath,
                       MAX_NAME_LEN,
                       "%s/%s/%d/%d/%s.%d.%s",
@@ -388,9 +543,9 @@ setPathForRandomScheme( char *objPath, const char *vaultPath, char *userName,
                       static_cast<unsigned int>(std::time(nullptr)),
                       rnd_str.c_str());
     }
-    else if (detail::random_scheme_style == 2) {
+    else if (randomSchemeStyle == 2) {
         const auto rnd_str =
-            irods::generate_random_alphanumeric_string(static_cast<std::int16_t>(detail::random_scheme_suffix_length));
+            irods::generate_random_alphanumeric_string(static_cast<std::int16_t>(randomSchemeSuffixLength));
         std::snprintf(outPath,
                       MAX_NAME_LEN,
                       "%s/%s/%d/%d/%d.%s",
@@ -953,18 +1108,16 @@ syncDataObjPhyPathS( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
         return 0;
     }
 
-    vaultPathPolicy_t vaultPathPolicy{};
-    int status = getVaultPathPolicy( rsComm, dataObjInfo, &vaultPathPolicy );
-    if ( status < 0 ) {
-        rodsLog( LOG_NOTICE,
-                 "syncDataObjPhyPathS: getVaultPathPolicy error for %s, status = %d",
-                 dataObjInfo->objPath, status );
+    auto config = detail::file_naming_policy_config{};
+    auto config_result = detail::get_file_naming_policy_config(dataObjInfo->rescId, config);
+    if (!config_result.ok()) {
+        irods::log(PASS(config_result));
+        return config_result.code();
     }
-    else {
-        if ( vaultPathPolicy.scheme != GRAFT_PATH_S ) {
-            /* no need to sync */
-            return 0;
-        }
+
+    if ( config.policy != detail::file_naming_policy::consistent ) {
+        /* no need to sync */
+        return 0;
     }
 
     if ( isInVault( dataObjInfo ) == 0 ) {
@@ -996,23 +1149,31 @@ syncDataObjPhyPathS( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
         dataObjInp_t myDdataObjInp;
         memset( &myDdataObjInp, 0, sizeof( myDdataObjInp ) );
         rstrcpy( myDdataObjInp.objPath, dataObjInfo->objPath, MAX_NAME_LEN );
-        status = getFilePathName(rsComm, dataObjInfo, &myDdataObjInp);
+        int status = getFilePathName(rsComm, dataObjInfo, &myDdataObjInp);
+        if (status < 0) {
+            const auto err{ERROR(status,
+                                 (boost::format("getFilePathName err for [%s]") %
+                                  dataObjInfo->objPath).str().c_str())};
+            irods::log(err);
+            return err.code();
+        }
     }
     else {
-        status = getFilePathName(rsComm, dataObjInfo, dataObjInp);
+        int status = getFilePathName(rsComm, dataObjInfo, dataObjInp);
+        if (status < 0) {
+            const auto err{ERROR(status,
+                                 (boost::format("getFilePathName err for [%s]") %
+                                  dataObjInfo->objPath).str().c_str())};
+            irods::log(err);
+            return err.code();
+        }
     }
-
-    if (status < 0) { 
-        const auto err{ERROR(status,
-                             (boost::format("getFilePathName err for [%s]") %
-                              dataObjInfo->objPath).str().c_str())};
-        irods::log(err);
-        return err.code();
-    }   
 
     if ( strcmp( fileRenameInp.oldFileName, dataObjInfo->filePath ) == 0 ) {
         return 0;
     }
+
+    int status = 0;
 
     /* see if the new file exist */
     if ( getSizeInVault( rsComm, dataObjInfo ) >= 0 ) {

--- a/server/re/include/irods/reSysDataObjOpr.hpp
+++ b/server/re/include/irods/reSysDataObjOpr.hpp
@@ -43,10 +43,11 @@ msiSetRandomScheme( ruleExecInfo_t *rei );
 
 /// Sets the random scheme style.
 ///
-/// This microservice allows administrators to change how physical paths are generated. The effects of
-/// this microservice are not applied unless the vault path policy is set to the random scheme.
+/// This microservice is retained for compatibility and is now a no-op. Configure random physical path
+/// naming per leaf resource with the resource context keys file_naming_policy=random and
+/// random_scheme_style.
 ///
-/// This microservice has no effect if invoked outside of acSetVaultPathPolicy() or an error occurs.
+/// The supported random_scheme_style values are 0, 1, and 2.
 ///
 /// Styles:
 /// - 0: Default style, i.e. <vault_root>/<int>/<int>/<filename>.<epoch_seconds>
@@ -71,10 +72,11 @@ int msi_random_scheme_set_style(MsParam* _style, ruleExecInfo_t* _rei);
 
 /// Sets the random scheme suffix length.
 ///
-/// The effects of this microservice are not applied unless the random scheme style is set to 1 or 2.
-/// See #msi_random_scheme_set_style for more information.
+/// This microservice is retained for compatibility and is now a no-op. Configure random physical path
+/// naming per leaf resource with the resource context keys file_naming_policy=random and
+/// random_scheme_suffix_length.
 ///
-/// This microservice has no effect if invoked outside of acSetVaultPathPolicy() or an error occurs.
+/// The supported random_scheme_suffix_length range is [1, 32].
 ///
 /// \param[in] _suffix_length The new length of the randomly-generated string. The value must
 ///                           satisfy the range [1, 32]. Failing to satisfy this requirement will

--- a/server/re/src/reSysDataObjOpr.cpp
+++ b/server/re/src/reSysDataObjOpr.cpp
@@ -965,9 +965,8 @@ setApiPerm( int apiNumber, int proxyPerm, int clientPerm ) {
 /**
  * \fn msiSetGraftPathScheme (msParam_t *xaddUserName, msParam_t *xtrimDirCnt, ruleExecInfo_t *rei)
  *
- * \brief  This microservice sets the VaultPath scheme to GRAFT_PATH.
- *    It grafts (adds) the logical path to the vault path of the resource
- *    when generating the physical path for a data object.
+ * \brief  Compatibility no-op. Physical path naming is configured per leaf
+ *    resource with the file_naming_policy resource context key.
  *
  * \module core
  *
@@ -989,8 +988,8 @@ setApiPerm( int apiNumber, int proxyPerm, int clientPerm ) {
  *    handled by the rule engine. The user does not include rei as a
  *    parameter in the rule invocation.
  *
- * \DolVarDependence - rei->inOutMsParamArray (label == VAULT_PATH_POLICY)
- * \DolVarModified - rei->inOutMsParamArray (label == VAULT_PATH_POLICY)
+ * \DolVarDependence none
+ * \DolVarModified none
  * \iCatAttrDependence none
  * \iCatAttrModified none
  * \sideeffect none
@@ -1002,75 +1001,22 @@ setApiPerm( int apiNumber, int proxyPerm, int clientPerm ) {
  * \sa none
  **/
 int
-msiSetGraftPathScheme( msParam_t *xaddUserName, msParam_t *xtrimDirCnt,
+msiSetGraftPathScheme( msParam_t* /*xaddUserName*/, msParam_t* /*xtrimDirCnt*/,
                        ruleExecInfo_t *rei ) {
-    char *addUserNameStr;
-    char *trimDirCntStr;
-    int addUserName;
-    int trimDirCnt;
-    msParam_t *msParam;
-    vaultPathPolicy_t *vaultPathPolicy;
-
     RE_TEST_MACRO( "    Calling msiSetGraftPathScheme" )
 
-    addUserNameStr = ( char * ) xaddUserName->inOutStruct;
-    trimDirCntStr = ( char * ) xtrimDirCnt->inOutStruct;
-
-    if ( strcmp( addUserNameStr, "no" ) == 0 ) {
-        addUserName = 0;
-    }
-    else if ( strcmp( addUserNameStr, "yes" ) == 0 ) {
-        addUserName = 1;
-    }
-    else {
-        rodsLog( LOG_ERROR,
-                 "msiSetGraftPathScheme: invalid input addUserName %s", addUserNameStr );
-        rei->status = SYS_INPUT_PERM_OUT_OF_RANGE;
-        return SYS_INPUT_PERM_OUT_OF_RANGE;
-    }
-
-    if ( !isdigit( trimDirCntStr[0] ) ) {
-        rodsLog( LOG_ERROR,
-                 "msiSetGraftPathScheme: input trimDirCnt %s", trimDirCntStr );
-        rei->status = SYS_INPUT_PERM_OUT_OF_RANGE;
-        return SYS_INPUT_PERM_OUT_OF_RANGE;
-    }
-    else {
-        trimDirCnt = atoi( trimDirCntStr );
-    }
-
     rei->status = 0;
-
-    if ( ( msParam = getMsParamByLabel( &rei->inOutMsParamArray,
-                                        VAULT_PATH_POLICY ) ) != NULL ) {
-        vaultPathPolicy = ( vaultPathPolicy_t * ) msParam->inOutStruct;
-        if ( vaultPathPolicy == NULL ) {
-            vaultPathPolicy = ( vaultPathPolicy_t* )malloc( sizeof( vaultPathPolicy_t ) );
-            msParam->inOutStruct = ( void * ) vaultPathPolicy;
-        }
-        vaultPathPolicy->scheme = GRAFT_PATH_S;
-        vaultPathPolicy->addUserName = addUserName;
-        vaultPathPolicy->trimDirCnt = trimDirCnt;
-        return 0;
-    }
-    else {
-        vaultPathPolicy = ( vaultPathPolicy_t * ) malloc(
-                              sizeof( vaultPathPolicy_t ) );
-        vaultPathPolicy->scheme = GRAFT_PATH_S;
-        vaultPathPolicy->addUserName = addUserName;
-        vaultPathPolicy->trimDirCnt = trimDirCnt;
-        addMsParam( &rei->inOutMsParamArray, VAULT_PATH_POLICY,
-                    VaultPathPolicy_MS_T, ( void * ) vaultPathPolicy, NULL );
-    }
+    log_msi::warn(
+        "msiSetGraftPathScheme is a no-op. Configure per-resource physical path naming with resource context key [{}].",
+        irods::vault_path_policy::file_naming_policy);
     return 0;
 }
 
 /**
  * \fn msiSetRandomScheme (ruleExecInfo_t *rei)
  *
- * \brief  This microservice sets the scheme for composing the physical path in the vault to RANDOM.  A randomly generated path is appended to the
- *         vaultPath when generating the physical path. e.g., $vaultPath/$userName/$randomPath. The advantage with the RANDOM scheme is renaming
- *         operations (imv, irm) are much faster because there is no need to rename the corresponding physical path.
+ * \brief  Compatibility no-op. Physical path naming is configured per leaf
+ *         resource with file_naming_policy=random in the resource context.
  *
  * \module core
  *
@@ -1084,8 +1030,8 @@ msiSetGraftPathScheme( msParam_t *xaddUserName, msParam_t *xtrimDirCnt,
  *    handled by the rule engine. The user does not include rei as a
  *    parameter in the rule invocation.
  *
- * \DolVarDependence - rei->inOutMsParamArray (label==VAULT_PATH_POLICY)
- * \DolVarModified - rei->inOutMsParamArray (label==VAULT_PATH_POLICY)
+ * \DolVarDependence none
+ * \DolVarModified none
  * \iCatAttrDependence none
  * \iCatAttrModified none
  * \sideeffect none
@@ -1098,132 +1044,30 @@ msiSetGraftPathScheme( msParam_t *xaddUserName, msParam_t *xtrimDirCnt,
  **/
 int
 msiSetRandomScheme( ruleExecInfo_t *rei ) {
-    msParam_t *msParam;
-    vaultPathPolicy_t *vaultPathPolicy;
-
     RE_TEST_MACRO( "    Calling msiSetRandomScheme" )
 
     rei->status = 0;
-
-    if ( ( msParam = getMsParamByLabel( &rei->inOutMsParamArray,
-                                        VAULT_PATH_POLICY ) ) != NULL ) {
-        vaultPathPolicy = ( vaultPathPolicy_t * ) msParam->inOutStruct;
-        if ( vaultPathPolicy == NULL ) {
-            vaultPathPolicy = ( vaultPathPolicy_t* )malloc( sizeof( vaultPathPolicy_t ) );
-            msParam->inOutStruct = ( void * ) vaultPathPolicy;
-        }
-        memset( vaultPathPolicy, 0, sizeof( vaultPathPolicy_t ) );
-        vaultPathPolicy->scheme = RANDOM_S;
-        return 0;
-    }
-    else {
-        vaultPathPolicy = ( vaultPathPolicy_t * ) malloc(
-                              sizeof( vaultPathPolicy_t ) );
-        memset( vaultPathPolicy, 0, sizeof( vaultPathPolicy_t ) );
-        vaultPathPolicy->scheme = RANDOM_S;
-        addMsParam( &rei->inOutMsParamArray, VAULT_PATH_POLICY,
-                    VaultPathPolicy_MS_T, ( void * ) vaultPathPolicy, NULL );
-    }
+    log_msi::warn(
+        "msiSetRandomScheme is a no-op. Configure per-resource physical path naming with resource context key [{}].",
+        irods::vault_path_policy::file_naming_policy);
     return 0;
 }
 
-auto msi_random_scheme_set_style(MsParam* _style, ruleExecInfo_t* _rei) -> int
+auto msi_random_scheme_set_style(MsParam* /*_style*/, ruleExecInfo_t* _rei) -> int
 {
     _rei->status = 0;
-
-    if (!_style) {
-        log_msi::error("Invalid argument: Expected valid pointer for [_style] parameter. Received nullptr.");
-        _rei->status = INVALID_INPUT_ARGUMENT_NULL_POINTER;
-        return INVALID_INPUT_ARGUMENT_NULL_POINTER;
-    }
-
-    if (!_style->type) {
-        log_msi::error("Invalid argument: Expected valid pointer for [_style->type] parameter. Received nullptr.");
-        _rei->status = INVALID_INPUT_ARGUMENT_NULL_POINTER;
-        return INVALID_INPUT_ARGUMENT_NULL_POINTER;
-    }
-
-    if (std::strncmp(_style->type, INT_MS_T, std::strlen(INT_MS_T)) != 0) {
-        log_msi::error("Invalid argument: Expected integer for [_style->type] parameter. Received [{}].", _style->type);
-        _rei->status = SYS_INVALID_INPUT_PARAM;
-        return SYS_INVALID_INPUT_PARAM;
-    }
-
-    if (!_style->inOutStruct) {
-        log_msi::error(
-            "Invalid argument: Expected valid pointer for [_style->inOutStruct] parameter. Received nullptr.");
-        _rei->status = INVALID_INPUT_ARGUMENT_NULL_POINTER;
-        return INVALID_INPUT_ARGUMENT_NULL_POINTER;
-    }
-
-    const auto new_style = *static_cast<int*>(_style->inOutStruct);
-    if (new_style < 0 || new_style > 2) {
-        log_msi::error("{}: Invalid style [{}] for vault path scheme. Expected 0, 1, or 2.", __func__, new_style);
-        _rei->status = SYS_INVALID_INPUT_PARAM;
-        return _rei->status;
-    }
-
-    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-no-malloc)
-    auto* style = static_cast<int*>(std::malloc(sizeof(int)));
-    *style = new_style;
-    addMsParam(&_rei->inOutMsParamArray,
-               irods::vault_path_policy::random_scheme_style,
-               INT_MS_T,
-               static_cast<void*>(style),
-               nullptr);
-
+    log_msi::warn(
+        "msi_random_scheme_set_style is a no-op. Configure [{}] in the resource context.",
+        irods::vault_path_policy::random_scheme_style);
     return 0;
 } // msi_random_scheme_set_style
 
-auto msi_random_scheme_set_suffix_length(MsParam* _suffix_length, ruleExecInfo_t* _rei) -> int
+auto msi_random_scheme_set_suffix_length(MsParam* /*_suffix_length*/, ruleExecInfo_t* _rei) -> int
 {
     _rei->status = 0;
-
-    if (!_suffix_length) {
-        log_msi::error("Invalid argument: Expected valid pointer for [_suffix_length] parameter. Received nullptr.");
-        _rei->status = INVALID_INPUT_ARGUMENT_NULL_POINTER;
-        return INVALID_INPUT_ARGUMENT_NULL_POINTER;
-    }
-
-    if (!_suffix_length->type) {
-        log_msi::error(
-            "Invalid argument: Expected valid pointer for [_suffix_length->type] parameter. Received nullptr.");
-        _rei->status = INVALID_INPUT_ARGUMENT_NULL_POINTER;
-        return INVALID_INPUT_ARGUMENT_NULL_POINTER;
-    }
-
-    if (std::strncmp(_suffix_length->type, INT_MS_T, std::strlen(INT_MS_T)) != 0) {
-        log_msi::error("Invalid argument: Expected integer for [_suffix_length->type] parameter. Received [{}].",
-                       _suffix_length->type);
-        _rei->status = SYS_INVALID_INPUT_PARAM;
-        return SYS_INVALID_INPUT_PARAM;
-    }
-
-    if (!_suffix_length->inOutStruct) {
-        log_msi::error(
-            "Invalid argument: Expected valid pointer for [_suffix_length->inOutStruct] parameter. Received nullptr.");
-        _rei->status = INVALID_INPUT_ARGUMENT_NULL_POINTER;
-        return INVALID_INPUT_ARGUMENT_NULL_POINTER;
-    }
-
-    const auto new_length = *static_cast<int*>(_suffix_length->inOutStruct);
-    if (new_length < 1 || new_length > 32) {
-        log_msi::error("{}: Invalid suffix length [{}] for vault path scheme. Length must satisfy the range [1, 32].",
-                       __func__,
-                       new_length);
-        _rei->status = SYS_INVALID_INPUT_PARAM;
-        return _rei->status;
-    }
-
-    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-no-malloc)
-    auto* length = static_cast<int*>(std::malloc(sizeof(int)));
-    *length = new_length;
-    addMsParam(&_rei->inOutMsParamArray,
-               irods::vault_path_policy::random_scheme_suffix_length,
-               INT_MS_T,
-               static_cast<void*>(length),
-               nullptr);
-
+    log_msi::warn(
+        "msi_random_scheme_set_suffix_length is a no-op. Configure [{}] in the resource context.",
+        irods::vault_path_policy::random_scheme_suffix_length);
     return 0;
 } // msi_random_scheme_set_suffix_length
 
@@ -1440,4 +1284,3 @@ msiSetBulkPutPostProcPolicy( msParam_t *xflag, ruleExecInfo_t *rei ) {
     }
     return rei->status;
 }
-

--- a/server/re/src/reSysDataObjOpr.cpp
+++ b/server/re/src/reSysDataObjOpr.cpp
@@ -1008,7 +1008,7 @@ msiSetGraftPathScheme( msParam_t* /*xaddUserName*/, msParam_t* /*xtrimDirCnt*/,
     rei->status = 0;
     log_msi::warn(
         "msiSetGraftPathScheme is a no-op. Configure per-resource physical path naming with resource context key [{}].",
-        irods::vault_path_policy::file_naming_policy);
+        irods::vault_path_policy::file_naming_policy_key);
     return 0;
 }
 
@@ -1049,7 +1049,7 @@ msiSetRandomScheme( ruleExecInfo_t *rei ) {
     rei->status = 0;
     log_msi::warn(
         "msiSetRandomScheme is a no-op. Configure per-resource physical path naming with resource context key [{}].",
-        irods::vault_path_policy::file_naming_policy);
+        irods::vault_path_policy::file_naming_policy_key);
     return 0;
 }
 

--- a/server/re/src/reSysDataObjOpr.cpp
+++ b/server/re/src/reSysDataObjOpr.cpp
@@ -1000,9 +1000,8 @@ setApiPerm( int apiNumber, int proxyPerm, int clientPerm ) {
  * \post none
  * \sa none
  **/
-int
-msiSetGraftPathScheme( msParam_t* /*xaddUserName*/, msParam_t* /*xtrimDirCnt*/,
-                       ruleExecInfo_t *rei ) {
+int msiSetGraftPathScheme(msParam_t* /*xaddUserName*/, msParam_t* /*xtrimDirCnt*/, ruleExecInfo_t* rei)
+{
     RE_TEST_MACRO( "    Calling msiSetGraftPathScheme" )
 
     rei->status = 0;
@@ -1042,8 +1041,8 @@ msiSetGraftPathScheme( msParam_t* /*xaddUserName*/, msParam_t* /*xtrimDirCnt*/,
  * \post none
  * \sa none
  **/
-int
-msiSetRandomScheme( ruleExecInfo_t *rei ) {
+int msiSetRandomScheme(ruleExecInfo_t* rei)
+{
     RE_TEST_MACRO( "    Calling msiSetRandomScheme" )
 
     rei->status = 0;
@@ -1056,18 +1055,16 @@ msiSetRandomScheme( ruleExecInfo_t *rei ) {
 auto msi_random_scheme_set_style(MsParam* /*_style*/, ruleExecInfo_t* _rei) -> int
 {
     _rei->status = 0;
-    log_msi::warn(
-        "msi_random_scheme_set_style is a no-op. Configure [{}] in the resource context.",
-        irods::vault_path_policy::random_scheme_style);
+    log_msi::warn("msi_random_scheme_set_style is a no-op. Configure [{}] in the resource context.",
+                  irods::vault_path_policy::random_scheme_style);
     return 0;
 } // msi_random_scheme_set_style
 
 auto msi_random_scheme_set_suffix_length(MsParam* /*_suffix_length*/, ruleExecInfo_t* _rei) -> int
 {
     _rei->status = 0;
-    log_msi::warn(
-        "msi_random_scheme_set_suffix_length is a no-op. Configure [{}] in the resource context.",
-        irods::vault_path_policy::random_scheme_suffix_length);
+    log_msi::warn("msi_random_scheme_set_suffix_length is a no-op. Configure [{}] in the resource context.",
+                  irods::vault_path_policy::random_scheme_suffix_length);
     return 0;
 } // msi_random_scheme_set_suffix_length
 


### PR DESCRIPTION
passes relevant tests locally, still needs a full run.

also want to discuss the naming conventions and general plan.

- `file_naming_policy` as the setting... is `file` misleading for object storage?
- there is a consideration for the S3 resource plugin
- `reversed_dataid` policy in the server, but used by the S3 plugin... does it make sense as separate?
- case sensitivity of the setting (S3 is pretty relaxed as I remember it)
- deprecation notices / timing in 5.x and a direct upgrade cutover in 6.0
- this is all the raw development commits - can definitely remove some files (planning and analysis)


this PR could still be combined with a `phy_id` approach that decomposes full path strings, but the main speedup available is by not doing a physical file rename.  the full string approach allows for substring manipulation with a single SQL roundtrip... decomposed `phy_id` might require `n` SQL roundtrips, which would actually be slower... not yet tested...