### PR TITLE
5423.m ibun double free (main)

### DIFF
--- a/scripts/irods/test/test_ibun.py
+++ b/scripts/irods/test/test_ibun.py
@@ -237,6 +237,67 @@ class Test_ibun(resource_suite.ResourceBase, unittest.TestCase):
             if os.path.exists(local_file):
                 os.unlink(local_file)
 
+    def test_ibun_reports_resource_mismatch_for_mounted_collection__issue_5423(self):
+        replication = 'issue_5423_repl'
+        resource_0 = 'issue_5423_ufs0'
+        resource_1 = 'issue_5423_ufs1'
+        mount_resource = 'issue_5423_mount_resc'
+        collection_path = os.path.join(self.admin.session_collection, 'issue_5423_src')
+        mounted_collection = os.path.join(collection_path, 'mnt')
+        archive_path = collection_path + '.zip'
+        mountpoint_directory = os.path.join(self.admin.local_session_dir, 'issue_5423_phymount')
+        rule_file = os.path.join(self.admin.local_session_dir, 'issue_5423_register_mount.r')
+
+        rule_text = '''\
+register_issue_5423_mount {{
+    msiCollCreate(*irodsColl, 0, *status);
+    msiPhyPathReg(*irodsColl, *irodsResc, *phyDir, "mountPoint", *status);
+}}
+
+INPUT *irodsColl="{mounted_collection}", *irodsResc="{mount_resource}", *phyDir="{mountpoint_directory}"
+OUTPUT ruleExecOut
+'''.format(**locals())
+
+        try:
+            lib.create_replication_resource(self.admin, replication)
+            lib.create_ufs_resource(self.admin, resource_0, test.settings.HOSTNAME_2)
+            lib.create_ufs_resource(self.admin, resource_1, test.settings.HOSTNAME_3)
+            lib.create_ufs_resource(self.admin, mount_resource, test.settings.HOSTNAME_1)
+            lib.add_child_resource(self.admin, replication, resource_0)
+            lib.add_child_resource(self.admin, replication, resource_1)
+
+            os.mkdir(mountpoint_directory)
+            with open(os.path.join(mountpoint_directory, 'foo'), 'w') as f:
+                f.write('payload')
+
+            with open(rule_file, 'w') as f:
+                f.write(rule_text)
+
+            self.admin.assert_icommand(['imkdir', collection_path])
+            self.admin.assert_icommand(['irule', '-F', rule_file])
+            self.admin.assert_icommand(['ils', '-AL', mounted_collection], 'STDOUT_SINGLELINE', 'mountP')
+
+            out, err, ec = self.admin.run_icommand(
+                ['ibun', '-c', '-Dzip', '-R', replication, archive_path, collection_path])
+            self.assertNotEqual(0, ec)
+            self.assertEqual('', out)
+            self.assertIn('SYS_COPY_NOT_EXIST_IN_RESC', err)
+            self.assertNotIn('SYS_INTERNAL_ERR', err)
+
+        finally:
+            self.admin.run_icommand(['imcoll', '-U', mounted_collection])
+            self.admin.run_icommand(['irm', '-f', archive_path])
+            self.admin.run_icommand(['irm', '-r', '-f', collection_path])
+            self.admin.run_icommand(['iadmin', 'rmchildfromresc', replication, resource_0])
+            self.admin.run_icommand(['iadmin', 'rmchildfromresc', replication, resource_1])
+            self.admin.run_icommand(['iadmin', 'rmresc', replication])
+            self.admin.run_icommand(['iadmin', 'rmresc', resource_0])
+            self.admin.run_icommand(['iadmin', 'rmresc', resource_1])
+            self.admin.run_icommand(['iadmin', 'rmresc', mount_resource])
+            shutil.rmtree(mountpoint_directory, ignore_errors=True)
+            if os.path.exists(rule_file):
+                os.unlink(rule_file)
+
     def test_ibun(self):
         test_file = "ibun_test_file"
         lib.make_file(test_file, 1000)

--- a/scripts/irods/test/test_ibun.py
+++ b/scripts/irods/test/test_ibun.py
@@ -183,6 +183,60 @@ class Test_ibun(resource_suite.ResourceBase, unittest.TestCase):
         do_test_ibun_atop_existing_archive_file_in_replication_hierarchy(self, 1038425, 1044480)
         do_test_ibun_atop_existing_archive_file_in_replication_hierarchy(self, 1040425, 1054720)
 
+    def test_ibun_zip_to_replication_resource_with_archive_name_matching_source_collection__issue_5423(self):
+        replication = 'issue_5423_repl'
+        resource_0 = 'issue_5423_ufs0'
+        resource_1 = 'issue_5423_ufs1'
+        collection_name = 'new'
+        filename = 'foo'
+        local_file = os.path.join(self.user0.local_session_dir, filename)
+        collection_path = os.path.join(self.user0.session_collection, collection_name)
+        put_path = os.path.join(collection_path, filename)
+        archive_path = os.path.join(self.user0.session_collection, collection_name + '.zip')
+
+        def assert_archive_replicas_are_good():
+            query = "select DATA_RESC_NAME, DATA_REPL_STATUS where COLL_NAME = '{}' and DATA_NAME = '{}'".format(
+                os.path.dirname(archive_path), os.path.basename(archive_path))
+            out, err, ec = self.admin.run_icommand(['iquest', '%s...%s', query])
+
+            self.assertEqual(0, ec)
+            self.assertEqual(0, len(err))
+
+            rows = [line.split('...') for line in out.splitlines()]
+            self.assertEqual(2, len(rows), out)
+            self.assertEqual(set([resource_0, resource_1]), set([row[0] for row in rows]))
+
+            for _, repl_status in rows:
+                self.assertEqual(1, int(repl_status))
+
+        try:
+            lib.create_replication_resource(self.admin, replication)
+            lib.create_ufs_resource(self.admin, resource_0, test.settings.HOSTNAME_2)
+            lib.create_ufs_resource(self.admin, resource_1, test.settings.HOSTNAME_3)
+            lib.add_child_resource(self.admin, replication, resource_0)
+            lib.add_child_resource(self.admin, replication, resource_1)
+
+            lib.make_file(local_file, 1024, 'random')
+            self.user0.assert_icommand(['imkdir', collection_path])
+            self.user0.assert_icommand(['iput', local_file, put_path])
+
+            self.user0.assert_icommand(['ibun', '-c', '-Dzip', '-R', replication, archive_path, collection_path])
+            assert_archive_replicas_are_good()
+
+            self.user0.assert_icommand(['ibun', '-c', '-Dzip', '-f', '-R', replication, archive_path, collection_path])
+            assert_archive_replicas_are_good()
+
+        finally:
+            self.user0.run_icommand(['irm', '-f', archive_path])
+            self.user0.run_icommand(['irm', '-r', '-f', collection_path])
+            lib.remove_child_resource(self.admin, replication, resource_0)
+            lib.remove_child_resource(self.admin, replication, resource_1)
+            lib.remove_resource(self.admin, replication)
+            lib.remove_resource(self.admin, resource_0)
+            lib.remove_resource(self.admin, resource_1)
+            if os.path.exists(local_file):
+                os.unlink(local_file)
+
     def test_ibun(self):
         test_file = "ibun_test_file"
         lib.make_file(test_file, 1000)

--- a/server/api/src/rsChkObjPermAndStat.cpp
+++ b/server/api/src/rsChkObjPermAndStat.cpp
@@ -147,7 +147,7 @@ chkCollForBundleOpr( rsComm_t *rsComm,
                              "chkCollForBundleOpr: specColl resc %s does not match %s",
                              collEnt->specColl.resource, resource );
                     rsCloseCollection( rsComm, &handleInx );
-                    freeCollEntForChkColl( collEnt );
+                    free( collEnt );
                     freeCollEntForChkColl( curCollEnt );
                     return SYS_COPY_NOT_EXIST_IN_RESC;
                 }
@@ -160,7 +160,7 @@ chkCollForBundleOpr( rsComm_t *rsComm,
                              "chkCollForBundleOpr: no accPerm to specColl %s. status = %d",
                              collEnt->specColl.collection, status );
                     rsCloseCollection( rsComm, &handleInx );
-                    freeCollEntForChkColl( collEnt );
+                    free( collEnt );
                     freeCollEntForChkColl( curCollEnt );
                     return status;
                 }
@@ -230,7 +230,7 @@ chkCollForBundleOpr( rsComm_t *rsComm,
                                      "chkCollForBundleOpr: no accPerm to %s. status = %d",
                                      myPath, status );
                             rsCloseCollection( rsComm, &handleInx );
-                            freeCollEntForChkColl( collEnt );
+                            free( collEnt );
                             return status;
                         }
                         else {
@@ -324,6 +324,9 @@ freeCollEntForChkColl( collEnt_t *collEnt ) {
     }
     if ( collEnt->resource != NULL ) {
         free( collEnt->resource );
+    }
+    if ( collEnt->resc_hier != NULL ) {
+        free( collEnt->resc_hier );
     }
 
     free( collEnt );

--- a/server/api/src/rsChkObjPermAndStat.cpp
+++ b/server/api/src/rsChkObjPermAndStat.cpp
@@ -147,7 +147,7 @@ chkCollForBundleOpr( rsComm_t *rsComm,
                              "chkCollForBundleOpr: specColl resc %s does not match %s",
                              collEnt->specColl.resource, resource );
                     rsCloseCollection( rsComm, &handleInx );
-                    free( collEnt );
+                    free(collEnt);
                     freeCollEntForChkColl( curCollEnt );
                     return SYS_COPY_NOT_EXIST_IN_RESC;
                 }
@@ -160,7 +160,7 @@ chkCollForBundleOpr( rsComm_t *rsComm,
                              "chkCollForBundleOpr: no accPerm to specColl %s. status = %d",
                              collEnt->specColl.collection, status );
                     rsCloseCollection( rsComm, &handleInx );
-                    free( collEnt );
+                    free(collEnt);
                     freeCollEntForChkColl( curCollEnt );
                     return status;
                 }
@@ -230,7 +230,7 @@ chkCollForBundleOpr( rsComm_t *rsComm,
                                      "chkCollForBundleOpr: no accPerm to %s. status = %d",
                                      myPath, status );
                             rsCloseCollection( rsComm, &handleInx );
-                            free( collEnt );
+                            free(collEnt);
                             return status;
                         }
                         else {
@@ -325,8 +325,8 @@ freeCollEntForChkColl( collEnt_t *collEnt ) {
     if ( collEnt->resource != NULL ) {
         free( collEnt->resource );
     }
-    if ( collEnt->resc_hier != NULL ) {
-        free( collEnt->resc_hier );
+    if (collEnt->resc_hier != NULL) {
+        free(collEnt->resc_hier);
     }
 
     free( collEnt );

--- a/server/api/src/rsChkObjPermAndStat.cpp
+++ b/server/api/src/rsChkObjPermAndStat.cpp
@@ -293,19 +293,19 @@ chkCollForBundleOpr( rsComm_t *rsComm,
  */
 int
 saveCollEntForChkColl( collEnt_t *collEnt ) {
-    if ( collEnt == NULL ) {
+    if ( collEnt == nullptr ) {
         return 0;
     }
-    if ( collEnt->collName != NULL ) {
+    if ( collEnt->collName != nullptr ) {
         collEnt->collName = strdup( collEnt->collName );
     }
-    if ( collEnt->dataName != NULL ) {
+    if ( collEnt->dataName != nullptr ) {
         collEnt->dataName = strdup( collEnt->dataName );
     }
-    if ( collEnt->resource != NULL ) {
+    if ( collEnt->resource != nullptr ) {
         collEnt->resource = strdup( collEnt->resource );
     }
-    if ( collEnt->resc_hier != NULL ) {
+    if ( collEnt->resc_hier != nullptr ) {
         collEnt->resc_hier = strdup( collEnt->resc_hier );
     }
     return 0;
@@ -313,19 +313,19 @@ saveCollEntForChkColl( collEnt_t *collEnt ) {
 
 int
 freeCollEntForChkColl( collEnt_t *collEnt ) {
-    if ( collEnt == NULL ) {
+    if ( collEnt == nullptr ) {
         return 0;
     }
-    if ( collEnt->collName != NULL ) {
+    if ( collEnt->collName != nullptr ) {
         free( collEnt->collName );
     }
-    if ( collEnt->dataName != NULL ) {
+    if ( collEnt->dataName != nullptr ) {
         free( collEnt->dataName );
     }
-    if ( collEnt->resource != NULL ) {
+    if ( collEnt->resource != nullptr ) {
         free( collEnt->resource );
     }
-    if (collEnt->resc_hier != NULL) {
+    if (collEnt->resc_hier != nullptr) {
         free(collEnt->resc_hier);
     }
 

--- a/server/api/src/rsChkObjPermAndStat.cpp
+++ b/server/api/src/rsChkObjPermAndStat.cpp
@@ -293,19 +293,19 @@ chkCollForBundleOpr( rsComm_t *rsComm,
  */
 int
 saveCollEntForChkColl( collEnt_t *collEnt ) {
-    if ( collEnt == nullptr ) {
+    if (collEnt == nullptr) {
         return 0;
     }
-    if ( collEnt->collName != nullptr ) {
+    if (collEnt->collName != nullptr) {
         collEnt->collName = strdup( collEnt->collName );
     }
-    if ( collEnt->dataName != nullptr ) {
+    if (collEnt->dataName != nullptr) {
         collEnt->dataName = strdup( collEnt->dataName );
     }
-    if ( collEnt->resource != nullptr ) {
+    if (collEnt->resource != nullptr) {
         collEnt->resource = strdup( collEnt->resource );
     }
-    if ( collEnt->resc_hier != nullptr ) {
+    if (collEnt->resc_hier != nullptr) {
         collEnt->resc_hier = strdup( collEnt->resc_hier );
     }
     return 0;
@@ -313,16 +313,16 @@ saveCollEntForChkColl( collEnt_t *collEnt ) {
 
 int
 freeCollEntForChkColl( collEnt_t *collEnt ) {
-    if ( collEnt == nullptr ) {
+    if (collEnt == nullptr) {
         return 0;
     }
-    if ( collEnt->collName != nullptr ) {
+    if (collEnt->collName != nullptr) {
         free( collEnt->collName );
     }
-    if ( collEnt->dataName != nullptr ) {
+    if (collEnt->dataName != nullptr) {
         free( collEnt->dataName );
     }
-    if ( collEnt->resource != nullptr ) {
+    if (collEnt->resource != nullptr) {
         free( collEnt->resource );
     }
     if (collEnt->resc_hier != nullptr) {

--- a/server/api/src/rsStructFileBundle.cpp
+++ b/server/api/src/rsStructFileBundle.cpp
@@ -3,6 +3,7 @@
 #include "irods/apiHeaderAll.h"
 #include "irods/dataObjOpr.hpp"
 #include "irods/irods_file_object.hpp"
+#include "irods/irods_hierarchy_parser.hpp"
 #include "irods/irods_log.hpp"
 #include "irods/irods_logger.hpp"
 #include "irods/irods_resource_redirect.hpp"
@@ -117,6 +118,54 @@ namespace
             }
         }
 
+        if ( ( structFileBundleInp->oprType & ADD_TO_TAR_OPR ) == 0 &&
+             fs::server::exists(*rsComm, structFileBundleInp->objPath) &&
+             !getValByKey(&structFileBundleInp->condInput, FORCE_FLAG_KW)) {
+            return OVERWRITE_WITHOUT_FORCE_FLAG;
+        }
+
+        // =-=-=-=-=-=-
+        // get the resc hier string
+        std::string resc_hier;
+        char* resc_hier_ptr = getValByKey( &structFileBundleInp->condInput, RESC_HIER_STR_KW );
+        if ( !resc_hier_ptr ) {
+            rodsLog( LOG_NOTICE, "%s :: RESC_HIER_STR_KW is NULL", __FUNCTION__ );
+            return SYS_INVALID_RESC_INPUT;
+        }
+
+        resc_hier = resc_hier_ptr;
+
+        irods::hierarchy_parser parser;
+        if (const auto err = parser.set_string(resc_hier); !err.ok()) {
+            irods::log(PASSMSG("failed to parse resource hierarchy", err));
+            return err.code();
+        }
+
+        std::string resource;
+        if (const auto err = parser.last_resc(resource); !err.ok()) {
+            irods::log(PASSMSG("failed to get leaf resource from hierarchy", err));
+            return err.code();
+        }
+
+        // =-=-=-=-=-=-
+        // Check the source collection before creating the archive object. This
+        // prevents the archive path from shadowing the source collection during
+        // recursive collection reads.
+        chkObjPermAndStat_t chkObjPermAndStatInp;
+        memset( &chkObjPermAndStatInp, 0, sizeof( chkObjPermAndStatInp ) );
+        rstrcpy( chkObjPermAndStatInp.objPath, structFileBundleInp->collection, MAX_NAME_LEN );
+        chkObjPermAndStatInp.flags = CHK_COLL_FOR_BUNDLE_OPR;
+        addKeyVal( &chkObjPermAndStatInp.condInput, RESC_NAME_KW, resource.c_str() );
+        addKeyVal( &chkObjPermAndStatInp.condInput, RESC_HIER_STR_KW, resc_hier.c_str() );
+        status = rsChkObjPermAndStat( rsComm, &chkObjPermAndStatInp );
+        clearKeyVal( &chkObjPermAndStatInp.condInput );
+
+        if ( status < 0 ) {
+            rodsLog( LOG_ERROR, "rsStructFileBundle: rsChkObjPermAndStat of %s error. stat = %d",
+                     chkObjPermAndStatInp.objPath, status );
+            return status;
+        }
+
         // =-=-=-=-=-=-=-
         // capture the object path in the data obj struct
         rstrcpy( dataObjInp.objPath, structFileBundleInp->objPath, MAX_NAME_LEN );
@@ -131,11 +180,6 @@ namespace
             l1descInx = rsDataObjOpen( rsComm, &dataObjInp );
         }
         else {
-            if (fs::server::exists(*rsComm, structFileBundleInp->objPath) &&
-                !getValByKey(&structFileBundleInp->condInput, FORCE_FLAG_KW)) {
-                return OVERWRITE_WITHOUT_FORCE_FLAG;
-            }
-
             l1descInx = rsDataObjCreate( rsComm, &dataObjInp );
         }
 
@@ -163,39 +207,6 @@ namespace
 
         // convert resc id to a string for the cond input
         std::string resc_id_str = boost::lexical_cast<std::string>(L1desc[l1descInx].dataObjInfo->rescId);
-
-        // =-=-=-=-=-=-=-
-        // check object permissions / stat
-        chkObjPermAndStat_t chkObjPermAndStatInp;
-        memset( &chkObjPermAndStatInp, 0, sizeof( chkObjPermAndStatInp ) );
-        rstrcpy( chkObjPermAndStatInp.objPath, structFileBundleInp->collection, MAX_NAME_LEN );
-        chkObjPermAndStatInp.flags = CHK_COLL_FOR_BUNDLE_OPR;
-        addKeyVal( &chkObjPermAndStatInp.condInput, RESC_NAME_KW,     L1desc[l1descInx].dataObjInfo->rescName );
-        addKeyVal( &chkObjPermAndStatInp.condInput, RESC_ID_KW, resc_id_str.c_str());
-
-        // =-=-=-=-=-=-=-
-        // get the resc hier string
-        std::string resc_hier;
-        char* resc_hier_ptr = getValByKey( &structFileBundleInp->condInput, RESC_HIER_STR_KW );
-        if ( !resc_hier_ptr ) {
-            rodsLog( LOG_NOTICE, "%s :: RESC_HIER_STR_KW is NULL", __FUNCTION__ );
-        }
-        else {
-            addKeyVal( &chkObjPermAndStatInp.condInput, RESC_HIER_STR_KW, resc_hier_ptr );
-            resc_hier = resc_hier_ptr;
-        }
-        status = rsChkObjPermAndStat( rsComm, &chkObjPermAndStatInp );
-        if ( status < 0 ) {
-            rodsLog( LOG_ERROR, "rsStructFileBundle: rsChkObjPermAndStat of %s error. stat = %d",
-                     chkObjPermAndStatInp.objPath, status );
-            openedDataObjInp_t dataObjCloseInp{};
-            dataObjCloseInp.l1descInx = l1descInx;
-            //L1desc[l1descInx].oprStatus = status;
-            rsDataObjClose( rsComm, &dataObjCloseInp );
-            return status;
-        }
-
-        clearKeyVal( &chkObjPermAndStatInp.condInput );
 
         // =-=-=-=-=-=-=-
         // create the special hidden directory where the bundling happens

--- a/server/api/src/rsStructFileBundle.cpp
+++ b/server/api/src/rsStructFileBundle.cpp
@@ -118,18 +118,19 @@ namespace
             }
         }
 
-        if ( ( structFileBundleInp->oprType & ADD_TO_TAR_OPR ) == 0 &&
-             fs::server::exists(*rsComm, structFileBundleInp->objPath) &&
-             !getValByKey(&structFileBundleInp->condInput, FORCE_FLAG_KW)) {
+        if ((structFileBundleInp->oprType & ADD_TO_TAR_OPR) == 0 &&
+            fs::server::exists(*rsComm, structFileBundleInp->objPath) &&
+            !getValByKey(&structFileBundleInp->condInput, FORCE_FLAG_KW))
+        {
             return OVERWRITE_WITHOUT_FORCE_FLAG;
         }
 
         // =-=-=-=-=-=-
         // get the resc hier string
         std::string resc_hier;
-        char* resc_hier_ptr = getValByKey( &structFileBundleInp->condInput, RESC_HIER_STR_KW );
-        if ( !resc_hier_ptr ) {
-            rodsLog( LOG_NOTICE, "%s :: RESC_HIER_STR_KW is NULL", __FUNCTION__ );
+        char* resc_hier_ptr = getValByKey(&structFileBundleInp->condInput, RESC_HIER_STR_KW);
+        if (!resc_hier_ptr) {
+            rodsLog(LOG_NOTICE, "%s :: RESC_HIER_STR_KW is NULL", __FUNCTION__);
             return SYS_INVALID_RESC_INPUT;
         }
 
@@ -152,17 +153,19 @@ namespace
         // prevents the archive path from shadowing the source collection during
         // recursive collection reads.
         chkObjPermAndStat_t chkObjPermAndStatInp;
-        memset( &chkObjPermAndStatInp, 0, sizeof( chkObjPermAndStatInp ) );
-        rstrcpy( chkObjPermAndStatInp.objPath, structFileBundleInp->collection, MAX_NAME_LEN );
+        memset(&chkObjPermAndStatInp, 0, sizeof(chkObjPermAndStatInp));
+        rstrcpy(chkObjPermAndStatInp.objPath, structFileBundleInp->collection, MAX_NAME_LEN);
         chkObjPermAndStatInp.flags = CHK_COLL_FOR_BUNDLE_OPR;
-        addKeyVal( &chkObjPermAndStatInp.condInput, RESC_NAME_KW, resource.c_str() );
-        addKeyVal( &chkObjPermAndStatInp.condInput, RESC_HIER_STR_KW, resc_hier.c_str() );
-        status = rsChkObjPermAndStat( rsComm, &chkObjPermAndStatInp );
-        clearKeyVal( &chkObjPermAndStatInp.condInput );
+        addKeyVal(&chkObjPermAndStatInp.condInput, RESC_NAME_KW, resource.c_str());
+        addKeyVal(&chkObjPermAndStatInp.condInput, RESC_HIER_STR_KW, resc_hier.c_str());
+        status = rsChkObjPermAndStat(rsComm, &chkObjPermAndStatInp);
+        clearKeyVal(&chkObjPermAndStatInp.condInput);
 
-        if ( status < 0 ) {
-            rodsLog( LOG_ERROR, "rsStructFileBundle: rsChkObjPermAndStat of %s error. stat = %d",
-                     chkObjPermAndStatInp.objPath, status );
+        if (status < 0) {
+            rodsLog(LOG_ERROR,
+                    "rsStructFileBundle: rsChkObjPermAndStat of %s error. stat = %d",
+                    chkObjPermAndStatInp.objPath,
+                    status);
             return status;
         }
 


### PR DESCRIPTION
The double free mentioned in the original issue (4-2-stable) is no longer reproducible - it was checked on 4.3.5 and 5.0.2.

However, inspecting the code resulted in detecting that bundling a mounted collection into a replication resource was still a problem.  Could make a new issue if we think it correct.

This passes relevant tests - has not passed a full test run.