### PR TITLE
[#8993] Only use good replicas for stat when possible (main)

### DIFF
--- a/server/api/src/rsObjStat.cpp
+++ b/server/api/src/rsObjStat.cpp
@@ -275,7 +275,7 @@ dataObjStat( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
              * (*rodsObjStatOut)->numCopies = genQueryOut->rowCnt; */
 
             for ( i = 0; i < genQueryOut->rowCnt; i++ ) {
-                if ( atoi( &replStatus->value[replStatus->len * i] ) == 1 ) {
+                if (atoi(&replStatus->value[replStatus->len * i]) == 1) {
                     rstrcpy( ( *rodsObjStatOut )->dataId,
                              &dataId->value[dataId->len * i], NAME_LEN );
                     ( *rodsObjStatOut )->objSize =

--- a/server/api/src/rsObjStat.cpp
+++ b/server/api/src/rsObjStat.cpp
@@ -275,7 +275,7 @@ dataObjStat( rsComm_t *rsComm, dataObjInp_t *dataObjInp,
              * (*rodsObjStatOut)->numCopies = genQueryOut->rowCnt; */
 
             for ( i = 0; i < genQueryOut->rowCnt; i++ ) {
-                if ( atoi( &replStatus->value[replStatus->len * i] ) > 0 ) {
+                if ( atoi( &replStatus->value[replStatus->len * i] ) == 1 ) {
                     rstrcpy( ( *rodsObjStatOut )->dataId,
                              &dataId->value[dataId->len * i], NAME_LEN );
                     ( *rodsObjStatOut )->objSize =

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -57,6 +57,7 @@ set(
   client_connection
   client_server_negotiation
   connection_pool
+  data_obj_stat_api
   data_object_finalize
   data_object_modify_info
   data_object_proxy

--- a/unit_tests/cmake/test_config/irods_data_obj_stat_api.cmake
+++ b/unit_tests/cmake/test_config/irods_data_obj_stat_api.cmake
@@ -1,0 +1,10 @@
+set(IRODS_TEST_TARGET irods_data_obj_stat_api)
+
+set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/test_data_obj_stat_api.cpp)
+
+set(IRODS_TEST_INCLUDE_PATH ${IRODS_EXTERNALS_FULLPATH_BOOST}/include)
+
+set(IRODS_TEST_LINK_LIBRARIES irods_common
+                              irods_client
+                              irods_plugin_dependencies
+                              ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so)

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -248,7 +248,6 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with mixed stale and good rep
 
     // We expect the good replica size
     REQUIRE(res->objSize == 0);
-    REQUIRE(res->objSize != bad_size);
 }
 
 TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas")
@@ -264,7 +263,6 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas")
 
     // We expect the first replica to give the stat when both replicas are stale
     REQUIRE(res->objSize == bad_size_one);
-    REQUIRE(res->objSize != bad_size_two);
 }
 
 TEST_CASE_METHOD(TestFixture, "Stat on data object with invalid status")
@@ -278,7 +276,6 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with invalid status")
 
     // We expect to have the size of the good replica
     REQUIRE(res->objSize == 0);
-    REQUIRE(res->objSize != bad_size);
 }
 
 TEST_CASE_METHOD(TestFixture, "Stat on data object with only invalid status")
@@ -298,5 +295,4 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with only invalid status")
 
     // We expect the first replica to give the stat when both replicas are stale
     REQUIRE(res->objSize == bad_size_one);
-    REQUIRE(res->objSize != bad_size_two);
 }

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -66,12 +66,12 @@ auto set_replica_status(RcComm& _comm,
     });
 
     // Specify the data object we want to mess with
-    DataObjInfo info_two{};
-    std::strncpy(static_cast<char*>(info_two.objPath), _path.c_str(), MAX_NAME_LEN - 1);
-    info_two.replNum = replica;
+    DataObjInfo info{};
+    std::strncpy(static_cast<char*>(info.objPath), _path.c_str(), MAX_NAME_LEN - 1);
+    info.replNum = replica;
 
     // Create the required input
-    ModDataObjMetaInp inp_two{&info_two, kvp.get()};
+    ModDataObjMetaInp inp_two{&info, kvp.get()};
     return rcModDataObjMeta(&_comm, &inp_two);
 }
 

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -303,7 +303,7 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with only invalid status")
     REQUIRE(set_replica_status(
                 comm, test_data_object, 1, bad_status_two, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >= 0);
 
-    REQUIRE(irods::experimental::replica::replica_status(comm, test_data_object, 0) == bad_size_one);
+    REQUIRE(irods::experimental::replica::replica_status(comm, test_data_object, 0) == bad_status_one);
     REQUIRE(irods::experimental::replica::replica_status(comm, test_data_object, 1) == bad_status_two);
 
     auto res{stat(conn, test_data_object)};

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -1,5 +1,8 @@
 #include <catch2/catch_all.hpp>
 
+#include <boost/uuid.hpp>
+
+#include "boost/uuid/random_generator.hpp"
 #include "irods/client_connection.hpp"
 #include "irods/connection_pool.hpp"
 #include "irods/data_object_modify_info.h"
@@ -11,22 +14,27 @@
 #include "irods/irods_pack_table.hpp"
 #include "irods/rodsClient.h"
 #include "irods/rodsErrorTable.h"
+#include "irods/touch.h"
 #include "irods/transport/default_transport.hpp"
 
-TEST_CASE("data_object_modify_info")
-{
-    namespace fs = irods::experimental::filesystem;
-    namespace io = irods::experimental::io;
+#include "irods/resource_administration.hpp"
 
-    auto& api_table = irods::get_client_api_table();
-    auto& pack_table = irods::get_pack_table();
-    init_api_table(api_table, pack_table);
+#include <array>
+#include <climits>
+#include <filesystem>
 
-    auto conn_pool = irods::make_connection_pool();
-    auto conn = conn_pool->get_connection();
+namespace fs = irods::experimental::filesystem;
+namespace io = irods::experimental::io;
+namespace adm = irods::experimental::administration;
+
+TEST_CASE("data_obj_stat_api")
+{    
+    load_client_api_plugins();
 
     rodsEnv env;
     _getRodsEnv(env);
+
+    irods::experimental::client_connection conn;
 
     const auto sandbox = fs::path{env.rodsHome} / "irods_unit_tests_sandbox";
     const auto path = sandbox / "dstream_data_object.txt";
@@ -38,79 +46,170 @@ TEST_CASE("data_object_modify_info")
     }};
 
     // Create a data object in iRODS.
+    // This is used in all future sections.
     {
         io::client::default_transport tp{conn};
         io::odstream out{tp, path};
     }
 
-    dataObjInfo_t info{};
-    std::strcpy(info.objPath, path.c_str());
-
-    const auto invalid_keywords = {
-        CHKSUM_KW,
-        COLL_ID_KW,
-        //DATA_COMMENTS_KW,
-        DATA_CREATE_KW,
-        //DATA_EXPIRY_KW,
-        DATA_ID_KW,
-        DATA_MAP_ID_KW,
-        DATA_MODE_KW,
-        //DATA_MODIFY_KW,
-        DATA_NAME_KW,
-        DATA_OWNER_KW,
-        DATA_OWNER_ZONE_KW,
-        //DATA_RESC_GROUP_NAME_KW, // Not defined.
-        DATA_SIZE_KW,
-        //DATA_TYPE_KW,
-        FILE_PATH_KW,
-        REPL_NUM_KW,
-        REPL_STATUS_KW,
-        RESC_HIER_STR_KW,
-        RESC_ID_KW,
-        RESC_NAME_KW,
-        STATUS_STRING_KW,
-        VERSION_KW
-    };
-
-    for (auto&& kw : invalid_keywords) {
-        DYNAMIC_SECTION("error on invalid keyword [" << kw << ']')
-        {
-            keyValPair_t reg_params{};
-            addKeyVal(&reg_params, kw, "");
-
-            modDataObjMeta_t input{};
-            input.dataObjInfo = &info;
-            input.regParam = &reg_params;
-
-            REQUIRE(rc_data_object_modify_info(static_cast<rcComm_t*>(conn), &input) == USER_BAD_KEYWORD_ERR);
-        }
+    // Just ensure you can get something in a stat
+    SECTION("Stat on good data object") {
+        REQUIRE_NOTHROW(fs::client::status(conn, path));
     }
+
+    namespace adm = irods::experimental::administration;
+
+    // Get hostname for unixfilesystem resources
+    std::array<char, HOST_NAME_MAX+1> hostname{};
+    REQUIRE(gethostname(hostname.data(), hostname.size()) == 0);
+
+    // Sanity check
+    // Make sure the hostname buffer is null terminated
+    REQUIRE(hostname.back() == '\0');
+
+    auto create_temp_directory{[](std::string_view _dir_name) -> std::filesystem::path {
+        const auto temp_path{std::filesystem::temp_directory_path()};
+        auto path_to_create{temp_path / _dir_name};
+        std::filesystem::create_directory(path_to_create);
+        return path_to_create;
+    }};
+
+    // Create some temp directories for the resources
+    const auto res_a_path{create_temp_directory("cool")};
+    const auto res_b_path{create_temp_directory("thing")};
+
+    // Cleanup the temp directories
+    irods::at_scope_exit remove_temp_directories{[&](){
+        std::filesystem::remove_all(res_b_path);
+        std::filesystem::remove_all(res_a_path);
+    }};
+
+    // Create resources
+    // Should you even test for no throw here?
+    const adm::resource_registration_info res_regis_a{.resource_name="cool", .resource_type=adm::resource_type::unixfilesystem, .host_name=hostname.data(), .vault_path=res_a_path.string()};
+    REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_a));
+
+    const adm::resource_registration_info res_regis_b{.resource_name="thing", .resource_type=adm::resource_type::unixfilesystem, .host_name=hostname.data(), .vault_path=res_b_path.string()};
+    REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_b));
+
+    const adm::resource_registration_info res_regis_repl{.resource_name="repl", .resource_type=adm::resource_type::replication};
+    REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_repl));
+
+    const adm::resource_registration_info res_regis_pt{.resource_name="pt", .resource_type=adm::resource_type::passthrough};
+    REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_pt));
+
+    // Cleanup the resources
+    irods::at_scope_exit clean_resources{[&](){
+        adm::client::remove_resource(conn, res_regis_pt.resource_name);
+        adm::client::remove_resource(conn, res_regis_repl.resource_name);
+        adm::client::remove_resource(conn, res_regis_b.resource_name);
+        adm::client::remove_resource(conn, res_regis_a.resource_name);
+    }};
+
+    // // Close connection and create new one to "commit" previous actions
+    conn.disconnect();
+    conn.connect();
+
+    // Create the hierarchy
+    REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_pt.resource_name, res_regis_repl.resource_name));
+    REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_repl.resource_name, res_regis_a.resource_name));
+    REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_repl.resource_name, res_regis_b.resource_name));
+
+    // Destruct the hierarchy
+    irods::at_scope_exit unlink_resource_hierarchy{[&](){
+        adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_b.resource_name);
+        adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_a.resource_name);
+        adm::client::remove_child_resource(conn, res_regis_pt.resource_name, res_regis_repl.resource_name);
+    }};
+
+    const auto bleh{sandbox / "cool-cool-epic.txt"};
+    {
+        io::client::default_transport tp{conn};
+        io::odstream out{tp, bleh, io::root_resource_name{res_regis_pt.resource_name}};
+    }
+
+    // TOOD: Use bad status? (-1)
 }
 
-TEST_CASE("#7338")
-{
-    load_client_api_plugins();
+struct TestFixture {
+    TestFixture() : {
+        load_client_api_plugins();
 
-    irods::experimental::client_connection conn{irods::experimental::defer_authentication};
+        // Get hostname for unixfilesystem resources
+        std::array<char, HOST_NAME_MAX+1> hostname{};
+        REQUIRE(gethostname(hostname.data(), hostname.size()) == 0);
 
-    modDataObjMeta_t input{};
-    CHECK(rc_data_object_modify_info(static_cast<RcComm*>(conn), &input) == SYS_NO_API_PRIV);
+        // Sanity check
+        // Make sure the hostname buffer is null terminated
+        REQUIRE(hostname.back() == '\0');
+
+        auto create_temp_directory{[](std::string_view _dir_name) -> std::filesystem::path {
+            const auto temp_path{std::filesystem::temp_directory_path()};
+            auto path_to_create{temp_path / _dir_name};
+            std::filesystem::create_directory(path_to_create);
+            return path_to_create;
+        }};
+
+        // Create some temp directories for the resources
+        const auto res_a_path{create_temp_directory("cool")};
+        const auto res_b_path{create_temp_directory("thing")};
+
+        // Create resources
+        // Should you even test for no throw here?
+        const adm::resource_registration_info res_regis_a{.resource_name="cool", .resource_type=adm::resource_type::unixfilesystem, .host_name=hostname.data(), .vault_path=res_a_path.string()};
+        REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_a));
+
+        const adm::resource_registration_info res_regis_b{.resource_name="thing", .resource_type=adm::resource_type::unixfilesystem, .host_name=hostname.data(), .vault_path=res_b_path.string()};
+        REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_b));
+
+        const adm::resource_registration_info res_regis_repl{.resource_name="repl", .resource_type=adm::resource_type::replication};
+        REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_repl));
+
+        const adm::resource_registration_info res_regis_pt{.resource_name="pt", .resource_type=adm::resource_type::passthrough};
+        REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_pt));
+        
+        // Close connection and create new one to "commit" previous actions
+        conn.disconnect();
+        conn.connect();
+
+        // Create the hierarchy
+        REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_pt.resource_name, res_regis_repl.resource_name));
+        REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_repl.resource_name, res_regis_a.resource_name));
+        REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_repl.resource_name, res_regis_b.resource_name));
+    }
+
+    ~TestFixture() {
+        // Cleanup all of the files
+        fs::client::remove_all(conn, sandbox, fs::remove_options::no_trash);
+
+        // Destruct the hierarchy
+        adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_b.resource_name);
+        adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_a.resource_name);
+        adm::client::remove_child_resource(conn, res_regis_pt.resource_name, res_regis_repl.resource_name);
+
+        // Cleanup the resources
+        adm::client::remove_resource(conn, res_regis_pt.resource_name);
+        adm::client::remove_resource(conn, res_regis_repl.resource_name);
+        adm::client::remove_resource(conn, res_regis_b.resource_name);
+        adm::client::remove_resource(conn, res_regis_a.resource_name);
+
+        // Cleanup the temp directories
+        std::filesystem::remove_all(res_b_path);
+        std::filesystem::remove_all(res_a_path);
+    }
+    
+    boost::uuids::uuid test_uuid;
+    irods::experimental::client_connection conn;
 }
 
-TEST_CASE("null inputs are checked")
-{
-    load_client_api_plugins();
+TEST_CASE_METHOD(TestFixture, "Stat on data object with only good replicas") {
+    REQUIRE_NOTHROW(fs::client::status(conn, bleh));
+}
 
-    modDataObjMeta_t input{};
+TEST_CASE_METHOD(TestFixture, "Stat on data object with mixed stale and good replicas") {
+    REQUIRE_NOTHROW(fs::client::status(conn, bleh));
+}
 
-    // The RcComm must not be null.
-    CHECK(INVALID_INPUT_ARGUMENT_NULL_POINTER == rc_data_object_modify_info(nullptr, &input));
-
-    irods::experimental::client_connection conn; // NOLINT(misc-const-correctness)
-
-    // The input structure must not be null.
-    CHECK(INVALID_INPUT_ARGUMENT_NULL_POINTER == rc_data_object_modify_info(static_cast<RcComm*>(conn), nullptr));
-
-    // The input structure must have a valid regParam member.
-    CHECK(USER_BAD_KEYWORD_ERR == rc_data_object_modify_info(static_cast<RcComm*>(conn), &input));
+TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas") {
+    REQUIRE_NOTHROW(fs::client::status(conn, bleh));
 }

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -1,10 +1,5 @@
-#include <algorithm>
 #include <catch2/catch_all.hpp>
 
-#include <boost/asio/ip/host_name.hpp>
-#include "boost/uuid/random_generator.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_io.hpp>
 #include "irods/client_connection.hpp"
 #include "irods/connection_pool.hpp"
 #include "irods/data_object_modify_info.h"
@@ -20,6 +15,7 @@
 #include "irods/objStat.h"
 #include "irods/rcConnect.h"
 #include "irods/rcMisc.h"
+#include "irods/resource_administration.hpp"
 #include "irods/rodsClient.h"
 #include "irods/rodsDef.h"
 #include "irods/rodsErrorTable.h"
@@ -28,8 +24,13 @@
 #include "irods/touch.h"
 #include "irods/transport/default_transport.hpp"
 
-#include "irods/resource_administration.hpp"
 
+#include <boost/asio/ip/host_name.hpp>
+#include "boost/uuid/random_generator.hpp"
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include <algorithm>
 #include <array>
 #include <climits>
 #include <filesystem>
@@ -40,7 +41,37 @@ namespace fs = irods::experimental::filesystem;
 namespace io = irods::experimental::io;
 namespace adm = irods::experimental::administration;
 
-TEST_CASE("data_obj_stat_api")
+auto stat(RcComm& _comm, const fs::path& _path) -> std::unique_ptr<rodsObjStat, decltype(freeRodsObjStat)*>
+{
+    dataObjInp_t input{};
+    std::strncpy(static_cast<char*>(input.objPath), _path.c_str(), std::strlen(_path.c_str()));
+
+    rodsObjStat* output{};
+
+    REQUIRE(rcObjStat(&_comm, &input, &output) >= 0);
+    return {output, freeRodsObjStat};
+}
+
+auto set_replica_status(RcComm& _comm, const fs::path& _path, int replica, int status, const std::unordered_map<std::string, std::string>& _additional_kvp_args) -> int {
+    auto [kvp, lm] = irods::experimental::make_key_value_proxy();
+    kvp[REPL_STATUS_KW] = std::to_string(status);
+    kvp[ADMIN_KW] = "";
+
+    std::for_each(std::cbegin(_additional_kvp_args), std::cend(_additional_kvp_args), [&kvp](auto& _thing){
+        kvp[_thing.first] = _thing.second;
+    });
+
+    // Specify the data object we want to mess with
+    DataObjInfo info_two{};
+    std::strncpy(static_cast<char*>(info_two.objPath), _path.c_str(), MAX_NAME_LEN - 1);
+    info_two.replNum = replica;
+
+    // Create the required input
+    ModDataObjMetaInp inp_two{&info_two, kvp.get()};
+    return rcModDataObjMeta(&_comm, &inp_two);
+}
+
+TEST_CASE("Stat on single data object")
 {    
     load_client_api_plugins();
 
@@ -49,7 +80,7 @@ TEST_CASE("data_obj_stat_api")
 
     irods::experimental::client_connection conn;
 
-    const auto sandbox = fs::path{env.rodsHome} / "irods_unit_tests_sandbox";
+    const auto sandbox = fs::path{static_cast<char*>(env.rodsHome)} / "irods_unit_tests_sandbox";
     const auto path = sandbox / "dstream_data_object.txt";
 
     fs::client::create_collection(conn, sandbox);
@@ -61,14 +92,12 @@ TEST_CASE("data_obj_stat_api")
     // Create a data object in iRODS.
     // This is used in all future sections.
     {
-        io::client::default_transport tp{conn};
-        io::odstream out{tp, path};
+        io::client::default_transport transport{conn};
+        io::odstream out{transport, path};
     }
 
-    // Just ensure you can get something in a stat
-    SECTION("Stat on good data object") {
-        REQUIRE_NOTHROW(fs::client::status(conn, path));
-    }
+    auto res{stat(conn, path)};
+    REQUIRE(res->objSize == 0);
 }
 
 struct TestFixture {
@@ -83,6 +112,7 @@ struct TestFixture {
     // Filesystem paths for the tests
     // Also includes paths for the new resources
     fs::path sandbox;
+    fs::path test_file;
     std::filesystem::path res_a_path;
     std::filesystem::path res_b_path;
 
@@ -157,6 +187,12 @@ struct TestFixture {
         // Reset connection jic!
         conn.disconnect();
         conn.connect();
+
+        test_file = sandbox / "cool-cool-epic.txt";
+        {
+            io::client::default_transport transport{conn};
+            io::odstream out{transport, test_file, io::root_resource_name{res_regis_pt.resource_name}};
+        }
     }
 
     ~TestFixture() {
@@ -184,76 +220,18 @@ struct TestFixture {
     }
 };
 
-auto stat(RcComm& _comm, const fs::path& _path) -> std::unique_ptr<rodsObjStat, decltype(freeRodsObjStat)*>
-{
-    dataObjInp_t input{};
-    std::strncpy(input.objPath, _path.c_str(), std::strlen(_path.c_str()));
-
-    rodsObjStat* output{};
-
-    REQUIRE(rcObjStat(&_comm, &input, &output) >= 0);
-    return {output, freeRodsObjStat};
-}
-
-auto set_replica_status(RcComm& _comm, const fs::path& _path, int replica, int status, const std::unordered_map<std::string, std::string>& _additional_kvp_args) -> int {
-    // Try to figure out the replica keywords...
-    auto [kvp, lm] = irods::experimental::make_key_value_proxy();
-    kvp[REPL_STATUS_KW] = std::to_string(status);
-    kvp[ADMIN_KW] = "";
-
-    std::for_each(std::cbegin(_additional_kvp_args), std::cend(_additional_kvp_args), [&kvp](auto& _thing){
-        kvp[_thing.first] = _thing.second;
-    });
-
-    // Specify the data object we want to mess with
-    // We might be able to reuse the previous data obj inf?
-    DataObjInfo info_two{};
-    std::strncpy(static_cast<char*>(info_two.objPath), _path.c_str(), MAX_NAME_LEN - 1);
-    info_two.replNum = replica;
-
-    // Create the required input
-    ModDataObjMetaInp inp_two{&info_two, kvp.get()};
-    return rcModDataObjMeta(&_comm, &inp_two);
-}
-
 
 TEST_CASE_METHOD(TestFixture, "Stat on data object with only good replicas") {
-    const auto bleh{sandbox / "cool-cool-epic.txt"};
-    {
-        io::client::default_transport tp{conn};
-        io::odstream out{tp, bleh, io::root_resource_name{res_regis_pt.resource_name}};
-    }
-
-    REQUIRE_NOTHROW(fs::client::status(conn, bleh));
+    auto res{stat(conn, test_file)};
+    REQUIRE(res->objSize == 0);
 }
 
 TEST_CASE_METHOD(TestFixture, "Stat on data object with mixed stale and good replicas") {
-    const auto bleh{sandbox / "cool-cool-epic.txt"};
-    {
-        io::client::default_transport tp{conn};
-        io::odstream out{tp, bleh, io::root_resource_name{res_regis_pt.resource_name}};
-    }
-
-    // Try to figure out the replica keywords...
-    auto [kvp, lm] = irods::experimental::make_key_value_proxy();
-    kvp[REPL_STATUS_KW] = std::to_string(STALE_REPLICA);
-    kvp[ADMIN_KW] = "";
     constexpr rodsLong_t bad_size{10};
-    kvp[DATA_SIZE_KW] = std::to_string(bad_size); // Assign arbitrary value to data size
-
-    // Specify the data object we want to mess with
-    DataObjInfo info{};
-    std::strncpy(static_cast<char*>(info.objPath), bleh.c_str(), MAX_NAME_LEN - 1);
-    info.replNum = 0;
-
-    // Create the required input
-    ModDataObjMetaInp inp{&info, kvp.get()};
-
     auto& comm{static_cast<RcComm&>(conn)};
-    REQUIRE(set_replica_status(comm, bleh, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size)}}));
-    REQUIRE(rcModDataObjMeta(&comm, &inp) >= 0);
+    REQUIRE(set_replica_status(comm, test_file, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size)}}) >= 0);
 
-    auto res{stat(conn, bleh)};
+    auto res{stat(conn, test_file)};
 
     // We expect the good replica size
     REQUIRE(res->objSize == 0);
@@ -261,51 +239,14 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with mixed stale and good rep
 }
 
 TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas") {\
-    const auto bleh{sandbox / "cool-cool-epic.txt"};
-    {
-        io::client::default_transport tp{conn};
-        io::odstream out{tp, bleh, io::root_resource_name{res_regis_pt.resource_name}};
-    }
-
-    // Try to figure out the replica keywords...
-    auto [kvp_one, lm_one] = irods::experimental::make_key_value_proxy();
-    kvp_one[REPL_STATUS_KW] = std::to_string(STALE_REPLICA);
-    kvp_one[ADMIN_KW] = "";
     constexpr rodsLong_t bad_size_one{10};
-    kvp_one[DATA_SIZE_KW] = std::to_string(bad_size_one); // Assign arbitrary value to data size
-
-    // Specify the data object we want to mess with
-    DataObjInfo info_one{};
-    std::strncpy(static_cast<char*>(info_one.objPath), bleh.c_str(), MAX_NAME_LEN - 1);
-    info_one.replNum = 0;
-
-    // Create the required input
-    ModDataObjMetaInp inp_one{&info_one, kvp_one.get()};
-
     auto& comm{static_cast<RcComm&>(conn)};
-    REQUIRE(rcModDataObjMeta(&comm, &inp_one) >= 0);
+    REQUIRE(set_replica_status(comm, test_file, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size_one)}}) >= 0);
 
-    // Try to figure out the replica keywords...
-    auto [kvp_two, lm_two] = irods::experimental::make_key_value_proxy();
-    kvp_two[REPL_STATUS_KW] = std::to_string(STALE_REPLICA);
-    kvp_two[ADMIN_KW] = "";
     constexpr rodsLong_t bad_size_two{20};
-    kvp_two[DATA_SIZE_KW] = std::to_string(bad_size_two); // Assign arbitrary value to data size
+    REQUIRE(set_replica_status(comm, test_file, 1, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >= 0);
 
-    // Specify the data object we want to mess with
-    // We might be able to reuse the previous data obj inf?
-    DataObjInfo info_two{};
-    std::strncpy(static_cast<char*>(info_two.objPath), bleh.c_str(), MAX_NAME_LEN - 1);
-    info_two.replNum = 1;
-
-    // Create the required input
-    ModDataObjMetaInp inp_two{&info_two, kvp_two.get()};
-    REQUIRE(rcModDataObjMeta(&comm, &inp_two) >= 0);
-
-    REQUIRE_NOTHROW(fs::client::status(conn, bleh));
-
-
-    auto res{stat(conn, bleh)};
+    auto res{stat(conn, test_file)};
 
     // We expect the first replica to give the stat when both replicas are stale
     REQUIRE(res->objSize == bad_size_one);
@@ -313,33 +254,12 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas") {\
 }
 
 TEST_CASE_METHOD(TestFixture, "Stat on data object with invalid status") {
-    const auto bleh{sandbox / "cool-cool-epic.txt"};
-    {
-        io::client::default_transport tp{conn};
-        io::odstream out{tp, bleh, io::root_resource_name{res_regis_pt.resource_name}};
-    }
-
-    // Try to figure out the replica keywords...
-    auto [kvp, lm] = irods::experimental::make_key_value_proxy();
-    kvp[REPL_STATUS_KW] = std::to_string(25); // Just an arbitrary number
-    kvp[ADMIN_KW] = "";
     constexpr rodsLong_t bad_size{10};
-    kvp[DATA_SIZE_KW] = std::to_string(bad_size); // Assign arbitrary value to data size
-
-    // Specify the data object we want to mess with
-    DataObjInfo info{};
-    std::strncpy(static_cast<char*>(info.objPath), bleh.c_str(), MAX_NAME_LEN - 1);
-    info.replNum = 0;
-
-    // Create the required input
-    ModDataObjMetaInp inp{&info, kvp.get()};
-
+    constexpr auto bad_status{42};
     auto& comm{static_cast<RcComm&>(conn)};
-    REQUIRE(rcModDataObjMeta(&comm, &inp) >= 0);
+    REQUIRE(set_replica_status(comm, test_file, 0, bad_status, {{DATA_SIZE_KW, std::to_string(bad_size)}}) >= 0);
 
-    REQUIRE_NOTHROW(fs::client::status(conn, bleh));
-
-    auto res{stat(conn, bleh)};
+    auto res{stat(conn, test_file)};
 
     // We expect to have the size of the good replica
     REQUIRE(res->objSize == 0);
@@ -347,51 +267,16 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with invalid status") {
 }
 
 TEST_CASE_METHOD(TestFixture, "Stat on data object with only invalid status") {
-    const auto bleh{sandbox / "cool-cool-epic.txt"};
-    {
-        io::client::default_transport tp{conn};
-        io::odstream out{tp, bleh, io::root_resource_name{res_regis_pt.resource_name}};
-    }
-
-    // Try to figure out the replica keywords...
-    auto [kvp_one, lm_one] = irods::experimental::make_key_value_proxy();
-    constexpr auto random_number{42};
-    kvp_one[REPL_STATUS_KW] = std::to_string(random_number);
-    kvp_one[ADMIN_KW] = "";
     constexpr rodsLong_t bad_size_one{10};
-    kvp_one[DATA_SIZE_KW] = std::to_string(bad_size_one); // Assign arbitrary value to data size
-
-    // Specify the data object we want to mess with
-    DataObjInfo info_one{};
-    std::strncpy(static_cast<char*>(info_one.objPath), bleh.c_str(), MAX_NAME_LEN - 1);
-    info_one.replNum = 0;
-
-    // Create the required input
-    ModDataObjMetaInp inp_one{&info_one, kvp_one.get()};
-
+    constexpr auto bad_status_one{42};
     auto& comm{static_cast<RcComm&>(conn)};
-    REQUIRE(rcModDataObjMeta(&comm, &inp_one) >= 0);
+    REQUIRE(set_replica_status(comm, test_file, 0, bad_status_one, {{DATA_SIZE_KW, std::to_string(bad_size_one)}}) >= 0);
 
-    // Try to figure out the replica keywords...
-    auto [kvp_two, lm_two] = irods::experimental::make_key_value_proxy();
-    constexpr auto different_random_number{56709};
-    kvp_two[REPL_STATUS_KW] = std::to_string(different_random_number);
-    kvp_two[ADMIN_KW] = "";
     constexpr rodsLong_t bad_size_two{20};
-    kvp_two[DATA_SIZE_KW] = std::to_string(bad_size_two); // Assign arbitrary value to data size
+    constexpr auto bad_status_two{56709};
+    REQUIRE(set_replica_status(comm, test_file, 1, bad_status_two, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >= 0);
 
-    // Specify the data object we want to mess with
-    // We might be able to reuse the previous data obj inf?
-    DataObjInfo info_two{};
-    std::strncpy(static_cast<char*>(info_two.objPath), bleh.c_str(), MAX_NAME_LEN - 1);
-    info_two.replNum = 1;
-
-    // Create the required input
-    ModDataObjMetaInp inp_two{&info_two, kvp_two.get()};
-    REQUIRE(rcModDataObjMeta(&comm, &inp_two) >= 0);
-
-    REQUIRE_NOTHROW(fs::client::status(conn, bleh));
-    auto res{stat(conn, bleh)};
+    auto res{stat(conn, test_file)};
 
     // We expect the first replica to give the stat when both replicas are stale
     REQUIRE(res->objSize == bad_size_one);

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -40,7 +40,7 @@ namespace fs = irods::experimental::filesystem;
 namespace io = irods::experimental::io;
 namespace adm = irods::experimental::administration;
 
-auto stat(RcComm& _comm, const fs::path& _path) -> std::unique_ptr<rodsObjStat, decltype(freeRodsObjStat)*>
+auto stat(RcComm& _comm, const fs::path& _path) -> std::unique_ptr<rodsObjStat, decltype(freeRodsObjStat)&>
 {
     dataObjInp_t input{};
     std::strncpy(static_cast<char*>(input.objPath), _path.c_str(), MAX_NAME_LEN - 1);

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -116,7 +116,7 @@ struct TestFixture
     // Filesystem paths for the tests
     // Also includes paths for the new resources
     fs::path sandbox;
-    fs::path test_file;
+    fs::path test_data_object;
     std::filesystem::path res_a_path;
     std::filesystem::path res_b_path;
 
@@ -194,10 +194,10 @@ struct TestFixture
         conn.disconnect();
         conn.connect();
 
-        test_file = sandbox / "cool-cool-epic.txt";
+        test_data_object = sandbox / "cool-cool-epic.txt";
         {
             io::client::default_transport transport{conn};
-            io::odstream out{transport, test_file, io::root_resource_name{res_regis_repl.resource_name}};
+            io::odstream out{transport, test_data_object, io::root_resource_name{res_regis_repl.resource_name}};
         }
     }
 
@@ -233,7 +233,7 @@ struct TestFixture
 
 TEST_CASE_METHOD(TestFixture, "Stat on data object with only good replicas")
 {
-    auto res{stat(conn, test_file)};
+    auto res{stat(conn, test_data_object)};
     REQUIRE(res->objSize == 0);
 }
 
@@ -241,9 +241,9 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with mixed stale and good rep
 {
     constexpr rodsLong_t bad_size{10};
     auto& comm{static_cast<RcComm&>(conn)};
-    REQUIRE(set_replica_status(comm, test_file, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size)}}) >= 0);
+    REQUIRE(set_replica_status(comm, test_data_object, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size)}}) >= 0);
 
-    auto res{stat(conn, test_file)};
+    auto res{stat(conn, test_data_object)};
 
     // We expect the good replica size
     REQUIRE(res->objSize == 0);
@@ -253,12 +253,12 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas")
 {
     constexpr rodsLong_t bad_size_one{10};
     auto& comm{static_cast<RcComm&>(conn)};
-    REQUIRE(set_replica_status(comm, test_file, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size_one)}}) >= 0);
+    REQUIRE(set_replica_status(comm, test_data_object, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size_one)}}) >= 0);
 
     constexpr rodsLong_t bad_size_two{20};
-    REQUIRE(set_replica_status(comm, test_file, 1, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >= 0);
+    REQUIRE(set_replica_status(comm, test_data_object, 1, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >= 0);
 
-    auto res{stat(conn, test_file)};
+    auto res{stat(conn, test_data_object)};
 
     // We expect the first replica to give the stat when both replicas are stale
     REQUIRE(res->objSize == bad_size_one);
@@ -269,9 +269,9 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with invalid status")
     constexpr rodsLong_t bad_size{10};
     constexpr auto bad_status{42};
     auto& comm{static_cast<RcComm&>(conn)};
-    REQUIRE(set_replica_status(comm, test_file, 0, bad_status, {{DATA_SIZE_KW, std::to_string(bad_size)}}) >= 0);
+    REQUIRE(set_replica_status(comm, test_data_object, 0, bad_status, {{DATA_SIZE_KW, std::to_string(bad_size)}}) >= 0);
 
-    auto res{stat(conn, test_file)};
+    auto res{stat(conn, test_data_object)};
 
     // We expect to have the size of the good replica
     REQUIRE(res->objSize == 0);
@@ -282,15 +282,15 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with only invalid status")
     constexpr rodsLong_t bad_size_one{10};
     constexpr auto bad_status_one{42};
     auto& comm{static_cast<RcComm&>(conn)};
-    REQUIRE(set_replica_status(comm, test_file, 0, bad_status_one, {{DATA_SIZE_KW, std::to_string(bad_size_one)}}) >=
+    REQUIRE(set_replica_status(comm, test_data_object, 0, bad_status_one, {{DATA_SIZE_KW, std::to_string(bad_size_one)}}) >=
             0);
 
     constexpr rodsLong_t bad_size_two{20};
     constexpr auto bad_status_two{56709};
-    REQUIRE(set_replica_status(comm, test_file, 1, bad_status_two, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >=
+    REQUIRE(set_replica_status(comm, test_data_object, 1, bad_status_two, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >=
             0);
 
-    auto res{stat(conn, test_file)};
+    auto res{stat(conn, test_data_object)};
 
     // We expect the first replica to give the stat when both replicas are stale
     REQUIRE(res->objSize == bad_size_one);

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -48,6 +48,7 @@ auto stat(RcComm& _comm, const fs::path& _path) -> std::unique_ptr<rodsObjStat, 
     rodsObjStat* output{};
 
     REQUIRE(rcObjStat(&_comm, &input, &output) >= 0);
+    REQUIRE(output != nullptr);
     return {output, freeRodsObjStat};
 }
 

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -43,7 +43,7 @@ namespace adm = irods::experimental::administration;
 auto stat(RcComm& _comm, const fs::path& _path) -> std::unique_ptr<rodsObjStat, decltype(freeRodsObjStat)*>
 {
     dataObjInp_t input{};
-    std::strncpy(static_cast<char*>(input.objPath), _path.c_str(), std::strlen(_path.c_str()));
+    std::strncpy(static_cast<char*>(input.objPath), _path.c_str(), MAX_NAME_LEN - 1);
 
     rodsObjStat* output{};
 

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -1,0 +1,116 @@
+#include <catch2/catch_all.hpp>
+
+#include "irods/client_connection.hpp"
+#include "irods/connection_pool.hpp"
+#include "irods/data_object_modify_info.h"
+#include "irods/dstream.hpp"
+#include "irods/filesystem.hpp"
+#include "irods/getRodsEnv.h"
+#include "irods/irods_at_scope_exit.hpp"
+#include "irods/irods_client_api_table.hpp"
+#include "irods/irods_pack_table.hpp"
+#include "irods/rodsClient.h"
+#include "irods/rodsErrorTable.h"
+#include "irods/transport/default_transport.hpp"
+
+TEST_CASE("data_object_modify_info")
+{
+    namespace fs = irods::experimental::filesystem;
+    namespace io = irods::experimental::io;
+
+    auto& api_table = irods::get_client_api_table();
+    auto& pack_table = irods::get_pack_table();
+    init_api_table(api_table, pack_table);
+
+    auto conn_pool = irods::make_connection_pool();
+    auto conn = conn_pool->get_connection();
+
+    rodsEnv env;
+    _getRodsEnv(env);
+
+    const auto sandbox = fs::path{env.rodsHome} / "irods_unit_tests_sandbox";
+    const auto path = sandbox / "dstream_data_object.txt";
+
+    fs::client::create_collection(conn, sandbox);
+
+    irods::at_scope_exit cleanup{[&] {
+        fs::client::remove_all(conn, sandbox, fs::remove_options::no_trash);
+    }};
+
+    // Create a data object in iRODS.
+    {
+        io::client::default_transport tp{conn};
+        io::odstream out{tp, path};
+    }
+
+    dataObjInfo_t info{};
+    std::strcpy(info.objPath, path.c_str());
+
+    const auto invalid_keywords = {
+        CHKSUM_KW,
+        COLL_ID_KW,
+        //DATA_COMMENTS_KW,
+        DATA_CREATE_KW,
+        //DATA_EXPIRY_KW,
+        DATA_ID_KW,
+        DATA_MAP_ID_KW,
+        DATA_MODE_KW,
+        //DATA_MODIFY_KW,
+        DATA_NAME_KW,
+        DATA_OWNER_KW,
+        DATA_OWNER_ZONE_KW,
+        //DATA_RESC_GROUP_NAME_KW, // Not defined.
+        DATA_SIZE_KW,
+        //DATA_TYPE_KW,
+        FILE_PATH_KW,
+        REPL_NUM_KW,
+        REPL_STATUS_KW,
+        RESC_HIER_STR_KW,
+        RESC_ID_KW,
+        RESC_NAME_KW,
+        STATUS_STRING_KW,
+        VERSION_KW
+    };
+
+    for (auto&& kw : invalid_keywords) {
+        DYNAMIC_SECTION("error on invalid keyword [" << kw << ']')
+        {
+            keyValPair_t reg_params{};
+            addKeyVal(&reg_params, kw, "");
+
+            modDataObjMeta_t input{};
+            input.dataObjInfo = &info;
+            input.regParam = &reg_params;
+
+            REQUIRE(rc_data_object_modify_info(static_cast<rcComm_t*>(conn), &input) == USER_BAD_KEYWORD_ERR);
+        }
+    }
+}
+
+TEST_CASE("#7338")
+{
+    load_client_api_plugins();
+
+    irods::experimental::client_connection conn{irods::experimental::defer_authentication};
+
+    modDataObjMeta_t input{};
+    CHECK(rc_data_object_modify_info(static_cast<RcComm*>(conn), &input) == SYS_NO_API_PRIV);
+}
+
+TEST_CASE("null inputs are checked")
+{
+    load_client_api_plugins();
+
+    modDataObjMeta_t input{};
+
+    // The RcComm must not be null.
+    CHECK(INVALID_INPUT_ARGUMENT_NULL_POINTER == rc_data_object_modify_info(nullptr, &input));
+
+    irods::experimental::client_connection conn; // NOLINT(misc-const-correctness)
+
+    // The input structure must not be null.
+    CHECK(INVALID_INPUT_ARGUMENT_NULL_POINTER == rc_data_object_modify_info(static_cast<RcComm*>(conn), nullptr));
+
+    // The input structure must have a valid regParam member.
+    CHECK(USER_BAD_KEYWORD_ERR == rc_data_object_modify_info(static_cast<RcComm*>(conn), &input));
+}

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -24,7 +24,6 @@
 #include "irods/touch.h"
 #include "irods/transport/default_transport.hpp"
 
-
 #include <boost/asio/ip/host_name.hpp>
 #include "boost/uuid/random_generator.hpp"
 #include <boost/uuid/uuid.hpp>
@@ -52,12 +51,17 @@ auto stat(RcComm& _comm, const fs::path& _path) -> std::unique_ptr<rodsObjStat, 
     return {output, freeRodsObjStat};
 }
 
-auto set_replica_status(RcComm& _comm, const fs::path& _path, int replica, int status, const std::unordered_map<std::string, std::string>& _additional_kvp_args) -> int {
+auto set_replica_status(RcComm& _comm,
+                        const fs::path& _path,
+                        int replica,
+                        int status,
+                        const std::unordered_map<std::string, std::string>& _additional_kvp_args) -> int
+{
     auto [kvp, lm] = irods::experimental::make_key_value_proxy();
     kvp[REPL_STATUS_KW] = std::to_string(status);
     kvp[ADMIN_KW] = "";
 
-    std::for_each(std::cbegin(_additional_kvp_args), std::cend(_additional_kvp_args), [&kvp](auto& _thing){
+    std::for_each(std::cbegin(_additional_kvp_args), std::cend(_additional_kvp_args), [&kvp](auto& _thing) {
         kvp[_thing.first] = _thing.second;
     });
 
@@ -72,7 +76,7 @@ auto set_replica_status(RcComm& _comm, const fs::path& _path, int replica, int s
 }
 
 TEST_CASE("Stat on single data object")
-{    
+{
     load_client_api_plugins();
 
     rodsEnv env;
@@ -85,9 +89,8 @@ TEST_CASE("Stat on single data object")
 
     fs::client::create_collection(conn, sandbox);
 
-    irods::at_scope_exit cleanup{[&] {
-        fs::client::remove_all(conn.operator RcComm&(), sandbox, fs::remove_options::no_trash);
-    }};
+    irods::at_scope_exit cleanup{
+        [&] { fs::client::remove_all(conn.operator RcComm&(), sandbox, fs::remove_options::no_trash); }};
 
     // Create a data object in iRODS.
     // This is used in all future sections.
@@ -100,7 +103,8 @@ TEST_CASE("Stat on single data object")
     REQUIRE(res->objSize == 0);
 }
 
-struct TestFixture {
+struct TestFixture
+{
     // Ignore member variable complaints for now
     // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
     // UUID for ensuring uniqueness of paths and resources
@@ -129,12 +133,17 @@ struct TestFixture {
     auto operator=(TestFixture&&) -> TestFixture = delete;
     TestFixture(TestFixture&&) = delete;
 
-    static auto generate_uuid() -> std::string {
+    static auto generate_uuid() -> std::string
+    {
         static boost::uuids::random_generator gen;
         return to_string(gen());
     }
 
-    TestFixture() : env{}, test_uui{generate_uuid()}, conn{irods::experimental::defer_connection} {
+    TestFixture()
+        : env{}
+        , test_uui{generate_uuid()}
+        , conn{irods::experimental::defer_connection}
+    {
         // No idea if this is needed per run?
         load_client_api_plugins();
         _getRodsEnv(env);
@@ -143,7 +152,7 @@ struct TestFixture {
 
         sandbox = fs::path{static_cast<char*>(env.rodsHome)} / fmt::format("irods_unit_test_sandbox-{}", test_uui);
         fs::client::create_collection(conn, sandbox);
- 
+
         // Get hostname for unixfilesystem resources
         auto hostname{boost::asio::ip::host_name()};
 
@@ -170,9 +179,11 @@ struct TestFixture {
                        .host_name = hostname,
                        .vault_path = res_b_path.string()};
         REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_b));
-        res_regis_repl = {.resource_name = fmt::format("repl-{}", test_uui), .resource_type = adm::resource_type::replication};
+        res_regis_repl = {
+            .resource_name = fmt::format("repl-{}", test_uui), .resource_type = adm::resource_type::replication};
         REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_repl));
-        res_regis_pt = {.resource_name = fmt::format("pt-{}", test_uui), .resource_type = adm::resource_type::passthrough};
+        res_regis_pt = {
+            .resource_name = fmt::format("pt-{}", test_uui), .resource_type = adm::resource_type::passthrough};
         REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_pt));
 
         // Close connection and create new one to "commit" previous actions
@@ -180,7 +191,8 @@ struct TestFixture {
         conn.connect();
 
         // Create the hierarchy
-        REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_pt.resource_name, res_regis_repl.resource_name));
+        REQUIRE_NOTHROW(
+            adm::client::add_child_resource(conn, res_regis_pt.resource_name, res_regis_repl.resource_name));
         REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_repl.resource_name, res_regis_a.resource_name));
         REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_repl.resource_name, res_regis_b.resource_name));
 
@@ -195,7 +207,8 @@ struct TestFixture {
         }
     }
 
-    ~TestFixture() {
+    ~TestFixture()
+    {
         // Reset connection jic!
         conn.disconnect();
         conn.connect();
@@ -220,13 +233,14 @@ struct TestFixture {
     }
 };
 
-
-TEST_CASE_METHOD(TestFixture, "Stat on data object with only good replicas") {
+TEST_CASE_METHOD(TestFixture, "Stat on data object with only good replicas")
+{
     auto res{stat(conn, test_file)};
     REQUIRE(res->objSize == 0);
 }
 
-TEST_CASE_METHOD(TestFixture, "Stat on data object with mixed stale and good replicas") {
+TEST_CASE_METHOD(TestFixture, "Stat on data object with mixed stale and good replicas")
+{
     constexpr rodsLong_t bad_size{10};
     auto& comm{static_cast<RcComm&>(conn)};
     REQUIRE(set_replica_status(comm, test_file, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size)}}) >= 0);
@@ -238,7 +252,8 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with mixed stale and good rep
     REQUIRE(res->objSize != bad_size);
 }
 
-TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas") {\
+TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas")
+{
     constexpr rodsLong_t bad_size_one{10};
     auto& comm{static_cast<RcComm&>(conn)};
     REQUIRE(set_replica_status(comm, test_file, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size_one)}}) >= 0);
@@ -253,7 +268,8 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas") {\
     REQUIRE(res->objSize != bad_size_two);
 }
 
-TEST_CASE_METHOD(TestFixture, "Stat on data object with invalid status") {
+TEST_CASE_METHOD(TestFixture, "Stat on data object with invalid status")
+{
     constexpr rodsLong_t bad_size{10};
     constexpr auto bad_status{42};
     auto& comm{static_cast<RcComm&>(conn)};
@@ -266,15 +282,18 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with invalid status") {
     REQUIRE(res->objSize != bad_size);
 }
 
-TEST_CASE_METHOD(TestFixture, "Stat on data object with only invalid status") {
+TEST_CASE_METHOD(TestFixture, "Stat on data object with only invalid status")
+{
     constexpr rodsLong_t bad_size_one{10};
     constexpr auto bad_status_one{42};
     auto& comm{static_cast<RcComm&>(conn)};
-    REQUIRE(set_replica_status(comm, test_file, 0, bad_status_one, {{DATA_SIZE_KW, std::to_string(bad_size_one)}}) >= 0);
+    REQUIRE(set_replica_status(comm, test_file, 0, bad_status_one, {{DATA_SIZE_KW, std::to_string(bad_size_one)}}) >=
+            0);
 
     constexpr rodsLong_t bad_size_two{20};
     constexpr auto bad_status_two{56709};
-    REQUIRE(set_replica_status(comm, test_file, 1, bad_status_two, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >= 0);
+    REQUIRE(set_replica_status(comm, test_file, 1, bad_status_two, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >=
+            0);
 
     auto res{stat(conn, test_file)};
 

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -60,9 +60,9 @@ auto set_replica_status(RcComm& _comm,
     kvp[REPL_STATUS_KW] = std::to_string(status);
     kvp[ADMIN_KW] = "";
 
-    std::for_each(std::cbegin(_additional_kvp_args), std::cend(_additional_kvp_args), [&kvp](const auto& _kv_to_insert) {
-        kvp[_kv_to_insert.first] = _kv_to_insert.second;
-    });
+    std::for_each(std::cbegin(_additional_kvp_args),
+                  std::cend(_additional_kvp_args),
+                  [&kvp](const auto& _kv_to_insert) { kvp[_kv_to_insert.first] = _kv_to_insert.second; });
 
     // Specify the data object we want to mess with
     DataObjInfo info{};

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -1,7 +1,6 @@
 #include <catch2/catch_all.hpp>
 
 #include "irods/client_connection.hpp"
-#include "irods/connection_pool.hpp"
 #include "irods/data_object_modify_info.h"
 #include "irods/dstream.hpp"
 #include "irods/filesystem.hpp"
@@ -25,7 +24,7 @@
 #include "irods/transport/default_transport.hpp"
 
 #include <boost/asio/ip/host_name.hpp>
-#include "boost/uuid/random_generator.hpp"
+#include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -88,8 +88,7 @@ TEST_CASE("Stat on single data object")
 
     fs::client::create_collection(conn, sandbox);
 
-    irods::at_scope_exit cleanup{
-        [&] { fs::client::remove_all(conn, sandbox, fs::remove_options::no_trash); }};
+    irods::at_scope_exit cleanup{[&] { fs::client::remove_all(conn, sandbox, fs::remove_options::no_trash); }};
 
     // Create a data object in iRODS.
     // This is used in all future sections.

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -1,8 +1,10 @@
+#include <algorithm>
 #include <catch2/catch_all.hpp>
 
-#include <boost/uuid.hpp>
-
+#include <boost/asio/ip/host_name.hpp>
 #include "boost/uuid/random_generator.hpp"
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include "irods/client_connection.hpp"
 #include "irods/connection_pool.hpp"
 #include "irods/data_object_modify_info.h"
@@ -12,8 +14,17 @@
 #include "irods/irods_at_scope_exit.hpp"
 #include "irods/irods_client_api_table.hpp"
 #include "irods/irods_pack_table.hpp"
+#include "irods/key_value_proxy.hpp"
+#include "irods/modDataObjMeta.h"
+#include "irods/objInfo.h"
+#include "irods/objStat.h"
+#include "irods/rcConnect.h"
+#include "irods/rcMisc.h"
 #include "irods/rodsClient.h"
+#include "irods/rodsDef.h"
 #include "irods/rodsErrorTable.h"
+#include "irods/rodsKeyWdDef.h"
+#include "irods/rodsType.h"
 #include "irods/touch.h"
 #include "irods/transport/default_transport.hpp"
 
@@ -22,6 +33,8 @@
 #include <array>
 #include <climits>
 #include <filesystem>
+#include <memory>
+#include <string>
 
 namespace fs = irods::experimental::filesystem;
 namespace io = irods::experimental::io;
@@ -42,7 +55,7 @@ TEST_CASE("data_obj_stat_api")
     fs::client::create_collection(conn, sandbox);
 
     irods::at_scope_exit cleanup{[&] {
-        fs::client::remove_all(conn, sandbox, fs::remove_options::no_trash);
+        fs::client::remove_all(conn.operator RcComm&(), sandbox, fs::remove_options::no_trash);
     }};
 
     // Create a data object in iRODS.
@@ -56,92 +69,53 @@ TEST_CASE("data_obj_stat_api")
     SECTION("Stat on good data object") {
         REQUIRE_NOTHROW(fs::client::status(conn, path));
     }
-
-    namespace adm = irods::experimental::administration;
-
-    // Get hostname for unixfilesystem resources
-    std::array<char, HOST_NAME_MAX+1> hostname{};
-    REQUIRE(gethostname(hostname.data(), hostname.size()) == 0);
-
-    // Sanity check
-    // Make sure the hostname buffer is null terminated
-    REQUIRE(hostname.back() == '\0');
-
-    auto create_temp_directory{[](std::string_view _dir_name) -> std::filesystem::path {
-        const auto temp_path{std::filesystem::temp_directory_path()};
-        auto path_to_create{temp_path / _dir_name};
-        std::filesystem::create_directory(path_to_create);
-        return path_to_create;
-    }};
-
-    // Create some temp directories for the resources
-    const auto res_a_path{create_temp_directory("cool")};
-    const auto res_b_path{create_temp_directory("thing")};
-
-    // Cleanup the temp directories
-    irods::at_scope_exit remove_temp_directories{[&](){
-        std::filesystem::remove_all(res_b_path);
-        std::filesystem::remove_all(res_a_path);
-    }};
-
-    // Create resources
-    // Should you even test for no throw here?
-    const adm::resource_registration_info res_regis_a{.resource_name="cool", .resource_type=adm::resource_type::unixfilesystem, .host_name=hostname.data(), .vault_path=res_a_path.string()};
-    REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_a));
-
-    const adm::resource_registration_info res_regis_b{.resource_name="thing", .resource_type=adm::resource_type::unixfilesystem, .host_name=hostname.data(), .vault_path=res_b_path.string()};
-    REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_b));
-
-    const adm::resource_registration_info res_regis_repl{.resource_name="repl", .resource_type=adm::resource_type::replication};
-    REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_repl));
-
-    const adm::resource_registration_info res_regis_pt{.resource_name="pt", .resource_type=adm::resource_type::passthrough};
-    REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_pt));
-
-    // Cleanup the resources
-    irods::at_scope_exit clean_resources{[&](){
-        adm::client::remove_resource(conn, res_regis_pt.resource_name);
-        adm::client::remove_resource(conn, res_regis_repl.resource_name);
-        adm::client::remove_resource(conn, res_regis_b.resource_name);
-        adm::client::remove_resource(conn, res_regis_a.resource_name);
-    }};
-
-    // // Close connection and create new one to "commit" previous actions
-    conn.disconnect();
-    conn.connect();
-
-    // Create the hierarchy
-    REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_pt.resource_name, res_regis_repl.resource_name));
-    REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_repl.resource_name, res_regis_a.resource_name));
-    REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_repl.resource_name, res_regis_b.resource_name));
-
-    // Destruct the hierarchy
-    irods::at_scope_exit unlink_resource_hierarchy{[&](){
-        adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_b.resource_name);
-        adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_a.resource_name);
-        adm::client::remove_child_resource(conn, res_regis_pt.resource_name, res_regis_repl.resource_name);
-    }};
-
-    const auto bleh{sandbox / "cool-cool-epic.txt"};
-    {
-        io::client::default_transport tp{conn};
-        io::odstream out{tp, bleh, io::root_resource_name{res_regis_pt.resource_name}};
-    }
-
-    // TOOD: Use bad status? (-1)
 }
 
 struct TestFixture {
-    TestFixture() : {
+    // Ignore member variable complaints for now
+    // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
+    // UUID for ensuring uniqueness of paths and resources
+    rodsEnv env;
+    std::string test_uui;
+
+    irods::experimental::client_connection conn;
+
+    // Filesystem paths for the tests
+    // Also includes paths for the new resources
+    fs::path sandbox;
+    std::filesystem::path res_a_path;
+    std::filesystem::path res_b_path;
+
+    // Resource info for the heirarchy
+    adm::resource_registration_info res_regis_a;
+    adm::resource_registration_info res_regis_b;
+    adm::resource_registration_info res_regis_repl;
+    adm::resource_registration_info res_regis_pt;
+    // NOLINTEND(misc-non-private-member-variables-in-classes)
+
+    // Make clang happy with the class
+    auto operator=(TestFixture&) -> TestFixture = delete;
+    TestFixture(TestFixture&) = delete;
+    auto operator=(TestFixture&&) -> TestFixture = delete;
+    TestFixture(TestFixture&&) = delete;
+
+    static auto generate_uuid() -> std::string {
+        static boost::uuids::random_generator gen;
+        return to_string(gen());
+    }
+
+    TestFixture() : env{}, test_uui{generate_uuid()}, conn{irods::experimental::defer_connection} {
+        // No idea if this is needed per run?
         load_client_api_plugins();
+        _getRodsEnv(env);
 
+        conn.connect();
+
+        sandbox = fs::path{static_cast<char*>(env.rodsHome)} / fmt::format("irods_unit_test_sandbox-{}", test_uui);
+        fs::client::create_collection(conn, sandbox);
+ 
         // Get hostname for unixfilesystem resources
-        std::array<char, HOST_NAME_MAX+1> hostname{};
-        REQUIRE(gethostname(hostname.data(), hostname.size()) == 0);
-
-        // Sanity check
-        // Make sure the hostname buffer is null terminated
-        REQUIRE(hostname.back() == '\0');
+        auto hostname{boost::asio::ip::host_name()};
 
         auto create_temp_directory{[](std::string_view _dir_name) -> std::filesystem::path {
             const auto temp_path{std::filesystem::temp_directory_path()};
@@ -151,23 +125,26 @@ struct TestFixture {
         }};
 
         // Create some temp directories for the resources
-        const auto res_a_path{create_temp_directory("cool")};
-        const auto res_b_path{create_temp_directory("thing")};
+        res_a_path = create_temp_directory(fmt::format("cool-{}", test_uui));
+        res_b_path = create_temp_directory(fmt::format("thing-{}", test_uui));
 
         // Create resources
         // Should you even test for no throw here?
-        const adm::resource_registration_info res_regis_a{.resource_name="cool", .resource_type=adm::resource_type::unixfilesystem, .host_name=hostname.data(), .vault_path=res_a_path.string()};
+        res_regis_a = {.resource_name = fmt::format("cool-{}", test_uui),
+                       .resource_type = adm::resource_type::unixfilesystem,
+                       .host_name = hostname,
+                       .vault_path = res_a_path.string()};
         REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_a));
-
-        const adm::resource_registration_info res_regis_b{.resource_name="thing", .resource_type=adm::resource_type::unixfilesystem, .host_name=hostname.data(), .vault_path=res_b_path.string()};
+        res_regis_b = {.resource_name = fmt::format("thing-{}", test_uui),
+                       .resource_type = adm::resource_type::unixfilesystem,
+                       .host_name = hostname,
+                       .vault_path = res_b_path.string()};
         REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_b));
-
-        const adm::resource_registration_info res_regis_repl{.resource_name="repl", .resource_type=adm::resource_type::replication};
+        res_regis_repl = {.resource_name = fmt::format("repl-{}", test_uui), .resource_type = adm::resource_type::replication};
         REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_repl));
-
-        const adm::resource_registration_info res_regis_pt{.resource_name="pt", .resource_type=adm::resource_type::passthrough};
+        res_regis_pt = {.resource_name = fmt::format("pt-{}", test_uui), .resource_type = adm::resource_type::passthrough};
         REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_pt));
-        
+
         // Close connection and create new one to "commit" previous actions
         conn.disconnect();
         conn.connect();
@@ -176,13 +153,21 @@ struct TestFixture {
         REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_pt.resource_name, res_regis_repl.resource_name));
         REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_repl.resource_name, res_regis_a.resource_name));
         REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_repl.resource_name, res_regis_b.resource_name));
+
+        // Reset connection jic!
+        conn.disconnect();
+        conn.connect();
     }
 
     ~TestFixture() {
+        // Reset connection jic!
+        conn.disconnect();
+        conn.connect();
+
         // Cleanup all of the files
         fs::client::remove_all(conn, sandbox, fs::remove_options::no_trash);
 
-        // Destruct the hierarchy
+        // Unlink the hierarchy
         adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_b.resource_name);
         adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_a.resource_name);
         adm::client::remove_child_resource(conn, res_regis_pt.resource_name, res_regis_repl.resource_name);
@@ -197,19 +182,218 @@ struct TestFixture {
         std::filesystem::remove_all(res_b_path);
         std::filesystem::remove_all(res_a_path);
     }
-    
-    boost::uuids::uuid test_uuid;
-    irods::experimental::client_connection conn;
+};
+
+auto stat(RcComm& _comm, const fs::path& _path) -> std::unique_ptr<rodsObjStat, decltype(freeRodsObjStat)*>
+{
+    dataObjInp_t input{};
+    std::strncpy(input.objPath, _path.c_str(), std::strlen(_path.c_str()));
+
+    rodsObjStat* output{};
+
+    REQUIRE(rcObjStat(&_comm, &input, &output) >= 0);
+    return {output, freeRodsObjStat};
 }
 
+auto set_replica_status(RcComm& _comm, const fs::path& _path, int replica, int status, const std::unordered_map<std::string, std::string>& _additional_kvp_args) -> int {
+    // Try to figure out the replica keywords...
+    auto [kvp, lm] = irods::experimental::make_key_value_proxy();
+    kvp[REPL_STATUS_KW] = std::to_string(status);
+    kvp[ADMIN_KW] = "";
+
+    std::for_each(std::cbegin(_additional_kvp_args), std::cend(_additional_kvp_args), [&kvp](auto& _thing){
+        kvp[_thing.first] = _thing.second;
+    });
+
+    // Specify the data object we want to mess with
+    // We might be able to reuse the previous data obj inf?
+    DataObjInfo info_two{};
+    std::strncpy(static_cast<char*>(info_two.objPath), _path.c_str(), MAX_NAME_LEN - 1);
+    info_two.replNum = replica;
+
+    // Create the required input
+    ModDataObjMetaInp inp_two{&info_two, kvp.get()};
+    return rcModDataObjMeta(&_comm, &inp_two);
+}
+
+
 TEST_CASE_METHOD(TestFixture, "Stat on data object with only good replicas") {
+    const auto bleh{sandbox / "cool-cool-epic.txt"};
+    {
+        io::client::default_transport tp{conn};
+        io::odstream out{tp, bleh, io::root_resource_name{res_regis_pt.resource_name}};
+    }
+
     REQUIRE_NOTHROW(fs::client::status(conn, bleh));
 }
 
 TEST_CASE_METHOD(TestFixture, "Stat on data object with mixed stale and good replicas") {
-    REQUIRE_NOTHROW(fs::client::status(conn, bleh));
+    const auto bleh{sandbox / "cool-cool-epic.txt"};
+    {
+        io::client::default_transport tp{conn};
+        io::odstream out{tp, bleh, io::root_resource_name{res_regis_pt.resource_name}};
+    }
+
+    // Try to figure out the replica keywords...
+    auto [kvp, lm] = irods::experimental::make_key_value_proxy();
+    kvp[REPL_STATUS_KW] = std::to_string(STALE_REPLICA);
+    kvp[ADMIN_KW] = "";
+    constexpr rodsLong_t bad_size{10};
+    kvp[DATA_SIZE_KW] = std::to_string(bad_size); // Assign arbitrary value to data size
+
+    // Specify the data object we want to mess with
+    DataObjInfo info{};
+    std::strncpy(static_cast<char*>(info.objPath), bleh.c_str(), MAX_NAME_LEN - 1);
+    info.replNum = 0;
+
+    // Create the required input
+    ModDataObjMetaInp inp{&info, kvp.get()};
+
+    auto& comm{static_cast<RcComm&>(conn)};
+    REQUIRE(set_replica_status(comm, bleh, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size)}}));
+    REQUIRE(rcModDataObjMeta(&comm, &inp) >= 0);
+
+    auto res{stat(conn, bleh)};
+
+    // We expect the good replica size
+    REQUIRE(res->objSize == 0);
+    REQUIRE(res->objSize != bad_size);
 }
 
-TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas") {
+TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas") {\
+    const auto bleh{sandbox / "cool-cool-epic.txt"};
+    {
+        io::client::default_transport tp{conn};
+        io::odstream out{tp, bleh, io::root_resource_name{res_regis_pt.resource_name}};
+    }
+
+    // Try to figure out the replica keywords...
+    auto [kvp_one, lm_one] = irods::experimental::make_key_value_proxy();
+    kvp_one[REPL_STATUS_KW] = std::to_string(STALE_REPLICA);
+    kvp_one[ADMIN_KW] = "";
+    constexpr rodsLong_t bad_size_one{10};
+    kvp_one[DATA_SIZE_KW] = std::to_string(bad_size_one); // Assign arbitrary value to data size
+
+    // Specify the data object we want to mess with
+    DataObjInfo info_one{};
+    std::strncpy(static_cast<char*>(info_one.objPath), bleh.c_str(), MAX_NAME_LEN - 1);
+    info_one.replNum = 0;
+
+    // Create the required input
+    ModDataObjMetaInp inp_one{&info_one, kvp_one.get()};
+
+    auto& comm{static_cast<RcComm&>(conn)};
+    REQUIRE(rcModDataObjMeta(&comm, &inp_one) >= 0);
+
+    // Try to figure out the replica keywords...
+    auto [kvp_two, lm_two] = irods::experimental::make_key_value_proxy();
+    kvp_two[REPL_STATUS_KW] = std::to_string(STALE_REPLICA);
+    kvp_two[ADMIN_KW] = "";
+    constexpr rodsLong_t bad_size_two{20};
+    kvp_two[DATA_SIZE_KW] = std::to_string(bad_size_two); // Assign arbitrary value to data size
+
+    // Specify the data object we want to mess with
+    // We might be able to reuse the previous data obj inf?
+    DataObjInfo info_two{};
+    std::strncpy(static_cast<char*>(info_two.objPath), bleh.c_str(), MAX_NAME_LEN - 1);
+    info_two.replNum = 1;
+
+    // Create the required input
+    ModDataObjMetaInp inp_two{&info_two, kvp_two.get()};
+    REQUIRE(rcModDataObjMeta(&comm, &inp_two) >= 0);
+
     REQUIRE_NOTHROW(fs::client::status(conn, bleh));
+
+
+    auto res{stat(conn, bleh)};
+
+    // We expect the first replica to give the stat when both replicas are stale
+    REQUIRE(res->objSize == bad_size_one);
+    REQUIRE(res->objSize != bad_size_two);
+}
+
+TEST_CASE_METHOD(TestFixture, "Stat on data object with invalid status") {
+    const auto bleh{sandbox / "cool-cool-epic.txt"};
+    {
+        io::client::default_transport tp{conn};
+        io::odstream out{tp, bleh, io::root_resource_name{res_regis_pt.resource_name}};
+    }
+
+    // Try to figure out the replica keywords...
+    auto [kvp, lm] = irods::experimental::make_key_value_proxy();
+    kvp[REPL_STATUS_KW] = std::to_string(25); // Just an arbitrary number
+    kvp[ADMIN_KW] = "";
+    constexpr rodsLong_t bad_size{10};
+    kvp[DATA_SIZE_KW] = std::to_string(bad_size); // Assign arbitrary value to data size
+
+    // Specify the data object we want to mess with
+    DataObjInfo info{};
+    std::strncpy(static_cast<char*>(info.objPath), bleh.c_str(), MAX_NAME_LEN - 1);
+    info.replNum = 0;
+
+    // Create the required input
+    ModDataObjMetaInp inp{&info, kvp.get()};
+
+    auto& comm{static_cast<RcComm&>(conn)};
+    REQUIRE(rcModDataObjMeta(&comm, &inp) >= 0);
+
+    REQUIRE_NOTHROW(fs::client::status(conn, bleh));
+
+    auto res{stat(conn, bleh)};
+
+    // We expect to have the size of the good replica
+    REQUIRE(res->objSize == 0);
+    REQUIRE(res->objSize != bad_size);
+}
+
+TEST_CASE_METHOD(TestFixture, "Stat on data object with only invalid status") {
+    const auto bleh{sandbox / "cool-cool-epic.txt"};
+    {
+        io::client::default_transport tp{conn};
+        io::odstream out{tp, bleh, io::root_resource_name{res_regis_pt.resource_name}};
+    }
+
+    // Try to figure out the replica keywords...
+    auto [kvp_one, lm_one] = irods::experimental::make_key_value_proxy();
+    constexpr auto random_number{42};
+    kvp_one[REPL_STATUS_KW] = std::to_string(random_number);
+    kvp_one[ADMIN_KW] = "";
+    constexpr rodsLong_t bad_size_one{10};
+    kvp_one[DATA_SIZE_KW] = std::to_string(bad_size_one); // Assign arbitrary value to data size
+
+    // Specify the data object we want to mess with
+    DataObjInfo info_one{};
+    std::strncpy(static_cast<char*>(info_one.objPath), bleh.c_str(), MAX_NAME_LEN - 1);
+    info_one.replNum = 0;
+
+    // Create the required input
+    ModDataObjMetaInp inp_one{&info_one, kvp_one.get()};
+
+    auto& comm{static_cast<RcComm&>(conn)};
+    REQUIRE(rcModDataObjMeta(&comm, &inp_one) >= 0);
+
+    // Try to figure out the replica keywords...
+    auto [kvp_two, lm_two] = irods::experimental::make_key_value_proxy();
+    constexpr auto different_random_number{56709};
+    kvp_two[REPL_STATUS_KW] = std::to_string(different_random_number);
+    kvp_two[ADMIN_KW] = "";
+    constexpr rodsLong_t bad_size_two{20};
+    kvp_two[DATA_SIZE_KW] = std::to_string(bad_size_two); // Assign arbitrary value to data size
+
+    // Specify the data object we want to mess with
+    // We might be able to reuse the previous data obj inf?
+    DataObjInfo info_two{};
+    std::strncpy(static_cast<char*>(info_two.objPath), bleh.c_str(), MAX_NAME_LEN - 1);
+    info_two.replNum = 1;
+
+    // Create the required input
+    ModDataObjMetaInp inp_two{&info_two, kvp_two.get()};
+    REQUIRE(rcModDataObjMeta(&comm, &inp_two) >= 0);
+
+    REQUIRE_NOTHROW(fs::client::status(conn, bleh));
+    auto res{stat(conn, bleh)};
+
+    // We expect the first replica to give the stat when both replicas are stale
+    REQUIRE(res->objSize == bad_size_one);
+    REQUIRE(res->objSize != bad_size_two);
 }

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -7,6 +7,7 @@
 #include "irods/getRodsEnv.h"
 #include "irods/irods_at_scope_exit.hpp"
 #include "irods/irods_client_api_table.hpp"
+#include "irods/irods_exception.hpp"
 #include "irods/irods_pack_table.hpp"
 #include "irods/key_value_proxy.hpp"
 #include "irods/modDataObjMeta.h"
@@ -199,27 +200,33 @@ struct TestFixture
         }
     }
 
-    ~TestFixture()
+    ~TestFixture() noexcept
     {
         // Reset connection jic!
         conn.disconnect();
-        conn.connect();
 
-        // Cleanup all of the files
-        fs::client::remove_all(conn, sandbox, fs::remove_options::no_trash);
+        try {
+            conn.connect();
 
-        // Unlink the hierarchy
-        adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_b.resource_name);
-        adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_a.resource_name);
+            // Cleanup all of the files
+            fs::client::remove_all(conn, sandbox, fs::remove_options::no_trash);
 
-        // Cleanup the resources
-        adm::client::remove_resource(conn, res_regis_repl.resource_name);
-        adm::client::remove_resource(conn, res_regis_b.resource_name);
-        adm::client::remove_resource(conn, res_regis_a.resource_name);
+            // Unlink the hierarchy
+            adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_b.resource_name);
+            adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_a.resource_name);
 
-        // Cleanup the temp directories
-        std::filesystem::remove_all(res_b_path);
-        std::filesystem::remove_all(res_a_path);
+            // Cleanup the resources
+            adm::client::remove_resource(conn, res_regis_repl.resource_name);
+            adm::client::remove_resource(conn, res_regis_b.resource_name);
+            adm::client::remove_resource(conn, res_regis_a.resource_name);
+
+            // Cleanup the temp directories
+            std::filesystem::remove_all(res_b_path);
+            std::filesystem::remove_all(res_a_path);
+        }
+        catch (const irods::exception& e) {
+            WARN("Exception thrown during cleanup: " << e.what() << "\nTest cleanup may be incomplete.");
+        }
     }
 };
 

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -242,7 +242,8 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with mixed stale and good rep
 {
     constexpr rodsLong_t bad_size{10};
     auto& comm{static_cast<RcComm&>(conn)};
-    REQUIRE(set_replica_status(comm, test_data_object, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size)}}) >= 0);
+    REQUIRE(set_replica_status(comm, test_data_object, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size)}}) >=
+            0);
 
     REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 0) == STALE_REPLICA);
     REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 1) == GOOD_REPLICA);
@@ -257,10 +258,12 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas")
 {
     constexpr rodsLong_t bad_size_one{10};
     auto& comm{static_cast<RcComm&>(conn)};
-    REQUIRE(set_replica_status(comm, test_data_object, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size_one)}}) >= 0);
+    REQUIRE(set_replica_status(
+                comm, test_data_object, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size_one)}}) >= 0);
 
     constexpr rodsLong_t bad_size_two{20};
-    REQUIRE(set_replica_status(comm, test_data_object, 1, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >= 0);
+    REQUIRE(set_replica_status(
+                comm, test_data_object, 1, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >= 0);
 
     auto res{stat(conn, test_data_object)};
 
@@ -286,13 +289,13 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with only invalid status")
     constexpr rodsLong_t bad_size_one{10};
     constexpr auto bad_status_one{42};
     auto& comm{static_cast<RcComm&>(conn)};
-    REQUIRE(set_replica_status(comm, test_data_object, 0, bad_status_one, {{DATA_SIZE_KW, std::to_string(bad_size_one)}}) >=
-            0);
+    REQUIRE(set_replica_status(
+                comm, test_data_object, 0, bad_status_one, {{DATA_SIZE_KW, std::to_string(bad_size_one)}}) >= 0);
 
     constexpr rodsLong_t bad_size_two{20};
     constexpr auto bad_status_two{56709};
-    REQUIRE(set_replica_status(comm, test_data_object, 1, bad_status_two, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >=
-            0);
+    REQUIRE(set_replica_status(
+                comm, test_data_object, 1, bad_status_two, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >= 0);
 
     auto res{stat(conn, test_data_object)};
 

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -245,8 +245,8 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with mixed stale and good rep
     REQUIRE(set_replica_status(comm, test_data_object, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size)}}) >=
             0);
 
-    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 0) == STALE_REPLICA);
-    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 1) == GOOD_REPLICA);
+    REQUIRE(irods::experimental::replica::replica_status(comm, test_data_object, 0) == STALE_REPLICA);
+    REQUIRE(irods::experimental::replica::replica_status(comm, test_data_object, 1) == GOOD_REPLICA);
 
     auto res{stat(conn, test_data_object)};
 
@@ -265,8 +265,8 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas")
     REQUIRE(set_replica_status(
                 comm, test_data_object, 1, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >= 0);
 
-    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 0) == STALE_REPLICA);
-    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 1) == STALE_REPLICA);
+    REQUIRE(irods::experimental::replica::replica_status(comm, test_data_object, 0) == STALE_REPLICA);
+    REQUIRE(irods::experimental::replica::replica_status(comm, test_data_object, 1) == STALE_REPLICA);
 
     auto res{stat(conn, test_data_object)};
 
@@ -281,8 +281,8 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with invalid status")
     auto& comm{static_cast<RcComm&>(conn)};
     REQUIRE(set_replica_status(comm, test_data_object, 0, bad_status, {{DATA_SIZE_KW, std::to_string(bad_size)}}) >= 0);
 
-    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 0) == bad_status);
-    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 1) == GOOD_REPLICA);
+    REQUIRE(irods::experimental::replica::replica_status(comm, test_data_object, 0) == bad_status);
+    REQUIRE(irods::experimental::replica::replica_status(comm, test_data_object, 1) == GOOD_REPLICA);
 
     auto res{stat(conn, test_data_object)};
 
@@ -303,8 +303,8 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with only invalid status")
     REQUIRE(set_replica_status(
                 comm, test_data_object, 1, bad_status_two, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >= 0);
 
-    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 0) == bad_size_one);
-    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 1) == bad_status_two);
+    REQUIRE(irods::experimental::replica::replica_status(comm, test_data_object, 0) == bad_size_one);
+    REQUIRE(irods::experimental::replica::replica_status(comm, test_data_object, 1) == bad_status_two);
 
     auto res{stat(conn, test_data_object)};
 

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -15,6 +15,7 @@
 #include "irods/objStat.h"
 #include "irods/rcConnect.h"
 #include "irods/rcMisc.h"
+#include "irods/replica.hpp"
 #include "irods/resource_administration.hpp"
 #include "irods/rodsClient.h"
 #include "irods/rodsDef.h"
@@ -68,7 +69,7 @@ auto set_replica_status(RcComm& _comm,
 
     // Specify the data object we want to mess with
     DataObjInfo info{};
-    std::strncpy(static_cast<char*>(info.objPath), _path.c_str(), sizeof(input.objPath) - 1);
+    std::strncpy(static_cast<char*>(info.objPath), _path.c_str(), sizeof(info.objPath) - 1);
     info.replNum = replica;
 
     // Create the required input
@@ -242,6 +243,9 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with mixed stale and good rep
     constexpr rodsLong_t bad_size{10};
     auto& comm{static_cast<RcComm&>(conn)};
     REQUIRE(set_replica_status(comm, test_data_object, 0, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size)}}) >= 0);
+
+    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 0) == STALE_REPLICA);
+    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 1) == GOOD_REPLICA);
 
     auto res{stat(conn, test_data_object)};
 

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -60,8 +60,8 @@ auto set_replica_status(RcComm& _comm,
     kvp[REPL_STATUS_KW] = std::to_string(status);
     kvp[ADMIN_KW] = "";
 
-    std::for_each(std::cbegin(_additional_kvp_args), std::cend(_additional_kvp_args), [&kvp](auto& _thing) {
-        kvp[_thing.first] = _thing.second;
+    std::for_each(std::cbegin(_additional_kvp_args), std::cend(_additional_kvp_args), [&kvp](const auto& _kv_to_insert) {
+        kvp[_kv_to_insert.first] = _kv_to_insert.second;
     });
 
     // Specify the data object we want to mess with
@@ -70,8 +70,8 @@ auto set_replica_status(RcComm& _comm,
     info.replNum = replica;
 
     // Create the required input
-    ModDataObjMetaInp inp_two{&info, kvp.get()};
-    return rcModDataObjMeta(&_comm, &inp_two);
+    ModDataObjMetaInp inp{&info, kvp.get()};
+    return rcModDataObjMeta(&_comm, &inp);
 }
 
 TEST_CASE("Stat on single data object")

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -123,7 +123,6 @@ struct TestFixture
     adm::resource_registration_info res_regis_a;
     adm::resource_registration_info res_regis_b;
     adm::resource_registration_info res_regis_repl;
-    adm::resource_registration_info res_regis_pt;
     // NOLINTEND(misc-non-private-member-variables-in-classes)
 
     // Make clang happy with the class
@@ -181,17 +180,12 @@ struct TestFixture
         res_regis_repl = {
             .resource_name = fmt::format("repl-{}", test_uui), .resource_type = adm::resource_type::replication};
         REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_repl));
-        res_regis_pt = {
-            .resource_name = fmt::format("pt-{}", test_uui), .resource_type = adm::resource_type::passthrough};
-        REQUIRE_NOTHROW(adm::client::add_resource(conn, res_regis_pt));
 
         // Close connection and create new one to "commit" previous actions
         conn.disconnect();
         conn.connect();
 
         // Create the hierarchy
-        REQUIRE_NOTHROW(
-            adm::client::add_child_resource(conn, res_regis_pt.resource_name, res_regis_repl.resource_name));
         REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_repl.resource_name, res_regis_a.resource_name));
         REQUIRE_NOTHROW(adm::client::add_child_resource(conn, res_regis_repl.resource_name, res_regis_b.resource_name));
 
@@ -202,7 +196,7 @@ struct TestFixture
         test_file = sandbox / "cool-cool-epic.txt";
         {
             io::client::default_transport transport{conn};
-            io::odstream out{transport, test_file, io::root_resource_name{res_regis_pt.resource_name}};
+            io::odstream out{transport, test_file, io::root_resource_name{res_regis_repl.resource_name}};
         }
     }
 
@@ -218,10 +212,8 @@ struct TestFixture
         // Unlink the hierarchy
         adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_b.resource_name);
         adm::client::remove_child_resource(conn, res_regis_repl.resource_name, res_regis_a.resource_name);
-        adm::client::remove_child_resource(conn, res_regis_pt.resource_name, res_regis_repl.resource_name);
 
         // Cleanup the resources
-        adm::client::remove_resource(conn, res_regis_pt.resource_name);
         adm::client::remove_resource(conn, res_regis_repl.resource_name);
         adm::client::remove_resource(conn, res_regis_b.resource_name);
         adm::client::remove_resource(conn, res_regis_a.resource_name);

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -43,7 +43,7 @@ namespace adm = irods::experimental::administration;
 auto stat(RcComm& _comm, const fs::path& _path) -> std::unique_ptr<rodsObjStat, decltype(freeRodsObjStat)&>
 {
     dataObjInp_t input{};
-    std::strncpy(static_cast<char*>(input.objPath), _path.c_str(), MAX_NAME_LEN - 1);
+    std::strncpy(static_cast<char*>(input.objPath), _path.c_str(), sizeof(input.objPath) - 1);
 
     rodsObjStat* output{};
 
@@ -68,7 +68,7 @@ auto set_replica_status(RcComm& _comm,
 
     // Specify the data object we want to mess with
     DataObjInfo info{};
-    std::strncpy(static_cast<char*>(info.objPath), _path.c_str(), MAX_NAME_LEN - 1);
+    std::strncpy(static_cast<char*>(info.objPath), _path.c_str(), sizeof(input.objPath) - 1);
     info.replNum = replica;
 
     // Create the required input

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -265,6 +265,9 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with only stale replicas")
     REQUIRE(set_replica_status(
                 comm, test_data_object, 1, STALE_REPLICA, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >= 0);
 
+    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 0) == STALE_REPLICA);
+    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 1) == STALE_REPLICA);
+
     auto res{stat(conn, test_data_object)};
 
     // We expect the first replica to give the stat when both replicas are stale
@@ -277,6 +280,9 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with invalid status")
     constexpr auto bad_status{42};
     auto& comm{static_cast<RcComm&>(conn)};
     REQUIRE(set_replica_status(comm, test_data_object, 0, bad_status, {{DATA_SIZE_KW, std::to_string(bad_size)}}) >= 0);
+
+    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 0) == bad_status);
+    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 1) == GOOD_REPLICA);
 
     auto res{stat(conn, test_data_object)};
 
@@ -296,6 +302,9 @@ TEST_CASE_METHOD(TestFixture, "Stat on data object with only invalid status")
     constexpr auto bad_status_two{56709};
     REQUIRE(set_replica_status(
                 comm, test_data_object, 1, bad_status_two, {{DATA_SIZE_KW, std::to_string(bad_size_two)}}) >= 0);
+
+    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 0) == bad_size_one);
+    REQUIRE(irods::experimental::replica::replica_status(conn, test_data_object, 1) == bad_status_two);
 
     auto res{stat(conn, test_data_object)};
 

--- a/unit_tests/src/test_data_obj_stat_api.cpp
+++ b/unit_tests/src/test_data_obj_stat_api.cpp
@@ -90,7 +90,7 @@ TEST_CASE("Stat on single data object")
     fs::client::create_collection(conn, sandbox);
 
     irods::at_scope_exit cleanup{
-        [&] { fs::client::remove_all(conn.operator RcComm&(), sandbox, fs::remove_options::no_trash); }};
+        [&] { fs::client::remove_all(conn, sandbox, fs::remove_options::no_trash); }};
 
     // Create a data object in iRODS.
     // This is used in all future sections.


### PR DESCRIPTION
Issue quick link: #8993 

This PR introduces a change to make ObjStat prefer using information from good replicas where possible. A majority of the changes introduced are from a new unit test asserting the behavior of `rcObjStat(...)`.